### PR TITLE
fix(#775): Fix unit tests on SleepAction XML bean definition parser

### DIFF
--- a/core/citrus-base/src/main/java/com/consol/citrus/actions/SleepAction.java
+++ b/core/citrus-base/src/main/java/com/consol/citrus/actions/SleepAction.java
@@ -38,7 +38,7 @@ public class SleepAction extends AbstractTestAction {
     private final TimeUnit timeUnit;
 
     /** Logger */
-    private static Logger log = LoggerFactory.getLogger(SleepAction.class);
+    private static final Logger LOG = LoggerFactory.getLogger(SleepAction.class);
 
     /**
      * Default constructor.
@@ -56,11 +56,28 @@ public class SleepAction extends AbstractTestAction {
         String duration = context.resolveDynamicValue(time);
 
         try {
-            log.info(String.format("Sleeping %s %s", duration, timeUnit.toString()));
+            LOG.info(String.format("Sleeping %s %s", duration, timeUnit));
 
-            timeUnit.sleep(Long.parseLong(duration));
+            if (duration.indexOf(".") > 0) {
+                switch (timeUnit) {
+                    case MILLISECONDS:
+                        TimeUnit.MILLISECONDS.sleep(Math.round(Double.parseDouble(duration)));
+                        break;
+                    case SECONDS:
+                        TimeUnit.MILLISECONDS.sleep(Math.round(Double.parseDouble(duration) * 1000));
+                        break;
+                    case MINUTES:
+                        TimeUnit.MILLISECONDS.sleep(Math.round(Double.parseDouble(duration) * 60 * 1000));
+                        break;
+                    default:
+                        throw new CitrusRuntimeException("Unsupported time expression for sleep action - " +
+                                "please use one of milliseconds, seconds, minutes");
+                }
+            } else {
+                timeUnit.sleep(Long.parseLong(duration));
+            }
 
-            log.info(String.format("Returning after %s %s", duration, timeUnit.toString()));
+            LOG.info(String.format("Returning after %s %s", duration, timeUnit));
         } catch (InterruptedException e) {
             throw new CitrusRuntimeException(e);
         }

--- a/core/citrus-base/src/test/java/com/consol/citrus/actions/SleepActionTest.java
+++ b/core/citrus-base/src/test/java/com/consol/citrus/actions/SleepActionTest.java
@@ -58,6 +58,27 @@ public class SleepActionTest extends AbstractTestNGUnitTest {
     }
 
     @Test
+    public void testSleepDecimalValueSupport() {
+        SleepAction sleep = new SleepAction.Builder()
+                .time("500.0", TimeUnit.MILLISECONDS)
+                .build();
+
+        sleep.execute(context);
+
+        sleep = new SleepAction.Builder()
+                .time("0.5", TimeUnit.SECONDS)
+                .build();
+
+        sleep.execute(context);
+
+        sleep = new SleepAction.Builder()
+                .time("0.01", TimeUnit.MINUTES)
+                .build();
+
+        sleep.execute(context);
+    }
+
+    @Test
     public void testSleepLegacy() {
         SleepAction sleep = new SleepAction.Builder()
                 .seconds(0.1)

--- a/core/citrus-spring/src/main/java/com/consol/citrus/config/xml/SleepActionParser.java
+++ b/core/citrus-spring/src/main/java/com/consol/citrus/config/xml/SleepActionParser.java
@@ -16,6 +16,8 @@
 
 package com.consol.citrus.config.xml;
 
+import java.util.concurrent.TimeUnit;
+
 import com.consol.citrus.actions.SleepAction;
 import com.consol.citrus.config.util.BeanDefinitionParserUtils;
 import org.springframework.beans.factory.config.BeanDefinition;
@@ -23,8 +25,6 @@ import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.BeanDefinitionParser;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.w3c.dom.Element;
-
-import java.util.concurrent.TimeUnit;
 
 /**
  * Bean definition parser for sleep action in test case.
@@ -62,7 +62,7 @@ public class SleepActionParser implements BeanDefinitionParser {
         }
 
         public void setTime(String time) {
-            builder.time(time);
+            builder.time(time, TimeUnit.SECONDS);
         }
 
         @Override

--- a/core/citrus-spring/src/test/java/com/consol/citrus/config/xml/SleepActionParserTest.java
+++ b/core/citrus-spring/src/test/java/com/consol/citrus/config/xml/SleepActionParserTest.java
@@ -39,12 +39,12 @@ public class SleepActionParserTest extends AbstractActionParserTest<SleepAction>
         Assert.assertEquals(action.getTimeUnit(), TimeUnit.MILLISECONDS);
 
         action = getNextTestActionFromTest();
-        Assert.assertEquals(action.getTime(), "1500");
-        Assert.assertEquals(action.getTimeUnit(), TimeUnit.MILLISECONDS);
+        Assert.assertEquals(action.getTime(), "1.5");
+        Assert.assertEquals(action.getTimeUnit(), TimeUnit.SECONDS);
 
         action = getNextTestActionFromTest();
-        Assert.assertEquals(action.getTime(), "1500");
-        Assert.assertEquals(action.getTimeUnit(), TimeUnit.MILLISECONDS);
+        Assert.assertEquals(action.getTime(), "1.5");
+        Assert.assertEquals(action.getTimeUnit(), TimeUnit.SECONDS);
 
         action = getNextTestActionFromTest();
         Assert.assertEquals(action.getTime(), "1500");


### PR DESCRIPTION
- Make sure to use seconds time unit when setting "time" attribute on sleep action in XML
- Properly convert seconds, minutes and decimal time values to milliseconds in sleep action