### PR TITLE
fix(#644): Cache server responses according to servlet request

### DIFF
--- a/endpoints/citrus-http/src/main/java/com/consol/citrus/http/config/annotation/HttpServerConfig.java
+++ b/endpoints/citrus-http/src/main/java/com/consol/citrus/http/config/annotation/HttpServerConfig.java
@@ -136,6 +136,12 @@ public @interface HttpServerConfig {
     HttpStatus defaultStatus() default HttpStatus.OK;
 
     /**
+     * Server default response cache size.
+     * @return
+     */
+    int responseCacheSize() default 100;
+
+    /**
      * Binary media types.
      * @return
      */

--- a/endpoints/citrus-http/src/main/java/com/consol/citrus/http/config/annotation/HttpServerConfigParser.java
+++ b/endpoints/citrus-http/src/main/java/com/consol/citrus/http/config/annotation/HttpServerConfigParser.java
@@ -136,6 +136,7 @@ public class HttpServerConfigParser implements AnnotationConfigParser<HttpServer
         }
 
         builder.defaultStatus(annotation.defaultStatus());
+        builder.responseCacheSize(annotation.responseCacheSize());
 
         return builder.initialize().build();
     }

--- a/endpoints/citrus-http/src/main/java/com/consol/citrus/http/config/xml/HttpServerParser.java
+++ b/endpoints/citrus-http/src/main/java/com/consol/citrus/http/config/xml/HttpServerParser.java
@@ -26,7 +26,7 @@ import org.w3c.dom.Element;
 
 /**
  * Parser for Http server implementation in Citrus http namespace.
- * 
+ *
  * @author Christoph Deppisch
  */
 public class HttpServerParser extends AbstractServerParser {
@@ -54,6 +54,7 @@ public class HttpServerParser extends AbstractServerParser {
         BeanDefinitionParserUtils.setPropertyValue(builder, element.getAttribute("handle-header-attributes"), "handleAttributeHeaders");
         BeanDefinitionParserUtils.setPropertyValue(builder, element.getAttribute("handle-cookies"), "handleCookies");
         BeanDefinitionParserUtils.setPropertyValue(builder, element.getAttribute("default-status-code"), "defaultStatusCode");
+        BeanDefinitionParserUtils.setPropertyValue(builder, element.getAttribute("response-cache-size"), "responseCacheSize");
     }
 
     @Override

--- a/endpoints/citrus-http/src/main/java/com/consol/citrus/http/server/AbstractHttpServerBuilder.java
+++ b/endpoints/citrus-http/src/main/java/com/consol/citrus/http/server/AbstractHttpServerBuilder.java
@@ -233,6 +233,16 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
     }
 
     /**
+     * Sets the default response cache size on this server instance.
+     * @param size
+     * @return
+     */
+    public B responseCacheSize(int size) {
+        endpoint.setResponseCacheSize(size);
+        return self;
+    }
+
+    /**
      * Sets the interceptors.
      * @param interceptors
      * @return

--- a/endpoints/citrus-http/src/main/java/com/consol/citrus/http/server/HttpServer.java
+++ b/endpoints/citrus-http/src/main/java/com/consol/citrus/http/server/HttpServer.java
@@ -114,6 +114,9 @@ public class HttpServer extends AbstractServer {
     /** Default status code returned by http server */
     private int defaultStatusCode = HttpStatus.OK.value();
 
+    /** Default size of in memory response cahce for message tracing reasons */
+    private int responseCacheSize = HttpServerSettings.responseCacheSize();
+
     /** List of media types that should be handled with binary content processing */
     private List<MediaType> binaryMediaTypes = Arrays.asList(MediaType.APPLICATION_OCTET_STREAM,
                                                                 MediaType.APPLICATION_PDF,
@@ -548,6 +551,22 @@ public class HttpServer extends AbstractServer {
      */
     public void setHandleCookies(boolean handleCookies) {
         this.handleCookies = handleCookies;
+    }
+
+    /**
+     * Gets the response cache size.
+     * @return
+     */
+    public int getResponseCacheSize() {
+        return responseCacheSize;
+    }
+
+    /**
+     * Sets the response cache size.
+     * @param responseCacheSize
+     */
+    public void setResponseCacheSize(int responseCacheSize) {
+        this.responseCacheSize = responseCacheSize;
     }
 
     /**

--- a/endpoints/citrus-http/src/main/java/com/consol/citrus/http/server/HttpServerSettings.java
+++ b/endpoints/citrus-http/src/main/java/com/consol/citrus/http/server/HttpServerSettings.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.consol.citrus.http.server;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class HttpServerSettings {
+
+    private static final String RESPONSE_CACHE_SIZE_PROPERTY = "citrus.http.server.response.cache.size";
+    private static final String RESPONSE_CACHE_SIZE_ENV = "CITRUS_HTTP_SERVER_RESPONSE_CACHE_SIZE";
+    private static final String RESPONSE_CACHE_SIZE_DEFAULT = "100";
+
+    /**
+     * Private constructor prevent instantiation of utility class
+     */
+    private HttpServerSettings() {
+        // prevent instantiation
+    }
+
+    /**
+     * The server response cache size. Each server instance holds this amount of response content in an in memory cache for
+     * message tracing reasons.
+     * @return
+     */
+    public static int responseCacheSize() {
+        return Integer.parseInt(System.getProperty(RESPONSE_CACHE_SIZE_PROPERTY, System.getenv(RESPONSE_CACHE_SIZE_ENV) != null ?
+                        System.getenv(RESPONSE_CACHE_SIZE_ENV) : RESPONSE_CACHE_SIZE_DEFAULT));
+    }
+}

--- a/endpoints/citrus-http/src/main/java/com/consol/citrus/http/servlet/CitrusDispatcherServlet.java
+++ b/endpoints/citrus-http/src/main/java/com/consol/citrus/http/servlet/CitrusDispatcherServlet.java
@@ -107,6 +107,8 @@ public class CitrusDispatcherServlet extends DispatcherServlet {
             endpointConfiguration.setDefaultStatusCode(httpServer.getDefaultStatusCode());
             messageController.setEndpointConfiguration(endpointConfiguration);
 
+            messageController.setResponseCacheSize(httpServer.getResponseCacheSize());
+
             if (endpointAdapter != null) {
                 messageController.setEndpointAdapter(endpointAdapter);
             }

--- a/endpoints/citrus-http/src/main/resources/com/consol/citrus/schema/citrus-http-config-3.0.0-SNAPSHOT.xsd
+++ b/endpoints/citrus-http/src/main/resources/com/consol/citrus/schema/citrus-http-config-3.0.0-SNAPSHOT.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- 
+<!--
  * Copyright 2006-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,7 +19,7 @@
      targetNamespace="http://www.citrusframework.org/schema/http/config"
      elementFormDefault="qualified"
      attributeFormDefault="unqualified">
-    
+
     <xs:element name="server">
       <xs:annotation>
         <xs:documentation>Http server implementation accepts client connections and receives messages via Http transport protocol.</xs:documentation>
@@ -47,6 +47,7 @@
         <xs:attribute name="handle-header-attributes" type="xs:boolean"/>
         <xs:attribute name="handle-cookies" type="xs:boolean"/>
         <xs:attribute name="default-status-code" type="xs:string"/>
+        <xs:attribute name="response-cache-size" type="xs:integer"/>
         <xs:attribute name="interceptors" type="xs:string"/>
         <xs:attribute name="debug-logging" type="xs:boolean"/>
         <xs:attribute name="actor" type="xs:string"/>

--- a/endpoints/citrus-http/src/main/resources/com/consol/citrus/schema/citrus-http-config.xsd
+++ b/endpoints/citrus-http/src/main/resources/com/consol/citrus/schema/citrus-http-config.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- 
+<!--
  * Copyright 2006-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,7 +19,7 @@
      targetNamespace="http://www.citrusframework.org/schema/http/config"
      elementFormDefault="qualified"
      attributeFormDefault="unqualified">
-    
+
     <xs:element name="server">
       <xs:annotation>
         <xs:documentation>Http server implementation accepts client connections and receives messages via Http transport protocol.</xs:documentation>
@@ -47,6 +47,7 @@
         <xs:attribute name="handle-header-attributes" type="xs:boolean"/>
         <xs:attribute name="handle-cookies" type="xs:boolean"/>
         <xs:attribute name="default-status-code" type="xs:string"/>
+        <xs:attribute name="response-cache-size" type="xs:integer"/>
         <xs:attribute name="interceptors" type="xs:string"/>
         <xs:attribute name="debug-logging" type="xs:boolean"/>
         <xs:attribute name="actor" type="xs:string"/>

--- a/endpoints/citrus-http/src/test/java/com/consol/citrus/http/config/xml/HttpServerParserTest.java
+++ b/endpoints/citrus-http/src/test/java/com/consol/citrus/http/config/xml/HttpServerParserTest.java
@@ -27,6 +27,7 @@ import com.consol.citrus.endpoint.adapter.EmptyResponseEndpointAdapter;
 import com.consol.citrus.endpoint.adapter.StaticResponseEndpointAdapter;
 import com.consol.citrus.endpoint.adapter.TimeoutProducingEndpointAdapter;
 import com.consol.citrus.http.server.HttpServer;
+import com.consol.citrus.http.server.HttpServerSettings;
 import com.consol.citrus.jms.endpoint.JmsEndpointAdapter;
 import com.consol.citrus.jms.endpoint.JmsEndpointConfiguration;
 import com.consol.citrus.testng.AbstractBeanDefinitionParserTest;
@@ -64,6 +65,7 @@ public class HttpServerParserTest extends AbstractBeanDefinitionParserTest {
         Assert.assertFalse(server.isDebugLogging());
         Assert.assertFalse(server.isUseRootContextAsParent());
         Assert.assertEquals(server.getDefaultStatusCode(), HttpStatus.OK.value());
+        Assert.assertEquals(server.getResponseCacheSize(), HttpServerSettings.responseCacheSize());
         Assert.assertEquals(server.getContextPath(), "/");
         Assert.assertEquals(server.getServletName(), "httpServer1-servlet");
         Assert.assertEquals(server.getServletMappingPath(), "/*");
@@ -85,6 +87,7 @@ public class HttpServerParserTest extends AbstractBeanDefinitionParserTest {
         Assert.assertTrue(server.isDebugLogging());
         Assert.assertTrue(server.isUseRootContextAsParent());
         Assert.assertEquals(server.getDefaultStatusCode(), HttpStatus.NOT_FOUND.value());
+        Assert.assertEquals(server.getResponseCacheSize(), 1000);
         Assert.assertEquals(server.getContextPath(), "/citrus");
         Assert.assertEquals(server.getServletName(), "citrus-http");
         Assert.assertEquals(server.getServletMappingPath(), "/foo");

--- a/endpoints/citrus-http/src/test/resources/com/consol/citrus/http/config/xml/HttpServerParserTest-context.xml
+++ b/endpoints/citrus-http/src/test/resources/com/consol/citrus/http/config/xml/HttpServerParserTest-context.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans  xmlns="http://www.springframework.org/schema/beans"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns:citrus-http="http://www.citrusframework.org/schema/http/config" 
+        xmlns:citrus-http="http://www.citrusframework.org/schema/http/config"
         xmlns:util="http://www.springframework.org/schema/util"
-        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd 
+        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
                             http://www.citrusframework.org/schema/http/config http://www.citrusframework.org/schema/http/config/citrus-http-config.xsd
                             http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
-    
+
     <citrus-http:server id="httpServer1"
                         auto-start="false"
                         port="8081"/>
-                        
+
     <citrus-http:server id="httpServer2"
                         auto-start="false"
                         port="8082"
@@ -22,12 +22,13 @@
                         resource-base="src/it/resources"
                         root-parent-context="true"
                         default-status-code="404"
+                        response-cache-size="1000"
                         binary-media-types="binaryMediaTypes"
                         debug-logging="true"
                         context-path="/citrus"
                         servlet-name="citrus-http"
                         servlet-mapping-path="/foo"/>
-                        
+
     <citrus-http:server id="httpServer3"
                         auto-start="false"
                         port="8083"
@@ -39,7 +40,7 @@
                         auto-start="false"
                         port="8084"
                         servlet-handler="servletHandler"/>
-    
+
     <citrus-http:server id="httpServer5"
                         auto-start="false"
                         port="8085"
@@ -54,7 +55,7 @@
         <constructor-arg value="org.springframework.web.servlet.HandlerInterceptor"/>
       </bean>
     </util:list>
-    
+
     <util:list id="connectors">
         <bean id="connector1" class="org.mockito.Mockito" factory-method="mock">
           <constructor-arg value="org.eclipse.jetty.server.Connector"/>
@@ -93,7 +94,7 @@
     <bean id="connector" class="org.mockito.Mockito" factory-method="mock">
         <constructor-arg value="org.eclipse.jetty.server.Connector"/>
     </bean>
-    
+
     <bean id="securityHandler" class="com.consol.citrus.http.security.SecurityHandlerFactory">
         <property name="users">
             <list>
@@ -114,7 +115,7 @@
             </map>
         </property>
     </bean>
-                
+
     <bean id ="servletHandler" class="org.mockito.Mockito" factory-method="mock">
         <constructor-arg value="org.eclipse.jetty.servlet.ServletHandler"/>
     </bean>

--- a/validation/citrus-validation-json/src/main/java/com/consol/citrus/json/JsonSettings.java
+++ b/validation/citrus-validation-json/src/main/java/com/consol/citrus/json/JsonSettings.java
@@ -26,7 +26,6 @@ import net.minidev.json.parser.JSONParser;
  */
 public final class JsonSettings {
 
-
     private static final String MESSAGE_VALIDATION_STRICT_PROPERTY = "citrus.json.message.validation.strict";
     private static final String MESSAGE_VALIDATION_STRICT_ENV = "CITRUS_JSON_MESSAGE_VALIDATION_STRICT";
     private static final String MESSAGE_VALIDATION_STRICT_DEFAULT = "true";


### PR DESCRIPTION
- Introduce map cache with servlet request as key and response as value
- Access cache with servlet request to make sure that multiple handler interceptors get the very same response content
- Introduce cache size to avoid memory issues with long running server instances
- Automatically clear cache when maximum number of responses is reached

This fixes #644 with multiple logging interceptor handlers calling for the response content. All interceptors access the cache with the same servlet request. This makes sure that each interceptor gets access to the very same response content.

The downside is that the in memory cache will grow with every communication on the server. Therefore a maximum cache size has been introduced and a mechanism to automatically free the cache when it is full.