### PR TITLE
Add WaitBuilderTest

### DIFF
--- a/modules/citrus-core/src/main/java/com/consol/citrus/condition/ActionCondition.java
+++ b/modules/citrus-core/src/main/java/com/consol/citrus/condition/ActionCondition.java
@@ -21,6 +21,7 @@ import com.consol.citrus.context.TestContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -126,5 +127,19 @@ public class ActionCondition extends AbstractCondition {
      */
     public void setCaughtException(Exception caughtException) {
         this.caughtException = caughtException;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ActionCondition that = (ActionCondition) o;
+        return Objects.equals(action, that.action) &&
+                Objects.equals(caughtException, that.caughtException);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(action, caughtException);
     }
 }

--- a/modules/citrus-core/src/main/java/com/consol/citrus/condition/FileCondition.java
+++ b/modules/citrus-core/src/main/java/com/consol/citrus/condition/FileCondition.java
@@ -21,7 +21,9 @@ import com.consol.citrus.util.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
+import java.util.Objects;
 
 /**
  * Tests for the presence of a file and returns true if the file exists
@@ -108,5 +110,19 @@ public class FileCondition extends AbstractCondition {
      */
     public void setFile(File file) {
         this.file = file;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        FileCondition that = (FileCondition) o;
+        return Objects.equals(filePath, that.filePath) &&
+                Objects.equals(file, that.file);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(filePath, file);
     }
 }

--- a/modules/citrus-core/src/main/java/com/consol/citrus/condition/HttpCondition.java
+++ b/modules/citrus-core/src/main/java/com/consol/citrus/condition/HttpCondition.java
@@ -22,7 +22,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.net.*;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Objects;
 
 /**
  * Tests if a HTTP Endpoint is reachable. The test is successful if the endpoint responds with the expected response
@@ -170,5 +173,21 @@ public class HttpCondition extends AbstractCondition {
 
     public void setHttpResponseCode(String httpResponseCode) {
         this.httpResponseCode = httpResponseCode;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        HttpCondition that = (HttpCondition) o;
+        return Objects.equals(url, that.url) &&
+                Objects.equals(timeout, that.timeout) &&
+                Objects.equals(httpResponseCode, that.httpResponseCode) &&
+                Objects.equals(method, that.method);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(url, timeout, httpResponseCode, method);
     }
 }

--- a/modules/citrus-core/src/main/java/com/consol/citrus/condition/MessageCondition.java
+++ b/modules/citrus-core/src/main/java/com/consol/citrus/condition/MessageCondition.java
@@ -18,6 +18,8 @@ package com.consol.citrus.condition;
 
 import com.consol.citrus.context.TestContext;
 
+import java.util.Objects;
+
 /**
  * Condition checks whether a message is present in test context message store. Messages are automatically
  * stored in that store when sending and receiving messages with respective test actions. So this condition
@@ -64,5 +66,18 @@ public class MessageCondition extends AbstractCondition {
      */
     public String getMessageName() {
         return messageName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MessageCondition that = (MessageCondition) o;
+        return Objects.equals(messageName, that.messageName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(messageName);
     }
 }

--- a/modules/citrus-java-dsl/src/main/java/com/consol/citrus/dsl/builder/WaitActionConditionBuilder.java
+++ b/modules/citrus-java-dsl/src/main/java/com/consol/citrus/dsl/builder/WaitActionConditionBuilder.java
@@ -57,4 +57,8 @@ public class WaitActionConditionBuilder extends WaitConditionBuilder<ActionCondi
 
         return getBuilder().build();
     }
+
+    Wait getAction() {
+        return action;
+    }
 }

--- a/modules/citrus-java-dsl/src/main/java/com/consol/citrus/dsl/builder/WaitBuilder.java
+++ b/modules/citrus-java-dsl/src/main/java/com/consol/citrus/dsl/builder/WaitBuilder.java
@@ -202,7 +202,9 @@ public class WaitBuilder extends AbstractTestContainerBuilder<Wait> {
      *
      * @param milliseconds The milliseconds to wait
      * @return The altered WaitBuilder
+     * @deprecated in favor of {@link #milliseconds(String)}
      */
+    @Deprecated
     public WaitBuilder ms(String milliseconds) {
         return milliseconds(milliseconds);
     }
@@ -212,7 +214,9 @@ public class WaitBuilder extends AbstractTestContainerBuilder<Wait> {
      *
      * @param milliseconds The milliseconds to wait
      * @return The altered WaitBuilder
+     * @deprecated in favor of {@link #milliseconds(Long)}
      */
+    @Deprecated
     public WaitBuilder ms(Long milliseconds) {
         return milliseconds(milliseconds);
     }

--- a/modules/citrus-java-dsl/src/main/java/com/consol/citrus/dsl/builder/WaitBuilder.java
+++ b/modules/citrus-java-dsl/src/main/java/com/consol/citrus/dsl/builder/WaitBuilder.java
@@ -16,7 +16,11 @@
 
 package com.consol.citrus.dsl.builder;
 
-import com.consol.citrus.condition.*;
+import com.consol.citrus.condition.ActionCondition;
+import com.consol.citrus.condition.Condition;
+import com.consol.citrus.condition.FileCondition;
+import com.consol.citrus.condition.HttpCondition;
+import com.consol.citrus.condition.MessageCondition;
 import com.consol.citrus.container.AbstractActionContainer;
 import com.consol.citrus.container.Wait;
 import com.consol.citrus.dsl.design.TestDesigner;
@@ -38,8 +42,8 @@ public class WaitBuilder extends AbstractTestContainerBuilder<Wait> {
     /**
      * Constructor using designer and action field.
      *
-     * @param designer
-     * @param action
+     * @param designer The designer to execute this action in
+     * @param action The container to add this action to
      */
     public WaitBuilder(TestDesigner designer, Wait action, Stack<AbstractActionContainer> containers) {
         super(designer, action);
@@ -49,8 +53,8 @@ public class WaitBuilder extends AbstractTestContainerBuilder<Wait> {
     /**
      * Constructor using runner and action field.
      *
-     * @param runner
-     * @param action
+     * @param runner The test runner to execute this action in
+     * @param action The container to add this action to
      */
     public WaitBuilder(TestRunner runner, Wait action) {
         super(runner, action);
@@ -60,8 +64,8 @@ public class WaitBuilder extends AbstractTestContainerBuilder<Wait> {
     /**
      * Condition to wait for during execution.
      *
-     * @param condition
-     * @return
+     * @param condition The condition to add to the wait action
+     * @return The wait action
      */
     public Wait condition(Condition condition) {
         container.setCondition(condition);
@@ -85,7 +89,7 @@ public class WaitBuilder extends AbstractTestContainerBuilder<Wait> {
     /**
      * The HTTP condition to wait for during execution.
      *
-     * @return
+     * @return A WaitHttpConditionBuilder for further configuration
      */
     public WaitHttpConditionBuilder http() {
         HttpCondition condition = new HttpCondition();
@@ -97,7 +101,7 @@ public class WaitBuilder extends AbstractTestContainerBuilder<Wait> {
      * The message condition to wait for during execution.
      *
      * @param name the message to wait on
-     * @return
+     * @return WaitConditionBuilder for further configuration
      * @deprecated in favor of {@link #message()}
      */
     @Deprecated
@@ -112,7 +116,7 @@ public class WaitBuilder extends AbstractTestContainerBuilder<Wait> {
     /**
      * The message condition to wait for during execution.
      *
-     * @return
+     * @return A WaitMessageConditionBuilder for further configuration
      */
     public WaitMessageConditionBuilder message() {
         MessageCondition condition = new MessageCondition();
@@ -123,7 +127,7 @@ public class WaitBuilder extends AbstractTestContainerBuilder<Wait> {
     /**
      * The test action condition to wait for during execution.
      *
-     * @return
+     * @return A WaitActionConditionBuilder for further configuration
      */
     public WaitActionConditionBuilder execution() {
         ActionCondition condition = new ActionCondition();
@@ -163,7 +167,7 @@ public class WaitBuilder extends AbstractTestContainerBuilder<Wait> {
     /**
      * The file condition to wait for during execution.
      *
-     * @return
+     * @return A WaitFileConditionBuilder for further configuration
      */
     public WaitFileConditionBuilder file() {
         FileCondition condition = new FileCondition();
@@ -174,8 +178,8 @@ public class WaitBuilder extends AbstractTestContainerBuilder<Wait> {
     /**
      * The total length of seconds to wait on the condition to be satisfied
      *
-     * @param seconds
-     * @return
+     * @param seconds The seconds to wait
+     * @return The altered WaitBuilder
      */
     public WaitBuilder seconds(String seconds) {
         container.setSeconds(seconds);
@@ -185,8 +189,8 @@ public class WaitBuilder extends AbstractTestContainerBuilder<Wait> {
     /**
      * The total length of seconds to wait on the condition to be satisfied
      *
-     * @param seconds
-     * @return
+     * @param seconds The seconds to wait
+     * @return The altered WaitBuilder
      */
     public WaitBuilder seconds(Long seconds) {
         container.setSeconds(seconds.toString());
@@ -196,30 +200,28 @@ public class WaitBuilder extends AbstractTestContainerBuilder<Wait> {
     /**
      * The total length of milliseconds to wait on the condition to be satisfied
      *
-     * @param milliseconds
-     * @return
+     * @param milliseconds The milliseconds to wait
+     * @return The altered WaitBuilder
      */
     public WaitBuilder ms(String milliseconds) {
-        container.setMilliseconds(milliseconds);
-        return this;
+        return milliseconds(milliseconds);
     }
 
     /**
      * The total length of milliseconds to wait on the condition to be satisfied
      *
-     * @param milliseconds
-     * @return
+     * @param milliseconds The milliseconds to wait
+     * @return The altered WaitBuilder
      */
     public WaitBuilder ms(Long milliseconds) {
-        container.setMilliseconds(String.valueOf(milliseconds));
-        return this;
+        return milliseconds(milliseconds);
     }
 
     /**
      * The total length of milliseconds to wait on the condition to be satisfied
      *
-     * @param milliseconds
-     * @return
+     * @param milliseconds The milliseconds to wait
+     * @return The altered WaitBuilder
      */
     public WaitBuilder milliseconds(String milliseconds) {
         container.setMilliseconds(milliseconds);
@@ -229,8 +231,8 @@ public class WaitBuilder extends AbstractTestContainerBuilder<Wait> {
     /**
      * The total length of milliseconds to wait on the condition to be satisfied
      *
-     * @param milliseconds
-     * @return
+     * @param milliseconds The milliseconds to wait
+     * @return The altered WaitBuilder
      */
     public WaitBuilder milliseconds(Long milliseconds) {
         container.setMilliseconds(String.valueOf(milliseconds));
@@ -240,8 +242,8 @@ public class WaitBuilder extends AbstractTestContainerBuilder<Wait> {
     /**
      * The interval in seconds to use between each test of the condition
      *
-     * @param interval
-     * @return
+     * @param interval  The interval to use
+     * @return The altered WaitBuilder
      */
     public WaitBuilder interval(String interval) {
         container.setInterval(interval);
@@ -251,8 +253,8 @@ public class WaitBuilder extends AbstractTestContainerBuilder<Wait> {
     /**
      * The interval in seconds to use between each test of the condition
      *
-     * @param interval
-     * @return
+     * @param interval The interval to use
+     * @return The altered WaitBuilder
      */
     public WaitBuilder interval(Long interval) {
         container.setInterval(String.valueOf(interval));
@@ -262,7 +264,7 @@ public class WaitBuilder extends AbstractTestContainerBuilder<Wait> {
     /**
      * Finishes action build process.
      *
-     * @return
+     * @return The Wait action to execute
      */
     public Wait buildAndRun() {
         if (designer != null) {
@@ -272,5 +274,9 @@ public class WaitBuilder extends AbstractTestContainerBuilder<Wait> {
         }
 
         return super.build();
+    }
+
+    Stack<AbstractActionContainer> getContainers() {
+        return containers;
     }
 }

--- a/modules/citrus-java-dsl/src/test/java/com/consol/citrus/dsl/builder/WaitBuilderTest.java
+++ b/modules/citrus-java-dsl/src/test/java/com/consol/citrus/dsl/builder/WaitBuilderTest.java
@@ -1,0 +1,265 @@
+/*
+ *    Copyright 2019 the original author or authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.consol.citrus.dsl.builder;
+
+import com.consol.citrus.condition.ActionCondition;
+import com.consol.citrus.condition.Condition;
+import com.consol.citrus.condition.FileCondition;
+import com.consol.citrus.condition.HttpCondition;
+import com.consol.citrus.condition.MessageCondition;
+import com.consol.citrus.container.Wait;
+import com.consol.citrus.dsl.runner.TestRunner;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.File;
+
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+
+public class WaitBuilderTest {
+
+    private TestRunner testRunnerMock = mock(TestRunner.class);
+    private Wait waitAction;
+    private WaitBuilder waitBuilder;
+
+    @BeforeMethod
+    public void setup(){
+        waitAction = new Wait();
+        waitBuilder = new WaitBuilder(testRunnerMock, waitAction);
+    }
+
+    @Test
+    public void testConditionIsSet(){
+
+        //GIVEN
+        Condition conditionMock = mock(Condition.class);
+
+        //WHEN
+        waitBuilder.condition(conditionMock);
+
+        //THEN
+        assertEquals(waitAction.getCondition(), conditionMock);
+    }
+
+    @Test
+    public void testWaitForHttpUrlIsSet(){
+
+        //GIVEN
+        String url = "google.de";
+
+        //WHEN
+        final WaitHttpConditionBuilder builder = waitBuilder.http(url);
+
+        //THEN
+        assertEquals(builder.getCondition().getUrl(), url);
+    }
+
+    @Test
+    public void testWaitForHttpConditionIsCreated(){
+
+        //GIVEN
+
+        //WHEN
+        final WaitHttpConditionBuilder builder = waitBuilder.http();
+
+        //THEN
+        assertEquals(builder.getCondition(), new HttpCondition());
+    }
+
+    @Test
+    public void testWaitForMessageStringIsSet(){
+
+        //GIVEN
+        String message = "{ \"massage\": \"fancy\" }";
+
+        //WHEN
+        final WaitConditionBuilder builder = waitBuilder.message(message);
+
+        //THEN
+        final MessageCondition condition = (MessageCondition) builder.getCondition();
+        assertEquals(condition.getMessageName(), message);
+    }
+
+    @Test
+    public void testWaitForMessageConditionIsCreated(){
+
+        //GIVEN
+
+        //WHEN
+        final WaitMessageConditionBuilder builder = waitBuilder.message();
+
+        //THEN
+        assertEquals(builder.getCondition(), new MessageCondition());
+    }
+
+    @Test
+    public void testWaitForExecutionConditionIsCreated(){
+
+        //GIVEN
+        ActionCondition expectedCondition = new ActionCondition();
+
+        //WHEN
+        final WaitActionConditionBuilder builder = waitBuilder.execution();
+
+        //THEN
+        assertEquals(builder.getCondition(), expectedCondition);
+        assertEquals(waitBuilder.getContainers().search(builder.getAction()),1 );
+    }
+
+    @Test
+    public void testWaitForFilePathIsSet(){
+
+        //GIVEN
+        final String path = "/path/to/file";
+
+        //WHEN
+        final WaitFileConditionBuilder builder = waitBuilder.file(path);
+
+        //THEN
+        assertEquals(builder.getCondition().getFilePath(), path);
+    }
+
+    @Test
+    public void testWaitForFileReferenceIsSet(){
+
+        //GIVEN
+        final File file = mock(File.class);
+
+        //WHEN
+        final WaitFileConditionBuilder builder = waitBuilder.file(file);
+
+        //THEN
+        assertEquals(builder.getCondition().getFile(), file);
+    }
+
+    @Test
+    public void testWaitForFileConditionIsCreated(){
+
+        //GIVEN
+
+        //WHEN
+        final WaitFileConditionBuilder builder = waitBuilder.file();
+
+        //THEN
+        assertEquals(builder.getCondition(), new FileCondition());
+    }
+
+    @Test
+    public void testSecondsToWaitAreSet(){
+
+        //GIVEN
+        String seconds = "42";
+
+        //WHEN
+        final WaitBuilder builder = waitBuilder.seconds(seconds);
+
+        //THEN
+        assertEquals(builder.container.getSeconds(), seconds);
+    }
+
+    @Test
+    public void testSecondsToWaitAsLongAreSet(){
+
+        //GIVEN
+        long seconds = 42L;
+
+        //WHEN
+        final WaitBuilder builder = waitBuilder.seconds(seconds);
+
+        //THEN
+        assertEquals(builder.container.getSeconds(), Long.toString(seconds));
+    }
+
+    @Test
+    public void testMillisecondsToWaitAreSet(){
+
+        //GIVEN
+        String milliseconds = "42";
+
+        //WHEN
+        final WaitBuilder builder = waitBuilder.milliseconds(milliseconds);
+
+        //THEN
+        assertEquals(builder.container.getMilliseconds(), milliseconds);
+    }
+
+    @Test
+    public void testMillisecondsToWaitAsLongAreSet(){
+
+        //GIVEN
+        long milliseconds = 42L;
+
+        //WHEN
+        final WaitBuilder builder = waitBuilder.milliseconds(milliseconds);
+
+        //THEN
+        assertEquals(builder.container.getMilliseconds(), Long.toString(milliseconds));
+    }
+
+    @Test
+    public void testMsToWaitAreSet(){
+
+        //GIVEN
+        String milliseconds = "42";
+
+        //WHEN
+        final WaitBuilder builder = waitBuilder.ms(milliseconds);
+
+        //THEN
+        assertEquals(builder.container.getMilliseconds(), milliseconds);
+    }
+
+    @Test
+    public void testMsToWaitAsLongAreSet(){
+
+        //GIVEN
+        long milliseconds = 42L;
+
+        //WHEN
+        final WaitBuilder builder = waitBuilder.ms(milliseconds);
+
+        //THEN
+        assertEquals(builder.container.getMilliseconds(), Long.toString(milliseconds));
+    }
+
+    @Test
+    public void testIntervalToWaitAreSet(){
+
+        //GIVEN
+        String interval = "42";
+
+        //WHEN
+        final WaitBuilder builder = waitBuilder.interval(interval);
+
+        //THEN
+        assertEquals(builder.container.getInterval(), interval);
+    }
+
+    @Test
+    public void testIntervalToWaitAsLongAreSet(){
+
+        //GIVEN
+        long interval = 42L;
+
+        //WHEN
+        final WaitBuilder builder = waitBuilder.interval(interval);
+
+        //THEN
+        assertEquals(builder.container.getInterval(), Long.toString(interval));
+    }
+}


### PR DESCRIPTION
Hi!

This PR intends to fix the broken quality gate.
During the reconstruction of the `WaitBuilder` API in #549, the quality gate broke because the reconstruction was now handles as untested *new code*.
Therefore I added test coverage to this class.

I also deprecated the `ms` methods which were a duplicated of `milliseconds`.