### PR TITLE
Extended HTTP DSL with "path" command and fixed "url" command.

### DIFF
--- a/modules/citrus-adapter/src/test/java/com/consol/citrus/adapter/common/endpoint/MessageHeaderEndpointUriResolverTest.java
+++ b/modules/citrus-adapter/src/test/java/com/consol/citrus/adapter/common/endpoint/MessageHeaderEndpointUriResolverTest.java
@@ -31,24 +31,48 @@ public class MessageHeaderEndpointUriResolverTest {
     @Test
     public void testEndpointMapping() {
         MessageHeaderEndpointUriResolver endpointUriResolver = new MessageHeaderEndpointUriResolver();
-        
+
         Message<?> testMessage;
-        
-        testMessage = MessageBuilder.withPayload("<TestRequest><Message>Hello World!</Message></TestRequest>")
+
+        testMessage = createBuilder()
                 .setHeader(MessageHeaderEndpointUriResolver.ENDPOINT_URI_HEADER_NAME, "http://localhost:8080/request")
                 .build();
-        
+
         Assert.assertEquals(endpointUriResolver.resolveEndpointUri(testMessage), "http://localhost:8080/request");
         Assert.assertEquals(endpointUriResolver.resolveEndpointUri(testMessage, "http://localhost:8080/default"), "http://localhost:8080/request");
     }
-    
+    @Test
+    public void testEndpointMappingWithPath() {
+        MessageHeaderEndpointUriResolver endpointUriResolver = new MessageHeaderEndpointUriResolver();
+
+        Message<?> testMessage;
+
+        for (String[] test : new String[][] {
+                { "http://localhost:8080/request", "/test", "http://localhost:8080/request/test" },
+                { "http://localhost:8080/request/", "/test", "http://localhost:8080/request/test" },
+                { "http://localhost:8080/request", "test", "http://localhost:8080/request/test"},
+                { "http://localhost:8080/request////", "test", "http://localhost:8080/request/test"},
+                { "http://localhost:8080/request/", "////test", "http://localhost:8080/request/test"},
+                { "http://localhost:8080/request", "test/", "http://localhost:8080/request/test/"},
+        }) {
+            testMessage = createBuilder()
+                    .setHeader(MessageHeaderEndpointUriResolver.ENDPOINT_URI_HEADER_NAME, test[0])
+                    .setHeader(MessageHeaderEndpointUriResolver.ENDPOINT_PATH_HEADER_NAME,test[1])
+                    .build();
+
+            Assert.assertEquals(endpointUriResolver.resolveEndpointUri(testMessage), test[2]);
+            Assert.assertEquals(endpointUriResolver.resolveEndpointUri(testMessage, "http://localhost:8080/default"), test[2]);
+
+        }
+    }
+
     @Test
     public void testDefaultEndpoint() {
         MessageHeaderEndpointUriResolver endpointUriResolver = new MessageHeaderEndpointUriResolver();
         
         Message<?> testMessage;
         
-        testMessage = MessageBuilder.withPayload("<TestRequest><Message>Hello World!</Message></TestRequest>").build();
+        testMessage = createBuilder().build();
         
         Assert.assertEquals(endpointUriResolver.resolveEndpointUri(testMessage, "http://localhost:8080/default"), "http://localhost:8080/default");
     }
@@ -59,7 +83,7 @@ public class MessageHeaderEndpointUriResolverTest {
         
         Message<?> testMessage;
         
-        testMessage = MessageBuilder.withPayload("<TestRequest><Message>Hello World!</Message></TestRequest>").build();
+        testMessage = createBuilder().build();
         
         try {
             endpointUriResolver.resolveEndpointUri(testMessage);
@@ -70,5 +94,9 @@ public class MessageHeaderEndpointUriResolverTest {
         }
         
         Assert.fail("Missing CitrusRuntimeException caused by unresolvable endpoint uri");
+    }
+
+    private MessageBuilder<String> createBuilder() {
+        return MessageBuilder.withPayload("<TestRequest><Message>Hello World!</Message></TestRequest>");
     }
 }

--- a/modules/citrus-core/src/main/java/com/consol/citrus/validation/builder/PayloadTemplateMessageBuilder.java
+++ b/modules/citrus-core/src/main/java/com/consol/citrus/validation/builder/PayloadTemplateMessageBuilder.java
@@ -17,15 +17,10 @@
 package com.consol.citrus.validation.builder;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
-import org.springframework.util.StringUtils;
 
 import com.consol.citrus.context.TestContext;
 import com.consol.citrus.exceptions.CitrusRuntimeException;
 import com.consol.citrus.util.FileUtils;
-import com.consol.citrus.validation.interceptor.MessageConstructionInterceptor;
 
 /**
  * @author Christoph Deppisch

--- a/modules/citrus-java-dsl/src/main/java/com/consol/citrus/dsl/CitrusTestBuilder.java
+++ b/modules/citrus-java-dsl/src/main/java/com/consol/citrus/dsl/CitrusTestBuilder.java
@@ -16,6 +16,12 @@
 
 package com.consol.citrus.dsl;
 
+import java.io.IOException;
+import java.util.*;
+
+import javax.jms.ConnectionFactory;
+import javax.sql.DataSource;
+
 import com.consol.citrus.*;
 import com.consol.citrus.actions.*;
 import com.consol.citrus.container.*;
@@ -37,11 +43,6 @@ import com.consol.citrus.ws.server.WebServiceServer;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.io.Resource;
-
-import javax.jms.ConnectionFactory;
-import javax.sql.DataSource;
-import java.io.IOException;
-import java.util.*;
 
 /**
  * Citrus test builder offers builder pattern methods in order to configure a
@@ -577,7 +578,7 @@ public class CitrusTestBuilder implements TestBuilder, InitializingBean {
         action.setEndpoint(messageEndpoint);
 
         testCase.addTestAction(action);
-        return new SendMessageActionDefinition(action, new PositionHandle(testCase.getActions()));
+        return new SendMessageActionDefinition<SendMessageAction,SendMessageActionDefinition>(action, new PositionHandle(testCase.getActions()));
     }
 
     /**
@@ -601,7 +602,7 @@ public class CitrusTestBuilder implements TestBuilder, InitializingBean {
             action.setEndpoint(messageEndpoint);
 
             testCase.addTestAction(action);
-            return new SendMessageActionDefinition(action, new PositionHandle(testCase.getActions()));
+            return new SendMessageActionDefinition<SendMessageAction,SendMessageActionDefinition>(action, new PositionHandle(testCase.getActions()));
         }
     }
 

--- a/modules/citrus-java-dsl/src/main/java/com/consol/citrus/dsl/definition/SendHttpMessageActionDefinition.java
+++ b/modules/citrus-java-dsl/src/main/java/com/consol/citrus/dsl/definition/SendHttpMessageActionDefinition.java
@@ -17,13 +17,11 @@
 package com.consol.citrus.dsl.definition;
 
 import com.consol.citrus.actions.SendMessageAction;
+import com.consol.citrus.adapter.common.endpoint.MessageHeaderEndpointUriResolver;
 import com.consol.citrus.dsl.util.PositionHandle;
 import com.consol.citrus.exceptions.CitrusRuntimeException;
 import com.consol.citrus.http.message.CitrusHttpMessageHeaders;
-import org.springframework.core.io.Resource;
 import org.springframework.http.HttpMethod;
-import org.springframework.integration.Message;
-import org.springframework.oxm.Marshaller;
 
 /**
  * Special method for HTTP senders. This definition is used to set the Citrus special headers with special
@@ -32,7 +30,7 @@ import org.springframework.oxm.Marshaller;
  * @author roland
  * @since 1.4
  */
-public class SendHttpMessageActionDefinition extends SendMessageActionDefinition {
+public class SendHttpMessageActionDefinition extends SendMessageActionDefinition<SendMessageAction,SendHttpMessageActionDefinition> {
 
     /**
      * Constructor delegating to the parent constructor
@@ -56,59 +54,32 @@ public class SendHttpMessageActionDefinition extends SendMessageActionDefinition
     }
 
     /**
-     * Set the endpoint URI for the request
+     * Set the endpoint URI for the request. This works only if the HTTP endpoint used
+     * doesn't provide an own endpoint URI resolver.
      *
      * @param uri absolute URI to use for the endpoint
      * @return chained definition builder
      */
     public SendHttpMessageActionDefinition uri(String uri) {
-        header(CitrusHttpMessageHeaders.HTTP_REQUEST_URI,uri);
+        // Set the endpoint URL properly.
+        header(MessageHeaderEndpointUriResolver.ENDPOINT_URI_HEADER_NAME,uri);
         return this;
     }
 
-    @Override
-    public SendHttpMessageActionDefinition fork(boolean forkMode) {
-        return (SendHttpMessageActionDefinition) super.fork(forkMode);
-    }
-
-    @Override
-    public SendHttpMessageActionDefinition message(Message<String> message) {
-        return (SendHttpMessageActionDefinition) super.message(message);
-    }
-
-    @Override
-    public SendHttpMessageActionDefinition payload(Object payload, Marshaller marshaller) {
-        return (SendHttpMessageActionDefinition) super.payload(payload, marshaller);
-    }
-
-    @Override
-    public SendHttpMessageActionDefinition payload(Resource payloadResource) {
-        return (SendHttpMessageActionDefinition) super.payload(payloadResource);
-    }
-
-    @Override
-    public SendHttpMessageActionDefinition payload(String payload) {
-        return (SendHttpMessageActionDefinition) super.payload(payload);
-    }
-
-    @Override
-    public SendHttpMessageActionDefinition header(String name, Object value) {
-        return (SendHttpMessageActionDefinition) super.header(name, value);
-    }
-
-    @Override
-    public SendHttpMessageActionDefinition description(String description) {
-        return (SendHttpMessageActionDefinition) super.description(description);
-    }
-
-    @Override
-    public SendHttpMessageActionDefinition extractFromHeader(String headerName, String variable) {
-        return (SendHttpMessageActionDefinition) super.extractFromHeader(headerName, variable);
-    }
-
-    @Override
-    public SendHttpMessageActionDefinition extractFromPayload(String xpath, String variable) {
-        return (SendHttpMessageActionDefinition) super.extractFromPayload(xpath, variable);
+    /**
+     * Add a path to the endpoint URL. The path should start with a '/', any
+     * multiple slashes on the concatenation point between endpoint URL and path are squeezed
+     * to a single '/'. This works only if the HTTP endpoint used
+     * doesn't provide an own endpoint URI resolver so that the default endpoint URI resolver, which
+     * evaluates the message header <code>citrus_endpoint_uri</code> and <code>citrus_endpoint_path</code>
+     * for resolving the endpoint uri.
+     *
+     * @param path to set
+     * @return chained definition builder
+     */
+    public SendHttpMessageActionDefinition path(String path) {
+        header(MessageHeaderEndpointUriResolver.ENDPOINT_PATH_HEADER_NAME,path);
+        return this;
     }
 
     @Override

--- a/modules/citrus-java-dsl/src/main/java/com/consol/citrus/dsl/definition/SendSoapFaultActionDefinition.java
+++ b/modules/citrus-java-dsl/src/main/java/com/consol/citrus/dsl/definition/SendSoapFaultActionDefinition.java
@@ -32,7 +32,7 @@ import com.consol.citrus.ws.message.builder.SoapFaultAwareMessageBuilder;
  * 
  * @author Christoph Deppisch
  */
-public class SendSoapFaultActionDefinition extends SendMessageActionDefinition {
+public class SendSoapFaultActionDefinition extends SendMessageActionDefinition<SendMessageAction,SendSoapFaultActionDefinition> {
 
     private SoapFaultAwareMessageBuilder soapFaultMessageBuilder = new SoapFaultAwareMessageBuilder();
     
@@ -101,33 +101,33 @@ public class SendSoapFaultActionDefinition extends SendMessageActionDefinition {
         }
         return this;
     }
-    
+
     /**
      * Adds message header name value pair.
      * @param name
      * @param value
      */
-    public SendMessageActionDefinition header(String name, Object value) {
+    public SendSoapFaultActionDefinition header(String name, Object value) {
         soapFaultMessageBuilder.getMessageHeaders().put(name, value);
         return this;
     }
-    
+
     /**
      * Adds message header data. Message header data is used in SOAP
      * messages for instance as header XML fragment.
      * @param data
      */
-    public SendMessageActionDefinition header(String data) {
+    public SendSoapFaultActionDefinition header(String data) {
         soapFaultMessageBuilder.setMessageHeaderData(data);
         return this;
     }
-    
+
     /**
      * Adds message header data as file resource. Message header data is used in SOAP
      * messages for instance as header XML fragment.
      * @param resource
      */
-    public SendMessageActionDefinition header(Resource resource) {
+    public SendSoapFaultActionDefinition header(Resource resource) {
         try {
             soapFaultMessageBuilder.setMessageHeaderData(FileUtils.readToString(resource));
         } catch (IOException e) {

--- a/modules/citrus-java-dsl/src/main/java/com/consol/citrus/dsl/definition/SendSoapMessageActionDefinition.java
+++ b/modules/citrus-java-dsl/src/main/java/com/consol/citrus/dsl/definition/SendSoapMessageActionDefinition.java
@@ -16,15 +16,13 @@
 
 package com.consol.citrus.dsl.definition;
 
+import java.io.IOException;
+
 import com.consol.citrus.exceptions.CitrusRuntimeException;
 import com.consol.citrus.util.FileUtils;
 import com.consol.citrus.ws.SoapAttachment;
 import com.consol.citrus.ws.actions.SendSoapMessageAction;
 import org.springframework.core.io.Resource;
-import org.springframework.integration.Message;
-import org.springframework.oxm.Marshaller;
-
-import java.io.IOException;
 
 /**
  * Send action definition adding SOAP specific properties like SOAP attachment and
@@ -32,7 +30,7 @@ import java.io.IOException;
  * 
  * @author Christoph Deppisch
  */
-public class SendSoapMessageActionDefinition extends SendMessageActionDefinition {
+public class SendSoapMessageActionDefinition extends SendMessageActionDefinition<SendSoapMessageAction,SendSoapMessageActionDefinition> {
 
     /**
      * Default constructor using action.
@@ -103,58 +101,8 @@ public class SendSoapMessageActionDefinition extends SendMessageActionDefinition
     }
 
     @Override
-    public SendSoapMessageActionDefinition fork(boolean forkMode) {
-        return (SendSoapMessageActionDefinition) super.fork(forkMode);
-    }
-    
-    @Override
-    public SendSoapMessageActionDefinition message(Message<String> message) {
-        return (SendSoapMessageActionDefinition) super.message(message);
-    }
-    
-    @Override
-    public SendSoapMessageActionDefinition payload(Object payload, Marshaller marshaller) {
-        return (SendSoapMessageActionDefinition) super.payload(payload, marshaller);
-    }
-    
-    @Override
-    public SendSoapMessageActionDefinition payload(Resource payloadResource) {
-        return (SendSoapMessageActionDefinition) super.payload(payloadResource);
-    }
-    
-    @Override
-    public SendSoapMessageActionDefinition payload(String payload) {
-        return (SendSoapMessageActionDefinition) super.payload(payload);
-    }
-    
-    @Override
-    public SendSoapMessageActionDefinition header(String name, Object value) {
-        return (SendSoapMessageActionDefinition) super.header(name, value);
-    }
-    
-    @Override
-    public SendSoapMessageActionDefinition description(String description) {
-        return (SendSoapMessageActionDefinition) super.description(description);
-    }
-    
-    @Override
-    public SendSoapMessageActionDefinition extractFromHeader(String headerName, String variable) {
-        return (SendSoapMessageActionDefinition) super.extractFromHeader(headerName, variable);
-    }
-    
-    @Override
-    public SendSoapMessageActionDefinition extractFromPayload(String xpath, String variable) {
-        return (SendSoapMessageActionDefinition) super.extractFromPayload(xpath, variable);
-    }
-    
-    @Override
     public SendSoapMessageActionDefinition soap() {
         return this;
-    }
-    
-    @Override
-    public SendSoapMessageAction getAction() {
-        return (SendSoapMessageAction)super.getAction();
     }
 
     @Override

--- a/modules/citrus-java-dsl/src/test/java/com/consol/citrus/dsl/definition/SendHttpMessageDefinitionTest.java
+++ b/modules/citrus-java-dsl/src/test/java/com/consol/citrus/dsl/definition/SendHttpMessageDefinitionTest.java
@@ -16,7 +16,10 @@
 
 package com.consol.citrus.dsl.definition;
 
+import java.util.HashMap;
+
 import com.consol.citrus.actions.SendMessageAction;
+import com.consol.citrus.adapter.common.endpoint.MessageHeaderEndpointUriResolver;
 import com.consol.citrus.container.SequenceBeforeTest;
 import com.consol.citrus.endpoint.Endpoint;
 import com.consol.citrus.exceptions.CitrusRuntimeException;
@@ -32,8 +35,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.integration.support.MessageBuilder;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import java.util.HashMap;
 
 import static org.easymock.EasyMock.*;
 
@@ -117,13 +118,14 @@ public class SendHttpMessageDefinitionTest extends AbstractTestNGUnitTest {
     }
 
     @Test
-    public void testHttpRequestUri() {
+    public void testHttpRequestUriAndPath() {
         MockBuilder builder = new MockBuilder(applicationContext) {
             @Override
             public void configure() {
                 send(httpClient)
                         .http()
-                        .uri("http://localhost:8080/test")
+                        .uri("http://localhost:8080/")
+                        .path("/test")
                         .payload("<TestRequest><Message>Hello World!</Message></TestRequest>");
             }
         };
@@ -141,8 +143,9 @@ public class SendHttpMessageDefinitionTest extends AbstractTestNGUnitTest {
 
         PayloadTemplateMessageBuilder messageBuilder = (PayloadTemplateMessageBuilder) action.getMessageBuilder();
         Assert.assertEquals(messageBuilder.getPayloadData(), "<TestRequest><Message>Hello World!</Message></TestRequest>");
-        Assert.assertEquals(messageBuilder.getMessageHeaders().size(), 1L);
-        Assert.assertEquals(messageBuilder.getMessageHeaders().get(CitrusHttpMessageHeaders.HTTP_REQUEST_URI), "http://localhost:8080/test");
+        Assert.assertEquals(messageBuilder.getMessageHeaders().size(), 2L);
+        Assert.assertEquals(messageBuilder.getMessageHeaders().get(MessageHeaderEndpointUriResolver.ENDPOINT_URI_HEADER_NAME), "http://localhost:8080/");
+        Assert.assertEquals(messageBuilder.getMessageHeaders().get(MessageHeaderEndpointUriResolver.ENDPOINT_PATH_HEADER_NAME), "/test");
     }
 
     @Test(expectedExceptions = CitrusRuntimeException.class,


### PR DESCRIPTION
Additionally, the `SendActionDefinition` has been refactored to avoid massive duplication
in subclasses.

What I remarked, too, is that `ActionDefinition` extends `Action`. This is IMHO not a wise decision since it results in a lot of "instanecof" calls which is a quite bad code smell. And yes, a ActionDefinition is **not** a Action (but a definition).

It would be much better to a have generic interface like `ActionHolder` with a method `getAction()`, implemented by `Action` and `ActionDefinition` and which is used in the test cases. `Action.getAction()` then can simply return `this`, while `ActionDefinition` returns the wrapped `Action`.

Just an idea ....
