### PR TITLE
Allow the JSON TextMessageValidator to be sloppy

### DIFF
--- a/modules/citrus-core/src/test/java/com/consol/citrus/validation/json/JsonTextMessageValidatorTest.java
+++ b/modules/citrus-core/src/test/java/com/consol/citrus/validation/json/JsonTextMessageValidatorTest.java
@@ -34,13 +34,23 @@ public class JsonTextMessageValidatorTest extends AbstractTestNGUnitTest {
     @Test
     public void testJsonValidation() {
         JsonTextMessageValidator validator = new JsonTextMessageValidator();
-        
+
         Message<String> receivedMessage = MessageBuilder.withPayload("{\"text\":\"Hello World!\", \"index\":5, \"id\":\"x123456789x\"}").build();
         Message<String> controlMessage = MessageBuilder.withPayload("{\"text\":\"Hello World!\", \"index\":5, \"id\":\"x123456789x\"}").build();
-        
+
         validator.validateMessagePayload(receivedMessage, controlMessage, context);
     }
-    
+
+    @Test
+    public void testSloppyJsonValidation() {
+        JsonTextMessageValidator validator = new JsonTextMessageValidator().sloppy();
+
+        Message<String> receivedMessage = MessageBuilder.withPayload("{\"text\":\"Hello World!\", \"index\":5, \"id\":\"x123456789x\"}").build();
+        Message<String> controlMessage = MessageBuilder.withPayload("{\"id\":\"x123456789x\"}").build();
+
+        validator.validateMessagePayload(receivedMessage, controlMessage, context);
+    }
+
     @Test
     public void testJsonValidationNestedObjects() {
         JsonTextMessageValidator validator = new JsonTextMessageValidator();
@@ -54,7 +64,7 @@ public class JsonTextMessageValidatorTest extends AbstractTestNGUnitTest {
     @Test
     public void testJsonValidationWithArrays() {
         JsonTextMessageValidator validator = new JsonTextMessageValidator();
-        
+
         Message<String> receivedMessage = MessageBuilder.withPayload("[" +
         		"{\"text\":\"Hello World!\", \"index\":1}, " +
         		"{\"text\":\"Hallo Welt!\", \"index\":2}, " +
@@ -63,10 +73,24 @@ public class JsonTextMessageValidatorTest extends AbstractTestNGUnitTest {
         		"{\"text\":\"Hello World!\", \"index\":1}, " +
         		"{\"text\":\"Hallo Welt!\", \"index\":2}, " +
         		"{\"text\":\"Hola del mundo!\", \"index\":3}]").build();
-        
+
         validator.validateMessagePayload(receivedMessage, controlMessage, context);
     }
-    
+
+    @Test
+    public void testSloppyJsonValidationWithArrays() {
+        JsonTextMessageValidator validator = new JsonTextMessageValidator();
+        validator.setSloppy(true);
+
+        Message<String> receivedMessage = MessageBuilder.withPayload("[" +
+        		"{\"text\":\"Hello World!\", \"index\":1}, " +
+        		"{\"text\":\"Hallo Welt!\", \"index\":2}, " +
+        		"{\"text\":\"Hola del mundo!\", \"index\":3}]").build();
+        Message<String> controlMessage = MessageBuilder.withPayload("[{\"text\":\"Hello World!\", \"index\":1}] ").build();
+
+        validator.validateMessagePayload(receivedMessage, controlMessage, context);
+    }
+
     @Test
     public void testJsonValidationWithNestedArrays() {
         JsonTextMessageValidator validator = new JsonTextMessageValidator();

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -25,6 +25,9 @@
         <action dev="christophd" type="add">
           CITRUS-172 LDAP server adapter
         </action>
+        <action dev="roland" type="add">
+          Allow the JSON Text Validator to be sloppy by setting a property
+        </action>
     </release>
 
     <release version="1.3.1" date="06.09.2013" description="1.3.1 release">

--- a/src/docbkx/validation-json.xml
+++ b/src/docbkx/validation-json.xml
@@ -18,7 +18,8 @@
         <listitem>
             <para>com.consol.citrus.validation.json.JsonTextMessageValidator: Basic JSON message validator implementation compares JSON objects (expected and received). 
             The order of JSON entries can differ as specified in JSON protocol. Tester defines an expected control JSON object with test variables and ignored entries. 
-            JSONArray as well as nested JSONObjects are supported, too.</para>
+            JSONArray as well as nested JSONObjects are supported, too. This validator has a property "sloppy" which can be set so that the control JSON object can be a
+            partial object in which case only the given fields are validated. All other keys in the received message are then ignored. By default this property is set to false.</para>
         </listitem>
         <listitem>
             <para>com.consol.citrus.validation.script.GroovyJsonMessageValidator: Extended groovy message validator provides specific JSON slurper support. With JSON slurper 


### PR DESCRIPTION
If this property is set it won't verify the size of an JSON Object then.

The Java DSL could used new `JsonTextMessageValdator().sloppy()` to create a sloppy validator. This validator is useful if you want to verify only a part of a message.
