### PR TITLE
fix(#715): False positive test report with Cucumber

### DIFF
--- a/core/citrus-api/src/main/java/com/consol/citrus/TestCase.java
+++ b/core/citrus-api/src/main/java/com/consol/citrus/TestCase.java
@@ -111,6 +111,12 @@ public interface TestCase extends TestActionContainer, TestActionListenersAware 
     void setTestResult(final TestResult testResult);
 
     /**
+     * Retrieve test result.
+     * @return
+     */
+    TestResult getTestResult();
+
+    /**
      * Marks this test case as Java DSL test runner.
      * @return
      */

--- a/core/citrus-api/src/main/java/com/consol/citrus/context/TestContext.java
+++ b/core/citrus-api/src/main/java/com/consol/citrus/context/TestContext.java
@@ -200,9 +200,9 @@ public class TestContext implements ReferenceResolverAware {
         } else if (variables.containsKey(variableName)) {
             return variables.get(variableName);
         } else if (variableName.contains(".")) {
-            String objectName = variableName.substring(0, variableName.indexOf("."));
+            String objectName = variableName.substring(0, variableName.indexOf('.'));
             if (variables.containsKey(objectName)) {
-                return getVariable(variables.get(objectName), variableName.substring(variableName.indexOf(".") + 1));
+                return getVariable(variables.get(objectName), variableName.substring(variableName.indexOf('.') + 1));
             }
         }
 
@@ -220,8 +220,8 @@ public class TestContext implements ReferenceResolverAware {
         String leftOver = null;
         String fieldName;
         if (pathExpression.contains(".")) {
-            fieldName = pathExpression.substring(0, pathExpression.indexOf("."));
-            leftOver = pathExpression.substring(pathExpression.indexOf(".") + 1);
+            fieldName = pathExpression.substring(0, pathExpression.indexOf('.'));
+            leftOver = pathExpression.substring(pathExpression.indexOf('.') + 1);
         } else {
             fieldName = pathExpression;
         }
@@ -260,7 +260,7 @@ public class TestContext implements ReferenceResolverAware {
         }
 
         if (log.isDebugEnabled()) {
-            log.debug("Setting variable: " + VariableUtils.cutOffVariablesPrefix(variableName) + " with value: '" + value + "'");
+            log.debug(String.format("Setting variable: %s with value: '%s'", VariableUtils.cutOffVariablesPrefix(variableName), value));
         }
 
         variables.put(VariableUtils.cutOffVariablesPrefix(variableName), value);
@@ -713,13 +713,7 @@ public class TestContext implements ReferenceResolverAware {
      * @param receivedMessage
      */
     public void onInboundMessage(Message receivedMessage) {
-        if (messageListeners != null && !messageListeners.isEmpty()) {
-            messageListeners.onInboundMessage(receivedMessage, this);
-        } else {
-            if (log.isDebugEnabled()) {
-                log.debug("Received message:" + System.getProperty("line.separator") + (receivedMessage != null ? receivedMessage.toString() : ""));
-            }
-        }
+        logMessage("Receive", receivedMessage);
     }
 
     /**
@@ -728,11 +722,20 @@ public class TestContext implements ReferenceResolverAware {
      * @param message
      */
     public void onOutboundMessage(Message message) {
+        logMessage("Send", message);
+    }
+
+    /**
+     * Informs message listeners if present that new outbound message is about to be sent.
+     *
+     * @param message
+     */
+    private void logMessage(String operation, Message message) {
         if (messageListeners != null && !messageListeners.isEmpty()) {
             messageListeners.onOutboundMessage(message, this);
         } else {
             if (log.isDebugEnabled()) {
-                log.debug("Sent message:" + System.getProperty("line.separator") + message.toString());
+                log.debug(String.format("%s message:%n%s", operation, Optional.ofNullable(message).map(Message::toString).orElse("")));
             }
         }
     }

--- a/core/citrus-api/src/main/java/com/consol/citrus/context/TestContext.java
+++ b/core/citrus-api/src/main/java/com/consol/citrus/context/TestContext.java
@@ -942,6 +942,11 @@ public class TestContext implements ReferenceResolverAware {
         }
 
         @Override
+        public TestResult getTestResult() {
+            return null;
+        }
+
+        @Override
         public void addFinalAction(TestActionBuilder<?> action) {
             // do nothing
         }

--- a/core/citrus-base/src/main/java/com/consol/citrus/DefaultTestCase.java
+++ b/core/citrus-base/src/main/java/com/consol/citrus/DefaultTestCase.java
@@ -416,6 +416,11 @@ public class DefaultTestCase extends AbstractActionContainer implements TestCase
     }
 
     @Override
+    public TestResult getTestResult() {
+        return testResult;
+    }
+
+    @Override
     public String[] getGroups() {
         return groups;
     }

--- a/runtime/citrus-cucumber/src/main/java/com/consol/citrus/cucumber/CitrusLifecycleHooks.java
+++ b/runtime/citrus-cucumber/src/main/java/com/consol/citrus/cucumber/CitrusLifecycleHooks.java
@@ -17,10 +17,14 @@
 package com.consol.citrus.cucumber;
 
 import com.consol.citrus.Citrus;
+import com.consol.citrus.TestCase;
 import com.consol.citrus.TestCaseRunner;
+import com.consol.citrus.TestResult;
 import com.consol.citrus.annotations.CitrusFramework;
 import com.consol.citrus.annotations.CitrusResource;
+import com.consol.citrus.context.TestContext;
 import com.consol.citrus.cucumber.backend.Scenario;
+import com.consol.citrus.exceptions.CitrusRuntimeException;
 import io.cucumber.java.After;
 import io.cucumber.java.Before;
 
@@ -36,6 +40,9 @@ public class CitrusLifecycleHooks {
     @CitrusResource
     protected TestCaseRunner runner;
 
+    @CitrusResource
+    private TestContext context;
+
     @Before
     public void before(Scenario scenario) {
         if (runner != null) {
@@ -48,6 +55,15 @@ public class CitrusLifecycleHooks {
     @After
     public void after(Scenario scenario) {
         if (runner != null) {
+            if (context != null && scenario.isFailed()) {
+                TestCase testCase = runner.getTestCase();
+                TestResult testResult = testCase.getTestResult();
+                if (testResult == null || !testResult.isFailed()) {
+                    runner.getTestCase().setTestResult(TestResult.failed(testCase.getName(), testCase.getTestClass().getName(),
+                            new CitrusRuntimeException(String.format("Scenario %s status %s", scenario.getId(), scenario.getStatus().name()))));
+                }
+            }
+
             runner.stop();
         }
     }

--- a/runtime/citrus-cucumber/src/test/java/com/consol/citrus/cucumber/backend/CitrusLifecycleHooksTest.java
+++ b/runtime/citrus-cucumber/src/test/java/com/consol/citrus/cucumber/backend/CitrusLifecycleHooksTest.java
@@ -1,0 +1,119 @@
+package com.consol.citrus.cucumber.backend;
+
+import com.consol.citrus.DefaultTestCase;
+import com.consol.citrus.TestCase;
+import com.consol.citrus.TestCaseRunner;
+import com.consol.citrus.TestResult;
+import com.consol.citrus.annotations.CitrusAnnotations;
+import com.consol.citrus.cucumber.CitrusLifecycleHooks;
+import com.consol.citrus.cucumber.UnitTestSupport;
+import com.consol.citrus.exceptions.CitrusRuntimeException;
+import com.consol.citrus.exceptions.ValidationException;
+import io.cucumber.core.backend.Status;
+import io.cucumber.core.backend.TestCaseState;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class CitrusLifecycleHooksTest extends UnitTestSupport {
+
+    @Mock
+    private TestCaseState state;
+
+    @Mock
+    private TestCaseRunner runner;
+
+    private CitrusLifecycleHooks citrusLifecycleHooks;
+
+    @BeforeMethod
+    public void setupMocks() {
+        MockitoAnnotations.initMocks(this);
+        citrusLifecycleHooks = new CitrusLifecycleHooks();
+        CitrusAnnotations.injectTestContext(citrusLifecycleHooks, context);
+        CitrusAnnotations.injectTestRunner(citrusLifecycleHooks, runner);
+    }
+
+    @Test
+    public void shouldStartTestCaseRunner() {
+        when(state.getId()).thenReturn("mockedScenario");
+        when(state.getName()).thenReturn("This is a mocked scenario");
+
+        citrusLifecycleHooks.before(new Scenario(state));
+        verify(runner).name("mockedScenario");
+        verify(runner).description("This is a mocked scenario");
+        verify(runner).start();
+    }
+
+    @Test
+    public void shouldHandleSuccessfulScenario() {
+        when(state.isFailed()).thenReturn(false);
+        citrusLifecycleHooks.after(new Scenario(state));
+
+        verify(runner).stop();
+        verify(runner, never()).getTestCase();
+    }
+
+    @Test
+    public void shouldOverwriteFailureState() {
+        TestCase testCase = new DefaultTestCase();
+        testCase.setTestResult(TestResult.success("foo", "FooClass"));
+
+        when(state.getId()).thenReturn("mockedScenario");
+        when(state.getStatus()).thenReturn(Status.FAILED);
+        when(state.isFailed()).thenReturn(true);
+        when(runner.getTestCase()).thenReturn(testCase);
+        citrusLifecycleHooks.after(new Scenario(state));
+
+        Assert.assertTrue(testCase.getTestResult().isFailed());
+        Assert.assertEquals(testCase.getTestResult().getCause().getClass(), CitrusRuntimeException.class);
+        Assert.assertEquals(testCase.getTestResult().getCause().getMessage(), "Scenario mockedScenario status FAILED");
+
+        verify(runner).stop();
+        verify(runner, atLeastOnce()).getTestCase();
+    }
+
+    @Test
+    public void shouldOverwriteEmptyTestResult() {
+        TestCase testCase = new DefaultTestCase();
+
+        when(state.getId()).thenReturn("mockedScenario");
+        when(state.getStatus()).thenReturn(Status.FAILED);
+        when(state.isFailed()).thenReturn(true);
+        when(runner.getTestCase()).thenReturn(testCase);
+        citrusLifecycleHooks.after(new Scenario(state));
+
+        Assert.assertTrue(testCase.getTestResult().isFailed());
+        Assert.assertEquals(testCase.getTestResult().getCause().getClass(), CitrusRuntimeException.class);
+        Assert.assertEquals(testCase.getTestResult().getCause().getMessage(), "Scenario mockedScenario status FAILED");
+
+        verify(runner).stop();
+        verify(runner, atLeastOnce()).getTestCase();
+    }
+
+    @Test
+    public void shouldPreserveTestCaseFailure() {
+        TestCase testCase = new DefaultTestCase();
+        testCase.setTestResult(TestResult.failed("foo", "FooClass", new ValidationException("Error!")));
+
+        when(state.isFailed()).thenReturn(true);
+        when(runner.getTestCase()).thenReturn(testCase);
+        citrusLifecycleHooks.after(new Scenario(state));
+
+        Assert.assertTrue(testCase.getTestResult().isFailed());
+        Assert.assertEquals(testCase.getTestResult().getCause().getClass(), ValidationException.class);
+        Assert.assertEquals(testCase.getTestResult().getCause().getMessage(), "Error!");
+
+        verify(runner).stop();
+        verify(runner, atLeastOnce()).getTestCase();
+    }
+}


### PR DESCRIPTION
Make sure to report the Citrus test as failed when the Cucumber scenario is marked as failed. At the same time preserve Citrus failure information when present.