### PR TITLE
(#553) reverted removal of autoReadFiles method to prevent breaking c…

### DIFF
--- a/modules/citrus-ftp/src/main/java/com/consol/citrus/ftp/client/ScpClientBuilder.java
+++ b/modules/citrus-ftp/src/main/java/com/consol/citrus/ftp/client/ScpClientBuilder.java
@@ -65,6 +65,19 @@ public class ScpClientBuilder extends AbstractEndpointBuilder<ScpClient> {
     }
 
     /**
+     * Sets the auto read files property.
+     *
+     * @param autoReadFiles
+     * @return
+     * @deprecated received files are always read automatically making this flag obsolete
+     */
+    @Deprecated
+    public ScpClientBuilder autoReadFiles(boolean autoReadFiles) {
+        endpoint.getEndpointConfiguration().setAutoReadFiles(autoReadFiles);
+        return this;
+    }
+
+    /**
      * Sets the client username.
      * @param username
      * @return


### PR DESCRIPTION
Reverted removal of method. 
The effort involved in adding an integration test to verify this change was not worth it; the method is deprecated and there were no existing Java DSL tests that could be adapted (I only found XML integration tests)