### PR TITLE
fix: Fix bean names for legacy projects

### DIFF
--- a/core/citrus-spring/src/main/java/com/consol/citrus/config/xml/AbstractEndpointParser.java
+++ b/core/citrus-spring/src/main/java/com/consol/citrus/config/xml/AbstractEndpointParser.java
@@ -43,6 +43,8 @@ public abstract class AbstractEndpointParser extends AbstractBeanDefinitionParse
         BeanDefinitionBuilder configurationBuilder = BeanDefinitionBuilder.genericBeanDefinition(getEndpointConfigurationClass());
         parseEndpointConfiguration(configurationBuilder, element, parserContext);
 
+        endpointBuilder.addPropertyValue("name", element.getAttribute(ID_ATTRIBUTE));
+
         String endpointConfigurationId = element.getAttribute(ID_ATTRIBUTE) + "Configuration";
         BeanDefinitionParserUtils.registerBean(endpointConfigurationId, configurationBuilder.getBeanDefinition(), parserContext, shouldFireEvents());
 

--- a/endpoints/citrus-http/src/test/java/com/consol/citrus/http/config/xml/HttpClientParserTest.java
+++ b/endpoints/citrus-http/src/test/java/com/consol/citrus/http/config/xml/HttpClientParserTest.java
@@ -46,6 +46,7 @@ public class HttpClientParserTest extends AbstractBeanDefinitionParserTest {
 
         // 1st message sender
         HttpClient httpClient = clients.get("httpClient1");
+        Assert.assertEquals(httpClient.getName(), "httpClient1");
         Assert.assertNotNull(httpClient.getEndpointConfiguration().getRestTemplate());
         Assert.assertEquals(httpClient.getEndpointConfiguration().getRequestUrl(), "http://localhost:8080/test");
         Assert.assertEquals(httpClient.getEndpointConfiguration().getRestTemplate().getRequestFactory().getClass(), InterceptingClientHttpRequestFactory.class);


### PR DESCRIPTION
Legacy Citrus projects may not receive correct bean names according to XML configuration with id attributes set on bean elements. This is because com.consol.citrus.config.ComponentLifecycleProcessor is not set properly. Users must add ComponentLifecycleProcessor manually or benefit from this fix.