### PR TITLE
fix: spring extension after all callback

### DIFF
--- a/runtime/citrus-junit5/src/main/java/com/consol/citrus/junit/jupiter/spring/CitrusSpringExtension.java
+++ b/runtime/citrus-junit5/src/main/java/com/consol/citrus/junit/jupiter/spring/CitrusSpringExtension.java
@@ -38,6 +38,7 @@ import com.consol.citrus.junit.jupiter.CitrusExtension;
 import com.consol.citrus.junit.jupiter.CitrusExtensionHelper;
 import com.consol.citrus.util.FileUtils;
 import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
@@ -66,7 +67,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
  * @author Christoph Deppisch
  */
 public class CitrusSpringExtension implements BeforeAllCallback, BeforeEachCallback, BeforeTestExecutionCallback,
-        AfterTestExecutionCallback, ParameterResolver, TestInstancePostProcessor, TestExecutionExceptionHandler {
+        AfterTestExecutionCallback, ParameterResolver, TestInstancePostProcessor, TestExecutionExceptionHandler, AfterAllCallback {
 
     private Citrus citrus;
     private ApplicationContext applicationContext;
@@ -76,6 +77,11 @@ public class CitrusSpringExtension implements BeforeAllCallback, BeforeEachCallb
     public void beforeAll(ExtensionContext extensionContext) {
         CitrusExtensionHelper.setCitrus(getCitrus(extensionContext), extensionContext);
         delegate.beforeAll(extensionContext);
+    }
+
+    @Override
+    public void afterAll(ExtensionContext extensionContext) throws Exception {
+        delegate.afterAll(extensionContext);
     }
 
     @Override


### PR DESCRIPTION
one must call the `afterAll` delegate as well. this was introduced to [`CitrusExtension`](https://github.com/citrusframework/citrus/blame/main/runtime/citrus-junit5/src/main/java/com/consol/citrus/junit/jupiter/CitrusExtension.java#L80) in b52b025158046d4b21c89dd93a4ebf1d72461121.