### PR TITLE
Fix duplicated cookie entries in http request

### DIFF
--- a/modules/citrus-http/src/main/java/com/consol/citrus/http/message/HttpMessage.java
+++ b/modules/citrus-http/src/main/java/com/consol/citrus/http/message/HttpMessage.java
@@ -407,6 +407,25 @@ public class HttpMessage extends DefaultMessage {
      * @param cookies
      */
     public void setCookies(Cookie[] cookies) {
+        clearCookies();
+        addCookies(cookies);
+    }
+
+    /**
+     * Clears existing cookies.
+     *
+     * @param cookies
+     */
+    public void clearCookies() {
+        this.cookies.clear();
+    }
+
+    /**
+     * Adds new cookies.
+     *
+     * @param cookies
+     */
+    public void addCookies(Cookie[] cookies) {
         if (cookies != null) {
             for (Cookie cookie : cookies) {
                 cookie(cookie);


### PR DESCRIPTION
Second overloading method `HttpMessageContentBuilder.buildMessageContent` uses
`HttpMessage.setCookies` to set cookies for message derived from
template without clearing old cookies from template.

This merge request fixes this by clearing old cookies in
`HttpMessage.setCookies`.

Feel free to reject this merge request if semantics change of `HttpMessage.setCookies` is harmful. Or should I degrade this merge request to an issue report ?

PS: I found only one usage of `HttpMessage.setCookies` in `HttpMessageController.handleRequestInternal` and didn't saw the harmness.