### PR TITLE
PR-439: Fix for exception on empty payload in SOAP request

### DIFF
--- a/modules/citrus-ws/src/main/java/com/consol/citrus/ws/message/converter/SoapMessageConverter.java
+++ b/modules/citrus-ws/src/main/java/com/consol/citrus/ws/message/converter/SoapMessageConverter.java
@@ -88,11 +88,12 @@ public class SoapMessageConverter implements WebServiceMessageConverter {
             soapMessage = new SoapMessage(message);
         }
 
+        TransformerFactory transformerFactory = TransformerFactory.newInstance();
+
         // Copy payload into soap-body:
         String payload = soapMessage.getPayload(String.class);
         if (StringUtils.hasText(payload)) {
             try {
-                TransformerFactory transformerFactory = TransformerFactory.newInstance();
                 Transformer transformer = transformerFactory.newTransformer();
                 transformer.transform(new StringSource(payload), soapRequest.getSoapBody().getPayloadResult());
             } catch (TransformerException e) {

--- a/modules/citrus-ws/src/main/java/com/consol/citrus/ws/message/converter/SoapMessageConverter.java
+++ b/modules/citrus-ws/src/main/java/com/consol/citrus/ws/message/converter/SoapMessageConverter.java
@@ -89,13 +89,15 @@ public class SoapMessageConverter implements WebServiceMessageConverter {
         }
 
         // Copy payload into soap-body:
-        TransformerFactory transformerFactory = TransformerFactory.newInstance();
-
-        try {
-            Transformer transformer = transformerFactory.newTransformer();
-            transformer.transform(new StringSource(soapMessage.getPayload(String.class)), soapRequest.getSoapBody().getPayloadResult());
-        } catch (TransformerException e) {
-            throw new CitrusRuntimeException("Failed to write SOAP body payload", e);
+        String payload = soapMessage.getPayload(String.class);
+        if (StringUtils.hasText(payload)) {
+            try {
+                TransformerFactory transformerFactory = TransformerFactory.newInstance();
+                Transformer transformer = transformerFactory.newTransformer();
+                transformer.transform(new StringSource(payload), soapRequest.getSoapBody().getPayloadResult());
+            } catch (TransformerException e) {
+                throw new CitrusRuntimeException("Failed to write SOAP body payload", e);
+            }
         }
 
         // Copy headers into soap-header:


### PR DESCRIPTION
Fix for issue #439 
Fixes a parsing exception when the payload of a SOAP request is empty