### PR TITLE
Suppress exceptions when XPath evaluations return false

### DIFF
--- a/modules/citrus-core/src/main/java/com/consol/citrus/TestCase.java
+++ b/modules/citrus-core/src/main/java/com/consol/citrus/TestCase.java
@@ -84,7 +84,7 @@ public class TestCase extends AbstractActionContainer implements BeanNameAware {
     private static Logger log = LoggerFactory.getLogger(TestCase.class);
 
     private static boolean suppressExceptionsOnXpathEvaluations;
-    
+
     static {
     	suppressExceptionsOnXpathEvaluations = Boolean.parseBoolean(System.getProperty("citrus.core.validation.xml.suppress_exceptions_on_xpath_evaluations", "false"));
     }
@@ -353,7 +353,7 @@ public class TestCase extends AbstractActionContainer implements BeanNameAware {
     public void addFinalAction(final TestAction testAction) {
         this.finalActions.add(testAction);
     }
-    
+
     /**
      * Get the test case meta information.
      * @return the metaInfo
@@ -540,7 +540,7 @@ public class TestCase extends AbstractActionContainer implements BeanNameAware {
      */
     protected TestResult evaluateTestResult(TestResult result, TestContext context) {
         if (suppressExceptionsOnXpathEvaluations && result.isSuccess() && context.hasFailures()) {
-        	XpathAssertionResult contextFailure = context.getFailures().get(0);
+        	XpathAssertionResult contextFailure = context.getFailures().remove(0);
         	return TestResult.failed(getName(), testClass.getName(), contextFailure.toString());
         }
         else {

--- a/modules/citrus-core/src/main/java/com/consol/citrus/context/TestContext.java
+++ b/modules/citrus-core/src/main/java/com/consol/citrus/context/TestContext.java
@@ -136,6 +136,11 @@ public class TestContext {
     private List<CitrusRuntimeException> exceptions = new ArrayList<>();
 
     /**
+     * List of XPath assertion failures that actions found during execution of forked operations
+     */
+    private List<XpathAssertionResult> failures = new ArrayList<>(); // TJV Added
+
+    /**
      * Default constructor
      */
     public TestContext() {
@@ -789,6 +794,34 @@ public class TestContext {
      */
     public boolean hasExceptions() {
         return !CollectionUtils.isEmpty(getExceptions());
+    }
+
+    /**
+     * Add new failure to the context marking the test as failed. This
+     * is usually used by actions to mark XPath assertion failures during forked operations.
+     *
+     * @param failure
+     */
+    public void addFailure(XpathAssertionResult failure) {
+        this.failures.add(failure);
+    }
+
+    /**
+     * Gets the value of the exceptions property.
+     *
+     * @return the failures
+     */
+    public List<XpathAssertionResult> getFailures() {
+        return failures;
+    }
+
+    /**
+     * Gets failure collection state.
+     *
+     * @return
+     */
+    public boolean hasFailures() {
+        return !CollectionUtils.isEmpty(getFailures());
     }
 
     /**

--- a/modules/citrus-core/src/main/java/com/consol/citrus/context/TestContext.java
+++ b/modules/citrus-core/src/main/java/com/consol/citrus/context/TestContext.java
@@ -138,7 +138,7 @@ public class TestContext {
     /**
      * List of XPath assertion failures that actions found during execution of forked operations
      */
-    private List<XpathAssertionResult> failures = new ArrayList<>(); // TJV Added
+    private List<XpathAssertionResult> failures = new ArrayList<>();
 
     /**
      * Default constructor

--- a/modules/citrus-core/src/main/java/com/consol/citrus/context/XpathAssertionResult.java
+++ b/modules/citrus-core/src/main/java/com/consol/citrus/context/XpathAssertionResult.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.consol.citrus.context;
+
+/**
+ * Immutable class that holds information about the result of evaluation of an XPath assertion.
+ * Holds the XPath expression that was evaluated, the expected and actual results.
+ */
+public class XpathAssertionResult {
+
+	/** Actual result of the XPath evaluation. */
+	private String actualResult;
+
+	/** Expected result of the XPath evaluation. */
+	private String expectedResult;
+
+	/** XPath expression that was evaluated. */
+	private String xpathExpression;
+	
+	/**
+	 * Construct an XpathAssertionResult from the XPath expression, expected and actual results.
+	 * @param xpathExpression XPath expression that was evaluated
+	 * @param expectedResult Expected result of evaluation
+	 * @param actualResult Actual result of evaluation
+	 */
+	public XpathAssertionResult(String xpathExpression, String expectedResult, String actualResult) {
+		this.xpathExpression = xpathExpression;
+		this.expectedResult = expectedResult;
+		this.actualResult = actualResult;
+	}
+
+	/*
+	 * Return the actual result of the XPath evaluation.
+	 */
+	public String getActualResult() {
+		return this.actualResult;
+	}
+
+	/*
+	 * Return the expected result of the XPath evaluation.
+	 */
+	public String getExpectedResult() {
+		return this.expectedResult;
+	}
+
+	/*
+	 * Return the XPath expression.
+	 */
+	public String getXpathExpression() {
+		return this.xpathExpression;
+	}
+	
+	public String toString() {
+		return "XPath assertion failure - " + this.xpathExpression + " : expected = " + this.expectedResult + ", actual = " + this.actualResult;
+	}
+	
+}

--- a/modules/citrus-core/src/main/java/com/consol/citrus/context/XpathAssertionResult.java
+++ b/modules/citrus-core/src/main/java/com/consol/citrus/context/XpathAssertionResult.java
@@ -22,50 +22,50 @@ package com.consol.citrus.context;
  */
 public class XpathAssertionResult {
 
-	/** Actual result of the XPath evaluation. */
-	private String actualResult;
+    /** Actual result of the XPath evaluation. */
+    private String actualResult;
 
-	/** Expected result of the XPath evaluation. */
-	private String expectedResult;
+    /** Expected result of the XPath evaluation. */
+    private String expectedResult;
 
-	/** XPath expression that was evaluated. */
-	private String xpathExpression;
-	
-	/**
-	 * Construct an XpathAssertionResult from the XPath expression, expected and actual results.
-	 * @param xpathExpression XPath expression that was evaluated
-	 * @param expectedResult Expected result of evaluation
-	 * @param actualResult Actual result of evaluation
-	 */
-	public XpathAssertionResult(String xpathExpression, String expectedResult, String actualResult) {
-		this.xpathExpression = xpathExpression;
-		this.expectedResult = expectedResult;
-		this.actualResult = actualResult;
-	}
+    /** XPath expression that was evaluated. */
+    private String xpathExpression;
 
-	/*
-	 * Return the actual result of the XPath evaluation.
-	 */
-	public String getActualResult() {
-		return this.actualResult;
-	}
+    /**
+     * Construct an XpathAssertionResult from the XPath expression, expected and actual results.
+     * @param xpathExpression XPath expression that was evaluated
+     * @param expectedResult Expected result of evaluation
+     * @param actualResult Actual result of evaluation
+     */
+    public XpathAssertionResult(String xpathExpression, String expectedResult, String actualResult) {
+        this.xpathExpression = xpathExpression;
+        this.expectedResult = expectedResult;
+        this.actualResult = actualResult;
+    }
 
-	/*
-	 * Return the expected result of the XPath evaluation.
-	 */
-	public String getExpectedResult() {
-		return this.expectedResult;
-	}
+    /*
+     * Return the actual result of the XPath evaluation.
+     */
+    public String getActualResult() {
+        return this.actualResult;
+    }
 
-	/*
-	 * Return the XPath expression.
-	 */
-	public String getXpathExpression() {
-		return this.xpathExpression;
-	}
-	
-	public String toString() {
-		return "XPath assertion failure - " + this.xpathExpression + " : expected = " + this.expectedResult + ", actual = " + this.actualResult;
-	}
-	
+    /*
+     * Return the expected result of the XPath evaluation.
+     */
+    public String getExpectedResult() {
+        return this.expectedResult;
+    }
+
+    /*
+     * Return the XPath expression.
+     */
+    public String getXpathExpression() {
+        return this.xpathExpression;
+    }
+
+    public String toString() {
+        return "XPath assertion failure - " + this.xpathExpression + " : expected = " + this.expectedResult + ", actual = " + this.actualResult;
+    }
+
 }

--- a/modules/citrus-core/src/main/java/com/consol/citrus/validation/xml/XpathMessageValidator.java
+++ b/modules/citrus-core/src/main/java/com/consol/citrus/validation/xml/XpathMessageValidator.java
@@ -49,9 +49,9 @@ public class XpathMessageValidator extends AbstractMessageValidator<XpathMessage
     private static Logger log = LoggerFactory.getLogger(XpathMessageValidator.class);
 
     private static boolean suppressExceptionsOnXpathEvaluations;
-    
+
     static {
-    	suppressExceptionsOnXpathEvaluations = Boolean.parseBoolean(System.getProperty("citrus.core.validation.xml.suppress_exceptions_on_xpath_evaluations", "false"));
+        suppressExceptionsOnXpathEvaluations = Boolean.parseBoolean(System.getProperty("citrus.core.validation.xml.suppress_exceptions_on_xpath_evaluations", "false"));
     }
 
     @Autowired(required = false)
@@ -141,23 +141,23 @@ public class XpathMessageValidator extends AbstractMessageValidator<XpathMessage
      * @param context Test Context in which the evaluation occurs
      */
     protected void validateValues(Object xPathResult, Object expectedValue, String xPathExpression, TestContext context) {
-    	try {
-    		ValidationUtils.validateValues(xPathResult, expectedValue, xPathExpression, context);
+        try {
+            ValidationUtils.validateValues(xPathResult, expectedValue, xPathExpression, context);
             if (log.isDebugEnabled()) {
                 log.debug("Validating element: " + xPathExpression + "='" + expectedValue + "': OK.");
             }
-    	}
-    	catch (ValidationException ex) {
-    		if (suppressExceptionsOnXpathEvaluations) {
-    			context.addFailure(new XpathAssertionResult(xPathExpression, (String)expectedValue, (String)xPathResult));
+        }
+        catch (ValidationException ex) {
+            if (suppressExceptionsOnXpathEvaluations) {
+                context.addFailure(new XpathAssertionResult(xPathExpression, (String)expectedValue, (String)xPathResult));
                 if (log.isDebugEnabled()) {
                     log.debug("Validating element: " + xPathExpression + "='" + expectedValue + "': Failed.");
                 }
-    		}
-    		else {
-    			throw ex;
-    		}
-    	}
+            }
+            else {
+                throw ex;
+            }
+        }
     }
 
     /**

--- a/modules/citrus-core/src/main/java/com/consol/citrus/validation/xml/XpathPayloadVariableExtractor.java
+++ b/modules/citrus-core/src/main/java/com/consol/citrus/validation/xml/XpathPayloadVariableExtractor.java
@@ -45,19 +45,19 @@ public class XpathPayloadVariableExtractor implements VariableExtractor {
 
     /** Map defines xpath expressions and target variable names */
     private Map<String, String> xPathExpressions = new HashMap<String, String>();
-    
+
     /** Namespace definitions used in xpath expressions */
     private Map<String, String> namespaces = new HashMap<String, String>();
-    
+
     /** Logger */
     private static Logger log = LoggerFactory.getLogger(XpathPayloadVariableExtractor.class);
-    
+
     private static boolean suppressExceptionsOnXpathEvaluations;
-    
+
     static {
-       	suppressExceptionsOnXpathEvaluations = Boolean.parseBoolean(System.getProperty("citrus.core.validation.xml.suppress_exceptions_on_xpath_evaluations", "false"));
+        suppressExceptionsOnXpathEvaluations = Boolean.parseBoolean(System.getProperty("citrus.core.validation.xml.suppress_exceptions_on_xpath_evaluations", "false"));
     }
-    
+
     /**
      * Extract variables using Xpath expressions.
      */
@@ -67,7 +67,7 @@ public class XpathPayloadVariableExtractor implements VariableExtractor {
         if (log.isDebugEnabled()) {
             log.debug("Reading XML elements with XPath");
         }
-        
+
         NamespaceContext nsContext = context.getNamespaceContextBuilder().buildContext(message, namespaces);
 
         for (Entry<String, String> entry : xPathExpressions.entrySet()) {
@@ -77,13 +77,13 @@ public class XpathPayloadVariableExtractor implements VariableExtractor {
             if (log.isDebugEnabled()) {
                 log.debug("Evaluating XPath expression: " + pathExpression);
             }
-            
+
             Document doc = XMLUtils.parseMessagePayload(message.getPayload(String.class));
-            
+
             if (XPathUtils.isXPathExpression(pathExpression)) {
                 XPathExpressionResult resultType = XPathExpressionResult.fromString(pathExpression, XPathExpressionResult.STRING);
                 pathExpression = XPathExpressionResult.cutOffPrefix(pathExpression);
-                
+
                 Object value = evaluate(doc, pathExpression, nsContext, resultType);
 
                 if (value == null) {
@@ -93,7 +93,7 @@ public class XpathPayloadVariableExtractor implements VariableExtractor {
                 if (value instanceof List) {
                     value = StringUtils.arrayToCommaDelimitedString(((List)value).toArray(new String[((List)value).size()]));
                 }
-                
+
                 context.setVariable(variableName, value);
             } else {
                 Node node = XMLUtils.findNodeByName(doc, pathExpression);
@@ -122,7 +122,7 @@ public class XpathPayloadVariableExtractor implements VariableExtractor {
     public void setXpathExpressions(Map<String, String> xPathExpressions) {
         this.xPathExpressions = xPathExpressions;
     }
-    
+
     /**
      * List of expected namespaces.
      * @param namespaces the namespaces to set
@@ -160,17 +160,17 @@ public class XpathPayloadVariableExtractor implements VariableExtractor {
      * @return Value of the XPath evaluation
      */
     protected Object evaluate(Document doc, String pathExpression, NamespaceContext nsContext, XPathExpressionResult resultType) {
-    	try {
-        	return XPathUtils.evaluate(doc, pathExpression, nsContext, resultType);
-    	}
-    	catch (CitrusRuntimeException ex) {
-           	if (suppressExceptionsOnXpathEvaluations && ex.getMessage().startsWith("No result for XPath expression")) {
-           		return "";
-           	}
-           	else {
-           		throw ex;
-           	}
-    	}
+        try {
+            return XPathUtils.evaluate(doc, pathExpression, nsContext, resultType);
+        }
+        catch (CitrusRuntimeException ex) {
+           if (suppressExceptionsOnXpathEvaluations && ex.getMessage().startsWith("No result for XPath expression")) {
+               return "";
+           }
+           else {
+               throw ex;
+           }
+        }
     }
 
 }


### PR DESCRIPTION
Citrus currently reacts to failed XPath assertions by throwing exceptions. This pull request allows these to be treated as failures without disrupting the normal control flow of each test. There are no breaking changes to the API, although the behavior is necessarily changed. But the new behavior is optional and depends on a configuration property whose default maintains the current behavior of Citrus.

Therefore, this pull request maintains backward compatibility for existing Citrus tests, but offers a path forward for testers that choose to follow this approach to XPath evaluation.

The behavior is selected by the boolean property citrus.core.validation.xml.suppress_exceptions_on_xpath_evaluations. The default is false, which preserves the current behavior of Citrus. Setting the property to true enables the behavior changes implemented in this pull request.

The TestContext class maintains a list of exceptions thrown in the course of a test. Here, a parallel structure has been added to maintain a list of failures. Failures are described by a new immutable class, XpathAssertionResult. The finish method of TestCase sets the member variable testResult by examining the TestContext. A new method (evaluateTestResult) is called in order to set the value of testResult, setting it to failed if failures have been detected and the above property is true.

The XpathMessageValidator's validateMessage method validates a set of XPath expressions, throwing a ValidationException if any of them fail. In this pull request, this behavior is altered by the validateValues method, which is called from validateMessage. This method catches ValidationExceptions, and if the above property is true, it suppresses the exceptions and adds an XpathAssertionResult to the list of failures in the TestContext. If the property is false, it re-throws the ValidationException, which preserves the current behavior of Citrus.

The method extractVariables of class XpathPayloadVariableExtractor evaluates the XPath expressions in the TestContext against the current Message, and stores the result of each evaluation as a variable in the TestContext. If the evaluation finds no result, it throws a CitrusRuntimeException. This pull request alters this behavior (as usual, controlled by the property, and preserving the current behavior when it is false) by catching CitrusRuntimeExceptions and producing a value of an empty string. The use of the empty string is significant because this result becomes the value of a Citrus variable, which cannot be null.