### PR TITLE
561: Lost cookie entries except the last one + Tests and refactoring

### DIFF
--- a/modules/citrus-http/src/main/java/com/consol/citrus/http/message/CookieParser.java
+++ b/modules/citrus-http/src/main/java/com/consol/citrus/http/message/CookieParser.java
@@ -18,6 +18,7 @@ package com.consol.citrus.http.message;
 
 import com.consol.citrus.exceptions.CitrusRuntimeException;
 import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
 
 import javax.servlet.http.Cookie;
 import java.util.LinkedList;
@@ -42,7 +43,7 @@ class CookieParser {
     Cookie[] convertCookies(HttpEntity<?> httpEntity) {
         final List<Cookie> cookies = new LinkedList<>();
 
-        List<String> inboundCookies = httpEntity.getHeaders().get("Set-Cookie");
+        List<String> inboundCookies = httpEntity.getHeaders().get(HttpHeaders.SET_COOKIE);
         if (inboundCookies != null) {
             for (String cookieString : inboundCookies) {
                 Cookie cookie = convertCookieString(cookieString);
@@ -108,7 +109,7 @@ class CookieParser {
         }
 
         if(SECURE.equals(param) && cookieString.contains(SECURE)) {
-            return "true";
+            return String.valueOf(true);
         }
 
         if (cookieString.contains(param + '=')) {

--- a/modules/citrus-http/src/main/java/com/consol/citrus/http/message/CookieParser.java
+++ b/modules/citrus-http/src/main/java/com/consol/citrus/http/message/CookieParser.java
@@ -1,0 +1,127 @@
+/*
+ *    Copyright 2018 the original author or authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.consol.citrus.http.message;
+
+import com.consol.citrus.exceptions.CitrusRuntimeException;
+import org.springframework.http.HttpEntity;
+
+import javax.servlet.http.Cookie;
+import java.util.LinkedList;
+import java.util.List;
+
+class CookieParser {
+
+    private static final String NAME = "Name";
+    private static final String VALUE = "Value";
+    private static final String SECURE = "Secure";
+    private static final String COMMENT = "Comment";
+    private static final String PATH = "Path";
+    private static final String DOMAIN = "Domain";
+    private static final String MAX_AGE = "Max-Age";
+    private static final String VERSION = "Version";
+
+    /**
+     * Converts cookies from a HttpEntity into Cookie objects
+     * @param httpEntity The message to convert
+     * @return A array of converted cookies
+     */
+    Cookie[] convertCookies(HttpEntity<?> httpEntity) {
+        final List<Cookie> cookies = new LinkedList<>();
+
+        List<String> inboundCookies = httpEntity.getHeaders().get("Set-Cookie");
+        if (inboundCookies != null) {
+            for (String cookieString : inboundCookies) {
+                Cookie cookie = convertCookieString(cookieString);
+                cookies.add(cookie);
+            }
+        }
+
+        return cookies.toArray(new Cookie[0]);
+    }
+
+    /**
+     * Converts a cookie string from a http header value into a Cookie object
+     * @param cookieString The string to convert
+     * @return The Cookie representation of the given String
+     */
+    private Cookie convertCookieString(String cookieString) {
+        Cookie cookie = new Cookie(getCookieParam(NAME, cookieString), getCookieParam(VALUE, cookieString));
+
+        if (cookieString.contains(COMMENT)) {
+            cookie.setComment(getCookieParam(COMMENT, cookieString));
+        }
+
+        if (cookieString.contains(PATH)) {
+            cookie.setPath(getCookieParam(PATH, cookieString));
+        }
+
+        if (cookieString.contains(DOMAIN)) {
+            cookie.setDomain(getCookieParam(DOMAIN, cookieString));
+        }
+
+        if (cookieString.contains(MAX_AGE)) {
+            cookie.setMaxAge(Integer.valueOf(getCookieParam(MAX_AGE, cookieString)));
+        }
+
+        if (cookieString.contains(SECURE)) {
+            cookie.setSecure(Boolean.valueOf(getCookieParam(SECURE, cookieString)));
+        }
+
+        if (cookieString.contains(VERSION)) {
+            cookie.setVersion(Integer.valueOf(getCookieParam(VERSION, cookieString)));
+        }
+
+        return cookie;
+    }
+
+    /**
+     * Extract cookie param from cookie string as it was provided by "Set-Cookie" header.
+     * @param param The parameter to extract from the cookie string
+     * @param cookieString The cookie string from the cookie header to extract the parameter from
+     * @return The value of the requested parameter
+     */
+    private String getCookieParam(String param, String cookieString) {
+        if (param.equals(NAME)) {
+            return cookieString.substring(0, cookieString.indexOf('='));
+        }
+
+        if (param.equals(VALUE)) {
+            if (cookieString.contains(";")) {
+                return cookieString.substring(cookieString.indexOf('=') + 1, cookieString.indexOf(';'));
+            } else {
+                return cookieString.substring(cookieString.indexOf('=') + 1);
+            }
+        }
+
+        if(SECURE.equals(param) && cookieString.contains(SECURE)) {
+            return "true";
+        }
+
+        if (cookieString.contains(param + '=')) {
+            final int endParam = cookieString.indexOf(';', cookieString.indexOf(param + '='));
+            final int beginIndex = cookieString.indexOf(param + '=') + param.length() + 1;
+            if (endParam > 0) {
+                return cookieString.substring(beginIndex, endParam);
+            } else {
+                return cookieString.substring(beginIndex);
+            }
+        }
+
+        throw new CitrusRuntimeException(String.format(
+                "Unable to get cookie argument '%s' from cookie String: %s", param, cookieString));
+    }
+}

--- a/modules/citrus-http/src/main/java/com/consol/citrus/http/message/HttpMessageConverter.java
+++ b/modules/citrus-http/src/main/java/com/consol/citrus/http/message/HttpMessageConverter.java
@@ -66,7 +66,7 @@ public class HttpMessageConverter implements MessageConverter<HttpEntity<?>, Htt
             return new ResponseEntity<>(payload, httpHeaders, httpMessage.getStatusCode());
         } else {
             for (Cookie cookie : httpMessage.getCookies()) {
-                httpHeaders.set("Cookie", cookie.getName() + "=" + context.replaceDynamicContentInString(cookie.getValue()));
+                httpHeaders.add("Cookie", cookie.getName() + "=" + context.replaceDynamicContentInString(cookie.getValue()));
             }
         }
 

--- a/modules/citrus-http/src/main/java/com/consol/citrus/http/message/HttpMessageConverter.java
+++ b/modules/citrus-http/src/main/java/com/consol/citrus/http/message/HttpMessageConverter.java
@@ -68,7 +68,7 @@ public class HttpMessageConverter implements MessageConverter<HttpEntity<?>, Htt
         } else {
             for (Cookie cookie : httpMessage.getCookies()) {
                 httpHeaders.add(
-                        "Cookie",
+                        HttpHeaders.COOKIE,
                         cookie.getName() + "=" + context.replaceDynamicContentInString(cookie.getValue()));
             }
         }
@@ -91,6 +91,9 @@ public class HttpMessageConverter implements MessageConverter<HttpEntity<?>, Htt
 
         if (message instanceof ResponseEntity<?>) {
             httpMessage.status(((ResponseEntity<?>) message).getStatusCode());
+
+            // We've no information here about the HTTP Version in this context.
+            // Because HTTP/2 is not supported anyways currently, this should be acceptable.
             httpMessage.version("HTTP/1.1");
 
             if (endpointConfiguration.isHandleCookies()) {

--- a/modules/citrus-http/src/main/java/com/consol/citrus/http/message/HttpMessageConverter.java
+++ b/modules/citrus-http/src/main/java/com/consol/citrus/http/message/HttpMessageConverter.java
@@ -17,7 +17,6 @@
 package com.consol.citrus.http.message;
 
 import com.consol.citrus.context.TestContext;
-import com.consol.citrus.exceptions.CitrusRuntimeException;
 import com.consol.citrus.http.client.HttpEndpointConfiguration;
 import com.consol.citrus.message.Message;
 import com.consol.citrus.message.MessageConverter;
@@ -33,7 +32,6 @@ import org.springframework.util.StringUtils;
 import javax.servlet.http.Cookie;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -44,6 +42,16 @@ import java.util.Map;
  * @since 2.0
  */
 public class HttpMessageConverter implements MessageConverter<HttpEntity<?>, HttpEntity<?>, HttpEndpointConfiguration> {
+
+    private CookieParser cookieParser;
+
+    public HttpMessageConverter() {
+        cookieParser = new CookieParser();
+    }
+
+    public HttpMessageConverter(CookieParser cookieParser) {
+        this.cookieParser = cookieParser;
+    }
 
     @Override
     public HttpEntity<?> convertOutbound(Message message,
@@ -86,7 +94,7 @@ public class HttpMessageConverter implements MessageConverter<HttpEntity<?>, Htt
             httpMessage.version("HTTP/1.1");
 
             if (endpointConfiguration.isHandleCookies()) {
-                httpMessage.setCookies(convertInboundCookies(message));
+                httpMessage.setCookies(cookieParser.convertCookies(message));
             }
         }
 
@@ -101,41 +109,7 @@ public class HttpMessageConverter implements MessageConverter<HttpEntity<?>, Htt
         throw new UnsupportedOperationException("HttpMessageConverter does not support predefined HttpEntity objects");
     }
 
-    /**
-     * Extract cookie param from cookie string as it was provided by "Set-Cookie" header.
-     * @param param The parameter to extract from the cookie string
-     * @param cookieString The cookie string from the cookie header to extract the parameter from
-     * @return The value of the requested parameter
-     */
-    private String getCookieParam(String param, String cookieString) {
-        if (param.equals("Name")) {
-            return cookieString.substring(0, cookieString.indexOf('='));
-        }
 
-        if (param.equals("Value")) {
-            if (cookieString.contains(";")) {
-                return cookieString.substring(cookieString.indexOf('=') + 1, cookieString.indexOf(';'));
-            } else {
-                return cookieString.substring(cookieString.indexOf('=') + 1);
-            }
-        }
-
-        if("Secure".equals(param) && cookieString.contains("Secure")) {
-            return "true";
-        }
-
-        if (cookieString.contains(param + '=')) {
-            final int endParam = cookieString.indexOf(';', cookieString.indexOf(param + '='));
-            final int beginIndex = cookieString.indexOf(param + '=') + param.length() + 1;
-            if (endParam > 0) {
-                return cookieString.substring(beginIndex, endParam);
-            } else {
-                return cookieString.substring(beginIndex);
-            }
-        }
-
-        throw new CitrusRuntimeException(String.format("Unable to get cookie argument '%s' from cookie String: %s", param, cookieString));
-    }
 
     /**
      * Message headers consist of standard HTTP message headers and custom headers.
@@ -286,59 +260,5 @@ public class HttpMessageConverter implements MessageConverter<HttpEntity<?>, Htt
      */
     private Object extractMessageBody(HttpEntity<?> message) {
         return message.getBody() != null ? message.getBody() : "";
-    }
-
-    /**
-     * Converts cookies from a HttpEntity into Cookie objects
-     * @param httpEntity The message to convert
-     * @return A array of converted cookies
-     */
-    private Cookie[] convertInboundCookies(HttpEntity<?> httpEntity) {
-        final List<Cookie> cookies = new LinkedList<>();
-
-        List<String> inboundCookies = httpEntity.getHeaders().get("Set-Cookie");
-        if (inboundCookies != null) {
-            for (String cookieString : inboundCookies) {
-                Cookie cookie = convertCookieString(cookieString);
-                cookies.add(cookie);
-            }
-        }
-
-        return cookies.toArray(new Cookie[0]);
-    }
-
-    /**
-     * Converts a cookie string from a http header value into a Cookie object
-     * @param cookieString The string to convert
-     * @return The Cookie representation of the given String
-     */
-    private Cookie convertCookieString(String cookieString) {
-        Cookie cookie = new Cookie(getCookieParam("Name", cookieString), getCookieParam("Value", cookieString));
-
-        if (cookieString.contains("Comment")) {
-            cookie.setComment(getCookieParam("Comment", cookieString));
-        }
-
-        if (cookieString.contains("Path")) {
-            cookie.setPath(getCookieParam("Path", cookieString));
-        }
-
-        if (cookieString.contains("Domain")) {
-            cookie.setDomain(getCookieParam("Domain", cookieString));
-        }
-
-        if (cookieString.contains("Max-Age")) {
-            cookie.setMaxAge(Integer.valueOf(getCookieParam("Max-Age", cookieString)));
-        }
-
-        if (cookieString.contains("Secure")) {
-            cookie.setSecure(Boolean.valueOf(getCookieParam("Secure", cookieString)));
-        }
-
-        if (cookieString.contains("Version")) {
-            cookie.setVersion(Integer.valueOf(getCookieParam("Version", cookieString)));
-        }
-
-        return cookie;
     }
 }

--- a/modules/citrus-http/src/test/java/com/consol/citrus/http/message/CookieParserTest.java
+++ b/modules/citrus-http/src/test/java/com/consol/citrus/http/message/CookieParserTest.java
@@ -1,0 +1,180 @@
+/*
+ *    Copyright 2018 the original author or authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.consol.citrus.http.message;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.testng.annotations.Test;
+
+import javax.servlet.http.Cookie;
+import java.util.Collections;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
+
+public class CookieParserTest {
+
+    private CookieParser cookieParser = new CookieParser();
+
+    @Test
+    public void testCookiesAreParsedCorrectly(){
+
+        //GIVEN
+        final HttpHeaders cookieHeaders = new HttpHeaders();
+        cookieHeaders.put("Set-Cookie", Collections.singletonList("foo=bar"));
+        final ResponseEntity<?> responseEntity = new ResponseEntity<>(cookieHeaders, HttpStatus.OK);
+
+        //WHEN
+        final Cookie[] cookies = cookieParser.convertCookies(responseEntity);
+
+        //THEN
+        assertEquals(1, cookies.length);
+        assertEquals("foo", cookies[0].getName());
+        assertEquals("bar", cookies[0].getValue());
+    }
+
+    @Test
+    public void testAdditionalCookieDirectivesAreDiscarded(){
+
+        //GIVEN
+        final HttpHeaders cookieHeaders = new HttpHeaders();
+        cookieHeaders.put("Set-Cookie", Collections.singletonList("foo=bar;HttpOnly"));
+        final ResponseEntity<?> responseEntity = new ResponseEntity<>(cookieHeaders, HttpStatus.OK);
+
+        //WHEN
+        final Cookie[] cookies = cookieParser.convertCookies(responseEntity);
+
+        //THEN
+        assertEquals(1, cookies.length);
+        assertEquals("foo", cookies[0].getName());
+        assertEquals("bar", cookies[0].getValue());
+    }
+
+    @Test
+    public void testCookieCommentIsPreserved(){
+
+        //GIVEN
+        final HttpHeaders cookieHeaders = new HttpHeaders();
+        cookieHeaders.put("Set-Cookie", Collections.singletonList("foo=bar;Comment=wtf"));
+        final ResponseEntity<?> responseEntity = new ResponseEntity<>(cookieHeaders, HttpStatus.OK);
+
+        //WHEN
+        final Cookie[] cookies = cookieParser.convertCookies(responseEntity);
+
+        //THEN
+        assertEquals(1, cookies.length);
+        assertEquals("wtf", cookies[0].getComment());
+    }
+
+    @Test
+    public void testCookieDomainIsPreserved(){
+
+        //GIVEN
+        final HttpHeaders cookieHeaders = new HttpHeaders();
+        cookieHeaders.put("Set-Cookie", Collections.singletonList("foo=bar;Domain=whatever"));
+        final ResponseEntity<?> responseEntity = new ResponseEntity<>(cookieHeaders, HttpStatus.OK);
+
+        //WHEN
+        final Cookie[] cookies = cookieParser.convertCookies(responseEntity);
+
+        //THEN
+        assertEquals(1, cookies.length);
+        assertEquals("whatever", cookies[0].getDomain());
+    }
+
+    @Test
+    public void testCookieEndParameterIsRecognizedAndPreserved(){
+
+        //GIVEN
+        final HttpHeaders cookieHeaders = new HttpHeaders();
+        cookieHeaders.put("Set-Cookie", Collections.singletonList("foo=bar;Version=1;"));
+        final ResponseEntity<?> responseEntity = new ResponseEntity<>(cookieHeaders, HttpStatus.OK);
+
+        //WHEN
+        final Cookie[] cookies = cookieParser.convertCookies(responseEntity);
+
+        //THEN
+        assertEquals(1, cookies.length);
+        assertEquals(1, cookies[0].getVersion());
+    }
+
+    @Test
+    public void testCookieMaxAgeIsPreserved(){
+
+        //GIVEN
+        final HttpHeaders cookieHeaders = new HttpHeaders();
+        cookieHeaders.put("Set-Cookie", Collections.singletonList("foo=bar;Max-Age=42"));
+        final ResponseEntity<?> responseEntity = new ResponseEntity<>(cookieHeaders, HttpStatus.OK);
+
+        //WHEN
+        final Cookie[] cookies = cookieParser.convertCookies(responseEntity);
+
+        //THEN
+        assertEquals(1, cookies.length);
+        assertEquals(42, cookies[0].getMaxAge());
+    }
+
+    @Test
+    public void testCookiePathIsPreserved(){
+
+        //GIVEN
+        final HttpHeaders cookieHeaders = new HttpHeaders();
+        cookieHeaders.put("Set-Cookie", Collections.singletonList("foo=bar;Path=foobar"));
+        final ResponseEntity<?> responseEntity = new ResponseEntity<>(cookieHeaders, HttpStatus.OK);
+
+        //WHEN
+        final Cookie[] cookies = cookieParser.convertCookies(responseEntity);
+
+        //THEN
+        assertEquals(1, cookies.length);
+        assertEquals("foobar", cookies[0].getPath());
+    }
+
+
+    @Test
+    public void testCookieSecureIsPreserved(){
+
+        //GIVEN
+        final HttpHeaders cookieHeaders = new HttpHeaders();
+        cookieHeaders.put("Set-Cookie", Collections.singletonList("foo=bar;Secure"));
+        final ResponseEntity<?> responseEntity = new ResponseEntity<>(cookieHeaders, HttpStatus.OK);
+
+        //WHEN
+        final Cookie[] cookies = cookieParser.convertCookies(responseEntity);
+
+        //THEN
+        assertEquals(1, cookies.length);
+        assertTrue(cookies[0].getSecure());
+    }
+
+    @Test
+    public void testCookieVersionIsPreserved(){
+
+        //GIVEN
+        final HttpHeaders cookieHeaders = new HttpHeaders();
+        cookieHeaders.put("Set-Cookie", Collections.singletonList("foo=bar;Version=1"));
+        final ResponseEntity<?> responseEntity = new ResponseEntity<>(cookieHeaders, HttpStatus.OK);
+
+        //WHEN
+        final Cookie[] cookies = cookieParser.convertCookies(responseEntity);
+
+        //THEN
+        assertEquals(1, cookies.length);
+        assertEquals(1, cookies[0].getVersion());
+    }
+}

--- a/modules/citrus-http/src/test/java/com/consol/citrus/http/message/HttpMessageConverterTest.java
+++ b/modules/citrus-http/src/test/java/com/consol/citrus/http/message/HttpMessageConverterTest.java
@@ -23,19 +23,28 @@ import com.consol.citrus.message.Message;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.integration.mapping.HeaderMapper;
 import org.springframework.messaging.MessageHeaders;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import javax.servlet.http.Cookie;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNull;
+import static org.testng.AssertJUnit.assertTrue;
 
 public class HttpMessageConverterTest {
 
@@ -338,5 +347,360 @@ public class HttpMessageConverterTest {
 
         //THEN
         verify(headersHeaderMapperMock).fromHeaders(any(MessageHeaders.class), any(HttpHeaders.class));
+    }
+
+    @Test
+    public void testSpringIntegrationHeaderMapperResultIsSetOnInbound(){
+
+        //GIVEN
+        final Map<String, Object> expectedHeaderMap = new HashMap<>();
+        expectedHeaderMap.put("foo", "bar");
+
+        @SuppressWarnings("unchecked")
+        HeaderMapper<HttpHeaders> headersHeaderMapperMock = (HeaderMapper<HttpHeaders>) mock(HeaderMapper.class);
+        when(headersHeaderMapperMock.toHeaders(any(HttpHeaders.class))).thenReturn(expectedHeaderMap);
+
+        endpointConfiguration.setHeaderMapper(headersHeaderMapperMock);
+
+        //WHEN
+        final HttpMessage httpMessage =
+                messageConverter.convertInbound(HttpEntity.EMPTY, endpointConfiguration, testContext);
+
+        //THEN
+        assertEquals("bar", httpMessage.getHeaders().get("foo"));
+    }
+
+    @Test
+    public void testCitrusDefaultHeaderAreSetOnInbound(){
+
+        //GIVEN
+
+        //WHEN
+        final HttpMessage httpMessage =
+                messageConverter.convertInbound(HttpEntity.EMPTY, endpointConfiguration, testContext);
+
+        //THEN
+        assertTrue(httpMessage.getHeaders().containsKey("citrus_message_id"));
+        assertTrue(httpMessage.getHeaders().containsKey("citrus_message_timestamp"));
+    }
+
+    @Test
+    public void testHttpEntityMessageBodyIsPreservedOnInbound(){
+
+        //GIVEN
+        final String payload = "Hello World";
+        final HttpEntity<String> httpEntity = new HttpEntity<>(payload);
+
+        //WHEN
+        final HttpMessage httpMessage =
+                messageConverter.convertInbound(httpEntity, endpointConfiguration, testContext);
+
+        //THEN
+        assertEquals(httpMessage.getPayload(String.class), payload);
+    }
+
+    @Test
+    public void testHttpEntityDefaultMessageBodyIsSetOnInbound(){
+
+        //GIVEN
+        final HttpEntity<String> httpEntity = new HttpEntity<>(null);
+
+        //WHEN
+        final HttpMessage httpMessage =
+                messageConverter.convertInbound(httpEntity, endpointConfiguration, testContext);
+
+        //THEN
+        assertEquals(httpMessage.getPayload(String.class), "");
+    }
+
+    @Test
+    public void testCustomHeadersAreSetOnInbound(){
+
+        //GIVEN
+        final HttpHeaders expectedHttpHeader = new HttpHeaders();
+        expectedHttpHeader.put("foo", Collections.singletonList("bar"));
+        final HttpEntity<?> httpEntity = new HttpEntity<>(null, expectedHttpHeader);
+
+        //WHEN
+        final HttpMessage httpMessage =
+                messageConverter.convertInbound(httpEntity, endpointConfiguration, testContext);
+
+        //THEN
+        assertEquals("bar", httpMessage.getHeaders().get("foo"));
+    }
+
+    @Test
+    public void testCustomHeadersListsAreConvertedToStringOnInbound(){
+
+        //GIVEN
+        final HttpHeaders expectedHttpHeader = new HttpHeaders();
+        expectedHttpHeader.put("foo", Arrays.asList("bar", "foobar", "foo"));
+        final HttpEntity<?> httpEntity = new HttpEntity<>(null, expectedHttpHeader);
+
+        //WHEN
+        final HttpMessage httpMessage =
+                messageConverter.convertInbound(httpEntity, endpointConfiguration, testContext);
+
+        //THEN
+        assertEquals("bar,foobar,foo", httpMessage.getHeaders().get("foo"));
+    }
+
+    @Test
+    public void testStatusCodeIsSetOnInbound(){
+
+        //GIVEN
+        final ResponseEntity<?> responseEntity = new ResponseEntity<>(HttpStatus.FORBIDDEN);
+
+        //WHEN
+        final HttpMessage httpMessage =
+                messageConverter.convertInbound(responseEntity, endpointConfiguration, testContext);
+
+        //THEN
+        assertEquals(HttpStatus.FORBIDDEN, httpMessage.getStatusCode());
+    }
+
+    @Test
+    public void testHttpVersionIsSetOnInbound(){
+
+        //GIVEN
+        final ResponseEntity<?> responseEntity = new ResponseEntity<>(HttpStatus.OK);
+
+        //WHEN
+        final HttpMessage httpMessage =
+                messageConverter.convertInbound(responseEntity, endpointConfiguration, testContext);
+
+        //THEN
+        assertEquals("HTTP/1.1", httpMessage.getVersion());
+    }
+
+    @Test
+    public void testNoCookiesPreservedByDefaultOnInbound(){
+
+        //GIVEN
+        final HttpHeaders cookieHeaders = new HttpHeaders();
+        cookieHeaders.put("Set-Cookie", Collections.singletonList("Path=foo"));
+        final ResponseEntity<?> responseEntity = new ResponseEntity<>(cookieHeaders, HttpStatus.OK);
+
+        //WHEN
+        final HttpMessage httpMessage =
+                messageConverter.convertInbound(responseEntity, endpointConfiguration, testContext);
+
+        //THEN
+        assertTrue(httpMessage.getCookies().isEmpty());
+    }
+
+    @Test
+    public void testCookiesPreservedOnConfigurationOnInbound(){
+
+        //GIVEN
+        final HttpHeaders cookieHeaders = new HttpHeaders();
+        cookieHeaders.put("Set-Cookie", Collections.singletonList("foo=bar"));
+        final ResponseEntity<?> responseEntity = new ResponseEntity<>(cookieHeaders, HttpStatus.OK);
+
+        endpointConfiguration.setHandleCookies(true);
+
+        //WHEN
+        final HttpMessage httpMessage =
+                messageConverter.convertInbound(responseEntity, endpointConfiguration, testContext);
+
+        //THEN
+        assertEquals(1, httpMessage.getCookies().size());
+        assertEquals("foo", httpMessage.getCookies().get(0).getName());
+        assertEquals("bar", httpMessage.getCookies().get(0).getValue());
+    }
+
+    @Test
+    public void testAdditionalCookieDirectivesAreDiscardedForValueOnInbound(){
+
+        //GIVEN
+        final HttpHeaders cookieHeaders = new HttpHeaders();
+        cookieHeaders.put("Set-Cookie", Collections.singletonList("foo=bar;HttpOnly"));
+        final ResponseEntity<?> responseEntity = new ResponseEntity<>(cookieHeaders, HttpStatus.OK);
+
+        endpointConfiguration.setHandleCookies(true);
+
+        //WHEN
+        final HttpMessage httpMessage =
+                messageConverter.convertInbound(responseEntity, endpointConfiguration, testContext);
+
+        //THEN
+        assertEquals(1, httpMessage.getCookies().size());
+        assertEquals("foo", httpMessage.getCookies().get(0).getName());
+        assertEquals("bar", httpMessage.getCookies().get(0).getValue());
+    }
+
+    @Test
+    public void testCookieCommentIsPreservedOnInbound(){
+
+        //GIVEN
+        final HttpHeaders cookieHeaders = new HttpHeaders();
+        cookieHeaders.put("Set-Cookie", Collections.singletonList("foo=bar;Comment=wtf"));
+        final ResponseEntity<?> responseEntity = new ResponseEntity<>(cookieHeaders, HttpStatus.OK);
+
+        endpointConfiguration.setHandleCookies(true);
+
+        //WHEN
+        final HttpMessage httpMessage =
+                messageConverter.convertInbound(responseEntity, endpointConfiguration, testContext);
+
+        //THEN
+        assertEquals(1, httpMessage.getCookies().size());
+        assertEquals("wtf", httpMessage.getCookies().get(0).getComment());
+    }
+
+    @Test
+    public void testCookiePathIsPreservedOnInbound(){
+
+        //GIVEN
+        final HttpHeaders cookieHeaders = new HttpHeaders();
+        cookieHeaders.put("Set-Cookie", Collections.singletonList("foo=bar;Path=foobar"));
+        final ResponseEntity<?> responseEntity = new ResponseEntity<>(cookieHeaders, HttpStatus.OK);
+
+        endpointConfiguration.setHandleCookies(true);
+
+        //WHEN
+        final HttpMessage httpMessage =
+                messageConverter.convertInbound(responseEntity, endpointConfiguration, testContext);
+
+        //THEN
+        assertEquals(1, httpMessage.getCookies().size());
+        assertEquals("foobar", httpMessage.getCookies().get(0).getPath());
+    }
+
+    @Test
+    public void testCookieDomainIsPreservedOnInbound(){
+
+        //GIVEN
+        final HttpHeaders cookieHeaders = new HttpHeaders();
+        cookieHeaders.put("Set-Cookie", Collections.singletonList("foo=bar;Domain=whatever"));
+        final ResponseEntity<?> responseEntity = new ResponseEntity<>(cookieHeaders, HttpStatus.OK);
+
+        endpointConfiguration.setHandleCookies(true);
+
+        //WHEN
+        final HttpMessage httpMessage =
+                messageConverter.convertInbound(responseEntity, endpointConfiguration, testContext);
+
+        //THEN
+        assertEquals(1, httpMessage.getCookies().size());
+        assertEquals("whatever", httpMessage.getCookies().get(0).getDomain());
+    }
+
+    @Test
+    public void testCookieMaxAgeIsPreservedOnInbound(){
+
+        //GIVEN
+        final HttpHeaders cookieHeaders = new HttpHeaders();
+        cookieHeaders.put("Set-Cookie", Collections.singletonList("foo=bar;Max-Age=42"));
+        final ResponseEntity<?> responseEntity = new ResponseEntity<>(cookieHeaders, HttpStatus.OK);
+
+        endpointConfiguration.setHandleCookies(true);
+
+        //WHEN
+        final HttpMessage httpMessage =
+                messageConverter.convertInbound(responseEntity, endpointConfiguration, testContext);
+
+        //THEN
+        assertEquals(1, httpMessage.getCookies().size());
+        assertEquals(42, httpMessage.getCookies().get(0).getMaxAge());
+    }
+
+    @Test
+    public void testCookieSecureIsPreservedOnInbound(){
+
+        //GIVEN
+        final HttpHeaders cookieHeaders = new HttpHeaders();
+        cookieHeaders.put("Set-Cookie", Collections.singletonList("foo=bar;Secure"));
+        final ResponseEntity<?> responseEntity = new ResponseEntity<>(cookieHeaders, HttpStatus.OK);
+
+        endpointConfiguration.setHandleCookies(true);
+
+        //WHEN
+        final HttpMessage httpMessage =
+                messageConverter.convertInbound(responseEntity, endpointConfiguration, testContext);
+
+        //THEN
+        assertEquals(1, httpMessage.getCookies().size());
+        assertTrue(httpMessage.getCookies().get(0).getSecure());
+    }
+
+    @Test
+    public void testCookieVersionIsPreservedOnInbound(){
+
+        //GIVEN
+        final HttpHeaders cookieHeaders = new HttpHeaders();
+        cookieHeaders.put("Set-Cookie", Collections.singletonList("foo=bar;Version=1"));
+        final ResponseEntity<?> responseEntity = new ResponseEntity<>(cookieHeaders, HttpStatus.OK);
+
+        endpointConfiguration.setHandleCookies(true);
+
+        //WHEN
+        final HttpMessage httpMessage =
+                messageConverter.convertInbound(responseEntity, endpointConfiguration, testContext);
+
+        //THEN
+        assertEquals(1, httpMessage.getCookies().size());
+        assertEquals(1, httpMessage.getCookies().get(0).getVersion());
+    }
+
+    @Test
+    public void testCookieEndParameterIsRecognizedAndPreservedOnInbound(){
+
+        //GIVEN
+        final HttpHeaders cookieHeaders = new HttpHeaders();
+        cookieHeaders.put("Set-Cookie", Collections.singletonList("foo=bar;Version=1;"));
+        final ResponseEntity<?> responseEntity = new ResponseEntity<>(cookieHeaders, HttpStatus.OK);
+
+        endpointConfiguration.setHandleCookies(true);
+
+        //WHEN
+        final HttpMessage httpMessage =
+                messageConverter.convertInbound(responseEntity, endpointConfiguration, testContext);
+
+        //THEN
+        assertEquals(1, httpMessage.getCookies().size());
+        assertEquals(1, httpMessage.getCookies().get(0).getVersion());
+    }
+
+    @Test
+    public void testSpringIntegrationHeaderMapperListResultIsConvertedOnInbound(){
+
+        //GIVEN
+        final Map<String, Object> mockedHeaderMap = new HashMap<>();
+        mockedHeaderMap.put("foo", Arrays.asList("bar", "foobar"));
+
+        @SuppressWarnings("unchecked")
+        HeaderMapper<HttpHeaders> headersHeaderMapperMock = (HeaderMapper<HttpHeaders>) mock(HeaderMapper.class);
+        when(headersHeaderMapperMock.toHeaders(any(HttpHeaders.class))).thenReturn(mockedHeaderMap);
+
+        endpointConfiguration.setHeaderMapper(headersHeaderMapperMock);
+
+        //WHEN
+        final HttpMessage httpMessage =
+                messageConverter.convertInbound(HttpEntity.EMPTY, endpointConfiguration, testContext);
+
+        //THEN
+        assertEquals("bar,foobar", httpMessage.getHeaders().get("foo"));
+    }
+
+    @Test
+    public void testSpringIntegrationHeaderMapperMediaTypeResultIsConvertedOnInbound(){
+
+        //GIVEN
+        final Map<String, Object> mockedHeaderMap = new HashMap<>();
+        mockedHeaderMap.put("foo", MediaType.APPLICATION_JSON);
+
+        @SuppressWarnings("unchecked")
+        HeaderMapper<HttpHeaders> headersHeaderMapperMock = (HeaderMapper<HttpHeaders>) mock(HeaderMapper.class);
+        when(headersHeaderMapperMock.toHeaders(any(HttpHeaders.class))).thenReturn(mockedHeaderMap);
+
+        endpointConfiguration.setHeaderMapper(headersHeaderMapperMock);
+
+        //WHEN
+        final HttpMessage httpMessage =
+                messageConverter.convertInbound(HttpEntity.EMPTY, endpointConfiguration, testContext);
+
+        //THEN
+        assertEquals("application/json", httpMessage.getHeaders().get("foo"));
     }
 }

--- a/modules/citrus-http/src/test/java/com/consol/citrus/http/message/HttpMessageConverterTest.java
+++ b/modules/citrus-http/src/test/java/com/consol/citrus/http/message/HttpMessageConverterTest.java
@@ -1,0 +1,300 @@
+/*
+ *    Copyright 2018 the original author or authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.consol.citrus.http.message;
+
+import com.consol.citrus.context.TestContext;
+import com.consol.citrus.http.client.HttpEndpointConfiguration;
+import com.consol.citrus.message.DefaultMessage;
+import com.consol.citrus.message.Message;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import javax.servlet.http.Cookie;
+import java.util.List;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNull;
+
+public class HttpMessageConverterTest {
+
+    private HttpMessageConverter messageConverter = new HttpMessageConverter();
+
+    private HttpEndpointConfiguration endpointConfiguration;
+    private TestContext testContext = new TestContext();
+
+    @BeforeMethod
+    public void setUp(){
+        endpointConfiguration = new HttpEndpointConfiguration();
+        testContext = new TestContext();
+    }
+
+    @Test
+    public void testDefaultMessageIsConvertedOnOutbound(){
+
+        //GIVEN
+        final String payload = "Hello World!";
+        Message message = new DefaultMessage(payload);
+
+        //WHEN
+        final HttpEntity<?> httpEntity = messageConverter.convertOutbound(message, endpointConfiguration, testContext);
+
+        //THEN
+        assertEquals(payload, httpEntity.getBody());
+    }
+
+    @Test
+    public void testHttpMessageCookiesArePreservedOnOutbound(){
+
+        //GIVEN
+        Cookie cookie = new Cookie("foo","bar");
+        HttpMessage message = new HttpMessage();
+        message.cookie(cookie);
+
+        String expectedCookie = "foo=bar";
+
+        //WHEN
+        final HttpEntity<?> httpEntity = messageConverter.convertOutbound(message, endpointConfiguration, testContext);
+
+        //THEN
+        final List<String> cookies = httpEntity.getHeaders().get("Cookie");
+        assert cookies != null;
+        assertEquals(1, cookies.size());
+        assertEquals(expectedCookie, cookies.get(0));
+    }
+
+    @Test
+    public void testHttpMessageCookiesValuesAreReplacedOnOutbound(){
+
+        //GIVEN
+        Cookie cookie = new Cookie("foo","${foobar}");
+        HttpMessage message = new HttpMessage();
+        message.cookie(cookie);
+
+        testContext.setVariable("foobar", "bar");
+
+        String expectedCookie = "foo=bar";
+
+        //WHEN
+        final HttpEntity<?> httpEntity = messageConverter.convertOutbound(message, endpointConfiguration, testContext);
+
+        //THEN
+        final List<String> cookies = httpEntity.getHeaders().get("Cookie");
+        assert cookies != null;
+        assertEquals(1, cookies.size());
+        assertEquals(expectedCookie, cookies.get(0));
+    }
+
+    @Test
+    public void testHttpMessageHeadersAreReplacedOnOutbound(){
+
+        //GIVEN
+        HttpMessage message = new HttpMessage();
+        message.header("foo","bar");
+
+        //WHEN
+        final HttpEntity<?> httpEntity = messageConverter.convertOutbound(message, endpointConfiguration, testContext);
+
+        //THEN
+        final List<String> fooHeader = httpEntity.getHeaders().get("foo");
+        assert fooHeader != null;
+        assertEquals(1, fooHeader.size());
+        assertEquals("bar", fooHeader.get(0));
+    }
+
+    @Test
+    public void testHttpContentTypeIsPresent(){
+
+        //GIVEN
+        HttpMessage message = new HttpMessage();
+        endpointConfiguration.setContentType("foobar");
+
+        //WHEN
+        final HttpEntity<?> httpEntity = messageConverter.convertOutbound(message, endpointConfiguration, testContext);
+
+        //THEN
+        final List<String> contentTypeHeader = httpEntity.getHeaders().get(HttpMessageHeaders.HTTP_CONTENT_TYPE);
+        assert contentTypeHeader != null;
+        assertEquals(1, contentTypeHeader.size());
+        assertEquals("foobar;charset=UTF-8", contentTypeHeader.get(0));
+    }
+
+    @Test
+    public void testHttpContentTypeContainsAlteredCharsetIsPresent(){
+
+        //GIVEN
+        HttpMessage message = new HttpMessage();
+        endpointConfiguration.setContentType("foobar");
+        endpointConfiguration.setCharset("whatever");
+
+        //WHEN
+        final HttpEntity<?> httpEntity = messageConverter.convertOutbound(message, endpointConfiguration, testContext);
+
+        //THEN
+        final List<String> contentTypeHeader = httpEntity.getHeaders().get(HttpMessageHeaders.HTTP_CONTENT_TYPE);
+        assert contentTypeHeader != null;
+        assertEquals(1, contentTypeHeader.size());
+        assertEquals("foobar;charset=whatever", contentTypeHeader.get(0));
+    }
+
+    @Test
+    public void testHttpContentTypeCharsetIsMissingWhenEmptyIsPresent(){
+
+        //GIVEN
+        HttpMessage message = new HttpMessage();
+        endpointConfiguration.setContentType("foobar");
+        endpointConfiguration.setCharset("");
+
+        //WHEN
+        final HttpEntity<?> httpEntity = messageConverter.convertOutbound(message, endpointConfiguration, testContext);
+
+        //THEN
+        final List<String> contentTypeHeader = httpEntity.getHeaders().get(HttpMessageHeaders.HTTP_CONTENT_TYPE);
+        assert contentTypeHeader != null;
+        assertEquals(1, contentTypeHeader.size());
+        assertEquals("foobar", contentTypeHeader.get(0));
+    }
+
+    @Test
+    public void testHttpMethodBodyIsSetForPostOnOutbound(){
+
+        //GIVEN
+        final String payload = "Hello World";
+        HttpMessage message = new HttpMessage();
+        message.setHeader(HttpMessageHeaders.HTTP_REQUEST_METHOD, HttpMethod.POST);
+        message.setPayload(payload);
+
+        //WHEN
+        final HttpEntity<?> httpEntity = messageConverter.convertOutbound(message, endpointConfiguration, testContext);
+
+        //THEN
+        assertEquals(payload, httpEntity.getBody());
+    }
+
+    @Test
+    public void testHttpMethodBodyIsSetForPutOnOutbound(){
+
+        //GIVEN
+        final String payload = "Hello World";
+        HttpMessage message = new HttpMessage();
+        message.setHeader(HttpMessageHeaders.HTTP_REQUEST_METHOD, HttpMethod.PUT);
+        message.setPayload(payload);
+
+        //WHEN
+        final HttpEntity<?> httpEntity = messageConverter.convertOutbound(message, endpointConfiguration, testContext);
+
+        //THEN
+        assertEquals(payload, httpEntity.getBody());
+    }
+
+    @Test
+    public void testHttpMethodBodyIsSetForDeleteOnOutbound(){
+
+        //GIVEN
+        final String payload = "Hello World";
+        HttpMessage message = new HttpMessage();
+        message.setHeader(HttpMessageHeaders.HTTP_REQUEST_METHOD, HttpMethod.DELETE);
+        message.setPayload(payload);
+
+        //WHEN
+        final HttpEntity<?> httpEntity = messageConverter.convertOutbound(message, endpointConfiguration, testContext);
+
+        //THEN
+        assertEquals(payload, httpEntity.getBody());
+    }
+
+    @Test
+    public void testHttpMethodBodyIsSetForPatchOnOutbound(){
+
+        //GIVEN
+        final String payload = "Hello World";
+        HttpMessage message = new HttpMessage();
+        message.setHeader(HttpMessageHeaders.HTTP_REQUEST_METHOD, HttpMethod.PATCH);
+        message.setPayload(payload);
+
+        //WHEN
+        final HttpEntity<?> httpEntity = messageConverter.convertOutbound(message, endpointConfiguration, testContext);
+
+        //THEN
+        assertEquals(payload, httpEntity.getBody());
+    }
+
+    @Test
+    public void testHttpMethodBodyIsNotSetForGetOnOutbound(){
+
+        //GIVEN
+        final String payload = "Hello World";
+        HttpMessage message = new HttpMessage();
+        message.setHeader(HttpMessageHeaders.HTTP_REQUEST_METHOD, HttpMethod.GET);
+        message.setPayload(payload);
+
+        //WHEN
+        final HttpEntity<?> httpEntity = messageConverter.convertOutbound(message, endpointConfiguration, testContext);
+
+        //THEN
+        assertNull(httpEntity.getBody());
+    }
+
+    @Test
+    public void testHttpMethodBodyIsNotSetForHeadOnOutbound(){
+
+        //GIVEN
+        final String payload = "Hello World";
+        HttpMessage message = new HttpMessage();
+        message.setHeader(HttpMessageHeaders.HTTP_REQUEST_METHOD, HttpMethod.HEAD);
+        message.setPayload(payload);
+
+        //WHEN
+        final HttpEntity<?> httpEntity = messageConverter.convertOutbound(message, endpointConfiguration, testContext);
+
+        //THEN
+        assertNull(httpEntity.getBody());
+    }
+
+    @Test
+    public void testHttpMethodBodyIsNotSetForOptionsOnOutbound(){
+
+        //GIVEN
+        final String payload = "Hello World";
+        HttpMessage message = new HttpMessage();
+        message.setHeader(HttpMessageHeaders.HTTP_REQUEST_METHOD, HttpMethod.OPTIONS);
+        message.setPayload(payload);
+
+        //WHEN
+        final HttpEntity<?> httpEntity = messageConverter.convertOutbound(message, endpointConfiguration, testContext);
+
+        //THEN
+        assertNull(httpEntity.getBody());
+    }
+
+    @Test
+    public void testHttpMethodBodyIsNotSetForTraceOnOutbound(){
+
+        //GIVEN
+        final String payload = "Hello World";
+        HttpMessage message = new HttpMessage();
+        message.setHeader(HttpMessageHeaders.HTTP_REQUEST_METHOD, HttpMethod.TRACE);
+        message.setPayload(payload);
+
+        //WHEN
+        final HttpEntity<?> httpEntity = messageConverter.convertOutbound(message, endpointConfiguration, testContext);
+
+        //THEN
+        assertNull(httpEntity.getBody());
+    }
+}

--- a/modules/citrus-integration/src/it/java/com/consol/citrus/http/HttpCookieIT.java
+++ b/modules/citrus-integration/src/it/java/com/consol/citrus/http/HttpCookieIT.java
@@ -22,7 +22,7 @@ public class HttpCookieIT extends TestNGCitrusTestRunner{
 
     @Test
     @CitrusTest
-    public void testGet() {
+    public void testCookiesAreTransmittedToServer() {
 
         //GIVEN
         final Cookie aCookie = new Cookie("a", "a");

--- a/modules/citrus-integration/src/it/java/com/consol/citrus/http/HttpCookieIT.java
+++ b/modules/citrus-integration/src/it/java/com/consol/citrus/http/HttpCookieIT.java
@@ -1,0 +1,45 @@
+package com.consol.citrus.http;
+
+import com.consol.citrus.annotations.CitrusTest;
+import com.consol.citrus.dsl.testng.TestNGCitrusTestRunner;
+import com.consol.citrus.http.client.HttpClient;
+import com.consol.citrus.http.server.HttpServer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.testng.annotations.Test;
+
+import javax.servlet.http.Cookie;
+
+public class HttpCookieIT extends TestNGCitrusTestRunner{
+
+    @Autowired
+    @Qualifier("echoHttpClient")
+    private HttpClient httpClient;
+
+    @Autowired
+    @Qualifier("echoHttpServer")
+    private HttpServer httpServer;
+
+    @Test
+    @CitrusTest
+    public void testGet() {
+
+        //GIVEN
+        final Cookie aCookie = new Cookie("a", "a");
+        final Cookie bCookie = new Cookie("b", "b");
+
+        //WHEN
+        http(http -> http.client(httpClient)
+                .send()
+                .delete()
+                .cookie(aCookie)
+                .cookie(bCookie));
+
+        //THEN
+        http(http -> http.server(httpServer)
+                .receive()
+                .delete()
+                .cookie(aCookie)
+                .cookie(bCookie));
+    }
+}


### PR DESCRIPTION
Hi!

This PR is based on PR #543 and issue #561 of @kezhuw.

I've added the integration test from the issue to proof, that the fix from the original PR solves the issue of overwritten cookies. In addition, I've added unit tests to the `HttpMessageConverter` based on the current implementation. The only thing I've changed implementation wise is the handling of the `Secure` flag for Cookies, based on the [Mozilla Set-Cookie documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie).

The old implementation expected the Secure flag to be `Secure=true`. I know that the fix is not ideal but I didn't want to change the contract of `getCookieParam`. :sweat_smile: 

To the reviewer: If you want to merge this directly after review, please merge the changes into the `v2.7-bugfix` branch as well or just approve and I'll do the merging. Thx! :+1: 

BR,
Sven