### PR TITLE
Fix overwritten cookie in HttpMessageConverter

### DIFF
--- a/modules/citrus-http/src/main/java/com/consol/citrus/http/message/HttpMessageConverter.java
+++ b/modules/citrus-http/src/main/java/com/consol/citrus/http/message/HttpMessageConverter.java
@@ -66,7 +66,7 @@ public class HttpMessageConverter implements MessageConverter<HttpEntity<?>, Htt
             return new ResponseEntity<>(payload, httpHeaders, httpMessage.getStatusCode());
         } else {
             for (Cookie cookie : httpMessage.getCookies()) {
-                httpHeaders.set("Cookie", cookie.getName() + "=" + context.replaceDynamicContentInString(cookie.getValue()));
+                httpHeaders.add("Cookie", cookie.getName() + "=" + context.replaceDynamicContentInString(cookie.getValue()));
             }
         }
 


### PR DESCRIPTION
Uses `HttpHeaders.add` to append cookie name-value pair instead of `HttpHeaders.set` which dropping old `Cookie` header.