### PR TITLE
Updated HttpMessageContentBuilder to account for variable substitution

### DIFF
--- a/modules/citrus-http/src/main/java/com/consol/citrus/http/message/HttpMessageContentBuilder.java
+++ b/modules/citrus-http/src/main/java/com/consol/citrus/http/message/HttpMessageContentBuilder.java
@@ -24,8 +24,7 @@ import com.consol.citrus.validation.interceptor.MessageConstructionInterceptor;
 import com.consol.citrus.variable.dictionary.DataDictionary;
 
 import javax.servlet.http.Cookie;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * @author Christoph Deppisch
@@ -48,18 +47,18 @@ public class HttpMessageContentBuilder extends AbstractMessageContentBuilder {
 
     @Override
     public Message buildMessageContent(TestContext context, String messageType) {
+        final Set<String> headersToRetain = new HashSet<>(2);
+        headersToRetain.add(MessageHeaders.ID);
+        headersToRetain.add(MessageHeaders.TIMESTAMP);
+
         delegate.getMessageHeaders().putAll(message.getHeaders());
-        message.getHeaders().clear();
-        message.getHeaders().put(MessageHeaders.ID, delegate.getMessageHeaders().get(MessageHeaders.ID));
-        message.getHeaders().put(MessageHeaders.TIMESTAMP, delegate.getMessageHeaders().get(MessageHeaders.TIMESTAMP));
 
         Message delegateMessage = delegate.buildMessageContent(context, messageType);
 
+        message.getHeaders().keySet().retainAll(headersToRetain);
+
         for (Map.Entry<String, Object> headerEntry : delegateMessage.getHeaders().entrySet()) {
-            if (!headerEntry.getKey().equals(MessageHeaders.ID) &&
-                    !headerEntry.getKey().equals(MessageHeaders.TIMESTAMP)) {
-                message.setHeader(headerEntry.getKey(), headerEntry.getValue());
-            }
+            message.getHeaders().putIfAbsent(headerEntry.getKey(), headerEntry.getValue());
         }
         message.setPayload(delegateMessage.getPayload());
         

--- a/modules/citrus-http/src/main/java/com/consol/citrus/http/message/HttpMessageContentBuilder.java
+++ b/modules/citrus-http/src/main/java/com/consol/citrus/http/message/HttpMessageContentBuilder.java
@@ -48,7 +48,10 @@ public class HttpMessageContentBuilder extends AbstractMessageContentBuilder {
 
     @Override
     public Message buildMessageContent(TestContext context, String messageType) {
-        delegate.setMessageHeaders(message.getHeaders());
+        delegate.getMessageHeaders().putAll(message.getHeaders());
+        message.getHeaders().clear();
+        message.getHeaders().put(MessageHeaders.ID, delegate.getMessageHeaders().get(MessageHeaders.ID));
+        message.getHeaders().put(MessageHeaders.TIMESTAMP, delegate.getMessageHeaders().get(MessageHeaders.TIMESTAMP));
 
         Message delegateMessage = delegate.buildMessageContent(context, messageType);
 

--- a/modules/citrus-http/src/test/java/com/consol/citrus/http/message/HttpMessageContentBuilderTest.java
+++ b/modules/citrus-http/src/test/java/com/consol/citrus/http/message/HttpMessageContentBuilderTest.java
@@ -19,6 +19,7 @@ package com.consol.citrus.http.message;
 
 import com.consol.citrus.context.TestContext;
 import com.consol.citrus.message.Message;
+import com.consol.citrus.message.MessageHeaders;
 import com.consol.citrus.message.MessageType;
 import com.consol.citrus.validation.builder.StaticMessageContentBuilder;
 import org.testng.Assert;
@@ -44,6 +45,8 @@ public class HttpMessageContentBuilderTest {
         Message builtMessage = builder.buildMessageContent(ctx, String.valueOf(MessageType.XML));
 
         Assert.assertEquals(builtMessage.getHeaders().entrySet().size(), 3);
+        Assert.assertEquals(msg.getHeader(MessageHeaders.ID), builtMessage.getHeader(MessageHeaders.ID));
+        Assert.assertEquals(msg.getHeader(MessageHeaders.TIMESTAMP), builtMessage.getHeader(MessageHeaders.TIMESTAMP));
         Assert.assertEquals(builtMessage.getHeader("foo"), "bar");
     }
 }

--- a/modules/citrus-http/src/test/java/com/consol/citrus/http/message/HttpMessageContentBuilderTest.java
+++ b/modules/citrus-http/src/test/java/com/consol/citrus/http/message/HttpMessageContentBuilderTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2006-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 package com.consol.citrus.http.message;
 
 import com.consol.citrus.context.TestContext;
@@ -7,6 +24,10 @@ import com.consol.citrus.validation.builder.StaticMessageContentBuilder;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+/**
+ * @author Simon Hofmann
+ * @since 2.7.3
+ */
 public class HttpMessageContentBuilderTest {
 
     @Test

--- a/modules/citrus-http/src/test/java/com/consol/citrus/http/message/HttpMessageContentBuilderTest.java
+++ b/modules/citrus-http/src/test/java/com/consol/citrus/http/message/HttpMessageContentBuilderTest.java
@@ -1,0 +1,28 @@
+package com.consol.citrus.http.message;
+
+import com.consol.citrus.context.TestContext;
+import com.consol.citrus.message.Message;
+import com.consol.citrus.message.MessageType;
+import com.consol.citrus.validation.builder.StaticMessageContentBuilder;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class HttpMessageContentBuilderTest {
+
+    @Test
+    public void testHeaderVariableSubstitution() {
+        TestContext ctx = new TestContext();
+        ctx.setVariable("testHeader", "foo");
+        ctx.setVariable("testValue", "bar");
+
+        HttpMessage msg = new HttpMessage("testPayload");
+        msg.setHeader("${testHeader}", "${testValue}");
+
+        HttpMessageContentBuilder builder = new HttpMessageContentBuilder(msg, new StaticMessageContentBuilder(msg));
+
+        Message builtMessage = builder.buildMessageContent(ctx, String.valueOf(MessageType.XML));
+
+        Assert.assertEquals(builtMessage.getHeaders().entrySet().size(), 3);
+        Assert.assertEquals(builtMessage.getHeader("foo"), "bar");
+    }
+}


### PR DESCRIPTION
in headers.

The existing implementation did not account for variable substitution in header keys.
In Citrus < 2.7.2 variable substitution for maps only worked on entries, not keys, so after substituting values in headers, existing entries would be overwritten.
With variable substitution for keys in place this no longer works and previous headers have to be cleared, otherwise there'd be one header containing ${variables} and a separate one with actual values.

This in fact can cause HTTP 400 - Bad request errors.