### PR TITLE
Use 'contains' instead of 'equals' in order to process compound Conte…

### DIFF
--- a/modules/citrus-http/src/main/java/com/consol/citrus/http/servlet/CachingHttpServletRequestWrapper.java
+++ b/modules/citrus-http/src/main/java/com/consol/citrus/http/servlet/CachingHttpServletRequestWrapper.java
@@ -55,7 +55,7 @@ public class CachingHttpServletRequestWrapper extends HttpServletRequestWrapper 
 
         Map<String, String[]> params = new HashMap<>();
         if (RequestMethod.POST.name().equals(getMethod()) || RequestMethod.PUT.name().equals(getMethod())) {
-            if ("application/x-www-form-urlencoded".equals(getContentType())) {
+            if (getContentType() != null && getContentType().contains("application/x-www-form-urlencoded")) {
                 fillParams(params, new String(body, Charset.forName(Citrus.CITRUS_FILE_ENCODING)));
             } else {
                 return super.getParameterMap();

--- a/modules/citrus-http/src/main/java/com/consol/citrus/http/servlet/CachingHttpServletRequestWrapper.java
+++ b/modules/citrus-http/src/main/java/com/consol/citrus/http/servlet/CachingHttpServletRequestWrapper.java
@@ -55,7 +55,7 @@ public class CachingHttpServletRequestWrapper extends HttpServletRequestWrapper 
 
         Map<String, String[]> params = new HashMap<>();
         if (RequestMethod.POST.name().equals(getMethod()) || RequestMethod.PUT.name().equals(getMethod())) {
-            if (getContentType() != null && getContentType().contains("application/x-www-form-urlencoded")) {
+            if (getContentType() != null && getContentType().startsWith("application/x-www-form-urlencoded")) {
                 fillParams(params, new String(body, Charset.forName(Citrus.CITRUS_FILE_ENCODING)));
             } else {
                 return super.getParameterMap();


### PR DESCRIPTION
…nt-Type headers (e.g. application/x-www-form-urlencoded;utf-8)