### PR TITLE
fix(#810): Filter internal message headers on outbound messages

### DIFF
--- a/endpoints/citrus-http/src/test/resources/citrus-context.xml
+++ b/endpoints/citrus-http/src/test/resources/citrus-context.xml
@@ -137,9 +137,12 @@
     <property name="watchTopicAdvisories" value="false"/>
   </bean>
 
-  <citrus-jms:endpoint id="httpServerRequestEndpoint" destination-name="${jms.queue.http.request.forward}"/>
+  <citrus-jms:endpoint id="httpServerRequestEndpoint"
+                       filter-internal-headers="false"
+                       destination-name="${jms.queue.http.request.forward}"/>
 
   <citrus-jms:endpoint id="httpServerResponseEndpoint"
+                       filter-internal-headers="false"
                        destination-name="${jms.queue.http.request.ack}"
                        actor="helloServer"/>
 

--- a/endpoints/citrus-jms/src/main/java/com/consol/citrus/jms/config/annotation/JmsEndpointConfig.java
+++ b/endpoints/citrus-jms/src/main/java/com/consol/citrus/jms/config/annotation/JmsEndpointConfig.java
@@ -105,6 +105,12 @@ public @interface JmsEndpointConfig {
     boolean useObjectMessages() default false;
 
     /**
+     * Should filter internal message headers.
+     * @return
+     */
+    boolean filterInternalHeaders() default true;
+
+    /**
      * Timeout.
      * @return
      */

--- a/endpoints/citrus-jms/src/main/java/com/consol/citrus/jms/config/annotation/JmsEndpointConfigParser.java
+++ b/endpoints/citrus-jms/src/main/java/com/consol/citrus/jms/config/annotation/JmsEndpointConfigParser.java
@@ -97,6 +97,7 @@ public class JmsEndpointConfigParser implements AnnotationConfigParser<JmsEndpoi
         }
 
         builder.useObjectMessages(annotation.useObjectMessages());
+        builder.filterInternalHeaders(annotation.filterInternalHeaders());
 
         if (StringUtils.hasText(annotation.messageConverter())) {
             builder.messageConverter(referenceResolver.resolve(annotation.messageConverter(), JmsMessageConverter.class));

--- a/endpoints/citrus-jms/src/main/java/com/consol/citrus/jms/config/annotation/JmsSyncEndpointConfig.java
+++ b/endpoints/citrus-jms/src/main/java/com/consol/citrus/jms/config/annotation/JmsSyncEndpointConfig.java
@@ -99,6 +99,12 @@ public @interface JmsSyncEndpointConfig {
     boolean useObjectMessages() default false;
 
     /**
+     * Should filter internal message headers.
+     * @return
+     */
+    boolean filterInternalHeaders() default true;
+
+    /**
      * Polling interval.
      * @return
      */

--- a/endpoints/citrus-jms/src/main/java/com/consol/citrus/jms/config/annotation/JmsSyncEndpointConfigParser.java
+++ b/endpoints/citrus-jms/src/main/java/com/consol/citrus/jms/config/annotation/JmsSyncEndpointConfigParser.java
@@ -82,6 +82,7 @@ public class JmsSyncEndpointConfigParser implements AnnotationConfigParser<JmsSy
 
         builder.pubSubDomain(annotation.pubSubDomain());
         builder.useObjectMessages(annotation.useObjectMessages());
+        builder.filterInternalHeaders(annotation.filterInternalHeaders());
         builder.messageConverter(referenceResolver.resolve(annotation.messageConverter(), JmsMessageConverter.class));
 
         if (StringUtils.hasText(annotation.destinationResolver())) {

--- a/endpoints/citrus-jms/src/main/java/com/consol/citrus/jms/config/xml/AbstractJmsEndpointParser.java
+++ b/endpoints/citrus-jms/src/main/java/com/consol/citrus/jms/config/xml/AbstractJmsEndpointParser.java
@@ -77,6 +77,7 @@ public abstract class AbstractJmsEndpointParser extends AbstractEndpointParser {
 
         BeanDefinitionParserUtils.setPropertyValue(endpointConfiguration, element.getAttribute("pub-sub-domain"), "pubSubDomain");
         BeanDefinitionParserUtils.setPropertyValue(endpointConfiguration, element.getAttribute("use-object-messages"), "useObjectMessages");
+        BeanDefinitionParserUtils.setPropertyValue(endpointConfiguration, element.getAttribute("filter-internal-headers"), "filterInternalHeaders");
         BeanDefinitionParserUtils.setPropertyReference(endpointConfiguration, element.getAttribute("message-converter"), "messageConverter");
         BeanDefinitionParserUtils.setPropertyReference(endpointConfiguration, element.getAttribute("destination-resolver"), "destinationResolver");
         BeanDefinitionParserUtils.setPropertyReference(endpointConfiguration, element.getAttribute("destination-name-resolver"), "destinationNameResolver");

--- a/endpoints/citrus-jms/src/main/java/com/consol/citrus/jms/endpoint/JmsEndpointBuilder.java
+++ b/endpoints/citrus-jms/src/main/java/com/consol/citrus/jms/endpoint/JmsEndpointBuilder.java
@@ -16,14 +16,14 @@
 
 package com.consol.citrus.jms.endpoint;
 
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+
 import com.consol.citrus.endpoint.AbstractEndpointBuilder;
 import com.consol.citrus.endpoint.resolver.EndpointUriResolver;
 import com.consol.citrus.jms.message.JmsMessageConverter;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.jms.support.destination.DestinationResolver;
-
-import javax.jms.ConnectionFactory;
-import javax.jms.Destination;
 
 /**
  * @author Christoph Deppisch
@@ -156,6 +156,16 @@ public class JmsEndpointBuilder extends AbstractEndpointBuilder<JmsEndpoint> {
      */
     public JmsEndpointBuilder useObjectMessages(boolean useObjectMessages) {
         endpoint.getEndpointConfiguration().setUseObjectMessages(useObjectMessages);
+        return this;
+    }
+
+    /**
+     * Sets the filterInternalHeaders property.
+     * @param filterInternalHeaders
+     * @return
+     */
+    public JmsEndpointBuilder filterInternalHeaders(boolean filterInternalHeaders) {
+        endpoint.getEndpointConfiguration().setFilterInternalHeaders(filterInternalHeaders);
         return this;
     }
 

--- a/endpoints/citrus-jms/src/main/java/com/consol/citrus/jms/endpoint/JmsEndpointConfiguration.java
+++ b/endpoints/citrus-jms/src/main/java/com/consol/citrus/jms/endpoint/JmsEndpointConfiguration.java
@@ -16,6 +16,12 @@
 
 package com.consol.citrus.jms.endpoint;
 
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.Queue;
+import javax.jms.Topic;
+
 import com.consol.citrus.endpoint.AbstractPollableEndpointConfiguration;
 import com.consol.citrus.endpoint.resolver.EndpointUriResolver;
 import com.consol.citrus.jms.endpoint.resolver.DynamicDestinationNameResolver;
@@ -28,8 +34,6 @@ import org.springframework.jms.support.JmsHeaderMapper;
 import org.springframework.jms.support.destination.DestinationResolver;
 import org.springframework.util.Assert;
 
-import javax.jms.*;
-
 /**
  * @author Christoph Deppisch
  * @since 1.4
@@ -37,7 +41,7 @@ import javax.jms.*;
 public class JmsEndpointConfiguration extends AbstractPollableEndpointConfiguration {
 
     /** Logger */
-    private static Logger log = LoggerFactory.getLogger(JmsEndpointConfiguration.class);
+    private static final Logger LOG = LoggerFactory.getLogger(JmsEndpointConfiguration.class);
 
     /** The connection factory */
     private ConnectionFactory connectionFactory;
@@ -76,6 +80,9 @@ public class JmsEndpointConfiguration extends AbstractPollableEndpointConfigurat
     /** Should always use object messages */
     private boolean useObjectMessages = false;
 
+    /** Enable/disable filtering of Citrus internal headers */
+    private boolean filterInternalHeaders = true;
+
     /**
      * Get the destination name (either a queue name or a topic name).
      * @param destination
@@ -91,7 +98,7 @@ public class JmsEndpointConfiguration extends AbstractPollableEndpointConfigurat
                 return destination.toString();
             }
         } catch (JMSException e) {
-            log.error("Unable to resolve destination name", e);
+            LOG.error("Unable to resolve destination name", e);
             return "";
         }
     }
@@ -254,7 +261,7 @@ public class JmsEndpointConfiguration extends AbstractPollableEndpointConfigurat
 
     /**
      * Determines weather to convert outbound messages or not. If conversion is disabled endpoint will not convert
-     * the outbound message. Instead the raw message object will be sent over the wire using a JMS object message.
+     * the outbound message. Instead, the raw message object will be sent over the wire using a JMS object message.
      * @return
      */
     public boolean isUseObjectMessages() {
@@ -262,11 +269,31 @@ public class JmsEndpointConfiguration extends AbstractPollableEndpointConfigurat
     }
 
     /**
-     *
+     * Setting to control object message mode.
      * @param useObjectMessages
      */
     public void setUseObjectMessages(boolean useObjectMessages) {
         this.useObjectMessages = useObjectMessages;
+    }
+
+    /**
+     * Determines if internal message headers should be filtered when creating the JMS message.
+     * @return
+     */
+    public boolean isFilterInternalHeaders() {
+        return filterInternalHeaders;
+    }
+
+    /**
+     * Setting to control filtering of internal message headers.
+     * @param filterInternalHeaders
+     */
+    public void setFilterInternalHeaders(boolean filterInternalHeaders) {
+        this.filterInternalHeaders = filterInternalHeaders;
+
+        if (headerMapper instanceof JmsMessageHeaderMapper) {
+            ((JmsMessageHeaderMapper) headerMapper).setFilterInternalHeaders(filterInternalHeaders);
+        }
     }
 
     /**

--- a/endpoints/citrus-jms/src/main/java/com/consol/citrus/jms/endpoint/JmsSyncEndpointBuilder.java
+++ b/endpoints/citrus-jms/src/main/java/com/consol/citrus/jms/endpoint/JmsSyncEndpointBuilder.java
@@ -16,15 +16,15 @@
 
 package com.consol.citrus.jms.endpoint;
 
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+
 import com.consol.citrus.endpoint.AbstractEndpointBuilder;
 import com.consol.citrus.endpoint.resolver.EndpointUriResolver;
 import com.consol.citrus.jms.message.JmsMessageConverter;
 import com.consol.citrus.message.MessageCorrelator;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.jms.support.destination.DestinationResolver;
-
-import javax.jms.ConnectionFactory;
-import javax.jms.Destination;
 
 /**
  * @author Christoph Deppisch
@@ -147,6 +147,16 @@ public class JmsSyncEndpointBuilder extends AbstractEndpointBuilder<JmsSyncEndpo
      */
     public JmsSyncEndpointBuilder useObjectMessages(boolean useObjectMessages) {
         endpoint.getEndpointConfiguration().setUseObjectMessages(useObjectMessages);
+        return this;
+    }
+
+    /**
+     * Sets the filterInternalHeaders property.
+     * @param filterInternalHeaders
+     * @return
+     */
+    public JmsSyncEndpointBuilder filterInternalHeaders(boolean filterInternalHeaders) {
+        endpoint.getEndpointConfiguration().setFilterInternalHeaders(filterInternalHeaders);
         return this;
     }
 

--- a/endpoints/citrus-jms/src/main/java/com/consol/citrus/jms/message/JmsMessageHeaderMapper.java
+++ b/endpoints/citrus-jms/src/main/java/com/consol/citrus/jms/message/JmsMessageHeaderMapper.java
@@ -16,13 +16,13 @@
 
 package com.consol.citrus.jms.message;
 
-import org.springframework.jms.support.JmsHeaders;
-import org.springframework.jms.support.SimpleJmsHeaderMapper;
-import org.springframework.messaging.MessageHeaders;
-
 import javax.jms.Message;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.springframework.jms.support.JmsHeaders;
+import org.springframework.jms.support.SimpleJmsHeaderMapper;
+import org.springframework.messaging.MessageHeaders;
 
 /**
  * Citrus JMS header mapper translates internal message headers to Spring integration message headers and
@@ -33,9 +33,11 @@ import java.util.Map;
  */
 public class JmsMessageHeaderMapper extends SimpleJmsHeaderMapper {
 
+    private boolean filterInternalHeaders = true;
+
     @Override
     public void fromHeaders(MessageHeaders headers, Message jmsMessage) {
-        Map<String, Object> integrationHeaders = new HashMap<String, Object>();
+        Map<String, Object> integrationHeaders = new HashMap<>();
 
         if (headers.get(JmsMessageHeaders.CORRELATION_ID) != null) {
             integrationHeaders.put(JmsHeaders.CORRELATION_ID, headers.get(JmsMessageHeaders.CORRELATION_ID));
@@ -78,10 +80,15 @@ public class JmsMessageHeaderMapper extends SimpleJmsHeaderMapper {
         }
 
         for (Map.Entry<String, Object> headerEntry : headers.entrySet()) {
-            if (!headerEntry.getKey().startsWith(JmsMessageHeaders.JMS_PREFIX)
-                    && !headerEntry.getKey().equals(com.consol.citrus.message.MessageHeaders.ID)
-                    && !headerEntry.getKey().equals(com.consol.citrus.message.MessageHeaders.TIMESTAMP)) {
-                integrationHeaders.put(headerEntry.getKey(), headerEntry.getValue());
+            if (filterInternalHeaders) {
+                if (!headerEntry.getKey().startsWith(com.consol.citrus.message.MessageHeaders.PREFIX)) {
+                    integrationHeaders.put(headerEntry.getKey(), headerEntry.getValue());
+                }
+            } else {
+                if (!headerEntry.getKey().equals(com.consol.citrus.message.MessageHeaders.ID)
+                        && !headerEntry.getKey().equals(com.consol.citrus.message.MessageHeaders.TIMESTAMP)) {
+                    integrationHeaders.put(headerEntry.getKey(), headerEntry.getValue());
+                }
             }
         }
 
@@ -140,5 +147,9 @@ public class JmsMessageHeaderMapper extends SimpleJmsHeaderMapper {
         }
 
         return new MessageHeaders(internalHeaders);
+    }
+
+    public void setFilterInternalHeaders(boolean filterInternalHeaders) {
+        this.filterInternalHeaders = filterInternalHeaders;
     }
 }

--- a/endpoints/citrus-jms/src/main/resources/com/consol/citrus/schema/citrus-jms-config-3.2.0-SNAPSHOT.xsd
+++ b/endpoints/citrus-jms/src/main/resources/com/consol/citrus/schema/citrus-jms-config-3.2.0-SNAPSHOT.xsd
@@ -33,6 +33,7 @@
     <xs:attribute name="destination-resolver" type="xs:string"/>
     <xs:attribute name="destination-name-resolver" type="xs:string"/>
     <xs:attribute name="pub-sub-domain" type="xs:boolean"/>
+    <xs:attribute name="filter-internal-headers" type="xs:boolean" default="true"/>
     <xs:attribute name="use-object-messages" type="xs:boolean"/>
     <xs:attribute name="actor" type="xs:string"/>
     <xs:attribute name="timeout" type="xs:string"/>

--- a/endpoints/citrus-jms/src/main/resources/com/consol/citrus/schema/citrus-jms-config.xsd
+++ b/endpoints/citrus-jms/src/main/resources/com/consol/citrus/schema/citrus-jms-config.xsd
@@ -33,6 +33,7 @@
     <xs:attribute name="destination-resolver" type="xs:string"/>
     <xs:attribute name="destination-name-resolver" type="xs:string"/>
     <xs:attribute name="pub-sub-domain" type="xs:boolean"/>
+    <xs:attribute name="filter-internal-headers" type="xs:boolean" default="true"/>
     <xs:attribute name="use-object-messages" type="xs:boolean"/>
     <xs:attribute name="actor" type="xs:string"/>
     <xs:attribute name="timeout" type="xs:string"/>

--- a/endpoints/citrus-jms/src/test/java/com/consol/citrus/jms/config/annotation/JmsEndpointConfigParserTest.java
+++ b/endpoints/citrus-jms/src/test/java/com/consol/citrus/jms/config/annotation/JmsEndpointConfigParserTest.java
@@ -73,6 +73,7 @@ public class JmsEndpointConfigParserTest extends AbstractTestNGUnitTest {
     @JmsEndpointConfig(pubSubDomain=true,
             autoStart=true,
             useObjectMessages=true,
+            filterInternalHeaders=false,
             jmsTemplate="jmsTemplate")
     private JmsEndpoint jmsEndpoint3;
 
@@ -164,6 +165,7 @@ public class JmsEndpointConfigParserTest extends AbstractTestNGUnitTest {
         Assert.assertFalse(jmsEndpoint1.getEndpointConfiguration().isAutoStart());
         Assert.assertFalse(jmsEndpoint1.getEndpointConfiguration().isDurableSubscription());
         Assert.assertFalse(jmsEndpoint1.getEndpointConfiguration().isUseObjectMessages());
+        Assert.assertTrue(jmsEndpoint1.getEndpointConfiguration().isFilterInternalHeaders());
 
         // 2nd message receiver
         Assert.assertNotNull(jmsEndpoint2.getEndpointConfiguration().getConnectionFactory());
@@ -183,6 +185,7 @@ public class JmsEndpointConfigParserTest extends AbstractTestNGUnitTest {
         Assert.assertTrue(jmsEndpoint3.getEndpointConfiguration().isPubSubDomain());
         Assert.assertTrue(jmsEndpoint3.getEndpointConfiguration().isAutoStart());
         Assert.assertTrue(jmsEndpoint3.getEndpointConfiguration().isUseObjectMessages());
+        Assert.assertFalse(jmsEndpoint3.getEndpointConfiguration().isFilterInternalHeaders());
 
         // 4th message receiver
         Assert.assertEquals(jmsEndpoint4.getEndpointConfiguration().getConnectionFactory(), topicConnectionFactory);

--- a/endpoints/citrus-jms/src/test/java/com/consol/citrus/jms/config/annotation/JmsSyncEndpointConfigParserTest.java
+++ b/endpoints/citrus-jms/src/test/java/com/consol/citrus/jms/config/annotation/JmsSyncEndpointConfigParserTest.java
@@ -80,6 +80,8 @@ public class JmsSyncEndpointConfigParserTest extends AbstractTestNGUnitTest {
             replyDestination="replyQueue",
             destinationResolver="destinationResolver",
             destinationNameResolver="destinationNameResolver",
+            useObjectMessages = true,
+            filterInternalHeaders = false,
             correlator="replyMessageCorrelator")
     private JmsSyncEndpoint jmsSyncEndpoint6;
 
@@ -166,6 +168,8 @@ public class JmsSyncEndpointConfigParserTest extends AbstractTestNGUnitTest {
         Assert.assertNull(jmsSyncEndpoint3.getEndpointConfiguration().getDestination());
         Assert.assertEquals(jmsSyncEndpoint3.getEndpointConfiguration().getCorrelator(), messageCorrelator);
         Assert.assertTrue(jmsSyncEndpoint3.getEndpointConfiguration().isPubSubDomain());
+        Assert.assertFalse(jmsSyncEndpoint3.getEndpointConfiguration().isUseObjectMessages());
+        Assert.assertTrue(jmsSyncEndpoint3.getEndpointConfiguration().isFilterInternalHeaders());
 
         // 4th message receiver
         Assert.assertNotNull(jmsSyncEndpoint4.getActor());
@@ -193,6 +197,8 @@ public class JmsSyncEndpointConfigParserTest extends AbstractTestNGUnitTest {
         Assert.assertEquals(jmsSyncEndpoint6.getEndpointConfiguration().getCorrelator(), messageCorrelator);
         Assert.assertEquals(jmsSyncEndpoint6.getEndpointConfiguration().getDestinationResolver(), destinationResolver);
         Assert.assertEquals(jmsSyncEndpoint6.getEndpointConfiguration().getDestinationNameResolver(), destinationNameResolver);
+        Assert.assertTrue(jmsSyncEndpoint6.getEndpointConfiguration().isUseObjectMessages());
+        Assert.assertFalse(jmsSyncEndpoint6.getEndpointConfiguration().isFilterInternalHeaders());
 
         // 7th message sender
         Assert.assertNull(jmsSyncEndpoint7.getEndpointConfiguration().getConnectionFactory());

--- a/endpoints/citrus-jms/src/test/java/com/consol/citrus/jms/config/xml/JmsEndpointAdapterParserTest.java
+++ b/endpoints/citrus-jms/src/test/java/com/consol/citrus/jms/config/xml/JmsEndpointAdapterParserTest.java
@@ -16,14 +16,14 @@
 
 package com.consol.citrus.jms.config.xml;
 
+import javax.jms.ConnectionFactory;
+import java.util.Map;
+
 import com.consol.citrus.endpoint.EndpointAdapter;
 import com.consol.citrus.jms.endpoint.JmsEndpointAdapter;
 import com.consol.citrus.testng.AbstractBeanDefinitionParserTest;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import javax.jms.ConnectionFactory;
-import java.util.Map;
 
 /**
  * @author Christoph Deppisch
@@ -42,7 +42,8 @@ public class JmsEndpointAdapterParserTest extends AbstractBeanDefinitionParserTe
         Assert.assertEquals(adapter.getName(), "endpointAdapter1");
         Assert.assertEquals(adapter.getEndpointConfiguration().getTimeout(), 5000L);
         Assert.assertEquals((adapter.getEndpointConfiguration()).getDestinationName(), "serverQueue");
-        Assert.assertEquals(adapter.getEndpointConfiguration().isUseObjectMessages(), false);
+        Assert.assertFalse(adapter.getEndpointConfiguration().isUseObjectMessages());
+        Assert.assertFalse(adapter.getEndpointConfiguration().isFilterInternalHeaders());
         Assert.assertEquals((adapter.getEndpointConfiguration()).getConnectionFactory(), beanDefinitionContext.getBean("connectionFactory", ConnectionFactory.class));
         Assert.assertNull(adapter.getFallbackEndpointAdapter());
 
@@ -50,7 +51,8 @@ public class JmsEndpointAdapterParserTest extends AbstractBeanDefinitionParserTe
         Assert.assertEquals(adapter.getEndpointConfiguration().getTimeout(), 2500L);
         Assert.assertEquals((adapter.getEndpointConfiguration()).getReplyDestinationName(), "replyQueue");
         Assert.assertEquals((adapter.getEndpointConfiguration()).getDestinationName(), "fooQueue");
-        Assert.assertEquals(adapter.getEndpointConfiguration().isUseObjectMessages(), true);
+        Assert.assertTrue(adapter.getEndpointConfiguration().isUseObjectMessages());
+        Assert.assertFalse(adapter.getEndpointConfiguration().isFilterInternalHeaders());
         Assert.assertEquals((adapter.getEndpointConfiguration()).getConnectionFactory(), beanDefinitionContext.getBean("connectionFactory", ConnectionFactory.class));
         Assert.assertEquals(adapter.getFallbackEndpointAdapter(), beanDefinitionContext.getBean("mockEndpointAdapter", EndpointAdapter.class));
     }

--- a/endpoints/citrus-jms/src/test/java/com/consol/citrus/jms/config/xml/JmsEndpointParserTest.java
+++ b/endpoints/citrus-jms/src/test/java/com/consol/citrus/jms/config/xml/JmsEndpointParserTest.java
@@ -16,14 +16,14 @@
 
 package com.consol.citrus.jms.config.xml;
 
+import java.util.Map;
+
 import com.consol.citrus.TestActor;
 import com.consol.citrus.jms.endpoint.JmsEndpoint;
 import com.consol.citrus.jms.message.JmsMessageConverter;
 import com.consol.citrus.testng.AbstractBeanDefinitionParserTest;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import java.util.Map;
 
 /**
  * @author Christoph Deppisch
@@ -44,10 +44,11 @@ public class JmsEndpointParserTest extends AbstractBeanDefinitionParserTest {
         Assert.assertEquals(jmsEndpoint.getEndpointConfiguration().getDestinationName(), "JMS.Queue.Test");
         Assert.assertNull(jmsEndpoint.getEndpointConfiguration().getDestination());
         Assert.assertEquals(jmsEndpoint.getEndpointConfiguration().getTimeout(), 5000L);
-        Assert.assertEquals(jmsEndpoint.getEndpointConfiguration().isPubSubDomain(), false);
-        Assert.assertEquals(jmsEndpoint.getEndpointConfiguration().isAutoStart(), false);
-        Assert.assertEquals(jmsEndpoint.getEndpointConfiguration().isDurableSubscription(), false);
-        Assert.assertEquals(jmsEndpoint.getEndpointConfiguration().isUseObjectMessages(), false);
+        Assert.assertFalse(jmsEndpoint.getEndpointConfiguration().isPubSubDomain());
+        Assert.assertFalse(jmsEndpoint.getEndpointConfiguration().isAutoStart());
+        Assert.assertFalse(jmsEndpoint.getEndpointConfiguration().isDurableSubscription());
+        Assert.assertFalse(jmsEndpoint.getEndpointConfiguration().isUseObjectMessages());
+        Assert.assertTrue(jmsEndpoint.getEndpointConfiguration().isFilterInternalHeaders());
 
         // 2nd message receiver
         jmsEndpoint = endpoints.get("jmsEndpoint2");
@@ -65,11 +66,12 @@ public class JmsEndpointParserTest extends AbstractBeanDefinitionParserTest {
         Assert.assertNull(jmsEndpoint.getEndpointConfiguration().getConnectionFactory());
         Assert.assertNull(jmsEndpoint.getEndpointConfiguration().getDestinationName());
         Assert.assertNull(jmsEndpoint.getEndpointConfiguration().getDestination());
-        Assert.assertEquals(jmsEndpoint.getEndpointConfiguration().isPubSubDomain(), true);
-        Assert.assertEquals(jmsEndpoint.getEndpointConfiguration().isAutoStart(), true);
-        Assert.assertEquals(jmsEndpoint.getEndpointConfiguration().isDurableSubscription(), true);
+        Assert.assertTrue(jmsEndpoint.getEndpointConfiguration().isPubSubDomain());
+        Assert.assertTrue(jmsEndpoint.getEndpointConfiguration().isAutoStart());
+        Assert.assertTrue(jmsEndpoint.getEndpointConfiguration().isDurableSubscription());
         Assert.assertEquals(jmsEndpoint.getEndpointConfiguration().getDurableSubscriberName(), "durableSubscriber");
-        Assert.assertEquals(jmsEndpoint.getEndpointConfiguration().isUseObjectMessages(), true);
+        Assert.assertTrue(jmsEndpoint.getEndpointConfiguration().isUseObjectMessages());
+        Assert.assertFalse(jmsEndpoint.getEndpointConfiguration().isFilterInternalHeaders());
 
         // 4th message receiver
         jmsEndpoint = endpoints.get("jmsEndpoint4");

--- a/endpoints/citrus-jms/src/test/resources/com/consol/citrus/jms/config/xml/JmsEndpointAdapterParserTest-context.xml
+++ b/endpoints/citrus-jms/src/test/resources/com/consol/citrus/jms/config/xml/JmsEndpointAdapterParserTest-context.xml
@@ -16,6 +16,7 @@
                                    connection-factory="connectionFactory"
                                    fallback-adapter="mockEndpointAdapter"
                                    use-object-messages="true"
+                                   filter-internal-headers="false"
                                    timeout="2500"/>
 
     <bean id="connectionFactory" class="org.mockito.Mockito" factory-method="mock">

--- a/endpoints/citrus-jms/src/test/resources/com/consol/citrus/jms/config/xml/JmsEndpointParserTest-context.xml
+++ b/endpoints/citrus-jms/src/test/resources/com/consol/citrus/jms/config/xml/JmsEndpointParserTest-context.xml
@@ -24,6 +24,7 @@
                                durable-subscription="true"
                                durable-subscriber-name="durableSubscriber"
                                use-object-messages="true"
+                               filter-internal-headers="false"
                                jms-template="jmsTemplate"/>
 
   <citrus-jms:endpoint id="jmsEndpoint4"

--- a/endpoints/citrus-kafka/src/main/java/com/consol/citrus/kafka/message/KafkaMessageHeaderMapper.java
+++ b/endpoints/citrus-kafka/src/main/java/com/consol/citrus/kafka/message/KafkaMessageHeaderMapper.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.consol.citrus.context.TestContext;
+import com.consol.citrus.message.MessageHeaders;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 
@@ -43,9 +44,7 @@ public class KafkaMessageHeaderMapper {
         Headers kafkaHeaders = new RecordHeaders();
 
         for (Map.Entry<String, Object> headerEntry : headers.entrySet()) {
-            if (!headerEntry.getKey().startsWith(KafkaMessageHeaders.KAFKA_PREFIX)
-                    && !headerEntry.getKey().equals(com.consol.citrus.message.MessageHeaders.ID)
-                    && !headerEntry.getKey().equals(com.consol.citrus.message.MessageHeaders.TIMESTAMP)) {
+            if (!headerEntry.getKey().startsWith(MessageHeaders.PREFIX)) {
                 kafkaHeaders.add(headerEntry.getKey(), context.getTypeConverter().convertIfNecessary(headerEntry.getValue(), byte[].class));
             }
         }

--- a/endpoints/citrus-spring-integration/src/main/java/com/consol/citrus/channel/ChannelEndpointAdapter.java
+++ b/endpoints/citrus-spring-integration/src/main/java/com/consol/citrus/channel/ChannelEndpointAdapter.java
@@ -36,14 +36,14 @@ import org.springframework.beans.factory.BeanFactory;
 public class ChannelEndpointAdapter extends AbstractEndpointAdapter {
 
     /** Endpoint handling incoming requests */
-    private ChannelSyncEndpoint endpoint;
-    private ChannelSyncProducer producer;
+    private final ChannelSyncEndpoint endpoint;
+    private final ChannelSyncProducer producer;
 
     /** Endpoint configuration */
     private final ChannelSyncEndpointConfiguration endpointConfiguration;
 
     /** Logger */
-    private static Logger log = LoggerFactory.getLogger(ChannelEndpointAdapter.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ChannelEndpointAdapter.class);
 
     /**
      * Default constructor using endpoint configuration.
@@ -52,6 +52,8 @@ public class ChannelEndpointAdapter extends AbstractEndpointAdapter {
     public ChannelEndpointAdapter(ChannelSyncEndpointConfiguration endpointConfiguration) {
         this.endpointConfiguration = endpointConfiguration;
 
+        this.endpointConfiguration.setFilterInternalHeaders(false);
+
         endpoint = new ChannelSyncEndpoint(endpointConfiguration);
         endpoint.setName(getName());
         producer = new ChannelSyncProducer(endpoint.getProducerName(), endpointConfiguration);
@@ -59,7 +61,7 @@ public class ChannelEndpointAdapter extends AbstractEndpointAdapter {
 
     @Override
     public Message handleMessageInternal(Message request) {
-        log.debug("Forwarding request to message channel ...");
+        LOG.debug("Forwarding request to message channel ...");
 
         TestContext context = getTestContext();
         Message replyMessage = null;
@@ -71,7 +73,7 @@ public class ChannelEndpointAdapter extends AbstractEndpointAdapter {
                 replyMessage = producer.receive(context, endpointConfiguration.getTimeout());
             }
         } catch (ActionTimeoutException e) {
-            log.warn(e.getMessage());
+            LOG.warn(e.getMessage());
         }
 
         return replyMessage;

--- a/endpoints/citrus-spring-integration/src/main/java/com/consol/citrus/channel/ChannelEndpointBuilder.java
+++ b/endpoints/citrus-spring-integration/src/main/java/com/consol/citrus/channel/ChannelEndpointBuilder.java
@@ -96,6 +96,16 @@ public class ChannelEndpointBuilder extends AbstractEndpointBuilder<ChannelEndpo
     }
 
     /**
+     * Sets the filterInternalHeaders property.
+     * @param filterInternalHeaders
+     * @return
+     */
+    public ChannelEndpointBuilder filterInternalHeaders(boolean filterInternalHeaders) {
+        endpoint.getEndpointConfiguration().setFilterInternalHeaders(filterInternalHeaders);
+        return this;
+    }
+
+    /**
      * Sets the default timeout.
      * @param timeout
      * @return

--- a/endpoints/citrus-spring-integration/src/main/java/com/consol/citrus/channel/ChannelEndpointConfiguration.java
+++ b/endpoints/citrus-spring-integration/src/main/java/com/consol/citrus/channel/ChannelEndpointConfiguration.java
@@ -50,6 +50,9 @@ public class ChannelEndpointConfiguration extends AbstractEndpointConfiguration 
     /** Should always use object messages */
     private boolean useObjectMessages = false;
 
+    /** Enable/disable filtering of Citrus internal headers */
+    private boolean filterInternalHeaders = true;
+
     /**
      * Set the message channel.
      * @param channel the channel to set
@@ -156,10 +159,26 @@ public class ChannelEndpointConfiguration extends AbstractEndpointConfiguration 
     }
 
     /**
-     *
+     * Sets the useObjectMessages flag.
      * @param useObjectMessages
      */
     public void setUseObjectMessages(boolean useObjectMessages) {
         this.useObjectMessages = useObjectMessages;
+    }
+
+    /**
+     * Determines if internal message headers should be filtered when creating the JMS message.
+     * @return
+     */
+    public boolean isFilterInternalHeaders() {
+        return filterInternalHeaders;
+    }
+
+    /**
+     * Setting to control filtering of internal message headers.
+     * @param filterInternalHeaders
+     */
+    public void setFilterInternalHeaders(boolean filterInternalHeaders) {
+        this.filterInternalHeaders = filterInternalHeaders;
     }
 }

--- a/endpoints/citrus-spring-integration/src/main/java/com/consol/citrus/channel/ChannelSyncEndpointBuilder.java
+++ b/endpoints/citrus-spring-integration/src/main/java/com/consol/citrus/channel/ChannelSyncEndpointBuilder.java
@@ -97,6 +97,16 @@ public class ChannelSyncEndpointBuilder extends AbstractEndpointBuilder<ChannelS
     }
 
     /**
+     * Sets the filterInternalHeaders property.
+     * @param filterInternalHeaders
+     * @return
+     */
+    public ChannelSyncEndpointBuilder filterInternalHeaders(boolean filterInternalHeaders) {
+        endpoint.getEndpointConfiguration().setFilterInternalHeaders(filterInternalHeaders);
+        return this;
+    }
+
+    /**
      * Sets the polling interval.
      * @param pollingInterval
      * @return

--- a/endpoints/citrus-spring-integration/src/main/java/com/consol/citrus/config/annotation/ChannelEndpointConfig.java
+++ b/endpoints/citrus-spring-integration/src/main/java/com/consol/citrus/config/annotation/ChannelEndpointConfig.java
@@ -69,6 +69,12 @@ public @interface ChannelEndpointConfig {
     boolean useObjectMessages() default false;
 
     /**
+     * Should filter internal message headers.
+     * @return
+     */
+    boolean filterInternalHeaders() default true;
+
+    /**
      * Timeout.
      * @return
      */

--- a/endpoints/citrus-spring-integration/src/main/java/com/consol/citrus/config/annotation/ChannelEndpointConfigParser.java
+++ b/endpoints/citrus-spring-integration/src/main/java/com/consol/citrus/config/annotation/ChannelEndpointConfigParser.java
@@ -57,6 +57,7 @@ public class ChannelEndpointConfigParser implements AnnotationConfigParser<Chann
         }
 
         builder.useObjectMessages(annotation.useObjectMessages());
+        builder.filterInternalHeaders(annotation.filterInternalHeaders());
 
         if (StringUtils.hasText(annotation.messageConverter())) {
             builder.messageConverter(referenceResolver.resolve(annotation.messageConverter(), ChannelMessageConverter.class));

--- a/endpoints/citrus-spring-integration/src/main/java/com/consol/citrus/config/annotation/ChannelSyncEndpointConfig.java
+++ b/endpoints/citrus-spring-integration/src/main/java/com/consol/citrus/config/annotation/ChannelSyncEndpointConfig.java
@@ -69,6 +69,12 @@ public @interface ChannelSyncEndpointConfig {
     boolean useObjectMessages() default false;
 
     /**
+     * Should filter internal message headers.
+     * @return
+     */
+    boolean filterInternalHeaders() default true;
+
+    /**
      * Polling interval.
      * @return
      */

--- a/endpoints/citrus-spring-integration/src/main/java/com/consol/citrus/config/annotation/ChannelSyncEndpointConfigParser.java
+++ b/endpoints/citrus-spring-integration/src/main/java/com/consol/citrus/config/annotation/ChannelSyncEndpointConfigParser.java
@@ -58,6 +58,7 @@ public class ChannelSyncEndpointConfigParser implements AnnotationConfigParser<C
         }
 
         builder.useObjectMessages(annotation.useObjectMessages());
+        builder.filterInternalHeaders(annotation.filterInternalHeaders());
 
         if (StringUtils.hasText(annotation.messageConverter())) {
             builder.messageConverter(referenceResolver.resolve(annotation.messageConverter(), ChannelMessageConverter.class));

--- a/endpoints/citrus-spring-integration/src/main/java/com/consol/citrus/config/xml/AbstractChannelEndpointParser.java
+++ b/endpoints/citrus-spring-integration/src/main/java/com/consol/citrus/config/xml/AbstractChannelEndpointParser.java
@@ -44,5 +44,8 @@ public abstract class AbstractChannelEndpointParser extends AbstractEndpointPars
 
         BeanDefinitionParserUtils.setPropertyValue(endpointConfiguration,
                 element.getAttribute("use-object-messages"), "useObjectMessages");
+
+        BeanDefinitionParserUtils.setPropertyValue(endpointConfiguration,
+                element.getAttribute("filter-internal-headers"), "filterInternalHeaders");
     }
 }

--- a/endpoints/citrus-spring-integration/src/main/resources/com/consol/citrus/schema/citrus-spring-integration-config-3.2.0-SNAPSHOT.xsd
+++ b/endpoints/citrus-spring-integration/src/main/resources/com/consol/citrus/schema/citrus-spring-integration-config-3.2.0-SNAPSHOT.xsd
@@ -55,6 +55,7 @@
     <xs:attribute name="channel-name" type="xs:string"/>
     <xs:attribute name="channel-resolver" type="xs:string"/>
     <xs:attribute name="use-object-messages" type="xs:boolean"/>
+    <xs:attribute name="filter-internal-headers" type="xs:boolean" default="true"/>
     <xs:attribute name="actor" type="xs:string"/>
     <xs:attribute name="timeout" type="xs:string"/>
   </xs:complexType>

--- a/endpoints/citrus-spring-integration/src/main/resources/com/consol/citrus/schema/citrus-spring-integration-config.xsd
+++ b/endpoints/citrus-spring-integration/src/main/resources/com/consol/citrus/schema/citrus-spring-integration-config.xsd
@@ -55,6 +55,7 @@
     <xs:attribute name="channel-name" type="xs:string"/>
     <xs:attribute name="channel-resolver" type="xs:string"/>
     <xs:attribute name="use-object-messages" type="xs:boolean"/>
+    <xs:attribute name="filter-internal-headers" type="xs:boolean" default="true"/>
     <xs:attribute name="actor" type="xs:string"/>
     <xs:attribute name="timeout" type="xs:string"/>
   </xs:complexType>

--- a/endpoints/citrus-spring-integration/src/test/java/com/consol/citrus/config/annotation/ChannelEndpointConfigParserTest.java
+++ b/endpoints/citrus-spring-integration/src/test/java/com/consol/citrus/config/annotation/ChannelEndpointConfigParserTest.java
@@ -58,6 +58,7 @@ public class ChannelEndpointConfigParserTest extends AbstractTestNGUnitTest {
 
     @CitrusEndpoint
     @ChannelEndpointConfig(useObjectMessages=true,
+            filterInternalHeaders=false,
             messagingTemplate="messagingTemplate")
     private ChannelEndpoint channelEndpoint3;
 
@@ -107,7 +108,8 @@ public class ChannelEndpointConfigParserTest extends AbstractTestNGUnitTest {
         Assert.assertEquals(channelEndpoint1.getEndpointConfiguration().getChannelName(), "testChannel");
         Assert.assertNull(channelEndpoint1.getEndpointConfiguration().getChannel());
         Assert.assertEquals(channelEndpoint1.getEndpointConfiguration().getTimeout(), 5000L);
-        Assert.assertEquals(channelEndpoint1.getEndpointConfiguration().isUseObjectMessages(), false);
+        Assert.assertFalse(channelEndpoint1.getEndpointConfiguration().isUseObjectMessages());
+        Assert.assertTrue(channelEndpoint1.getEndpointConfiguration().isFilterInternalHeaders());
 
         // 2nd message receiver
         Assert.assertEquals(channelEndpoint2.getEndpointConfiguration().getMessageConverter(), messageConverter);
@@ -119,7 +121,8 @@ public class ChannelEndpointConfigParserTest extends AbstractTestNGUnitTest {
         // 3rd message receiver
         Assert.assertNull(channelEndpoint3.getEndpointConfiguration().getChannelName());
         Assert.assertNull(channelEndpoint3.getEndpointConfiguration().getChannel());
-        Assert.assertEquals(channelEndpoint3.getEndpointConfiguration().isUseObjectMessages(), true);
+        Assert.assertTrue(channelEndpoint3.getEndpointConfiguration().isUseObjectMessages());
+        Assert.assertFalse(channelEndpoint3.getEndpointConfiguration().isFilterInternalHeaders());
 
         // 4th message receiver
         Assert.assertNotNull(channelEndpoint4.getActor());

--- a/endpoints/citrus-spring-integration/src/test/java/com/consol/citrus/config/annotation/ChannelSyncEndpointConfigParserTest.java
+++ b/endpoints/citrus-spring-integration/src/test/java/com/consol/citrus/config/annotation/ChannelSyncEndpointConfigParserTest.java
@@ -75,6 +75,7 @@ public class ChannelSyncEndpointConfigParserTest extends AbstractTestNGUnitTest 
     @ChannelSyncEndpointConfig(timeout=10000L,
             channel="channelQueue",
             channelResolver="channelResolver",
+            filterInternalHeaders = false,
             correlator="replyMessageCorrelator")
     private ChannelSyncEndpoint channelSyncEndpoint6;
 
@@ -133,6 +134,7 @@ public class ChannelSyncEndpointConfigParserTest extends AbstractTestNGUnitTest 
         Assert.assertNull(channelSyncEndpoint1.getEndpointConfiguration().getChannel());
         Assert.assertEquals(channelSyncEndpoint1.getEndpointConfiguration().getTimeout(), 5000L);
         Assert.assertEquals(channelSyncEndpoint1.getEndpointConfiguration().getCorrelator().getClass(), DefaultMessageCorrelator.class);
+        Assert.assertTrue(channelSyncEndpoint1.getEndpointConfiguration().isFilterInternalHeaders());
 
         // 2nd message receiver
         Assert.assertNull(channelSyncEndpoint2.getEndpointConfiguration().getChannelName());
@@ -162,6 +164,7 @@ public class ChannelSyncEndpointConfigParserTest extends AbstractTestNGUnitTest 
         Assert.assertEquals(channelSyncEndpoint6.getEndpointConfiguration().getTimeout(), 10000L);
         Assert.assertEquals(channelSyncEndpoint6.getEndpointConfiguration().getCorrelator(), messageCorrelator);
         Assert.assertEquals(channelSyncEndpoint6.getEndpointConfiguration().getChannelResolver(), channelResolver);
+        Assert.assertFalse(channelSyncEndpoint6.getEndpointConfiguration().isFilterInternalHeaders());
 
         // 7th message sender
         Assert.assertNull(channelSyncEndpoint7.getEndpointConfiguration().getChannelName());

--- a/endpoints/citrus-spring-integration/src/test/java/com/consol/citrus/config/xml/ChannelEndpointAdapterParserTest.java
+++ b/endpoints/citrus-spring-integration/src/test/java/com/consol/citrus/config/xml/ChannelEndpointAdapterParserTest.java
@@ -16,12 +16,12 @@
 
 package com.consol.citrus.config.xml;
 
+import java.util.Map;
+
 import com.consol.citrus.channel.ChannelEndpointAdapter;
 import com.consol.citrus.testng.AbstractBeanDefinitionParserTest;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import java.util.Map;
 
 /**
  * @author Christoph Deppisch
@@ -41,14 +41,16 @@ public class ChannelEndpointAdapterParserTest extends AbstractBeanDefinitionPars
         Assert.assertEquals(adapter.getEndpointConfiguration().getTimeout(), 5000L);
         Assert.assertEquals(adapter.getEndpointConfiguration().getPollingInterval(), 500L);
         Assert.assertEquals((adapter.getEndpointConfiguration()).getChannelName(), "serverChannel");
-        Assert.assertEquals(adapter.getEndpointConfiguration().isUseObjectMessages(), false);
+        Assert.assertFalse(adapter.getEndpointConfiguration().isUseObjectMessages());
+        Assert.assertFalse(adapter.getEndpointConfiguration().isFilterInternalHeaders());
         Assert.assertNull(adapter.getFallbackEndpointAdapter());
 
         adapter = adapters.get("endpointAdapter2");
         Assert.assertEquals(adapter.getEndpointConfiguration().getTimeout(), 10000L);
         Assert.assertEquals(adapter.getEndpointConfiguration().getPollingInterval(), 250L);
         Assert.assertEquals((adapter.getEndpointConfiguration()).getChannelName(), "fooChannel");
-        Assert.assertEquals(adapter.getEndpointConfiguration().isUseObjectMessages(), true);
+        Assert.assertTrue(adapter.getEndpointConfiguration().isUseObjectMessages());
+        Assert.assertFalse(adapter.getEndpointConfiguration().isFilterInternalHeaders());
         Assert.assertEquals(adapter.getFallbackEndpointAdapter(), beanDefinitionContext.getBean("mockEndpointAdapter"));
     }
 }

--- a/endpoints/citrus-spring-integration/src/test/java/com/consol/citrus/config/xml/ChannelEndpointParserTest.java
+++ b/endpoints/citrus-spring-integration/src/test/java/com/consol/citrus/config/xml/ChannelEndpointParserTest.java
@@ -16,13 +16,13 @@
 
 package com.consol.citrus.config.xml;
 
+import java.util.Map;
+
 import com.consol.citrus.TestActor;
 import com.consol.citrus.channel.ChannelEndpoint;
 import com.consol.citrus.testng.AbstractBeanDefinitionParserTest;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import java.util.Map;
 
 /**
  * @author Christoph Deppisch
@@ -41,7 +41,8 @@ public class ChannelEndpointParserTest extends AbstractBeanDefinitionParserTest 
         Assert.assertNull(channelEndpoint.getEndpointConfiguration().getChannel());
         Assert.assertEquals(channelEndpoint.getEndpointConfiguration().getTimeout(), 5000L);
         Assert.assertNotNull(channelEndpoint.getEndpointConfiguration().getChannelResolver());
-        Assert.assertEquals(channelEndpoint.getEndpointConfiguration().isUseObjectMessages(), false);
+        Assert.assertFalse(channelEndpoint.getEndpointConfiguration().isUseObjectMessages());
+        Assert.assertTrue(channelEndpoint.getEndpointConfiguration().isFilterInternalHeaders());
 
         // 2nd message receiver
         channelEndpoint = endpoints.get("channelEndpoint2");
@@ -59,7 +60,8 @@ public class ChannelEndpointParserTest extends AbstractBeanDefinitionParserTest 
         // 4th message receiver
         channelEndpoint = endpoints.get("channelEndpoint4");
         Assert.assertNotNull(channelEndpoint.getActor());
-        Assert.assertEquals(channelEndpoint.getEndpointConfiguration().isUseObjectMessages(), true);
+        Assert.assertTrue(channelEndpoint.getEndpointConfiguration().isUseObjectMessages());
+        Assert.assertFalse(channelEndpoint.getEndpointConfiguration().isFilterInternalHeaders());
         Assert.assertEquals(channelEndpoint.getActor(), beanDefinitionContext.getBean("testActor", TestActor.class));
     }
 }

--- a/endpoints/citrus-spring-integration/src/test/java/com/consol/citrus/config/xml/ChannelSyncEndpointParserTest.java
+++ b/endpoints/citrus-spring-integration/src/test/java/com/consol/citrus/config/xml/ChannelSyncEndpointParserTest.java
@@ -16,6 +16,8 @@
 
 package com.consol.citrus.config.xml;
 
+import java.util.Map;
+
 import com.consol.citrus.TestActor;
 import com.consol.citrus.channel.ChannelSyncEndpoint;
 import com.consol.citrus.message.DefaultMessageCorrelator;
@@ -24,8 +26,6 @@ import com.consol.citrus.testng.AbstractBeanDefinitionParserTest;
 import org.springframework.integration.core.MessagingTemplate;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import java.util.Map;
 
 /**
  * @author Christoph Deppisch
@@ -46,6 +46,7 @@ public class ChannelSyncEndpointParserTest extends AbstractBeanDefinitionParserT
         Assert.assertEquals(channelSyncEndpoint.getEndpointConfiguration().getPollingInterval(), 500L);
         Assert.assertNotNull(channelSyncEndpoint.getEndpointConfiguration().getChannelResolver());
         Assert.assertEquals(channelSyncEndpoint.getEndpointConfiguration().getCorrelator().getClass(), DefaultMessageCorrelator.class);
+        Assert.assertTrue(channelSyncEndpoint.getEndpointConfiguration().isFilterInternalHeaders());
 
         // 2nd message receiver
         channelSyncEndpoint = endpoints.get("syncChannelEndpoint2");
@@ -64,6 +65,7 @@ public class ChannelSyncEndpointParserTest extends AbstractBeanDefinitionParserT
         Assert.assertNotNull(channelSyncEndpoint.getEndpointConfiguration().getMessagingTemplate());
         Assert.assertEquals(channelSyncEndpoint.getEndpointConfiguration().getMessagingTemplate(), beanDefinitionContext.getBean("messagingTemplate", MessagingTemplate.class));
         Assert.assertEquals(channelSyncEndpoint.getEndpointConfiguration().getPollingInterval(), 250L);
+        Assert.assertFalse(channelSyncEndpoint.getEndpointConfiguration().isFilterInternalHeaders());
         Assert.assertNotNull(channelSyncEndpoint.getActor());
         Assert.assertEquals(channelSyncEndpoint.getActor(), beanDefinitionContext.getBean("testActor", TestActor.class));
     }

--- a/endpoints/citrus-spring-integration/src/test/resources/com/consol/citrus/config/xml/ChannelEndpointAdapterParserTest-context.xml
+++ b/endpoints/citrus-spring-integration/src/test/resources/com/consol/citrus/config/xml/ChannelEndpointAdapterParserTest-context.xml
@@ -12,6 +12,7 @@
                                    channel-name="fooChannel"
                                    polling-interval="250"
                                    use-object-messages="true"
+                                   filter-internal-headers="false"
                                    fallback-adapter="mockEndpointAdapter"
                                    timeout="10000"/>
 

--- a/endpoints/citrus-spring-integration/src/test/resources/com/consol/citrus/config/xml/ChannelEndpointParserTest-context.xml
+++ b/endpoints/citrus-spring-integration/src/test/resources/com/consol/citrus/config/xml/ChannelEndpointParserTest-context.xml
@@ -22,6 +22,7 @@
                                    channel-resolver="channelResolver"
                                    channel-name="channelName"
                                    use-object-messages="true"
+                                   filter-internal-headers="false"
                                    actor="testActor"/>
 
   <citrus:actor id="testActor" name="TESTACTOR" disabled="false"/>

--- a/endpoints/citrus-spring-integration/src/test/resources/com/consol/citrus/config/xml/ChannelSyncEndpointParserTest-context.xml
+++ b/endpoints/citrus-spring-integration/src/test/resources/com/consol/citrus/config/xml/ChannelSyncEndpointParserTest-context.xml
@@ -19,6 +19,7 @@
   <citrus-si:channel-sync-endpoint id="syncChannelEndpoint3"
                                         actor="testActor"
                                         polling-interval="250"
+                                        filter-internal-headers="false"
                                         messaging-template="messagingTemplate"/>
 
   <citrus:actor id="testActor" name="TESTACTOR" disabled="false"/>

--- a/endpoints/citrus-ws/src/test/resources/citrus-context.xml
+++ b/endpoints/citrus-ws/src/test/resources/citrus-context.xml
@@ -146,10 +146,12 @@
                     resource-base="src/test/resources"/>
 
   <citrus-jms:endpoint id="soapRequestEndpoint"
+                       filter-internal-headers="false"
                        destination-name="SoapServer.inbound"/>
 
   <citrus-jms:endpoint id="soapResponseEndpoint"
                            use-object-messages="true"
+                           filter-internal-headers="false"
                            destination-name="SoapServer.outbound"/>
 
   <citrus-http:client id="echoHttpClient"

--- a/vintage/citrus-java-dsl/src/test/resources/citrus-context.xml
+++ b/vintage/citrus-java-dsl/src/test/resources/citrus-context.xml
@@ -99,10 +99,12 @@
          message-factory="messageFactory"/>
 
     <citrus-jms:endpoint id="webServiceRequestReceiver"
-                             destination-name="${jms.ws.stub.request}"/>
+                         filter-internal-headers="false"
+                         destination-name="${jms.ws.stub.request}"/>
 
     <citrus-jms:endpoint id="webServiceResponseSender"
          use-object-messages="true"
+         filter-internal-headers="false"
          destination-name="${jms.ws.stub.response}"/>
 
     <citrus-ws:client id="webServiceHelloClient"
@@ -205,11 +207,14 @@
          request-method="POST"
          content-type="text/xml"/>
 
-    <citrus-jms:endpoint id="httpServerRequestEndpoint" destination-name="${jms.queue.http.request.forward}"/>
+    <citrus-jms:endpoint id="httpServerRequestEndpoint"
+                         filter-internal-headers="false"
+                         destination-name="${jms.queue.http.request.forward}"/>
 
     <citrus-jms:endpoint id="httpServerResponseEndpoint"
-         destination-name="${jms.queue.http.request.ack}"
-         actor="helloServer"/>
+                         filter-internal-headers="false"
+                         destination-name="${jms.queue.http.request.ack}"
+                         actor="helloServer"/>
 
     <!-- JDBC data sources -->
     <bean id="testDataSource" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
@@ -241,7 +246,8 @@
     </bean>
 
     <!-- Citrus JMS Endpoints -->
-    <citrus-jms:endpoint id="helloRequestSender" destination-name="${jms.queue.hello.request}"/>
+    <citrus-jms:endpoint id="helloRequestSender"
+         destination-name="${jms.queue.hello.request}"/>
 
     <citrus-jms:endpoint id="helloResponseReceiver"
          timeout="5000"


### PR DESCRIPTION
- Adjust Kafka message converter to filter Citrus internal headers
- Add filter internal header setting on JMS endpoint configuration
- Filter internal headers on JMS endpoint based on filter settings
- Auto disable filtering on JMS endpoint adapter
- Add filter internal header setting on Spring message channel endpoint
- Filter internal headers on Spring message channel endpoint based on filter settings

Fixes #810 