### PR TITLE
Updated JMS dependency to a dependency found in Maven Central

### DIFF
--- a/modules/citrus-core/pom.xml
+++ b/modules/citrus-core/pom.xml
@@ -35,7 +35,7 @@
     </dependency>
     <dependency>
     	<groupId>javax.jms</groupId>
-    	<artifactId>jms</artifactId>
+    	<artifactId>jms-api</artifactId>
     </dependency>
     <dependency>
     	<groupId>xalan</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -168,8 +168,8 @@
       </dependency>
       <dependency>
         <groupId>javax.jms</groupId>
-        <artifactId>jms</artifactId>
-        <version>1.1</version>
+        <artifactId>jms-api</artifactId>
+        <version>1.1-rev-1</version>
       </dependency>
       <dependency>
         <groupId>javax.activation</groupId>


### PR DESCRIPTION
I changed the JMS-API dependency to 

```
 <dependency>
    <groupId>javax.jms</groupId>
    <artifactId>jms-api</artifactId>
    <version>1.1-rev-1</version>
  </dependency>
```

since the original dependency doesn't exist (anymore ?) on Maven central.
