### PR TITLE
Bugfix: using validation matchers in templates

### DIFF
--- a/modules/citrus-core/src/main/java/com/consol/citrus/container/Template.java
+++ b/modules/citrus-core/src/main/java/com/consol/citrus/container/Template.java
@@ -80,6 +80,7 @@ public class Template extends AbstractTestAction {
             innerContext.getVariables().putAll(context.getVariables());
             
             innerContext.setMessageValidatorRegistry(context.getMessageValidatorRegistry());
+            innerContext.setValidationMatcherRegistry(context.getValidationMatcherRegistry());
         }
         
         for (Entry<String, String> entry : parameter.entrySet()) {


### PR DESCRIPTION
The validation matcher repository was not propagated to test contexts of templates.
