### PR TITLE
bugfix: use super-interface endpoint in HttpActionBuilder

### DIFF
--- a/endpoints/citrus-http/src/main/java/com/consol/citrus/http/actions/HttpActionBuilder.java
+++ b/endpoints/citrus-http/src/main/java/com/consol/citrus/http/actions/HttpActionBuilder.java
@@ -18,6 +18,7 @@ package com.consol.citrus.http.actions;
 
 import com.consol.citrus.TestAction;
 import com.consol.citrus.TestActionBuilder;
+import com.consol.citrus.endpoint.Endpoint;
 import com.consol.citrus.http.client.HttpClient;
 import com.consol.citrus.http.server.HttpServer;
 import com.consol.citrus.spi.ReferenceResolver;
@@ -68,8 +69,8 @@ public class HttpActionBuilder implements TestActionBuilder.DelegatingTestAction
 	/**
 	 * Initiate http server action.
 	 */
-	public HttpServerActionBuilder server(HttpServer httpServer) {
-		HttpServerActionBuilder serverActionBuilder = new HttpServerActionBuilder(httpServer)
+	public HttpServerActionBuilder server(Endpoint endpoint) {
+		HttpServerActionBuilder serverActionBuilder = new HttpServerActionBuilder(endpoint)
 				.withReferenceResolver(referenceResolver);
 		this.delegate = serverActionBuilder;
 		return serverActionBuilder;


### PR DESCRIPTION
step 1 for `//TODO` in [`HttpScenarioActionBuilder` of citrusframework/citrus-simulator](https://github.com/postfinance/citrus-simulator/blob/a126e9ef4c45669f8196133d4998763daca21731/simulator-starter/src/main/java/com/consol/citrus/simulator/http/HttpScenarioActionBuilder.java#L54).

contributor: @zauggmori.