### PR TITLE
Fix/562/maven plugin creates invalid tests

### DIFF
--- a/modules/citrus-cucumber/pom.xml
+++ b/modules/citrus-cucumber/pom.xml
@@ -106,8 +106,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/modules/citrus-integration/pom.xml
+++ b/modules/citrus-integration/pom.xml
@@ -33,7 +33,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>2.19.1</version>
+          <version>${surefire.version}</version>
           <configuration>
             <properties>
               <property>
@@ -46,19 +46,14 @@
           </configuration>
           <dependencies>
             <dependency>
-              <groupId>org.junit.platform</groupId>
-              <artifactId>junit-platform-surefire-provider</artifactId>
-              <version>${junit.platform.version}</version>
-            </dependency>
-            <dependency>
               <groupId>org.apache.maven.surefire</groupId>
               <artifactId>surefire-junit47</artifactId>
-              <version>2.19.1</version>
+              <version>${surefire.version}</version>
             </dependency>
             <dependency>
               <groupId>org.apache.maven.surefire</groupId>
               <artifactId>surefire-testng</artifactId>
-              <version>2.19.1</version>
+              <version>${surefire.version}</version>
             </dependency>
           </dependencies>
         </plugin>
@@ -216,14 +211,13 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>${junit.jupiter.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/modules/citrus-integration/pom.xml
+++ b/modules/citrus-integration/pom.xml
@@ -46,9 +46,9 @@
           </configuration>
           <dependencies>
             <dependency>
-              <groupId>org.apache.maven.surefire</groupId>
-              <artifactId>surefire-junit-platform</artifactId>
-              <version>${surefire.version}</version>
+              <groupId>org.junit.platform</groupId>
+              <artifactId>junit-platform-surefire-provider</artifactId>
+              <version>${junit.platform.version}</version>
             </dependency>
             <dependency>
               <groupId>org.apache.maven.surefire</groupId>

--- a/modules/citrus-integration/pom.xml
+++ b/modules/citrus-integration/pom.xml
@@ -47,6 +47,11 @@
           <dependencies>
             <dependency>
               <groupId>org.apache.maven.surefire</groupId>
+              <artifactId>surefire-junit-platform</artifactId>
+              <version>${surefire.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.apache.maven.surefire</groupId>
               <artifactId>surefire-junit47</artifactId>
               <version>${surefire.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -73,66 +73,6 @@
       </roles>
     </developer>
     <developer>
-      <id>cwied</id>
-      <name>Christian Wied</name>
-      <email>citrus-dev-l@consol.de</email>
-      <organization>ConSol Software GmbH</organization>
-      <organizationUrl>http://www.consol.de/</organizationUrl>
-      <roles>
-        <role>Developer</role>
-      </roles>
-    </developer>
-    <developer>
-      <id>philkom</id>
-      <name>Philipp Komninos</name>
-      <email>citrus-dev-l@consol.de</email>
-      <organization>ConSol Software GmbH</organization>
-      <organizationUrl>http://www.consol.de/</organizationUrl>
-      <roles>
-        <role>Developer</role>
-      </roles>
-    </developer>
-    <developer>
-      <id>jblipphaus</id>
-      <name>Jan Lipphaus</name>
-      <email>citrus-dev-l@consol.de</email>
-      <organization>ConSol Software GmbH</organization>
-      <organizationUrl>http://www.consol.de/</organizationUrl>
-      <roles>
-        <role>Developer</role>
-      </roles>
-    </developer>
-    <developer>
-      <id>jza</id>
-      <name>Jan Zahalka</name>
-      <email>citrus-dev-l@consol.de</email>
-      <organization>ConSol Software GmbH</organization>
-      <organizationUrl>http://www.consol.de/</organizationUrl>
-      <roles>
-        <role>Developer</role>
-      </roles>
-    </developer>
-    <developer>
-      <id>maherma</id>
-      <name>Martin Maher</name>
-      <email>citrus-dev-l@consol.de</email>
-      <organization>ConSol Software GmbH</organization>
-      <organizationUrl>http://www.consol.de/</organizationUrl>
-      <roles>
-        <role>Developer</role>
-      </roles>
-    </developer>
-    <developer>
-      <id>movchin</id>
-      <name>Michael Movchin</name>
-      <email>citrus-dev-l@consol.de</email>
-      <organization>ConSol Software GmbH</organization>
-      <organizationUrl>http://www.consol.de/</organizationUrl>
-      <roles>
-        <role>Web Developer</role>
-      </roles>
-    </developer>
-    <developer>
       <id>svettwer</id>
       <name>Sven Hettwer</name>
       <email>citrus-dev-l@consol.de</email>
@@ -208,8 +148,7 @@
     <jetty.version>9.4.8.v20171121</jetty.version>
     <testng.version>6.11</testng.version>
     <junit.version>4.12</junit.version>
-    <junit.jupiter.version>5.0.3</junit.jupiter.version>
-    <junit.platform.version>1.0.3</junit.platform.version>
+    <junit.jupiter.version>5.3.2</junit.jupiter.version>
     <slf4j.version>1.7.25</slf4j.version>
     <jaxb.version>2.2.11</jaxb.version>
     <jackson.version>2.9.8</jackson.version>
@@ -218,6 +157,7 @@
     <zookeeper.version>3.4.10</zookeeper.version>
     <json.schema.validator.version>2.2.8</json.schema.validator.version>
     <citrus.db.version>0.1.4</citrus.db.version>
+    <surefire.version>2.22.1</surefire.version>
 
     <skip.integration.tests>false</skip.integration.tests>
     <skip.unit.tests>false</skip.unit.tests>
@@ -451,6 +391,7 @@
         <version>${testng.version}</version>
       </dependency>
       <dependency>
+        <!-- Required for the core module as the vintage engine does not provide a Junit4 compile scope -->
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>${junit.version}</version>
@@ -460,7 +401,16 @@
         <artifactId>junit-jupiter-api</artifactId>
         <version>${junit.jupiter.version}</version>
       </dependency>
-
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-engine</artifactId>
+        <version>${junit.jupiter.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.vintage</groupId>
+        <artifactId>junit-vintage-engine</artifactId>
+        <version>${junit.jupiter.version}</version>
+      </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-server</artifactId>
@@ -997,7 +947,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.20.1</version>
+          <version>${surefire.version}</version>
           <configuration>
             <systemProperties>
               <property>
@@ -1020,7 +970,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>2.20.1</version>
+          <version>${surefire.version}</version>
           <executions>
             <execution>
               <id>integration-tests</id>

--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,7 @@
     <testng.version>6.11</testng.version>
     <junit.version>4.12</junit.version>
     <junit.jupiter.version>5.3.2</junit.jupiter.version>
+    <junit.platform.version>1.0.3</junit.platform.version>
     <slf4j.version>1.7.25</slf4j.version>
     <jaxb.version>2.2.11</jaxb.version>
     <jackson.version>2.9.8</jackson.version>

--- a/src/manual/changes-new.adoc
+++ b/src/manual/changes-new.adoc
@@ -1,8 +1,6 @@
 [[changes-new]]
 = What's new in Citrus 2.7?!
 
-We have the following features included in the box.
-
 [[changes-2-7-9]]
 == Since Citrus 2.7.9
 
@@ -33,6 +31,12 @@ downwards compatibility are marked as `@Deprecated` and will be removed with the
 [[changes-security-2-7-9]]
 === Security fixes
 * https://github.com/citrusframework/citrus/issues/584[#584 - Update com.fasterxml.jackson.core:jackson-databind to version 2.9.8 or later]
+
+[[changes-enhancements-2-7-9]]
+=== Enhancements
+* https://github.com/citrusframework/citrus/issues/591[#591 - Improve documentation concerning parallel messages]
+
+=== Fixed bugs
 
 [[changes-2-7-8]]
 == Since Citrus 2.7.8

--- a/src/manual/changes-new.adoc
+++ b/src/manual/changes-new.adoc
@@ -11,6 +11,7 @@
 * https://github.com/citrusframework/citrus/issues/535[#535 - Inconsistent values of global variables]
 * https://github.com/citrusframework/citrus/issues/569[#569 - duplicated cookie entries in http request]
 * https://github.com/citrusframework/citrus/issues/455[#455 - Cookies are not recognized by HTTP client]
+* https://github.com/citrusframework/citrus/issues/562[#562 - maven plugin creates invalid testNG Citrus tests]
 
 [[fixed-breaking-changes-2-7-9]]
 === Fixed breaking changes

--- a/tools/maven/citrus-maven-plugin-integration/pom.xml
+++ b/tools/maven/citrus-maven-plugin-integration/pom.xml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~    Copyright 2019 the original author or authors
+  ~
+  ~    Licensed under the Apache License, Version 2.0 (the "License");
+  ~    you may not use this file except in compliance with the License.
+  ~    You may obtain a copy of the License at
+  ~
+  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~    Unless required by applicable law or agreed to in writing, software
+  ~    distributed under the License is distributed on an "AS IS" BASIS,
+  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~    See the License for the specific language governing permissions and
+  ~    limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>citrus-maven</artifactId>
+        <groupId>com.consol.citrus.mvn</groupId>
+        <version>2.7.9-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>citrus-maven-plugin-integration</artifactId>
+    <name>citrus-maven-plugin-integration</name>
+
+
+    <dependencies>
+        <dependency>
+            <groupId>com.consol.citrus</groupId>
+            <artifactId>citrus-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.consol.citrus</groupId>
+            <artifactId>citrus-java-dsl</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.consol.citrus.mvn</groupId>
+                <artifactId>citrus-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <executions>
+                    <execution>
+                        <id>generate-tests-junit4</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>generate-tests</goal>
+                        </goals>
+                        <configuration>
+                            <type>java</type>
+                            <framework>junit4</framework>
+                            <tests>
+                                <test>
+                                    <name>JUnit4Test</name>
+                                </test>
+                            </tests>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>generate-tests-testng</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>generate-tests</goal>
+                        </goals>
+                        <configuration>
+                            <type>java</type>
+                            <framework>testng</framework>
+                            <tests>
+                                <test>
+                                    <name>TestNgTest</name>
+                                </test>
+                            </tests>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>generate-tests-junit5</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>generate-tests</goal>
+                        </goals>
+                        <configuration>
+                            <type>java</type>
+                            <framework>junit5</framework>
+                            <tests>
+                                <test>
+                                    <name>JUnit5Test</name>
+                                </test>
+                            </tests>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>add-test-sources</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.build.directory}/generated/citrus/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <properties>
+                        <property>
+                            <name>junit</name>
+                            <value>false</value>
+                        </property>
+                    </properties>
+                    <threadCount>1</threadCount>
+                    <failIfNoTests>true</failIfNoTests>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit-platform</artifactId>
+                        <version>${surefire.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit47</artifactId>
+                        <version>${surefire.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-testng</artifactId>
+                        <version>${surefire.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tools/maven/pom.xml
+++ b/tools/maven/pom.xml
@@ -17,5 +17,6 @@
   
   <modules>
     <module>citrus-maven-plugin</module>
+    <module>citrus-maven-plugin-integration</module>
   </modules>
 </project>

--- a/tools/test-generator/pom.xml
+++ b/tools/test-generator/pom.xml
@@ -51,5 +51,5 @@
       <artifactId>xmlbeans</artifactId>
     </dependency>
   </dependencies>
-  
+
 </project>

--- a/tools/test-generator/src/test/java/com/consol/citrus/generate/javadsl/JavaDslTestGeneratorTest.java
+++ b/tools/test-generator/src/test/java/com/consol/citrus/generate/javadsl/JavaDslTestGeneratorTest.java
@@ -4,6 +4,7 @@ import com.consol.citrus.Citrus;
 import com.consol.citrus.exceptions.CitrusRuntimeException;
 import com.consol.citrus.generate.UnitFramework;
 import com.consol.citrus.util.FileUtils;
+import com.consol.citrus.utils.CleanupUtils;
 import org.springframework.core.io.FileSystemResource;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -16,15 +17,13 @@ import java.io.IOException;
 public class JavaDslTestGeneratorTest {
 
     private JavaDslTestGenerator generatorUnderTest = new JavaDslTestGenerator();
-
     private File testFile = new File(Citrus.DEFAULT_TEST_SRC_DIRECTORY + "/java/com/consol/citrus/FooTest.java");
+
+    private final CleanupUtils cleanupUtils = new CleanupUtils();
 
     @AfterMethod
     public void cleanUp(){
-        if(testFile.exists()){
-            //noinspection ResultOfMethodCallIgnored
-            testFile.delete();
-        }
+        cleanupUtils.deleteFile(testFile);
     }
 
     @Test

--- a/tools/test-generator/src/test/java/com/consol/citrus/generate/javadsl/WsdlJavaTestGeneratorTest.java
+++ b/tools/test-generator/src/test/java/com/consol/citrus/generate/javadsl/WsdlJavaTestGeneratorTest.java
@@ -72,6 +72,8 @@ public class WsdlJavaTestGeneratorTest {
         Assert.assertTrue(javaContent.contains("* This is a sample test"));
         Assert.assertTrue(javaContent.contains("package com.consol.citrus;"));
         Assert.assertTrue(javaContent.contains("extends TestNGCitrusTestRunner"));
+        Assert.assertTrue(javaContent.contains(requestName));
+        Assert.assertTrue(javaContent.contains(responseName));
     }
 
 }

--- a/tools/test-generator/src/test/java/com/consol/citrus/generate/javadsl/WsdlJavaTestGeneratorTest.java
+++ b/tools/test-generator/src/test/java/com/consol/citrus/generate/javadsl/WsdlJavaTestGeneratorTest.java
@@ -19,18 +19,30 @@ package com.consol.citrus.generate.javadsl;
 import com.consol.citrus.Citrus;
 import com.consol.citrus.generate.UnitFramework;
 import com.consol.citrus.util.FileUtils;
+import com.consol.citrus.utils.CleanupUtils;
 import org.springframework.core.io.FileSystemResource;
 import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 
 /**
  * @author Christoph Deppisch
  * @since 2.7.4
  */
 public class WsdlJavaTestGeneratorTest {
+
+    private String testDir = Citrus.DEFAULT_TEST_SRC_DIRECTORY + "java/com/consol/citrus/";
+
+    private final CleanupUtils cleanupUtils = new CleanupUtils();
+
+    @AfterMethod
+    public void cleanUp(){
+        cleanupUtils.deleteFiles(testDir, Collections.singleton("BookStore*"));
+    }
 
     @Test
     public void testCreateTest() throws IOException {
@@ -51,7 +63,7 @@ public class WsdlJavaTestGeneratorTest {
     }
 
     private void verifyTest(String name, String requestName, String responseName) throws IOException {
-        File javaFile = new File(Citrus.DEFAULT_TEST_SRC_DIRECTORY + "java/com/consol/citrus/" + name + ".java");
+        File javaFile = new File(testDir + name + ".java");
         Assert.assertTrue(javaFile.exists());
 
         String javaContent = FileUtils.readToString(new FileSystemResource(javaFile));

--- a/tools/test-generator/src/test/java/com/consol/citrus/utils/CleanupUtils.java
+++ b/tools/test-generator/src/test/java/com/consol/citrus/utils/CleanupUtils.java
@@ -1,0 +1,38 @@
+/*
+ *    Copyright 2019 the original author or authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.consol.citrus.utils;
+
+import com.consol.citrus.util.FileUtils;
+
+import java.io.File;
+import java.util.Set;
+
+public class CleanupUtils {
+
+    public void deleteFiles(final String startDir, final Set<String> fileNamePatterns){
+        //noinspection ResultOfMethodCallIgnored
+        FileUtils.findFiles(startDir, fileNamePatterns).
+                forEach(File::delete);
+    }
+
+    public void deleteFile(File fileToDelete){
+        if(fileToDelete.exists()){
+            //noinspection ResultOfMethodCallIgnored
+            fileToDelete.delete();
+        }
+    }
+}


### PR DESCRIPTION
This PR is concerning #562.

I've applied some additional changes that are unrelated to the issue at first glance.

* Use Junit5 where possible - including vintage engine
* updated surefire -> easier config for Junit5
* Added documentation I forgot for #591

To ensure that the generated tests of the plugin are correct, I added several tests concerning the files content as well as a final integration test for the citrus-maven-plugin as a whole.
The latter one is located in the `citrus-maven-plugin-integration` module, I added.

I also tried to cleanup the test generator code a little bit but it is still cluttering.

BR,
Sven