### PR TITLE
fix(#802): Simplify registry binding operations

### DIFF
--- a/core/citrus-api/src/main/java/com/consol/citrus/CitrusSettings.java
+++ b/core/citrus-api/src/main/java/com/consol/citrus/CitrusSettings.java
@@ -82,16 +82,10 @@ public final class CitrusSettings {
     public static final String VARIABLE_SUFFIX = "}";
     public static final String VARIABLE_ESCAPE = "//";
 
-    /** Default application context name */
-    public static final String DEFAULT_APPLICATION_CONTEXT_PROPERTY = "citrus.spring.application.context";
-    public static final String DEFAULT_APPLICATION_CONTEXT_ENV = "CITRUS_SPRING_APPLICATION_CONTEXT";
-    public static final String DEFAULT_APPLICATION_CONTEXT = System.getProperty(DEFAULT_APPLICATION_CONTEXT_PROPERTY, System.getenv(DEFAULT_APPLICATION_CONTEXT_ENV) != null ?
-            System.getenv(DEFAULT_APPLICATION_CONTEXT_ENV) : "classpath*:citrus-context.xml");
-
     /** Default application context class */
-    public static final String DEFAULT_APPLICATION_CONTEXT_CLASS_PROPERTY = "citrus.spring.java.config";
-    public static final String DEFAULT_APPLICATION_CONTEXT_CLASS_ENV = "CITRUS_SPRING_JAVA_CONFIG";
-    public static final String DEFAULT_APPLICATION_CONTEXT_CLASS = System.getProperty(DEFAULT_APPLICATION_CONTEXT_CLASS_PROPERTY, System.getenv(DEFAULT_APPLICATION_CONTEXT_CLASS_ENV));
+    public static final String DEFAULT_CONFIG_CLASS_PROPERTY = "citrus.java.config";
+    public static final String DEFAULT_CONFIG_CLASS_ENV = "CITRUS_JAVA_CONFIG";
+    public static final String DEFAULT_CONFIG_CLASS = System.getProperty(DEFAULT_CONFIG_CLASS_PROPERTY, System.getenv(DEFAULT_CONFIG_CLASS_ENV));
 
     /** Default test directories */
     public static final String DEFAULT_TEST_SRC_DIRECTORY_PROPERTY = "citrus.default.src.directory";

--- a/core/citrus-api/src/main/java/com/consol/citrus/annotations/CitrusConfiguration.java
+++ b/core/citrus-api/src/main/java/com/consol/citrus/annotations/CitrusConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with
@@ -17,30 +17,21 @@
  * limitations under the License.
  */
 
-package com.consol.citrus.testng;
+package com.consol.citrus.annotations;
 
-import org.testng.ITestContext;
-import org.testng.annotations.AfterSuite;
-import org.testng.annotations.BeforeSuite;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * @author Christoph Deppisch
  */
-public interface TestNGSuiteListener {
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Target({ ElementType.TYPE })
+public @interface CitrusConfiguration {
 
-    /**
-     * Runs tasks before test suite.
-     * @param testContext the test context.
-     */
-    @BeforeSuite(alwaysRun = true)
-    default void beforeSuite(ITestContext testContext) {
-    }
-
-    /**
-     * Runs tasks after test suite.
-     * @param testContext the test context.
-     */
-    @AfterSuite(alwaysRun = true)
-    default void afterSuite(ITestContext testContext) {
-    }
+    Class<?>[] classes() default {};
 }

--- a/core/citrus-api/src/main/java/com/consol/citrus/spi/BindToRegistry.java
+++ b/core/citrus-api/src/main/java/com/consol/citrus/spi/BindToRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with
@@ -17,30 +17,26 @@
  * limitations under the License.
  */
 
-package com.consol.citrus.testng;
+package com.consol.citrus.spi;
 
-import org.testng.ITestContext;
-import org.testng.annotations.AfterSuite;
-import org.testng.annotations.BeforeSuite;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
+ * Used to bind an object to the Citrus context reference registry for dependency injection reasons.
+ *
+ * Object is bound with given name. In case no explicit name is given the registry will auto compute the name from given
+ * Class name, method name or field name.
+ *
  * @author Christoph Deppisch
  */
-public interface TestNGSuiteListener {
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Target({ ElementType.FIELD, ElementType.METHOD })
+public @interface BindToRegistry {
 
-    /**
-     * Runs tasks before test suite.
-     * @param testContext the test context.
-     */
-    @BeforeSuite(alwaysRun = true)
-    default void beforeSuite(ITestContext testContext) {
-    }
-
-    /**
-     * Runs tasks after test suite.
-     * @param testContext the test context.
-     */
-    @AfterSuite(alwaysRun = true)
-    default void afterSuite(ITestContext testContext) {
-    }
+    String name() default "";
 }

--- a/core/citrus-api/src/main/java/com/consol/citrus/spi/ReferenceRegistry.java
+++ b/core/citrus-api/src/main/java/com/consol/citrus/spi/ReferenceRegistry.java
@@ -1,9 +1,29 @@
 package com.consol.citrus.spi;
 
+import org.springframework.util.StringUtils;
+
 /**
+ * Bind objects to registry for later reference. Objects declared in registry can be injected in various ways (e.g. annotations).
+ * Usually used in combination with {@link com.consol.citrus.spi.ReferenceResolver}.
+ *
  * @author Christoph Deppisch
  */
+@FunctionalInterface
 public interface ReferenceRegistry {
 
     void bind(String name, Object value);
+
+    /**
+     * Get proper bean name for future bind operation on registry.
+     * @param bindAnnotation
+     * @param defaultName
+     * @return
+     */
+    static String getName(BindToRegistry bindAnnotation, String defaultName) {
+        if (StringUtils.hasText(bindAnnotation.name())) {
+            return bindAnnotation.name();
+        }
+
+        return defaultName;
+    }
 }

--- a/core/citrus-api/src/main/java/com/consol/citrus/validation/MessageValidatorRegistry.java
+++ b/core/citrus-api/src/main/java/com/consol/citrus/validation/MessageValidatorRegistry.java
@@ -42,7 +42,7 @@ import org.springframework.util.StringUtils;
 public class MessageValidatorRegistry {
 
     /** Logger */
-    private static Logger log = LoggerFactory.getLogger(MessageValidatorRegistry.class);
+    private static final Logger LOG = LoggerFactory.getLogger(MessageValidatorRegistry.class);
 
     /** The default bean id in Spring application context*/
     public static final String BEAN_NAME = "citrusMessageValidatorRegistry";
@@ -54,7 +54,7 @@ public class MessageValidatorRegistry {
     private MessageValidator<? extends ValidationContext> defaultMessageHeaderValidator;
 
     /** Default empty message validator */
-    private DefaultEmptyMessageValidator defaultEmptyMessageValidator = new DefaultEmptyMessageValidator();
+    private final DefaultEmptyMessageValidator defaultEmptyMessageValidator = new DefaultEmptyMessageValidator();
 
     /**
      * Finds matching message validators for this message type.
@@ -93,12 +93,12 @@ public class MessageValidatorRegistry {
         }
 
         if (isEmptyOrDefault(matchingValidators)) {
-            log.warn(String.format("Unable to find proper message validator. Message type is '%s' and message payload is '%s'", messageType, message.getPayload(String.class)));
+            LOG.warn(String.format("Unable to find proper message validator. Message type is '%s' and message payload is '%s'", messageType, message.getPayload(String.class)));
             throw new CitrusRuntimeException("Failed to find proper message validator for message");
         }
 
-        if (log.isDebugEnabled()) {
-            log.debug(String.format("Found %s message validators for message", matchingValidators.size()));
+        if (LOG.isDebugEnabled()) {
+            LOG.debug(String.format("Found %s message validators for message", matchingValidators.size()));
         }
 
         return matchingValidators;
@@ -171,8 +171,8 @@ public class MessageValidatorRegistry {
      * @param messageValidator
      */
     public void addMessageValidator(String name, MessageValidator<? extends ValidationContext> messageValidator) {
-        if (this.messageValidators.containsKey(name) && log.isDebugEnabled()) {
-            log.debug(String.format("Overwriting message validator '%s' in registry", name));
+        if (this.messageValidators.containsKey(name) && LOG.isDebugEnabled()) {
+            LOG.debug(String.format("Overwriting message validator '%s' in registry", name));
         }
 
         this.messageValidators.put(name, messageValidator);

--- a/core/citrus-base/src/main/java/com/consol/citrus/Citrus.java
+++ b/core/citrus-base/src/main/java/com/consol/citrus/Citrus.java
@@ -48,7 +48,7 @@ public final class Citrus implements TestListenerAware, TestSuiteListenerAware, 
     }
 
     /**
-     * Initializing method with given Citrus context and its components
+     * Initializing method creating a Citrus instance with new default CitrusContext and its components
      * such as test listeners and test context factory.
      * @return
      */
@@ -57,12 +57,12 @@ public final class Citrus implements TestListenerAware, TestSuiteListenerAware, 
     }
 
     /**
-     * Initializing method with given Citrus context and its components
-     * such as test listeners and test context factory.
+     * Initializing method creating a Citrus instance with given Citrus context provider.
+     * Provider creates new CitrusContext and its components such as test listeners and test context factory.
      * @return
      */
-    public static Citrus newInstance(CitrusContext citrusContext) {
-        return CitrusInstanceManager.newInstance(citrusContext);
+    public static Citrus newInstance(CitrusContextProvider contextProvider) {
+        return CitrusInstanceManager.newInstance(contextProvider);
     }
 
     /**

--- a/core/citrus-base/src/main/java/com/consol/citrus/CitrusContextProvider.java
+++ b/core/citrus-base/src/main/java/com/consol/citrus/CitrusContextProvider.java
@@ -41,7 +41,11 @@ public interface CitrusContextProvider {
 
         if (provider.isEmpty()) {
             LOG.debug("Using default Citrus context provider");
-            return CitrusContext::create;
+            return new DefaultCitrusContextProvider();
+        }
+
+        if (provider.size() > 1) {
+            LOG.warn(String.format("Found %d Citrus context provider implementations. Please choose one of them.", provider.size()));
         }
 
         if (LOG.isDebugEnabled()) {

--- a/core/citrus-base/src/main/java/com/consol/citrus/CitrusInstanceManager.java
+++ b/core/citrus-base/src/main/java/com/consol/citrus/CitrusInstanceManager.java
@@ -32,27 +32,17 @@ public class CitrusInstanceManager {
      * @return
      */
     public static Citrus newInstance() {
-        if (strategy.equals(CitrusInstanceStrategy.NEW) || citrus == null) {
-            CitrusContextProvider contextProvider = CitrusContextProvider.lookup();
-            citrus = newInstance(contextProvider.create());
-        }
-
-        return citrus;
+        return newInstance(CitrusContextProvider.lookup());
     }
 
     /**
      * Create new Citrus instance with given context.
-     * @param citrusContext
+     * @param contextProvider
      * @return
      */
-    public static Citrus newInstance(CitrusContext citrusContext) {
-        if (strategy.equals(CitrusInstanceStrategy.NEW)) {
-            Citrus instance = new Citrus(citrusContext);
-            instanceProcessors.forEach(processor -> processor.process(instance));
-            citrus = instance;
-            return instance;
-        } else if (citrus == null) {
-            citrus = new Citrus(citrusContext);
+    public static Citrus newInstance(CitrusContextProvider contextProvider) {
+        if (strategy.equals(CitrusInstanceStrategy.NEW) || citrus == null) {
+            citrus = new Citrus(contextProvider.create());
             instanceProcessors.forEach(processor -> processor.process(citrus));
         }
 

--- a/core/citrus-base/src/main/java/com/consol/citrus/CitrusInstanceManager.java
+++ b/core/citrus-base/src/main/java/com/consol/citrus/CitrusInstanceManager.java
@@ -13,7 +13,7 @@ public class CitrusInstanceManager {
     private static Citrus citrus;
 
     /** List of instance resolvers capable of taking part in Citrus instance creation process */
-    private static List<CitrusInstanceProcessor> instanceProcessors = new ArrayList<>();
+    private static final List<CitrusInstanceProcessor> instanceProcessors = new ArrayList<>();
 
     /** Strategy decides which instances are created */
     protected static CitrusInstanceStrategy strategy = CitrusInstanceStrategy.NEW;
@@ -32,8 +32,11 @@ public class CitrusInstanceManager {
      * @return
      */
     public static Citrus newInstance() {
-        CitrusContextProvider contextProvider = CitrusContextProvider.lookup();
-        citrus = newInstance(contextProvider.create());
+        if (strategy.equals(CitrusInstanceStrategy.NEW) || citrus == null) {
+            CitrusContextProvider contextProvider = CitrusContextProvider.lookup();
+            citrus = newInstance(contextProvider.create());
+        }
+
         return citrus;
     }
 

--- a/core/citrus-base/src/main/java/com/consol/citrus/DefaultCitrusContextProvider.java
+++ b/core/citrus-base/src/main/java/com/consol/citrus/DefaultCitrusContextProvider.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.consol.citrus;
+
+/**
+ * Default implementation of CitrusContext provider. Works with default CitrusContext and creates new instances based on
+ * a given strategy. Either creates a new instance for each provider call or always returns a singleton context instance.
+ *
+ * @author Christoph Deppisch
+ */
+public class DefaultCitrusContextProvider implements CitrusContextProvider {
+
+    private static CitrusContext context;
+
+    private final CitrusInstanceStrategy strategy;
+
+    public DefaultCitrusContextProvider() {
+        this(CitrusInstanceStrategy.SINGLETON);
+    }
+
+    public DefaultCitrusContextProvider(CitrusInstanceStrategy strategy) {
+        this.strategy = strategy;
+    }
+
+    @Override
+    public CitrusContext create() {
+        if (strategy.equals(CitrusInstanceStrategy.NEW) || context == null) {
+            context = CitrusContext.create();
+        }
+
+        return context;
+    }
+}

--- a/core/citrus-base/src/main/java/com/consol/citrus/annotations/CitrusAnnotations.java
+++ b/core/citrus-base/src/main/java/com/consol/citrus/annotations/CitrusAnnotations.java
@@ -68,6 +68,9 @@ public abstract class CitrusAnnotations {
      */
     public static void injectAll(final Object target, final Citrus citrusFramework, final TestContext context) {
         injectCitrusFramework(target, citrusFramework);
+
+        citrusFramework.getCitrusContext().parseConfiguration(target);
+
         injectEndpoints(target, context);
         injectTestContext(target, context);
     }

--- a/core/citrus-base/src/test/java/com/consol/citrus/CitrusContextTest.java
+++ b/core/citrus-base/src/test/java/com/consol/citrus/CitrusContextTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.consol.citrus;
+
+import com.consol.citrus.exceptions.CitrusRuntimeException;
+import com.consol.citrus.spi.BindToRegistry;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class CitrusContextTest {
+
+    @Test
+    public void shouldParseConfiguration() {
+        CitrusContext context = CitrusContext.create();
+        context.parseConfiguration(FooConfig.class);
+
+        Assert.assertTrue(context.getReferenceResolver().isResolvable("foo"));
+        Assert.assertEquals(context.getReferenceResolver().resolve("foo"), "Foo");
+        Assert.assertTrue(context.getReferenceResolver().isResolvable("bar"));
+        Assert.assertEquals(context.getReferenceResolver().resolve("bar"), "Bar");
+        Assert.assertTrue(context.getReferenceResolver().isResolvable("foobar"));
+        Assert.assertEquals(context.getReferenceResolver().resolve("foobar"), "FooBar");
+    }
+
+    public static class FooConfig {
+        @BindToRegistry
+        String bar = "Bar";
+
+        @BindToRegistry
+        public String foo() {
+            return "Foo";
+        }
+
+        @BindToRegistry(name = "foobar")
+        public String bar() {
+            return "FooBar";
+        }
+    }
+
+    @Test(expectedExceptions = CitrusRuntimeException.class,
+            expectedExceptionsMessageRegExp = "Missing or non-accessible default constructor on custom configuration class")
+    public void shouldRaiseErrorWithNoDefaultConstructor() {
+        CitrusContext context = CitrusContext.create();
+        context.parseConfiguration(NoDefaultConstructorConfig.class);
+    }
+
+    public static class NoDefaultConstructorConfig {
+        public NoDefaultConstructorConfig(String config) {
+            LoggerFactory.getLogger(NoDefaultConstructorConfig.class).info(config);
+        }
+    }
+
+    @Test(expectedExceptions = CitrusRuntimeException.class,
+            expectedExceptionsMessageRegExp = "Failed to invoke configuration method")
+    public void shouldRaiseErrorWithPrivateMethod() {
+        CitrusContext context = CitrusContext.create();
+        context.parseConfiguration(PrivateMethodConfig.class);
+    }
+
+    public static class PrivateMethodConfig {
+
+        @BindToRegistry
+        private String error() {
+            return "should fail";
+        }
+    }
+}

--- a/core/citrus-spring/src/main/java/com/consol/citrus/CitrusSpringContextProvider.java
+++ b/core/citrus-spring/src/main/java/com/consol/citrus/CitrusSpringContextProvider.java
@@ -1,15 +1,47 @@
 package com.consol.citrus;
 
+import com.consol.citrus.config.CitrusSpringConfig;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
 /**
  * Context provider registered via resource path lookup. When module is on classpath this provider will be used to instantiate
  * Citrus.
+ *
+ * Provider creates a CitrusContext that is backed with a Spring application context. Provider caches the last application context
+ * that has created a context. When very same application context creates another CitrusContext use the cached instance. This
+ * caching should give us some performance improvements and less instance duplications.
  *
  * @author Christoph Deppisch
  */
 public class CitrusSpringContextProvider implements CitrusContextProvider {
 
+    private static CitrusSpringContext context;
+
+    private final ApplicationContext applicationContext;
+
+    public CitrusSpringContextProvider() {
+        this.applicationContext = null;
+    }
+
+    public CitrusSpringContextProvider(Class<? extends CitrusSpringConfig> configClass) {
+        this(new AnnotationConfigApplicationContext(configClass));
+    }
+
+    public CitrusSpringContextProvider(ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
+    }
+
     @Override
     public CitrusContext create() {
-        return CitrusSpringContext.create();
+        if (applicationContext == null) {
+            context = CitrusSpringContext.create();
+        } else if (context == null) {
+            context = CitrusSpringContext.create(applicationContext);
+        } else if (!context.getApplicationContext().equals(applicationContext)) {
+            context = CitrusSpringContext.create(applicationContext);
+        }
+
+        return context;
     }
 }

--- a/core/citrus-spring/src/main/java/com/consol/citrus/CitrusSpringSettings.java
+++ b/core/citrus-spring/src/main/java/com/consol/citrus/CitrusSpringSettings.java
@@ -40,6 +40,7 @@ public class CitrusSpringSettings {
     /** Default application context class */
     public static final String DEFAULT_APPLICATION_CONTEXT_CLASS_PROPERTY = "citrus.spring.java.config";
     public static final String DEFAULT_APPLICATION_CONTEXT_CLASS_ENV = "CITRUS_SPRING_JAVA_CONFIG";
-    public static final String DEFAULT_APPLICATION_CONTEXT_CLASS = System.getProperty(DEFAULT_APPLICATION_CONTEXT_CLASS_PROPERTY, System.getenv(DEFAULT_APPLICATION_CONTEXT_CLASS_ENV));
+    public static final String DEFAULT_APPLICATION_CONTEXT_CLASS = System.getProperty(DEFAULT_APPLICATION_CONTEXT_CLASS_PROPERTY,
+            System.getenv(DEFAULT_APPLICATION_CONTEXT_CLASS_ENV) != null ? System.getenv(DEFAULT_APPLICATION_CONTEXT_CLASS_ENV) : CitrusSettings.DEFAULT_CONFIG_CLASS);
 
 }

--- a/core/citrus-spring/src/main/java/com/consol/citrus/CitrusSpringSettings.java
+++ b/core/citrus-spring/src/main/java/com/consol/citrus/CitrusSpringSettings.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.consol.citrus;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class CitrusSpringSettings {
+
+    /**
+     * Prevent instantiation of utility class.
+     */
+    private CitrusSpringSettings() {
+        // prevent instantiation
+    }
+
+    /** Default application context name */
+    public static final String DEFAULT_APPLICATION_CONTEXT_PROPERTY = "citrus.spring.application.context";
+    public static final String DEFAULT_APPLICATION_CONTEXT_ENV = "CITRUS_SPRING_APPLICATION_CONTEXT";
+    public static final String DEFAULT_APPLICATION_CONTEXT = System.getProperty(DEFAULT_APPLICATION_CONTEXT_PROPERTY, System.getenv(DEFAULT_APPLICATION_CONTEXT_ENV) != null ?
+            System.getenv(DEFAULT_APPLICATION_CONTEXT_ENV) : "classpath*:citrus-context.xml");
+
+    /** Default application context class */
+    public static final String DEFAULT_APPLICATION_CONTEXT_CLASS_PROPERTY = "citrus.spring.java.config";
+    public static final String DEFAULT_APPLICATION_CONTEXT_CLASS_ENV = "CITRUS_SPRING_JAVA_CONFIG";
+    public static final String DEFAULT_APPLICATION_CONTEXT_CLASS = System.getProperty(DEFAULT_APPLICATION_CONTEXT_CLASS_PROPERTY, System.getenv(DEFAULT_APPLICATION_CONTEXT_CLASS_ENV));
+
+}

--- a/core/citrus-spring/src/main/java/com/consol/citrus/config/CitrusBeanDefinitionReader.java
+++ b/core/citrus-spring/src/main/java/com/consol/citrus/config/CitrusBeanDefinitionReader.java
@@ -16,7 +16,7 @@
 
 package com.consol.citrus.config;
 
-import com.consol.citrus.CitrusSettings;
+import com.consol.citrus.CitrusSpringSettings;
 import org.springframework.beans.factory.BeanDefinitionStoreException;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
@@ -39,6 +39,6 @@ public class CitrusBeanDefinitionReader extends XmlBeanDefinitionReader {
 
     @Override
     public int loadBeanDefinitions(String location) throws BeanDefinitionStoreException {
-        return super.loadBeanDefinitions(CitrusSettings.DEFAULT_APPLICATION_CONTEXT);
+        return super.loadBeanDefinitions(CitrusSpringSettings.DEFAULT_APPLICATION_CONTEXT);
     }
 }

--- a/core/citrus-spring/src/main/java/com/consol/citrus/config/CitrusConfigImport.java
+++ b/core/citrus-spring/src/main/java/com/consol/citrus/config/CitrusConfigImport.java
@@ -16,7 +16,7 @@
 
 package com.consol.citrus.config;
 
-import com.consol.citrus.CitrusSettings;
+import com.consol.citrus.CitrusSpringSettings;
 import org.springframework.context.annotation.DeferredImportSelector;
 import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.util.StringUtils;
@@ -29,8 +29,8 @@ public class CitrusConfigImport implements DeferredImportSelector {
 
     @Override
     public String[] selectImports(AnnotationMetadata importingClassMetadata) {
-        if (StringUtils.hasText(CitrusSettings.DEFAULT_APPLICATION_CONTEXT_CLASS)) {
-            return new String[] { CitrusSettings.DEFAULT_APPLICATION_CONTEXT_CLASS };
+        if (StringUtils.hasText(CitrusSpringSettings.DEFAULT_APPLICATION_CONTEXT_CLASS)) {
+            return new String[] { CitrusSpringSettings.DEFAULT_APPLICATION_CONTEXT_CLASS };
         } else {
             return new String[] {};
         }

--- a/core/citrus-spring/src/test/java/com/consol/citrus/BeanDefinitionParserTestSupport.java
+++ b/core/citrus-spring/src/test/java/com/consol/citrus/BeanDefinitionParserTestSupport.java
@@ -39,7 +39,7 @@ public class BeanDefinitionParserTestSupport extends AbstractBeanDefinitionParse
     public void beforeSuite(ITestContext testContext) throws Exception {
         super.beforeSuite(testContext);
 
-        citrus = Citrus.newInstance(CitrusSpringContext.create(applicationContext));
+        citrus = Citrus.newInstance(new CitrusSpringContextProvider(applicationContext));
         citrus.beforeSuite(testContext.getSuite().getName(), testContext.getIncludedGroups());
     }
 

--- a/core/citrus-spring/src/test/java/com/consol/citrus/TestSuiteTest.java
+++ b/core/citrus-spring/src/test/java/com/consol/citrus/TestSuiteTest.java
@@ -30,7 +30,9 @@ import com.consol.citrus.report.TestListeners;
 import com.consol.citrus.report.TestSuiteListener;
 import com.consol.citrus.report.TestSuiteListeners;
 import com.consol.citrus.testng.AbstractTestNGUnitTest;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 import org.springframework.context.ApplicationContext;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
@@ -38,7 +40,6 @@ import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -47,11 +48,17 @@ import static org.mockito.Mockito.when;
  */
 public class TestSuiteTest extends AbstractTestNGUnitTest {
 
+    @Mock
     private TestSuiteListeners testSuiteListeners;
-    private TestSuiteListener testSuiteListener = Mockito.mock(TestSuiteListener.class);
-    private ApplicationContext applicationContextMock = Mockito.mock(ApplicationContext.class);
-    private TestContextFactoryBean testContextFactory = Mockito.mock(TestContextFactoryBean.class);
-    private TestAction actionMock = Mockito.mock(TestAction.class);
+    @Mock
+    private TestSuiteListener testSuiteListener;
+    @Mock
+    private ApplicationContext applicationContextMock;
+    @Mock
+    private TestContextFactoryBean testContextFactory;
+    @Mock
+    private TestAction actionMock;
+
     private Citrus citrus;
 
     private BeforeSuite beforeActions;
@@ -59,9 +66,7 @@ public class TestSuiteTest extends AbstractTestNGUnitTest {
 
     @BeforeMethod
     public void resetMocks() {
-        reset(testSuiteListener);
-        reset(applicationContextMock);
-        reset(actionMock);
+        MockitoAnnotations.openMocks(this);
 
         testSuiteListeners = new TestSuiteListeners();
         testSuiteListeners.addTestSuiteListener(testSuiteListener);
@@ -75,7 +80,7 @@ public class TestSuiteTest extends AbstractTestNGUnitTest {
         when(applicationContextMock.getBean(TestSuiteListeners.class)).thenReturn(testSuiteListeners);
         when(applicationContextMock.getBean(TestListeners.class)).thenReturn(new TestListeners());
 
-        citrus = Citrus.newInstance(CitrusSpringContext.create(applicationContextMock));
+        citrus = Citrus.newInstance(new CitrusSpringContextProvider(applicationContextMock));
     }
 
     @Test

--- a/core/citrus-spring/src/test/java/com/consol/citrus/UnitTestSupport.java
+++ b/core/citrus-spring/src/test/java/com/consol/citrus/UnitTestSupport.java
@@ -39,7 +39,7 @@ public class UnitTestSupport extends AbstractTestNGUnitTest {
     public void beforeSuite(ITestContext testContext) throws Exception {
         super.beforeSuite(testContext);
 
-        citrus = Citrus.newInstance(CitrusSpringContext.create(applicationContext));
+        citrus = Citrus.newInstance(new CitrusSpringContextProvider(applicationContext));
         citrus.beforeSuite(testContext.getSuite().getName(), testContext.getIncludedGroups());
     }
 

--- a/runtime/citrus-cucumber/src/main/java/com/consol/citrus/cucumber/backend/spring/CitrusSpringObjectFactory.java
+++ b/runtime/citrus-cucumber/src/main/java/com/consol/citrus/cucumber/backend/spring/CitrusSpringObjectFactory.java
@@ -20,6 +20,7 @@ import com.consol.citrus.Citrus;
 import com.consol.citrus.CitrusContext;
 import com.consol.citrus.CitrusInstanceManager;
 import com.consol.citrus.CitrusSpringContext;
+import com.consol.citrus.CitrusSpringContextProvider;
 import com.consol.citrus.DefaultTestCaseRunner;
 import com.consol.citrus.TestCaseRunner;
 import com.consol.citrus.annotations.CitrusAnnotations;
@@ -120,7 +121,7 @@ public class CitrusSpringObjectFactory implements ObjectFactory {
             }
         }
 
-        Citrus.newInstance(CitrusSpringContext.create(applicationContext));
+        Citrus.newInstance(new CitrusSpringContextProvider(applicationContext));
     }
 
     @Override

--- a/runtime/citrus-cucumber/src/test/java/com/consol/citrus/cucumber/UnitTestSupport.java
+++ b/runtime/citrus-cucumber/src/test/java/com/consol/citrus/cucumber/UnitTestSupport.java
@@ -1,7 +1,7 @@
 package com.consol.citrus.cucumber;
 
 import com.consol.citrus.Citrus;
-import com.consol.citrus.CitrusSpringContext;
+import com.consol.citrus.CitrusSpringContextProvider;
 import com.consol.citrus.config.CitrusSpringConfig;
 import com.consol.citrus.context.TestContext;
 import com.consol.citrus.context.TestContextFactory;
@@ -38,7 +38,7 @@ public class UnitTestSupport extends AbstractTestNGUnitTest {
 
     @BeforeClass(alwaysRun = true)
     public void beforeSuite(ITestContext testContext) throws Exception {
-        citrus = Citrus.newInstance(CitrusSpringContext.create(applicationContext));
+        citrus = Citrus.newInstance(new CitrusSpringContextProvider(applicationContext));
         citrus.beforeSuite(testContext.getSuite().getName(), testContext.getIncludedGroups());
     }
 

--- a/runtime/citrus-cucumber/src/test/java/com/consol/citrus/cucumber/backend/CitrusLifecycleHooksTest.java
+++ b/runtime/citrus-cucumber/src/test/java/com/consol/citrus/cucumber/backend/CitrusLifecycleHooksTest.java
@@ -37,7 +37,7 @@ public class CitrusLifecycleHooksTest extends UnitTestSupport {
 
     @BeforeMethod
     public void setupMocks() {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
         citrusLifecycleHooks = new CitrusLifecycleHooks();
         CitrusAnnotations.injectTestContext(citrusLifecycleHooks, context);
         CitrusAnnotations.injectTestRunner(citrusLifecycleHooks, runner);

--- a/runtime/citrus-junit/src/main/java/com/consol/citrus/junit/TestSuiteExecutionListener.java
+++ b/runtime/citrus-junit/src/main/java/com/consol/citrus/junit/TestSuiteExecutionListener.java
@@ -17,7 +17,7 @@
 package com.consol.citrus.junit;
 
 import com.consol.citrus.Citrus;
-import com.consol.citrus.CitrusSpringContext;
+import com.consol.citrus.CitrusSpringContextProvider;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.support.AbstractTestExecutionListener;
@@ -39,7 +39,7 @@ public class TestSuiteExecutionListener extends AbstractTestExecutionListener {
         if (TestSuiteState.shouldExecuteBeforeSuite()) {
             ApplicationContext ctx = testContext.getApplicationContext();
 
-            Citrus citrus = Citrus.newInstance(CitrusSpringContext.create(ctx));
+            Citrus citrus = Citrus.newInstance(new CitrusSpringContextProvider(ctx));
             citrus.beforeSuite(SUITE_NAME);
 
             Runtime.getRuntime().addShutdownHook(new Thread(new AfterSuiteShutdownHook(citrus)));

--- a/runtime/citrus-junit/src/main/java/com/consol/citrus/junit/spring/JUnit4CitrusSpringSupport.java
+++ b/runtime/citrus-junit/src/main/java/com/consol/citrus/junit/spring/JUnit4CitrusSpringSupport.java
@@ -20,6 +20,7 @@ import java.util.Date;
 
 import com.consol.citrus.Citrus;
 import com.consol.citrus.CitrusSpringContext;
+import com.consol.citrus.CitrusSpringContextProvider;
 import com.consol.citrus.GherkinTestActionRunner;
 import com.consol.citrus.TestAction;
 import com.consol.citrus.TestActionBuilder;
@@ -65,7 +66,7 @@ public class JUnit4CitrusSpringSupport extends AbstractJUnit4SpringContextTests
     @Override
     public void run(CitrusFrameworkMethod frameworkMethod) {
         if (citrus == null) {
-            citrus = Citrus.newInstance(CitrusSpringContext.create(applicationContext));
+            citrus = Citrus.newInstance(new CitrusSpringContextProvider(applicationContext));
         }
 
         TestContext ctx = prepareTestContext(citrus.getCitrusContext().createTestContext());

--- a/runtime/citrus-junit/src/test/java/com/consol/citrus/junit/integration/EndpointInjectionIT.java
+++ b/runtime/citrus-junit/src/test/java/com/consol/citrus/junit/integration/EndpointInjectionIT.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.consol.citrus.junit.integration;
+
+import java.util.List;
+
+import com.consol.citrus.Citrus;
+import com.consol.citrus.annotations.CitrusEndpoint;
+import com.consol.citrus.annotations.CitrusFramework;
+import com.consol.citrus.annotations.CitrusTest;
+import com.consol.citrus.context.TestContext;
+import com.consol.citrus.endpoint.Endpoint;
+import com.consol.citrus.endpoint.direct.DirectEndpoint;
+import com.consol.citrus.endpoint.direct.DirectEndpointBuilder;
+import com.consol.citrus.endpoint.direct.annotation.DirectEndpointConfig;
+import com.consol.citrus.exceptions.ValidationException;
+import com.consol.citrus.junit.spring.JUnit4CitrusSpringSupport;
+import com.consol.citrus.message.DefaultMessageQueue;
+import com.consol.citrus.message.Message;
+import com.consol.citrus.message.MessageQueue;
+import com.consol.citrus.message.MessageType;
+import com.consol.citrus.spi.BindToRegistry;
+import com.consol.citrus.validation.MessageValidator;
+import com.consol.citrus.validation.context.DefaultValidationContext;
+import com.consol.citrus.validation.context.ValidationContext;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static com.consol.citrus.actions.ReceiveMessageAction.Builder.receive;
+import static com.consol.citrus.actions.SendMessageAction.Builder.send;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class EndpointInjectionIT extends JUnit4CitrusSpringSupport {
+
+    @CitrusFramework
+    private Citrus citrus;
+
+    @CitrusEndpoint
+    @DirectEndpointConfig(queueName = "FOO.direct.queue")
+    @BindToRegistry
+    private Endpoint directEndpoint;
+
+    @CitrusEndpoint
+    private Endpoint foo;
+
+    @BindToRegistry
+    private final MessageQueue messages = new DefaultMessageQueue("messages");
+
+    @BindToRegistry
+    public MessageValidator<DefaultValidationContext> plaintextValidator() {
+        return new MessageValidator<>() {
+            @Override
+            public void validateMessage(Message receivedMessage, Message controlMessage, TestContext context, List<ValidationContext> validationContexts) throws ValidationException {
+                org.testng.Assert.assertEquals(receivedMessage.getPayload(String.class), controlMessage.getPayload());
+            }
+
+            @Override
+            public boolean supportsMessageType(String messageType, Message message) {
+                return messageType.equalsIgnoreCase(MessageType.PLAINTEXT.name());
+            }
+        };
+    }
+
+    @BindToRegistry
+    public DirectEndpoint foo() {
+        return new DirectEndpointBuilder()
+                .queue(messages)
+                .build();
+    }
+
+    @BindToRegistry(name = "FOO.direct.queue")
+    public MessageQueue queue() {
+        return new DefaultMessageQueue("FOO.direct.queue");
+    }
+
+    @Test
+    @CitrusTest
+    public void injectEndpoint() {
+        Assert.assertNotNull(foo);
+
+        run(send(directEndpoint)
+                .message()
+                .type(MessageType.PLAINTEXT)
+                .body("Hello!"));
+
+        run(receive(directEndpoint)
+                .message()
+                .type(MessageType.PLAINTEXT)
+                .body("Hello!"));
+
+        run(send("directEndpoint")
+                .message()
+                .type(MessageType.PLAINTEXT)
+                .body("Hi!"));
+
+        run(receive("directEndpoint")
+                .message()
+                .type(MessageType.PLAINTEXT)
+                .body("Hi!"));
+
+        run(send(foo)
+                .message()
+                .type(MessageType.PLAINTEXT)
+                .body("Hello Citrus!"));
+
+        run(receive(foo)
+                .message()
+                .type(MessageType.PLAINTEXT)
+                .body("Hello Citrus!"));
+
+        Assert.assertNotNull(citrus);
+    }
+}

--- a/runtime/citrus-junit5/src/main/java/com/consol/citrus/junit/jupiter/CitrusExtension.java
+++ b/runtime/citrus-junit5/src/main/java/com/consol/citrus/junit/jupiter/CitrusExtension.java
@@ -18,6 +18,7 @@ package com.consol.citrus.junit.jupiter;
 
 import com.consol.citrus.Citrus;
 import com.consol.citrus.CitrusContext;
+import com.consol.citrus.CitrusInstanceManager;
 import com.consol.citrus.TestCase;
 import com.consol.citrus.TestCaseRunner;
 import com.consol.citrus.TestResult;
@@ -66,7 +67,7 @@ public class CitrusExtension implements BeforeAllCallback, BeforeEachCallback, B
     @Override
     public void beforeAll(ExtensionContext extensionContext) {
         if (CitrusExtensionHelper.requiresCitrus(extensionContext)) {
-            CitrusExtensionHelper.setCitrus(CitrusCache.getCitrus(), extensionContext);
+            CitrusExtensionHelper.setCitrus(CitrusInstanceManager.getOrDefault(), extensionContext);
         }
 
         if (beforeSuite) {
@@ -147,25 +148,6 @@ public class CitrusExtension implements BeforeAllCallback, BeforeEachCallback, B
     @Override
     public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
         return CitrusExtensionHelper.resolveParameter(parameterContext, extensionContext);
-    }
-
-    /**
-     * Static cache of Citrus instance.
-     */
-    private static class CitrusCache {
-        private static Citrus citrus;
-
-        /**
-         * Initialize and get Citrus instance.
-         * @return
-         */
-        static Citrus getCitrus() {
-            if (citrus == null) {
-                citrus = Citrus.newInstance();
-            }
-
-            return citrus;
-        }
     }
 
     /**

--- a/runtime/citrus-junit5/src/main/java/com/consol/citrus/junit/jupiter/spring/CitrusSpringExtension.java
+++ b/runtime/citrus-junit5/src/main/java/com/consol/citrus/junit/jupiter/spring/CitrusSpringExtension.java
@@ -28,7 +28,7 @@ import java.util.stream.Stream;
 import com.consol.citrus.Citrus;
 import com.consol.citrus.CitrusInstanceManager;
 import com.consol.citrus.CitrusSettings;
-import com.consol.citrus.CitrusSpringContext;
+import com.consol.citrus.CitrusSpringContextProvider;
 import com.consol.citrus.TestCase;
 import com.consol.citrus.TestCaseRunner;
 import com.consol.citrus.TestResult;
@@ -146,10 +146,10 @@ public class CitrusSpringExtension implements BeforeAllCallback, BeforeEachCallb
         ApplicationContext ctx = SpringExtension.getApplicationContext(extensionContext);
         if (applicationContext == null) {
             applicationContext = ctx;
-            citrus = Citrus.newInstance(CitrusSpringContext.create(ctx));
+            citrus = Citrus.newInstance(new CitrusSpringContextProvider(ctx));
         } else if (!applicationContext.equals(ctx)) {
             applicationContext = ctx;
-            citrus = Citrus.newInstance(CitrusSpringContext.create(ctx));
+            citrus = Citrus.newInstance(new CitrusSpringContextProvider(ctx));
         }
 
         return citrus;

--- a/runtime/citrus-junit5/src/test/java/com/consol/citrus/junit/jupiter/integration/CitrusConfigurationIT.java
+++ b/runtime/citrus-junit5/src/test/java/com/consol/citrus/junit/jupiter/integration/CitrusConfigurationIT.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2006-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.consol.citrus.junit.jupiter.integration;
+
+import java.util.List;
+
+import com.consol.citrus.Citrus;
+import com.consol.citrus.TestActionRunner;
+import com.consol.citrus.annotations.CitrusConfiguration;
+import com.consol.citrus.annotations.CitrusEndpoint;
+import com.consol.citrus.annotations.CitrusFramework;
+import com.consol.citrus.annotations.CitrusResource;
+import com.consol.citrus.annotations.CitrusTest;
+import com.consol.citrus.context.TestContext;
+import com.consol.citrus.endpoint.Endpoint;
+import com.consol.citrus.endpoint.direct.DirectEndpoint;
+import com.consol.citrus.endpoint.direct.DirectEndpointBuilder;
+import com.consol.citrus.exceptions.ValidationException;
+import com.consol.citrus.junit.jupiter.CitrusSupport;
+import com.consol.citrus.message.DefaultMessageQueue;
+import com.consol.citrus.message.Message;
+import com.consol.citrus.message.MessageQueue;
+import com.consol.citrus.message.MessageType;
+import com.consol.citrus.spi.BindToRegistry;
+import com.consol.citrus.validation.MessageValidator;
+import com.consol.citrus.validation.context.DefaultValidationContext;
+import com.consol.citrus.validation.context.ValidationContext;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static com.consol.citrus.actions.ReceiveMessageAction.Builder.receive;
+import static com.consol.citrus.actions.SendMessageAction.Builder.send;
+
+/**
+ * @author Christoph Deppisch
+ */
+@CitrusSupport
+@CitrusConfiguration(classes = CitrusConfigurationIT.Endpoints.class)
+public class CitrusConfigurationIT {
+
+    @CitrusFramework
+    private Citrus citrus;
+
+    @CitrusEndpoint
+    private Endpoint directEndpoint;
+
+    @CitrusEndpoint
+    private Endpoint foo;
+
+    @Test
+    @CitrusTest
+    public void shouldLoadConfiguration(@CitrusResource TestActionRunner $) {
+        Assertions.assertNotNull(foo);
+
+        $.run(send(directEndpoint)
+                .message()
+                .type(MessageType.PLAINTEXT)
+                .body("Hello!"));
+
+        $.run(receive(directEndpoint)
+                .message()
+                .type(MessageType.PLAINTEXT)
+                .body("Hello!"));
+
+        $.run(send("directEndpoint")
+                .message()
+                .type(MessageType.PLAINTEXT)
+                .body("Hi!"));
+
+        $.run(receive("directEndpoint")
+                .message()
+                .type(MessageType.PLAINTEXT)
+                .body("Hi!"));
+
+        $.run(send(foo)
+                .message()
+                .type(MessageType.PLAINTEXT)
+                .body("Hello Citrus!"));
+
+        $.run(receive(foo)
+                .message()
+                .type(MessageType.PLAINTEXT)
+                .body("Hello Citrus!"));
+
+        Assertions.assertNotNull(citrus);
+    }
+
+    public static class Endpoints {
+        @BindToRegistry
+        private Endpoint directEndpoint = new DirectEndpointBuilder()
+                .queue("TEST.direct.queue")
+                .build();
+
+        @BindToRegistry
+        private final MessageQueue messages = new DefaultMessageQueue("messages");
+
+        @BindToRegistry
+        public MessageValidator<DefaultValidationContext> plaintextValidator() {
+            return new MessageValidator<>() {
+                @Override
+                public void validateMessage(Message receivedMessage, Message controlMessage, TestContext context, List<ValidationContext> validationContexts) throws ValidationException {
+                    org.testng.Assert.assertEquals(receivedMessage.getPayload(String.class), controlMessage.getPayload());
+                }
+
+                @Override
+                public boolean supportsMessageType(String messageType, Message message) {
+                    return messageType.equalsIgnoreCase(MessageType.PLAINTEXT.name());
+                }
+            };
+        }
+
+        @BindToRegistry
+        public DirectEndpoint foo() {
+            return new DirectEndpointBuilder()
+                    .queue(messages)
+                    .build();
+        }
+
+        @BindToRegistry(name = "TEST.direct.queue")
+        public MessageQueue queue() {
+            return new DefaultMessageQueue("FOO.direct.queue");
+        }
+    }
+}

--- a/runtime/citrus-junit5/src/test/java/com/consol/citrus/junit/jupiter/integration/EndpointInjectionIT.java
+++ b/runtime/citrus-junit5/src/test/java/com/consol/citrus/junit/jupiter/integration/EndpointInjectionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2016 the original author or authors.
+ * Copyright 2006-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,32 +14,44 @@
  * limitations under the License.
  */
 
-package com.consol.citrus.integration.inject;
+package com.consol.citrus.junit.jupiter.integration;
+
+import java.util.List;
 
 import com.consol.citrus.Citrus;
 import com.consol.citrus.CitrusContext;
+import com.consol.citrus.TestActionRunner;
 import com.consol.citrus.annotations.CitrusEndpoint;
 import com.consol.citrus.annotations.CitrusFramework;
+import com.consol.citrus.annotations.CitrusResource;
 import com.consol.citrus.annotations.CitrusTest;
+import com.consol.citrus.context.TestContext;
 import com.consol.citrus.endpoint.Endpoint;
 import com.consol.citrus.endpoint.direct.DirectEndpointBuilder;
 import com.consol.citrus.endpoint.direct.annotation.DirectEndpointConfig;
+import com.consol.citrus.exceptions.ValidationException;
+import com.consol.citrus.junit.jupiter.CitrusExtension;
+import com.consol.citrus.junit.jupiter.CitrusSupport;
 import com.consol.citrus.message.DefaultMessageQueue;
+import com.consol.citrus.message.Message;
 import com.consol.citrus.message.MessageQueue;
 import com.consol.citrus.message.MessageType;
 import com.consol.citrus.spi.BindToRegistry;
-import com.consol.citrus.testng.spring.TestNGCitrusSpringSupport;
+import com.consol.citrus.validation.MessageValidator;
+import com.consol.citrus.validation.context.DefaultValidationContext;
+import com.consol.citrus.validation.context.ValidationContext;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.testng.Assert;
-import org.testng.annotations.Test;
 
 import static com.consol.citrus.actions.ReceiveMessageAction.Builder.receive;
 import static com.consol.citrus.actions.SendMessageAction.Builder.send;
 
 /**
  * @author Christoph Deppisch
- * @since 2.5
  */
-public class EndpointInjectionJavaIT extends TestNGCitrusSpringSupport {
+@CitrusSupport
+public class EndpointInjectionIT implements CitrusExtension.TestListener {
 
     @CitrusFramework
     private Citrus citrus;
@@ -52,14 +64,31 @@ public class EndpointInjectionJavaIT extends TestNGCitrusSpringSupport {
     @CitrusEndpoint
     private Endpoint foo;
 
+    @BindToRegistry
+    private final MessageQueue messages = new DefaultMessageQueue("messages");
+
     @Override
     public void before(CitrusContext context) {
         Assert.assertNotNull(citrus);
 
-        context.bind("messages", new DefaultMessageQueue("messages"));
         context.bind("foo", new DirectEndpointBuilder()
                 .queue("messages")
                 .build());
+    }
+
+    @BindToRegistry
+    public MessageValidator<DefaultValidationContext> plaintextValidator() {
+        return new MessageValidator<>() {
+            @Override
+            public void validateMessage(Message receivedMessage, Message controlMessage, TestContext context, List<ValidationContext> validationContexts) throws ValidationException {
+                org.testng.Assert.assertEquals(receivedMessage.getPayload(String.class), controlMessage.getPayload());
+            }
+
+            @Override
+            public boolean supportsMessageType(String messageType, Message message) {
+                return messageType.equalsIgnoreCase(MessageType.PLAINTEXT.name());
+            }
+        };
     }
 
     @BindToRegistry(name = "FOO.direct.queue")
@@ -69,39 +98,39 @@ public class EndpointInjectionJavaIT extends TestNGCitrusSpringSupport {
 
     @Test
     @CitrusTest
-    public void injectEndpoint() {
-        Assert.assertNotNull(foo);
+    public void injectEndpoint(@CitrusResource TestActionRunner $) {
+        Assertions.assertNotNull(foo);
 
-        run(send(directEndpoint)
+        $.run(send(directEndpoint)
                 .message()
                 .type(MessageType.PLAINTEXT)
                 .body("Hello!"));
 
-        run(receive(directEndpoint)
+        $.run(receive(directEndpoint)
                 .message()
-                    .type(MessageType.PLAINTEXT)
-                    .body("Hello!"));
+                .type(MessageType.PLAINTEXT)
+                .body("Hello!"));
 
-        run(send("directEndpoint")
+        $.run(send("directEndpoint")
                 .message()
                 .type(MessageType.PLAINTEXT)
                 .body("Hi!"));
 
-        run(receive("directEndpoint")
+        $.run(receive("directEndpoint")
                 .message()
-                    .type(MessageType.PLAINTEXT)
-                    .body("Hi!"));
+                .type(MessageType.PLAINTEXT)
+                .body("Hi!"));
 
-        run(send(foo)
+        $.run(send(foo)
                 .message()
                 .type(MessageType.PLAINTEXT)
                 .body("Hello Citrus!"));
 
-        run(receive(foo)
+        $.run(receive(foo)
                 .message()
-                    .type(MessageType.PLAINTEXT)
-                    .body("Hello Citrus!"));
+                .type(MessageType.PLAINTEXT)
+                .body("Hello Citrus!"));
 
-        Assert.assertNotNull(citrus);
+        Assertions.assertNotNull(citrus);
     }
 }

--- a/runtime/citrus-main/src/main/java/com/consol/citrus/main/CitrusApp.java
+++ b/runtime/citrus-main/src/main/java/com/consol/citrus/main/CitrusApp.java
@@ -89,7 +89,7 @@ public class CitrusApp {
 
         if (citrusApp.configuration.isSkipTests()) {
             citrusApp.configuration.setDefaultProperties();
-            Citrus.newInstance();
+            CitrusInstanceManager.getOrDefault();
         } else {
             try {
                 citrusApp.run();

--- a/runtime/citrus-main/src/main/java/com/consol/citrus/main/CitrusApp.java
+++ b/runtime/citrus-main/src/main/java/com/consol/citrus/main/CitrusApp.java
@@ -16,7 +16,6 @@
 
 package com.consol.citrus.main;
 
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -25,7 +24,6 @@ import java.util.concurrent.TimeoutException;
 
 import com.consol.citrus.Citrus;
 import com.consol.citrus.CitrusInstanceManager;
-import com.consol.citrus.CitrusSettings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,7 +66,7 @@ public class CitrusApp {
      * @param args
      */
     public CitrusApp(String[] args) {
-        this(CitrusAppOptions.apply(args));
+        this(new CitrusAppOptions<>().apply(args));
     }
 
     /**
@@ -90,7 +88,7 @@ public class CitrusApp {
         }
 
         if (citrusApp.configuration.isSkipTests()) {
-            setDefaultProperties(citrusApp.configuration);
+            citrusApp.configuration.setDefaultProperties();
             Citrus.newInstance();
         } else {
             try {
@@ -123,7 +121,7 @@ public class CitrusApp {
         }
 
         LOG.info(String.format("Running Citrus %s", Citrus.getVersion()));
-        setDefaultProperties(configuration);
+        configuration.setDefaultProperties();
         TestEngine.lookup(configuration).run();
     }
 
@@ -158,23 +156,6 @@ public class CitrusApp {
         if (citrus.isPresent()) {
             LOG.info("Closing Citrus and its context");
             citrus.get().close();
-        }
-    }
-
-    /**
-     * Reads default properties in configuration and sets them as system properties.
-     * @param configuration
-     */
-    private static void setDefaultProperties(TestRunConfiguration configuration) {
-        for (Map.Entry<String, String> entry : configuration.getDefaultProperties().entrySet()) {
-            LOG.debug(String.format("Setting application property %s=%s", entry.getKey(), entry.getValue()));
-            System.setProperty(entry.getKey(), Optional.ofNullable(entry.getValue()).orElse(""));
-        }
-
-        if (configuration instanceof CitrusAppConfiguration &&
-                ((CitrusAppConfiguration)configuration).getConfigClass() != null) {
-            System.setProperty(CitrusSettings.DEFAULT_APPLICATION_CONTEXT_CLASS_PROPERTY,
-                                ((CitrusAppConfiguration)configuration).getConfigClass());
         }
     }
 

--- a/runtime/citrus-main/src/main/java/com/consol/citrus/main/CitrusAppConfiguration.java
+++ b/runtime/citrus-main/src/main/java/com/consol/citrus/main/CitrusAppConfiguration.java
@@ -16,11 +16,21 @@
 
 package com.consol.citrus.main;
 
+import java.util.Map;
+import java.util.Optional;
+
+import com.consol.citrus.CitrusSettings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * @author Christoph Deppisch
  * @since 2.7.4
  */
 public class CitrusAppConfiguration extends TestRunConfiguration {
+
+    /** Logger */
+    private static final Logger LOG = LoggerFactory.getLogger(CitrusAppConfiguration.class);
 
     /** Server time to live in milliseconds */
     private long timeToLive = 0;
@@ -106,4 +116,17 @@ public class CitrusAppConfiguration extends TestRunConfiguration {
         this.systemExit = systemExit;
     }
 
+    /**
+     * Reads default properties in configuration and sets them as system properties.
+     */
+    public void setDefaultProperties() {
+        for (Map.Entry<String, String> entry : getDefaultProperties().entrySet()) {
+            LOG.debug(String.format("Setting application property %s=%s", entry.getKey(), entry.getValue()));
+            System.setProperty(entry.getKey(), Optional.ofNullable(entry.getValue()).orElse(""));
+        }
+
+        if (getConfigClass() != null) {
+            System.setProperty(CitrusSettings.DEFAULT_CONFIG_CLASS_PROPERTY, getConfigClass());
+        }
+    }
 }

--- a/runtime/citrus-main/src/main/java/com/consol/citrus/main/CitrusAppOptions.java
+++ b/runtime/citrus-main/src/main/java/com/consol/citrus/main/CitrusAppOptions.java
@@ -42,7 +42,7 @@ public class CitrusAppOptions<T extends CitrusAppConfiguration> {
     protected final List<CliOption<T>> options = new ArrayList<>();
 
     protected CitrusAppOptions() {
-        options.add(new CliOption<T>("h", "help", "Displays cli option usage") {
+        options.add(new CliOption<>("h", "help", "Displays cli option usage") {
             @Override
             protected void doProcess(T configuration, String arg, String value, LinkedList<String> remainingArgs) {
                 StringBuilder builder = new StringBuilder();
@@ -57,7 +57,7 @@ public class CitrusAppOptions<T extends CitrusAppConfiguration> {
             }
         });
 
-        options.add(new CliOption<T>("d", "duration", "Maximum time in milliseconds the server should be up and running - server will terminate automatically when time exceeds") {
+        options.add(new CliOption<>("d", "duration", "Maximum time in milliseconds the server should be up and running - server will terminate automatically when time exceeds") {
             @Override
             protected void doProcess(T configuration, String arg, String value, LinkedList<String> remainingArgs) {
                 if (value != null && value.length() > 0) {
@@ -68,7 +68,7 @@ public class CitrusAppOptions<T extends CitrusAppConfiguration> {
             }
         });
 
-        options.add(new CliOption<T>("c", "config", "Custom Spring configuration class") {
+        options.add(new CliOption<>("c", "config", "Custom configuration class") {
             @Override
             protected void doProcess(T configuration, String arg, String value, LinkedList<String> remainingArgs) {
                 if (StringUtils.hasText(value)) {
@@ -84,7 +84,7 @@ public class CitrusAppOptions<T extends CitrusAppConfiguration> {
             }
         });
 
-        options.add(new CliOption<T>("s", "skipTests", "Skip test execution") {
+        options.add(new CliOption<>("s", "skipTests", "Skip test execution") {
             @Override
             protected void doProcess(T configuration, String arg, String value, LinkedList<String> remainingArgs) {
                 if (StringUtils.hasText(value)) {
@@ -95,7 +95,7 @@ public class CitrusAppOptions<T extends CitrusAppConfiguration> {
             }
         });
 
-        options.add(new CliOption<T>("p", "package", "Test package to execute") {
+        options.add(new CliOption<>("p", "package", "Test package to execute") {
             @Override
             protected void doProcess(T configuration, String arg, String value, LinkedList<String> remainingArgs) {
                 if (StringUtils.hasText(value)) {
@@ -106,7 +106,7 @@ public class CitrusAppOptions<T extends CitrusAppConfiguration> {
             }
         });
 
-        options.add(new CliOption<T>("D", "properties", "Default system properties to set") {
+        options.add(new CliOption<>("D", "properties", "Default system properties to set") {
             @Override
             protected void doProcess(T configuration, String arg, String value, LinkedList<String> remainingArgs) {
                 if (StringUtils.hasText(value)) {
@@ -120,7 +120,7 @@ public class CitrusAppOptions<T extends CitrusAppConfiguration> {
             }
         });
 
-        options.add(new CliOption<T>("", "exit", "Force system exit when finished") {
+        options.add(new CliOption<>("", "exit", "Force system exit when finished") {
             @Override
             protected void doProcess(T configuration, String arg, String value, LinkedList<String> remainingArgs) {
                 if (StringUtils.hasText(value)) {
@@ -131,7 +131,7 @@ public class CitrusAppOptions<T extends CitrusAppConfiguration> {
             }
         });
 
-        options.add(new CliOption<T>("e", "engine", "Set test engine name used to run the tests") {
+        options.add(new CliOption<>("e", "engine", "Set test engine name used to run the tests") {
             @Override
             protected void doProcess(T configuration, String arg, String value, LinkedList<String> remainingArgs) {
                 if (StringUtils.hasText(value)) {
@@ -142,7 +142,7 @@ public class CitrusAppOptions<T extends CitrusAppConfiguration> {
             }
         });
 
-        options.add(new CliOption<T>("t", "test", "Test class/method to execute") {
+        options.add(new CliOption<>("t", "test", "Test class/method to execute") {
             @Override
             protected void doProcess(T configuration, String arg, String value, LinkedList<String> remainingArgs) {
                 if (StringUtils.hasText(value)) {
@@ -166,7 +166,7 @@ public class CitrusAppOptions<T extends CitrusAppConfiguration> {
             }
         });
 
-        options.add(new CliOption<T>("j", "jar", "External test jar to load tests from") {
+        options.add(new CliOption<>("j", "jar", "External test jar to load tests from") {
             @Override
             protected void doProcess(T configuration, String arg, String value, LinkedList<String> remainingArgs) {
                 if (StringUtils.hasText(value)) {
@@ -182,8 +182,8 @@ public class CitrusAppOptions<T extends CitrusAppConfiguration> {
      * Apply options based on given argument line.
      * @param arguments
      */
-    public static CitrusAppConfiguration apply(String[] arguments) {
-        return apply(new CitrusAppConfiguration(), arguments);
+    public T apply(String[] arguments) {
+        return apply((T) new CitrusAppConfiguration(), arguments);
     }
 
     /**
@@ -191,7 +191,7 @@ public class CitrusAppOptions<T extends CitrusAppConfiguration> {
      * @param configuration
      * @param arguments
      */
-    public static <T extends CitrusAppConfiguration> T apply(T configuration, String[] arguments) {
+    public T apply(T configuration, String[] arguments) {
         LinkedList<String> args = new LinkedList<>(Arrays.asList(arguments));
 
         CitrusAppOptions<T> options = new CitrusAppOptions<>();

--- a/runtime/citrus-main/src/main/java/com/consol/citrus/main/spring/CitrusSpringApp.java
+++ b/runtime/citrus-main/src/main/java/com/consol/citrus/main/spring/CitrusSpringApp.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.consol.citrus.main.spring;
+
+import com.consol.citrus.main.CitrusApp;
+
+/**
+ * Main command line application callable via static run methods and command line main method invocation.
+ * Command line options are passed to the application for optional arguments. Application will run until the
+ * duration time option has passed by or until the JVM terminates.
+ *
+ * @author Christoph Deppisch
+ * @since 2.7.4
+ */
+public class CitrusSpringApp extends CitrusApp {
+
+    /**
+     * Default constructor using default configuration.
+     */
+    public CitrusSpringApp() {
+        super(new CitrusSpringAppConfiguration());
+    }
+
+    /**
+     * Construct with given configuration.
+     * @param configuration
+     */
+    public CitrusSpringApp(CitrusSpringAppConfiguration configuration) {
+        super(configuration);
+    }
+
+    /**
+     * Construct from command line arguments.
+     * @param args
+     */
+    public CitrusSpringApp(String[] args) {
+        this(new CitrusSpringAppOptions().apply(args));
+    }
+}

--- a/runtime/citrus-main/src/main/java/com/consol/citrus/main/spring/CitrusSpringAppConfiguration.java
+++ b/runtime/citrus-main/src/main/java/com/consol/citrus/main/spring/CitrusSpringAppConfiguration.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.consol.citrus.main.spring;
+
+import java.util.Map;
+import java.util.Optional;
+
+import com.consol.citrus.CitrusSpringSettings;
+import com.consol.citrus.main.CitrusAppConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class CitrusSpringAppConfiguration extends CitrusAppConfiguration {
+
+    /** Logger */
+    private static final Logger LOG = LoggerFactory.getLogger(CitrusSpringAppConfiguration.class);
+
+    @Override
+    public void setDefaultProperties() {
+        for (Map.Entry<String, String> entry : getDefaultProperties().entrySet()) {
+            LOG.debug(String.format("Setting application property %s=%s", entry.getKey(), entry.getValue()));
+            System.setProperty(entry.getKey(), Optional.ofNullable(entry.getValue()).orElse(""));
+        }
+
+        if (getConfigClass() != null) {
+            System.setProperty(CitrusSpringSettings.DEFAULT_APPLICATION_CONTEXT_CLASS_PROPERTY, getConfigClass());
+        }
+    }
+}

--- a/runtime/citrus-main/src/main/java/com/consol/citrus/main/spring/CitrusSpringAppOptions.java
+++ b/runtime/citrus-main/src/main/java/com/consol/citrus/main/spring/CitrusSpringAppOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with
@@ -17,30 +17,12 @@
  * limitations under the License.
  */
 
-package com.consol.citrus.testng;
+package com.consol.citrus.main.spring;
 
-import org.testng.ITestContext;
-import org.testng.annotations.AfterSuite;
-import org.testng.annotations.BeforeSuite;
+import com.consol.citrus.main.CitrusAppOptions;
 
 /**
  * @author Christoph Deppisch
  */
-public interface TestNGSuiteListener {
-
-    /**
-     * Runs tasks before test suite.
-     * @param testContext the test context.
-     */
-    @BeforeSuite(alwaysRun = true)
-    default void beforeSuite(ITestContext testContext) {
-    }
-
-    /**
-     * Runs tasks after test suite.
-     * @param testContext the test context.
-     */
-    @AfterSuite(alwaysRun = true)
-    default void afterSuite(ITestContext testContext) {
-    }
+public class CitrusSpringAppOptions extends CitrusAppOptions<CitrusSpringAppConfiguration> {
 }

--- a/runtime/citrus-main/src/test/java/com/consol/citrus/integration/CitrusStandaloneIT.java
+++ b/runtime/citrus-main/src/test/java/com/consol/citrus/integration/CitrusStandaloneIT.java
@@ -17,7 +17,7 @@
 package com.consol.citrus.integration;
 
 import com.consol.citrus.Citrus;
-import com.consol.citrus.CitrusSpringContext;
+import com.consol.citrus.CitrusSpringContextProvider;
 import com.consol.citrus.DefaultTestCaseRunner;
 import com.consol.citrus.TestCaseRunner;
 import com.consol.citrus.annotations.CitrusAnnotations;
@@ -62,7 +62,7 @@ public class CitrusStandaloneIT extends AbstractTestNGSpringContextTests {
 
     @BeforeClass
     public void beforeAll() {
-        citrus = Citrus.newInstance(CitrusSpringContext.create(applicationContext));
+        citrus = Citrus.newInstance(new CitrusSpringContextProvider(applicationContext));
     }
 
     @BeforeMethod

--- a/runtime/citrus-testng/src/main/java/com/consol/citrus/testng/TestNGCitrusSupport.java
+++ b/runtime/citrus-testng/src/main/java/com/consol/citrus/testng/TestNGCitrusSupport.java
@@ -49,7 +49,7 @@ import org.testng.ITestResult;
  *
  * @author Christoph Deppisch
  */
-public class TestNGCitrusSupport implements IHookable, TestNGSuiteListener, GherkinTestActionRunner {
+public class TestNGCitrusSupport implements IHookable, TestNGTestListener, TestNGSuiteListener, GherkinTestActionRunner {
 
     /** Logger */
     protected final Logger log = LoggerFactory.getLogger(getClass());
@@ -119,8 +119,40 @@ public class TestNGCitrusSupport implements IHookable, TestNGSuiteListener, Gher
     }
 
     @Override
-    public void beforeSuite(ITestContext testContext) {
+    public final void before() {
+        if (citrus == null) {
+            citrus = Citrus.newInstance();
+            CitrusAnnotations.injectCitrusFramework(this, citrus);
+        }
+
+        before(citrus.getCitrusContext());
+    }
+
+    /**
+     * Subclasses may add before test actions on the provided context.
+     * @param context the Citrus context.
+     */
+    protected void before(CitrusContext context) {
+    }
+
+    @Override
+    public final void after() {
+        if (citrus != null) {
+            after(citrus.getCitrusContext());
+        }
+    }
+
+    /**
+     * Subclasses may add after test actions on the provided context.
+     * @param context the Citrus context.
+     */
+    protected void after(CitrusContext context) {
+    }
+
+    @Override
+    public final void beforeSuite(ITestContext testContext) {
         citrus = Citrus.newInstance();
+        CitrusAnnotations.injectCitrusFramework(this, citrus);
         beforeSuite(citrus.getCitrusContext());
         citrus.beforeSuite(testContext.getSuite().getName(), testContext.getIncludedGroups());
     }
@@ -133,7 +165,7 @@ public class TestNGCitrusSupport implements IHookable, TestNGSuiteListener, Gher
     }
 
     @Override
-    public void afterSuite(ITestContext testContext) {
+    public final void afterSuite(ITestContext testContext) {
         if (citrus != null) {
             afterSuite(citrus.getCitrusContext());
             citrus.afterSuite(testContext.getSuite().getName(), testContext.getIncludedGroups());

--- a/runtime/citrus-testng/src/main/java/com/consol/citrus/testng/TestNGTestListener.java
+++ b/runtime/citrus-testng/src/main/java/com/consol/citrus/testng/TestNGTestListener.java
@@ -19,28 +19,25 @@
 
 package com.consol.citrus.testng;
 
-import org.testng.ITestContext;
-import org.testng.annotations.AfterSuite;
-import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 
 /**
  * @author Christoph Deppisch
  */
-public interface TestNGSuiteListener {
+public interface TestNGTestListener {
 
     /**
-     * Runs tasks before test suite.
-     * @param testContext the test context.
+     * Runs tasks before test class.
      */
-    @BeforeSuite(alwaysRun = true)
-    default void beforeSuite(ITestContext testContext) {
+    @BeforeClass(alwaysRun = true)
+    default void before() {
     }
 
     /**
-     * Runs tasks after test suite.
-     * @param testContext the test context.
+     * Runs tasks after test class.
      */
-    @AfterSuite(alwaysRun = true)
-    default void afterSuite(ITestContext testContext) {
+    @AfterClass(alwaysRun = true)
+    default void after() {
     }
 }

--- a/runtime/citrus-testng/src/main/java/com/consol/citrus/testng/spring/TestNGCitrusSpringSupport.java
+++ b/runtime/citrus-testng/src/main/java/com/consol/citrus/testng/spring/TestNGCitrusSpringSupport.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Optional;
 
 import com.consol.citrus.Citrus;
+import com.consol.citrus.CitrusContext;
 import com.consol.citrus.CitrusSpringContext;
 import com.consol.citrus.GherkinTestActionRunner;
 import com.consol.citrus.TestAction;
@@ -44,6 +45,7 @@ import com.consol.citrus.context.TestContext;
 import com.consol.citrus.exceptions.CitrusRuntimeException;
 import com.consol.citrus.testng.PrepareTestNGMethodInterceptor;
 import com.consol.citrus.testng.TestNGHelper;
+import com.consol.citrus.testng.TestNGTestListener;
 import com.consol.citrus.testng.TestNGSuiteListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,7 +68,8 @@ import org.testng.annotations.Listeners;
  */
 @ContextConfiguration(classes = CitrusSpringConfig.class)
 @Listeners( { PrepareTestNGMethodInterceptor.class } )
-public class TestNGCitrusSpringSupport extends AbstractTestNGSpringContextTests implements GherkinTestActionRunner, TestNGSuiteListener {
+public class TestNGCitrusSpringSupport extends AbstractTestNGSpringContextTests
+        implements GherkinTestActionRunner, TestNGTestListener, TestNGSuiteListener {
 
     /** Logger */
     protected final Logger log = LoggerFactory.getLogger(getClass());
@@ -133,11 +136,12 @@ public class TestNGCitrusSpringSupport extends AbstractTestNGSpringContextTests 
      * @param invocationCount
      */
     protected void run(ITestResult testResult, Method method, TestLoader testLoader, int invocationCount) {
-        if (method != null && method.getAnnotation(CitrusXmlTest.class) != null) {
-            if (citrus == null) {
-                citrus = Citrus.newInstance(CitrusSpringContext.create(applicationContext));
-            }
+        if (citrus == null) {
+            citrus = Citrus.newInstance(CitrusSpringContext.create(applicationContext));
+            CitrusAnnotations.injectCitrusFramework(this, citrus);
+        }
 
+        if (method != null && method.getAnnotation(CitrusXmlTest.class) != null) {
             TestContext ctx = prepareTestContext(citrus.getCitrusContext().createTestContext());
             TestCase testCase = testLoader.load();
 
@@ -148,10 +152,6 @@ public class TestNGCitrusSpringSupport extends AbstractTestNGSpringContextTests 
             TestNGHelper.invokeTestMethod(citrus, this, testResult, method, testCase, ctx, invocationCount);
         } else {
             try {
-                if (citrus == null) {
-                    citrus = Citrus.newInstance(CitrusSpringContext.create(applicationContext));
-                }
-
                 TestContext ctx = prepareTestContext(citrus.getCitrusContext().createTestContext());
 
                 TestCaseRunner runner = TestNGHelper.createTestCaseRunner(this, method, ctx);
@@ -170,7 +170,38 @@ public class TestNGCitrusSpringSupport extends AbstractTestNGSpringContextTests 
     }
 
     @Override
-    public void beforeSuite(ITestContext testContext) {
+    public final void before() {
+        if (citrus == null) {
+            citrus = Citrus.newInstance(CitrusSpringContext.create(applicationContext));
+            CitrusAnnotations.injectCitrusFramework(this, citrus);
+        }
+
+        before(citrus.getCitrusContext());
+    }
+
+    /**
+     * Subclasses may add before test actions on the provided context.
+     * @param context the Citrus context.
+     */
+    protected void before(CitrusContext context) {
+    }
+
+    @Override
+    public final void after() {
+        if (citrus != null) {
+            after(citrus.getCitrusContext());
+        }
+    }
+
+    /**
+     * Subclasses may add after test actions on the provided context.
+     * @param context the Citrus context.
+     */
+    protected void after(CitrusContext context) {
+    }
+
+    @Override
+    public final void beforeSuite(ITestContext testContext) {
         try {
             springTestContextPrepareTestInstance();
         } catch (Exception e) {
@@ -179,14 +210,31 @@ public class TestNGCitrusSpringSupport extends AbstractTestNGSpringContextTests 
         Assert.notNull(applicationContext, "Missing proper application context in before suite initialization");
 
         citrus = Citrus.newInstance(CitrusSpringContext.create(applicationContext));
+        CitrusAnnotations.injectCitrusFramework(this, citrus);
+        beforeSuite(citrus.getCitrusContext());
         citrus.beforeSuite(testContext.getSuite().getName(), testContext.getIncludedGroups());
     }
 
+    /**
+     * Subclasses may add before suite actions on the provided context.
+     * @param context the Citrus context.
+     */
+    protected void beforeSuite(CitrusContext context) {
+    }
+
     @Override
-    public void afterSuite(ITestContext testContext) {
+    public final void afterSuite(ITestContext testContext) {
         if (citrus != null) {
+            afterSuite(citrus.getCitrusContext());
             citrus.afterSuite(testContext.getSuite().getName(), testContext.getIncludedGroups());
         }
+    }
+
+    /**
+     * Subclasses may add after suite actions on the provided context.
+     * @param context the Citrus context.
+     */
+    protected void afterSuite(CitrusContext context) {
     }
 
     /**

--- a/runtime/citrus-testng/src/main/java/com/consol/citrus/testng/spring/TestNGCitrusSpringSupport.java
+++ b/runtime/citrus-testng/src/main/java/com/consol/citrus/testng/spring/TestNGCitrusSpringSupport.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 import com.consol.citrus.Citrus;
 import com.consol.citrus.CitrusContext;
 import com.consol.citrus.CitrusSpringContext;
+import com.consol.citrus.CitrusSpringContextProvider;
 import com.consol.citrus.GherkinTestActionRunner;
 import com.consol.citrus.TestAction;
 import com.consol.citrus.TestActionBuilder;
@@ -45,8 +46,8 @@ import com.consol.citrus.context.TestContext;
 import com.consol.citrus.exceptions.CitrusRuntimeException;
 import com.consol.citrus.testng.PrepareTestNGMethodInterceptor;
 import com.consol.citrus.testng.TestNGHelper;
-import com.consol.citrus.testng.TestNGTestListener;
 import com.consol.citrus.testng.TestNGSuiteListener;
+import com.consol.citrus.testng.TestNGTestListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.test.context.ContextConfiguration;
@@ -137,7 +138,7 @@ public class TestNGCitrusSpringSupport extends AbstractTestNGSpringContextTests
      */
     protected void run(ITestResult testResult, Method method, TestLoader testLoader, int invocationCount) {
         if (citrus == null) {
-            citrus = Citrus.newInstance(CitrusSpringContext.create(applicationContext));
+            citrus = Citrus.newInstance(new CitrusSpringContextProvider(applicationContext));
             CitrusAnnotations.injectCitrusFramework(this, citrus);
         }
 
@@ -172,7 +173,7 @@ public class TestNGCitrusSpringSupport extends AbstractTestNGSpringContextTests
     @Override
     public final void before() {
         if (citrus == null) {
-            citrus = Citrus.newInstance(CitrusSpringContext.create(applicationContext));
+            citrus = Citrus.newInstance(new CitrusSpringContextProvider(applicationContext));
             CitrusAnnotations.injectCitrusFramework(this, citrus);
         }
 
@@ -209,7 +210,7 @@ public class TestNGCitrusSpringSupport extends AbstractTestNGSpringContextTests
         }
         Assert.notNull(applicationContext, "Missing proper application context in before suite initialization");
 
-        citrus = Citrus.newInstance(CitrusSpringContext.create(applicationContext));
+        citrus = Citrus.newInstance(new CitrusSpringContextProvider(applicationContext));
         CitrusAnnotations.injectCitrusFramework(this, citrus);
         beforeSuite(citrus.getCitrusContext());
         citrus.beforeSuite(testContext.getSuite().getName(), testContext.getIncludedGroups());

--- a/runtime/citrus-testng/src/test/java/com/consol/citrus/integration/container/WaitIT.java
+++ b/runtime/citrus-testng/src/test/java/com/consol/citrus/integration/container/WaitIT.java
@@ -45,7 +45,9 @@ public class WaitIT extends TestNGCitrusSpringSupport {
 
     @AfterClass(alwaysRun = true)
     public void stopServer() {
-        server.stop(0);
+        if (server != null) {
+            server.stop(0);
+        }
     }
 
     @Test

--- a/runtime/citrus-testng/src/test/java/com/consol/citrus/integration/container/WaitJavaIT.java
+++ b/runtime/citrus-testng/src/test/java/com/consol/citrus/integration/container/WaitJavaIT.java
@@ -56,7 +56,9 @@ public class WaitJavaIT extends TestNGCitrusSpringSupport {
 
     @AfterClass(alwaysRun = true)
     public void stopServer() {
-        server.stop(0);
+        if (server != null) {
+            server.stop(0);
+        }
     }
 
     @CitrusTest

--- a/runtime/citrus-testng/src/test/java/com/consol/citrus/testng/CitrusSpringConfigTest.java
+++ b/runtime/citrus-testng/src/test/java/com/consol/citrus/testng/CitrusSpringConfigTest.java
@@ -1,6 +1,6 @@
 package com.consol.citrus.testng;
 
-import com.consol.citrus.CitrusSettings;
+import com.consol.citrus.CitrusSpringSettings;
 import com.consol.citrus.context.SpringBeanReferenceResolver;
 import com.consol.citrus.context.TestContextFactoryBean;
 import com.consol.citrus.endpoint.DefaultEndpointFactory;
@@ -51,7 +51,7 @@ import org.testng.annotations.Test;
 public class CitrusSpringConfigTest extends TestNGCitrusSpringSupport {
 
     static {
-        System.setProperty(CitrusSettings.DEFAULT_APPLICATION_CONTEXT_PROPERTY, "classpath:citrus-unit-context.xml");
+        System.setProperty(CitrusSpringSettings.DEFAULT_APPLICATION_CONTEXT_PROPERTY, "classpath:citrus-unit-context.xml");
     }
 
     @Autowired

--- a/src/manual/configuration.adoc
+++ b/src/manual/configuration.adoc
@@ -22,11 +22,8 @@ such as Docker or Kubernetes. The following settings do support this kind of env
 | citrus.application.properties
 | File location for application property file that holds other settings. These properties get loaded as system properties on startup. (default="classpath:citrus-application.properties")
 
-| citrus.spring.application.context
-| File location for Spring XML configurations (default="classpath*:citrus-context.xml")
-
-| citrus.spring.java.config
-| Class name for Spring Java config (default=null)
+| citrus.java.config
+| Class name for custom Java configuration (default=null)
 
 | citrus.file.encoding
 | Default file encoding used in Citrus when reading and writing file content (default=Charset.defaultCharset())
@@ -59,11 +56,8 @@ Same properties are settable via environment variables.
 | CITRUS_APPLICATION_PROPERTIES
 | File location for application property file that holds other settings. These properties get loaded as system properties on startup. (default="classpath:citrus-application.properties")
 
-| CITRUS_SPRING_APPLICATION_CONTEXT
-| File location for Spring XML configurations (default="classpath*:citrus-context.xml")
-
-| CITRUS_SPRING_JAVA_CONFIG
-| Class name for Spring Java config (default=null)
+| CITRUS_JAVA_CONFIG
+| Class name for custom Java configuration (default=null)
 
 | CITRUS_FILE_ENCODING
 | Default file encoding used in Citrus when reading and writing file content (default=Charset.defaultCharset())
@@ -85,6 +79,36 @@ Same properties are settable via environment variables.
 
 | CITRUS_JAVA_FILE_NAME_PATTERN
 | File name patterns used for Java test sources package scan (default="/\\**/*Test.java,/**/*IT.java")
+|===
+
+[[configuration-spring]]
+== Spring configuration settings
+
+When spring framework is enabled in Citrus you can set specific settings regarding the Spring
+application context.
+
+.System properties
+|===
+|System properties |Description
+
+| citrus.spring.application.context
+| File location for Spring XML configurations (default="classpath*:citrus-context.xml")
+
+| citrus.spring.java.config
+| Class name for Spring Java config (default=null)
+
+|===
+
+.Environment variables
+|===
+|Environment variable |Description
+
+| CITRUS_SPRING_APPLICATION_CONTEXT
+| File location for Spring XML configurations (default="classpath*:citrus-context.xml")
+
+| CITRUS_SPRING_JAVA_CONFIG
+| Class name for Spring Java config (default=null)
+
 |===
 
 [[configuration-property-file]]

--- a/src/manual/run-java.adoc
+++ b/src/manual/run-java.adoc
@@ -352,6 +352,143 @@ current test context which holds the list of test variables as well as many othe
 This is why you should wrap custom code in a test action an run that code via the test action runner methods. You can also put your custom code in
 a test action implementation and reference the logic from multiple tests.
 
+[[java-bind-to-registry]]
+== Bind objects to registry
+
+The Citrus context is a place where objects can register themselves in order to enable dependency injection and instance sharing
+in multiple tests. Once you register the object in the context others can resolve the reference with its given name.
+
+In a simple example the context can register a new endpoint that is injected in several tests.
+
+You can access the Citrus context within the provided before/after methods on the test.
+
+.Register endpoint in Citrus context
+[source,java]
+----
+public class CitrusRegisterEndpoint_IT extends TestNGCitrusSupport {
+
+    @Override
+    public void beforeSuite(CitrusContext context) {
+        context.bind("foo", new FooEndpoint());
+    }
+}
+----
+
+With the CitrusContext you can bind objects to the registry. Each binding receives a name so others can resolve the instance
+reference for injection.
+
+.Inject endpoint in other tests
+[source,java]
+----
+public class InjectEndpoint_IT extends TestNGCitrusSupport {
+
+    @CitrusEndpoint
+    private FooEndpoint foo;
+
+    @Test
+    @CitrusTest
+    public void injectEndpointTest() {
+        $(send(foo)
+                .message()
+                .body("Hello foo!"));
+
+        $(receive(foo)
+                .message()
+                .body("Hello Citrus!"));
+    }
+}
+----
+
+The `@CitrusEndpoint` annotation injects the endpoint resolving the instance with the given name `foo`.
+Test methods can use this endpoint in the following in send and receive actions.
+
+[[java-bind-to-registry-annotation]]
+=== @BindToRegistry
+
+An alternative to using the `bind()` method on the CitrusContext is to use the `@BindToRegistry` annotation.
+Methods and fields annotated will automatically register in the CitrusContext registry.
+
+.@BindToRegistry annotation
+[source,java]
+----
+public class CitrusRegisterEndpoint_IT extends TestNGCitrusSupport {
+
+    @CitrusFramework
+    private Citrus citrus;
+
+    @BindToRegistry(name = "fooQueue")
+    private MessageQueue queue = new DefaultMessageQueue("fooQueue");
+
+    @BindToRegistry
+    public void foo() {
+        return new FooEndpoint();
+    }
+}
+----
+
+The annotation is able to specify an explicit binding name.
+The annotation works with public methods and fields in tests.
+
+[[java-configuration-class]]
+=== Configuration classes
+
+As an alternative to adding the registry binding configuration directly to the test you can load configuration classes.
+
+Configuration classes are automatically loaded before a test suite run and all methods and fields are parsed for potential bindings.
+You can use the environment settings `citrus.java.config` and/or `CITRUS_JAVA_CONFIG` to set a default configuration class.
+
+.citrus-application.properties
+[source,properties]
+----
+citrus.java.config=MyConfig.class
+----
+
+.MyConfig.class
+[source,java]
+----
+public class MyConfig {
+
+    @BindToRegistry(name = "fooQueue")
+    private MessageQueue queue = new DefaultMessageQueue("fooQueue");
+
+    @BindToRegistry
+    public void foo() {
+        return new FooEndpoint();
+    }
+}
+----
+
+[[java-configuration-class-annotation]]
+=== @CitrusConfiguration
+
+Each test is able to use the `@CitrusConfiguration` annotation to add registry bindings, too.
+
+.@CitrusConfiguration annotation
+[source,java]
+----
+@CitrusConfiguration(classes = MyConfig.class)
+public class CitrusRegisterEndpoint_IT extends TestNGCitrusSupport {
+
+    @CitrusEndpoint
+    private FooEndpoint foo;
+
+    @Test
+    @CitrusTest
+    public void injectEndpointTest() {
+        $(send(foo)
+                .message()
+                .body("Hello foo!"));
+
+        $(receive(foo)
+                .message()
+                .body("Hello Citrus!"));
+    }
+}
+----
+
+The `@CitrusConfiguration` annotation is able to load configuration classes and bind all components to the registry for later usage.
+The test can inject endpoints and other components using the `@CitrusEndpoint` and `@CitrusResource` annotation on fields.
+
 [[java-resource-injection]]
 == Resource injection
 

--- a/tools/remote/citrus-remote-server/src/main/java/com/consol/citrus/remote/CitrusRemoteOptions.java
+++ b/tools/remote/citrus-remote-server/src/main/java/com/consol/citrus/remote/CitrusRemoteOptions.java
@@ -31,7 +31,7 @@ public class CitrusRemoteOptions extends CitrusAppOptions<CitrusRemoteConfigurat
     protected CitrusRemoteOptions() {
         super();
 
-        options.add(new CliOption<CitrusRemoteConfiguration>("P", "port", "Server port") {
+        options.add(new CliOption<>("P", "port", "Server port") {
             @Override
             protected void doProcess(CitrusRemoteConfiguration configuration, String arg, String value, LinkedList<String> remainingArgs) {
                 if (StringUtils.hasText(value)) {

--- a/tools/remote/citrus-remote-server/src/main/java/com/consol/citrus/remote/CitrusRemoteServer.java
+++ b/tools/remote/citrus-remote-server/src/main/java/com/consol/citrus/remote/CitrusRemoteServer.java
@@ -16,12 +16,15 @@
 
 package com.consol.citrus.remote;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
 import com.consol.citrus.remote.controller.RunController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import spark.Spark;
-
-import java.util.concurrent.*;
 
 import static spark.Spark.port;
 
@@ -57,7 +60,7 @@ public class CitrusRemoteServer {
     }
 
     public CitrusRemoteServer(String[] args) {
-        this(CitrusRemoteOptions.apply(new CitrusRemoteConfiguration(), args));
+        this(new CitrusRemoteOptions().apply(new CitrusRemoteConfiguration(), args));
     }
 
     /**

--- a/validation/citrus-validation-json/src/test/java/com/consol/citrus/UnitTestSupport.java
+++ b/validation/citrus-validation-json/src/test/java/com/consol/citrus/UnitTestSupport.java
@@ -31,7 +31,7 @@ public abstract class UnitTestSupport extends AbstractTestNGUnitTest {
         factory.getMessageValidatorRegistry().addMessageValidator("header", new DefaultMessageHeaderValidator());
         factory.getMessageValidatorRegistry().addMessageValidator("json", new JsonTextMessageValidator());
         factory.getMessageValidatorRegistry().addMessageValidator("jsonPath", new JsonPathMessageValidator());
-        factory.getMessageValidatorRegistry().addMessageValidator("plaintext", new MessageValidator<ValidationContext>() {
+        factory.getMessageValidatorRegistry().addMessageValidator("plaintext", new MessageValidator<>() {
             @Override
             public void validateMessage(Message receivedMessage, Message controlMessage, TestContext context, List<ValidationContext> validationContexts) throws ValidationException {
                 Assert.assertEquals(receivedMessage.getPayload(String.class), controlMessage.getPayload());

--- a/vintage/citrus-arquillian/src/main/java/com/consol/citrus/arquillian/enricher/CitrusInstanceProducer.java
+++ b/vintage/citrus-arquillian/src/main/java/com/consol/citrus/arquillian/enricher/CitrusInstanceProducer.java
@@ -17,13 +17,15 @@
 package com.consol.citrus.arquillian.enricher;
 
 import com.consol.citrus.Citrus;
-import com.consol.citrus.CitrusSpringContext;
+import com.consol.citrus.CitrusSpringContextProvider;
 import com.consol.citrus.arquillian.CitrusExtensionConstants;
 import com.consol.citrus.arquillian.configuration.CitrusConfiguration;
 import org.jboss.arquillian.container.spi.event.container.BeforeDeploy;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.InstanceProducer;
-import org.jboss.arquillian.core.api.annotation.*;
+import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.api.annotation.Observes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,7 +56,7 @@ public class CitrusInstanceProducer {
         try {
             if (!event.getDeployment().testable()) {
                 log.info("Producing Citrus framework instance");
-                citrusInstance.set(Citrus.newInstance(CitrusSpringContext.create(configurationInstance.get().getConfigurationClass())));
+                citrusInstance.set(Citrus.newInstance(new CitrusSpringContextProvider(configurationInstance.get().getConfigurationClass())));
             }
         } catch (Exception e) {
             log.error(CitrusExtensionConstants.CITRUS_EXTENSION_ERROR, e);

--- a/vintage/citrus-arquillian/src/main/java/com/consol/citrus/arquillian/enricher/CitrusRemoteInstanceProducer.java
+++ b/vintage/citrus-arquillian/src/main/java/com/consol/citrus/arquillian/enricher/CitrusRemoteInstanceProducer.java
@@ -17,12 +17,14 @@
 package com.consol.citrus.arquillian.enricher;
 
 import com.consol.citrus.Citrus;
-import com.consol.citrus.CitrusSpringContext;
+import com.consol.citrus.CitrusSpringContextProvider;
 import com.consol.citrus.arquillian.CitrusExtensionConstants;
 import com.consol.citrus.arquillian.configuration.CitrusConfiguration;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.InstanceProducer;
-import org.jboss.arquillian.core.api.annotation.*;
+import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.api.annotation.Observes;
 import org.jboss.arquillian.test.spi.event.suite.BeforeSuite;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,7 +51,7 @@ public class CitrusRemoteInstanceProducer {
     public void beforeSuite(@Observes(precedence = CitrusExtensionConstants.INSTANCE_REMOTE_PRECEDENCE) BeforeSuite event) {
         try {
             log.info("Producing Citrus framework instance");
-            citrusInstance.set(Citrus.newInstance(CitrusSpringContext.create(configurationInstance.get().getConfigurationClass())));
+            citrusInstance.set(Citrus.newInstance(new CitrusSpringContextProvider(configurationInstance.get().getConfigurationClass())));
         } catch (Exception e) {
             log.error(CitrusExtensionConstants.CITRUS_EXTENSION_ERROR, e);
             throw e;

--- a/vintage/citrus-arquillian/src/test/java/com/consol/citrus/arquillian/enricher/CitrusTestEnricherTest.java
+++ b/vintage/citrus-arquillian/src/test/java/com/consol/citrus/arquillian/enricher/CitrusTestEnricherTest.java
@@ -19,7 +19,7 @@ package com.consol.citrus.arquillian.enricher;
 import java.net.URL;
 
 import com.consol.citrus.Citrus;
-import com.consol.citrus.CitrusSpringContext;
+import com.consol.citrus.CitrusSpringContextProvider;
 import com.consol.citrus.DefaultTestCaseRunner;
 import com.consol.citrus.TestCaseRunner;
 import com.consol.citrus.arquillian.helper.InjectionHelper;
@@ -39,7 +39,7 @@ public class CitrusTestEnricherTest {
 
     private CitrusTestEnricher testEnricher = new CitrusTestEnricher();
 
-    private Citrus citrusFramework = Citrus.newInstance(CitrusSpringContext.create(ArquillianTestConfig.class));
+    private Citrus citrusFramework = Citrus.newInstance(new CitrusSpringContextProvider(ArquillianTestConfig.class));
 
     @Mock
     private Instance<Citrus> citrusInstance;

--- a/vintage/citrus-arquillian/src/test/java/com/consol/citrus/arquillian/lifecycle/CitrusLifecycleHandlerTest.java
+++ b/vintage/citrus-arquillian/src/test/java/com/consol/citrus/arquillian/lifecycle/CitrusLifecycleHandlerTest.java
@@ -19,7 +19,7 @@ package com.consol.citrus.arquillian.lifecycle;
 import java.util.Properties;
 
 import com.consol.citrus.Citrus;
-import com.consol.citrus.CitrusSpringContext;
+import com.consol.citrus.CitrusSpringContextProvider;
 import com.consol.citrus.arquillian.configuration.CitrusConfiguration;
 import com.consol.citrus.arquillian.helper.InjectionHelper;
 import org.jboss.arquillian.container.spi.client.container.DeployableContainer;
@@ -41,7 +41,7 @@ public class CitrusLifecycleHandlerTest {
 
     private CitrusConfiguration configuration = CitrusConfiguration.from(new Properties());
 
-    private Citrus citrusFramework = Citrus.newInstance(CitrusSpringContext.create());
+    private Citrus citrusFramework = Citrus.newInstance(new CitrusSpringContextProvider());
 
     @Mock
     private Instance<Citrus> citrusInstance;

--- a/vintage/citrus-arquillian/src/test/java/com/consol/citrus/arquillian/lifecycle/CitrusRemoteLifecycleHandlerTest.java
+++ b/vintage/citrus-arquillian/src/test/java/com/consol/citrus/arquillian/lifecycle/CitrusRemoteLifecycleHandlerTest.java
@@ -19,7 +19,7 @@ package com.consol.citrus.arquillian.lifecycle;
 import java.util.Properties;
 
 import com.consol.citrus.Citrus;
-import com.consol.citrus.CitrusSpringContext;
+import com.consol.citrus.CitrusSpringContextProvider;
 import com.consol.citrus.arquillian.configuration.CitrusConfiguration;
 import com.consol.citrus.arquillian.helper.InjectionHelper;
 import org.jboss.arquillian.core.api.Instance;
@@ -39,7 +39,7 @@ public class CitrusRemoteLifecycleHandlerTest {
 
     private CitrusConfiguration configuration = CitrusConfiguration.from(new Properties());
 
-    private Citrus citrusFramework = Citrus.newInstance(CitrusSpringContext.create());
+    private Citrus citrusFramework = Citrus.newInstance(new CitrusSpringContextProvider());
 
     @Mock
     private Instance<Citrus> citrusInstance;

--- a/vintage/citrus-java-dsl/src/main/java/com/consol/citrus/dsl/junit/JUnit4CitrusTest.java
+++ b/vintage/citrus-java-dsl/src/main/java/com/consol/citrus/dsl/junit/JUnit4CitrusTest.java
@@ -19,7 +19,7 @@ package com.consol.citrus.dsl.junit;
 import java.lang.reflect.Method;
 
 import com.consol.citrus.Citrus;
-import com.consol.citrus.CitrusSpringContext;
+import com.consol.citrus.CitrusSpringContextProvider;
 import com.consol.citrus.TestCase;
 import com.consol.citrus.TestCaseBuilder;
 import com.consol.citrus.TestResult;
@@ -38,7 +38,9 @@ import org.springframework.util.ReflectionUtils;
 /**
  * @author Christoph Deppisch
  * @since 2.5
+ * @deprecated in favor of using {@link com.consol.citrus.junit.spring.JUnit4CitrusSpringSupport}
  */
+@Deprecated
 public class JUnit4CitrusTest extends AbstractJUnit4CitrusTest {
 
     private static final String DESIGNER_ATTRIBUTE = "designer";
@@ -47,7 +49,7 @@ public class JUnit4CitrusTest extends AbstractJUnit4CitrusTest {
     @Override
     public void run(CitrusFrameworkMethod frameworkMethod) {
         if (citrus == null) {
-            citrus = Citrus.newInstance(CitrusSpringContext.create(applicationContext));
+            citrus = Citrus.newInstance(new CitrusSpringContextProvider(applicationContext));
         }
 
         TestContext ctx = prepareTestContext(citrus.getCitrusContext().createTestContext());

--- a/vintage/citrus-java-dsl/src/main/java/com/consol/citrus/dsl/testng/TestNGCitrusTest.java
+++ b/vintage/citrus-java-dsl/src/main/java/com/consol/citrus/dsl/testng/TestNGCitrusTest.java
@@ -19,7 +19,7 @@ package com.consol.citrus.dsl.testng;
 import java.lang.reflect.Method;
 
 import com.consol.citrus.Citrus;
-import com.consol.citrus.CitrusSpringContext;
+import com.consol.citrus.CitrusSpringContextProvider;
 import com.consol.citrus.TestCase;
 import com.consol.citrus.TestCaseBuilder;
 import com.consol.citrus.TestResult;
@@ -44,7 +44,9 @@ import org.testng.ITestResult;
 /**
  * @author Christoph Deppisch
  * @since 2.5
+ * @deprecated in favor of using {@link com.consol.citrus.testng.spring.TestNGCitrusSpringSupport}
  */
+@Deprecated
 public class TestNGCitrusTest extends AbstractTestNGCitrusTest {
 
     private static final String DESIGNER_ATTRIBUTE = "designer";
@@ -87,7 +89,7 @@ public class TestNGCitrusTest extends AbstractTestNGCitrusTest {
 
             try {
                 if (citrus == null) {
-                    citrus = Citrus.newInstance(CitrusSpringContext.create(applicationContext));
+                    citrus = Citrus.newInstance(new CitrusSpringContextProvider(applicationContext));
                 }
 
                 TestContext ctx = prepareTestContext(citrus.getCitrusContext().createTestContext());

--- a/vintage/citrus-java-dsl/src/main/java/com/consol/citrus/junit/AbstractJUnit4CitrusTest.java
+++ b/vintage/citrus-java-dsl/src/main/java/com/consol/citrus/junit/AbstractJUnit4CitrusTest.java
@@ -23,6 +23,7 @@ import java.lang.annotation.Annotation;
 
 import com.consol.citrus.Citrus;
 import com.consol.citrus.CitrusSpringContext;
+import com.consol.citrus.CitrusSpringContextProvider;
 import com.consol.citrus.TestCase;
 import com.consol.citrus.annotations.CitrusResource;
 import com.consol.citrus.common.TestLoader;
@@ -58,7 +59,7 @@ public abstract class AbstractJUnit4CitrusTest extends AbstractJUnit4SpringConte
     @Override
     public void run(CitrusFrameworkMethod frameworkMethod) {
         if (citrus == null) {
-            citrus = Citrus.newInstance(CitrusSpringContext.create(applicationContext));
+            citrus = Citrus.newInstance(new CitrusSpringContextProvider(applicationContext));
         }
 
         TestContext ctx = prepareTestContext(citrus.getCitrusContext().createTestContext());

--- a/vintage/citrus-java-dsl/src/main/java/com/consol/citrus/junit/jupiter/CitrusBaseExtension.java
+++ b/vintage/citrus-java-dsl/src/main/java/com/consol/citrus/junit/jupiter/CitrusBaseExtension.java
@@ -20,6 +20,7 @@
 package com.consol.citrus.junit.jupiter;
 
 import com.consol.citrus.Citrus;
+import com.consol.citrus.CitrusInstanceManager;
 import com.consol.citrus.annotations.CitrusAnnotations;
 import com.consol.citrus.context.TestContext;
 import com.consol.citrus.junit.jupiter.spring.CitrusSpringExtension;
@@ -43,7 +44,6 @@ public class CitrusBaseExtension implements BeforeAllCallback, TestInstancePostP
     /** Test suite name */
     private static final String SUITE_NAME = "citrus-junit5-suite";
 
-    protected static Citrus citrus;
     private static boolean beforeSuite = true;
     private static boolean afterSuite = true;
 
@@ -77,10 +77,6 @@ public class CitrusBaseExtension implements BeforeAllCallback, TestInstancePostP
      * @return
      */
     protected Citrus getCitrus() {
-        if (citrus == null) {
-            citrus = Citrus.newInstance();
-        }
-
-        return citrus;
+        return CitrusInstanceManager.getOrDefault();
     }
 }

--- a/vintage/citrus-java-dsl/src/main/java/com/consol/citrus/testng/AbstractTestNGCitrusTest.java
+++ b/vintage/citrus-java-dsl/src/main/java/com/consol/citrus/testng/AbstractTestNGCitrusTest.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 
 import com.consol.citrus.Citrus;
 import com.consol.citrus.CitrusSpringContext;
+import com.consol.citrus.CitrusSpringContextProvider;
 import com.consol.citrus.TestCase;
 import com.consol.citrus.TestGroupAware;
 import com.consol.citrus.TestResult;
@@ -108,7 +109,7 @@ public abstract class AbstractTestNGCitrusTest extends AbstractTestNGSpringConte
      */
     protected void run(ITestResult testResult, Method method, TestLoader testLoader, int invocationCount) {
         if (citrus == null) {
-            citrus = Citrus.newInstance(CitrusSpringContext.create(applicationContext));
+            citrus = Citrus.newInstance(new CitrusSpringContextProvider(applicationContext));
         }
 
         TestContext ctx = prepareTestContext(citrus.getCitrusContext().createTestContext());
@@ -230,7 +231,7 @@ public abstract class AbstractTestNGCitrusTest extends AbstractTestNGSpringConte
         springTestContextPrepareTestInstance();
         Assert.notNull(applicationContext, "Missing proper application context in before suite initialization");
 
-        citrus = Citrus.newInstance(CitrusSpringContext.create(applicationContext));
+        citrus = Citrus.newInstance(new CitrusSpringContextProvider(applicationContext));
         citrus.beforeSuite(testContext.getSuite().getName(), testContext.getIncludedGroups());
     }
 

--- a/vintage/citrus-java-dsl/src/test/java/com/consol/citrus/dsl/UnitTestSupport.java
+++ b/vintage/citrus-java-dsl/src/test/java/com/consol/citrus/dsl/UnitTestSupport.java
@@ -1,7 +1,7 @@
 package com.consol.citrus.dsl;
 
 import com.consol.citrus.Citrus;
-import com.consol.citrus.CitrusSpringContext;
+import com.consol.citrus.CitrusSpringContextProvider;
 import com.consol.citrus.CitrusSpringSettings;
 import com.consol.citrus.config.CitrusSpringConfig;
 import com.consol.citrus.context.TestContext;
@@ -46,7 +46,7 @@ public class UnitTestSupport extends AbstractTestNGUnitTest {
     public void beforeSuite(ITestContext testContext) throws Exception {
         super.beforeSuite(testContext);
 
-        citrus = Citrus.newInstance(CitrusSpringContext.create(applicationContext));
+        citrus = Citrus.newInstance(new CitrusSpringContextProvider(applicationContext));
         citrus.beforeSuite(testContext.getSuite().getName(), testContext.getIncludedGroups());
     }
 

--- a/vintage/citrus-java-dsl/src/test/java/com/consol/citrus/dsl/UnitTestSupport.java
+++ b/vintage/citrus-java-dsl/src/test/java/com/consol/citrus/dsl/UnitTestSupport.java
@@ -1,8 +1,8 @@
 package com.consol.citrus.dsl;
 
 import com.consol.citrus.Citrus;
-import com.consol.citrus.CitrusSettings;
 import com.consol.citrus.CitrusSpringContext;
+import com.consol.citrus.CitrusSpringSettings;
 import com.consol.citrus.config.CitrusSpringConfig;
 import com.consol.citrus.context.TestContext;
 import com.consol.citrus.context.TestContextFactory;
@@ -25,7 +25,7 @@ import org.testng.annotations.BeforeSuite;
 public class UnitTestSupport extends AbstractTestNGUnitTest {
 
     static {
-        System.setProperty(CitrusSettings.DEFAULT_APPLICATION_CONTEXT_PROPERTY, "classpath:citrus-unit-context.xml");
+        System.setProperty(CitrusSpringSettings.DEFAULT_APPLICATION_CONTEXT_PROPERTY, "classpath:citrus-unit-context.xml");
     }
 
     /** Factory bean for test context */


### PR DESCRIPTION
# Simplify registry binding operations
- Add BindToRegistry annotation
- Make sure to parse tests for bindings
- Add configuration class annotation to load registry bindings
- Introduce plain Java configuration class environment settings
- Load and parse registry bindings as part of JUnit4, JUnit5 and TestNG tests
- Add endpoint injection integration tests
- Add configuration class integration tests
- Add some documentation

# Refactor Citrus context management
- Move instance strategy to context provider so different implementations can use different strategies
- Introduce default context provider with singleton strategy
- Bind instance strategy for Spring based Citrus context provider to Spring ApplicationContext creation