### PR TITLE
fix(#879): Avoid concurrent modification exception 

### DIFF
--- a/connectors/citrus-sql/src/main/java/com/consol/citrus/actions/AbstractDatabaseConnectingTestAction.java
+++ b/connectors/citrus-sql/src/main/java/com/consol/citrus/actions/AbstractDatabaseConnectingTestAction.java
@@ -87,7 +87,9 @@ public abstract class AbstractDatabaseConnectingTestAction extends JdbcDaoSuppor
      * Do basic logging and delegate execution to subclass.
      */
     public void execute(TestContext context) {
-        doExecute(context);
+        if (!isDisabled(context)) {
+            doExecute(context);
+        }
     }
 
     /**

--- a/core/citrus-api/src/main/java/com/consol/citrus/container/TestActionContainer.java
+++ b/core/citrus-api/src/main/java/com/consol/citrus/container/TestActionContainer.java
@@ -70,6 +70,12 @@ public interface TestActionContainer extends TestAction {
     void setActiveAction(TestAction action);
 
     /**
+     * Sets the last action that has been executed.
+     * @param action
+     */
+    void setExecutedAction(TestAction action);
+
+    /**
      * Get the action that was executed most recently.
      * @return
      */

--- a/core/citrus-api/src/main/java/com/consol/citrus/context/TestContext.java
+++ b/core/citrus-api/src/main/java/com/consol/citrus/context/TestContext.java
@@ -1050,6 +1050,11 @@ public class TestContext implements ReferenceResolverAware, TestActionListenerAw
         }
 
         @Override
+        public void setExecutedAction(TestAction action) {
+            // do nothing
+        }
+
+        @Override
         public void setTestClass(Class<?> type) {
             // do nothing
         }

--- a/core/citrus-base/src/main/java/com/consol/citrus/DefaultTestCase.java
+++ b/core/citrus-base/src/main/java/com/consol/citrus/DefaultTestCase.java
@@ -130,8 +130,8 @@ public class DefaultTestCase extends AbstractActionContainer implements TestCase
         }
 
         try {
+            setActiveAction(action);
             if (!action.isDisabled(context)) {
-                setActiveAction(action);
                 context.getTestActionListeners().onTestActionStart(this, action);
 
                 action.execute(context);
@@ -142,6 +142,8 @@ public class DefaultTestCase extends AbstractActionContainer implements TestCase
         } catch (final Exception | AssertionError e) {
             testResult = TestResult.failed(getName(), testClass.getName(), e);
             throw new TestCaseFailedException(e);
+        } finally {
+            setExecutedAction(action);
         }
     }
 

--- a/core/citrus-base/src/main/java/com/consol/citrus/actions/AbstractTestAction.java
+++ b/core/citrus-base/src/main/java/com/consol/citrus/actions/AbstractTestAction.java
@@ -55,7 +55,9 @@ public abstract class AbstractTestAction implements TestAction, Named, Described
      * Do basic logging and delegate execution to subclass.
      */
     public void execute(TestContext context) {
-        doExecute(context);
+        if (!isDisabled(context)) {
+            doExecute(context);
+        }
     }
 
     /**

--- a/core/citrus-base/src/main/java/com/consol/citrus/container/AbstractActionContainer.java
+++ b/core/citrus-base/src/main/java/com/consol/citrus/container/AbstractActionContainer.java
@@ -60,6 +60,20 @@ public abstract class AbstractActionContainer extends AbstractTestAction impleme
         actions = builder.getActions();
     }
 
+    /**
+     * Runs the give action and makes sure to properly set active and executed action state for this container.
+     * @param action
+     * @param context
+     */
+    protected void executeAction(TestAction action, TestContext context) {
+        try {
+            setActiveAction(action);
+            action.execute(context);
+        } finally {
+            setExecutedAction(action);
+        }
+    }
+
     @Override
     public AbstractActionContainer setActions(List<TestAction> actions) {
         this.actions = actions.stream().map(action -> (TestActionBuilder<?>) () -> action).collect(Collectors.toList());
@@ -79,11 +93,19 @@ public abstract class AbstractActionContainer extends AbstractTestAction impleme
 
     @Override
     public boolean isDone(TestContext context) {
-        if (isDisabled(context)) {
+        if (actions.isEmpty() || isDisabled(context)) {
             return true;
         }
 
-        for (TestAction action : executedActions) {
+        if (activeAction == null && executedActions.isEmpty()) {
+            return true;
+        }
+
+        if (!executedActions.contains(activeAction)) {
+            return false;
+        }
+
+        for (TestAction action : new ArrayList<>(executedActions)) {
             if (action instanceof Completable && !((Completable) action).isDone(context)) {
                 if (log.isDebugEnabled()) {
                     log.debug(Optional.ofNullable(action.getName()).filter(name -> name.trim().length() > 0)
@@ -130,6 +152,10 @@ public abstract class AbstractActionContainer extends AbstractTestAction impleme
     @Override
     public void setActiveAction(TestAction action) {
         this.activeAction = action;
+    }
+
+    @Override
+    public void setExecutedAction(TestAction action) {
         this.executedActions.add(action);
     }
 

--- a/core/citrus-base/src/main/java/com/consol/citrus/container/AbstractIteratingActionContainer.java
+++ b/core/citrus-base/src/main/java/com/consol/citrus/container/AbstractIteratingActionContainer.java
@@ -20,7 +20,6 @@ import java.util.Properties;
 
 import com.consol.citrus.AbstractIteratingContainerBuilder;
 import com.consol.citrus.CitrusSettings;
-import com.consol.citrus.TestAction;
 import com.consol.citrus.TestActionBuilder;
 import com.consol.citrus.context.TestContext;
 import com.consol.citrus.exceptions.ValidationException;
@@ -77,9 +76,7 @@ public abstract class AbstractIteratingActionContainer extends AbstractActionCon
         context.setVariable(indexName, String.valueOf(index));
 
         for (TestActionBuilder<?> actionBuilder: actions) {
-            TestAction action = actionBuilder.build();
-            setActiveAction(action);
-            action.execute(context);
+            executeAction(actionBuilder.build(), context);
         }
     }
 
@@ -94,7 +91,7 @@ public abstract class AbstractIteratingActionContainer extends AbstractActionCon
 
         // replace dynamic content with each iteration
         String conditionString = condition;
-        if (conditionString.indexOf(CitrusSettings.VARIABLE_PREFIX + indexName + CitrusSettings.VARIABLE_SUFFIX) != -1) {
+        if (conditionString.contains(CitrusSettings.VARIABLE_PREFIX + indexName + CitrusSettings.VARIABLE_SUFFIX)) {
             Properties props = new Properties();
             props.put(indexName, String.valueOf(index));
             conditionString = new PropertyPlaceholderHelper(CitrusSettings.VARIABLE_PREFIX, CitrusSettings.VARIABLE_SUFFIX).replacePlaceholders(conditionString, props);

--- a/core/citrus-base/src/main/java/com/consol/citrus/container/Assert.java
+++ b/core/citrus-base/src/main/java/com/consol/citrus/container/Assert.java
@@ -67,9 +67,7 @@ public class Assert extends AbstractActionContainer {
         }
 
         try {
-            TestAction action = this.action.build();
-            setActiveAction(action);
-            action.execute(context);
+            executeAction(this.action.build(), context);
         } catch (Exception e) {
             log.debug("Validating caught exception ...");
 

--- a/core/citrus-base/src/main/java/com/consol/citrus/container/Async.java
+++ b/core/citrus-base/src/main/java/com/consol/citrus/container/Async.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
 public class Async extends AbstractActionContainer {
 
     /** Logger */
-    private static Logger log = LoggerFactory.getLogger(Async.class);
+    private static final Logger LOG = LoggerFactory.getLogger(Async.class);
 
     private final List<TestActionBuilder<?>> errorActions;
     private final List<TestActionBuilder<?>> successActions;
@@ -51,21 +51,19 @@ public class Async extends AbstractActionContainer {
 
     @Override
     public void doExecute(TestContext context) {
-        log.debug("Async container forking action execution ...");
+        LOG.debug("Async container forking action execution ...");
 
         AbstractAsyncTestAction asyncTestAction = new AbstractAsyncTestAction() {
             @Override
             public void doExecuteAsync(TestContext context) {
                 for (TestActionBuilder<?> actionBuilder : actions) {
-                    TestAction action = actionBuilder.build();
-                    setActiveAction(action);
-                    action.execute(context);
+                    executeAction(actionBuilder.build(), context);
                 }
             }
 
             @Override
             public void onError(TestContext context, Throwable error) {
-                log.info("Apply error actions after async container ...");
+                LOG.info("Apply error actions after async container ...");
                 for (TestActionBuilder<?> actionBuilder : errorActions) {
                     TestAction action = actionBuilder.build();
                     action.execute(context);
@@ -74,7 +72,7 @@ public class Async extends AbstractActionContainer {
 
             @Override
             public void onSuccess(TestContext context) {
-                log.info("Apply success actions after async container ...");
+                LOG.info("Apply success actions after async container ...");
                 for (TestActionBuilder<?> actionBuilder : successActions) {
                     TestAction action = actionBuilder.build();
                     action.execute(context);
@@ -82,8 +80,7 @@ public class Async extends AbstractActionContainer {
             }
         };
 
-        setActiveAction(asyncTestAction);
-        asyncTestAction.execute(context);
+        executeAction(asyncTestAction, context);
     }
 
     /**
@@ -109,8 +106,8 @@ public class Async extends AbstractActionContainer {
      */
     public static class Builder extends AbstractTestContainerBuilder<Async, Builder> {
 
-        private List<TestActionBuilder<?>> errorActions = new ArrayList<>();
-        private List<TestActionBuilder<?>> successActions = new ArrayList<>();
+        private final List<TestActionBuilder<?>> errorActions = new ArrayList<>();
+        private final List<TestActionBuilder<?>> successActions = new ArrayList<>();
 
         /**
          * Fluent API action building entry method used in Java DSL.

--- a/core/citrus-base/src/main/java/com/consol/citrus/container/Catch.java
+++ b/core/citrus-base/src/main/java/com/consol/citrus/container/Catch.java
@@ -17,7 +17,6 @@
 package com.consol.citrus.container;
 
 import com.consol.citrus.AbstractExceptionContainerBuilder;
-import com.consol.citrus.TestAction;
 import com.consol.citrus.TestActionBuilder;
 import com.consol.citrus.context.TestContext;
 import com.consol.citrus.exceptions.CitrusRuntimeException;
@@ -53,9 +52,7 @@ public class Catch extends AbstractActionContainer {
 
         for (TestActionBuilder<?> actionBuilder: actions) {
             try {
-                TestAction action = actionBuilder.build();
-                setActiveAction(action);
-                action.execute(context);
+                executeAction(actionBuilder.build(), context);
             } catch (Exception e) {
                 if (exception != null && exception.equals(e.getClass().getName())) {
                     log.info("Caught exception " + e.getClass() + ": " + e.getLocalizedMessage());

--- a/core/citrus-base/src/main/java/com/consol/citrus/container/Conditional.java
+++ b/core/citrus-base/src/main/java/com/consol/citrus/container/Conditional.java
@@ -17,7 +17,6 @@
 package com.consol.citrus.container;
 
 import com.consol.citrus.AbstractTestContainerBuilder;
-import com.consol.citrus.TestAction;
 import com.consol.citrus.TestActionBuilder;
 import com.consol.citrus.context.TestContext;
 import com.consol.citrus.exceptions.ValidationException;
@@ -59,9 +58,7 @@ public class Conditional extends AbstractActionContainer {
             log.debug("Condition [ {} ] evaluates to true, executing nested actions", condition);
 
             for (TestActionBuilder<?> actionBuilder : actions) {
-                TestAction action = actionBuilder.build();
-                setActiveAction(action);
-                action.execute(context);
+                executeAction(actionBuilder.build(), context);
             }
         } else {
             log.debug("Condition [ {} ] evaluates to false, not executing nested actions", condition);

--- a/core/citrus-base/src/main/java/com/consol/citrus/container/Sequence.java
+++ b/core/citrus-base/src/main/java/com/consol/citrus/container/Sequence.java
@@ -17,7 +17,6 @@
 package com.consol.citrus.container;
 
 import com.consol.citrus.AbstractTestContainerBuilder;
-import com.consol.citrus.TestAction;
 import com.consol.citrus.TestActionBuilder;
 import com.consol.citrus.context.TestContext;
 import org.slf4j.Logger;
@@ -44,9 +43,7 @@ public class Sequence extends AbstractActionContainer {
     @Override
     public void doExecute(TestContext context) {
         for (TestActionBuilder<?> actionBuilder: actions) {
-            TestAction action = actionBuilder.build();
-            setActiveAction(action);
-            action.execute(context);
+            executeAction(actionBuilder.build(), context);
         }
 
         log.debug("Action sequence finished successfully");

--- a/core/citrus-base/src/main/java/com/consol/citrus/container/Timer.java
+++ b/core/citrus-base/src/main/java/com/consol/citrus/container/Timer.java
@@ -20,7 +20,6 @@ import java.util.TimerTask;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.consol.citrus.AbstractTestContainerBuilder;
-import com.consol.citrus.TestAction;
 import com.consol.citrus.TestActionBuilder;
 import com.consol.citrus.context.TestContext;
 import com.consol.citrus.exceptions.CitrusRuntimeException;
@@ -91,9 +90,7 @@ public class Timer extends AbstractActionContainer implements StopTimer {
                     log.debug(String.format("Timer event fired #%s - executing nested actions", indexCount));
 
                     for (TestActionBuilder<?> actionBuilder : actions)  {
-                        TestAction action = actionBuilder.build();
-                        setActiveAction(action);
-                        action.execute(context);
+                        executeAction(actionBuilder.build(), context);
                     }
                     if (indexCount >= repeatCount) {
                         log.debug(String.format("Timer complete: %s iterations reached", repeatCount));

--- a/core/citrus-base/src/test/java/com/consol/citrus/container/AsyncTest.java
+++ b/core/citrus-base/src/test/java/com/consol/citrus/container/AsyncTest.java
@@ -48,9 +48,9 @@ public class AsyncTest extends UnitTestSupport {
     /** Logger */
     private static final Logger LOG = LoggerFactory.getLogger(AsyncTest.class);
 
-    private TestAction action = Mockito.mock(TestAction.class);
-    private TestAction success = Mockito.mock(TestAction.class);
-    private TestAction error = Mockito.mock(TestAction.class);
+    private final TestAction action = Mockito.mock(TestAction.class);
+    private final TestAction success = Mockito.mock(TestAction.class);
+    private final TestAction error = Mockito.mock(TestAction.class);
 
     @Test
     public void testSingleAction() throws Exception {

--- a/core/citrus-base/src/test/java/com/consol/citrus/report/FailureStackTestListenerTest.java
+++ b/core/citrus-base/src/test/java/com/consol/citrus/report/FailureStackTestListenerTest.java
@@ -219,6 +219,7 @@ public class FailureStackTestListenerTest extends UnitTestSupport {
                 new MockedTestAction("sleep"),
                 failedContainer);
         nestedContainer.setActiveAction(failedContainer);
+        nestedContainer.setExecutedAction(failedContainer);
         actions.add(nestedContainer);
 
         actions.add(new MockedTestAction("fail"));
@@ -331,6 +332,7 @@ public class FailureStackTestListenerTest extends UnitTestSupport {
     private void setActiveActions(TestActionContainer container, TestAction failedAction) {
         for (TestAction action : container.getActions()) {
             container.setActiveAction(action);
+            container.setExecutedAction(action);
             if (action.equals(failedAction)) {
                 break;
             }

--- a/endpoints/citrus-ws/src/main/java/com/consol/citrus/ws/actions/AssertSoapFault.java
+++ b/endpoints/citrus-ws/src/main/java/com/consol/citrus/ws/actions/AssertSoapFault.java
@@ -77,7 +77,7 @@ public class AssertSoapFault extends AbstractActionContainer {
     private final SoapFaultValidationContext validationContext;
 
     /** Logger */
-    private static Logger log = LoggerFactory.getLogger(AssertSoapFault.class);
+    private static Logger LOG = LoggerFactory.getLogger(AssertSoapFault.class);
 
     /**
      * Default constructor.
@@ -98,19 +98,19 @@ public class AssertSoapFault extends AbstractActionContainer {
 
     @Override
     public void doExecute(TestContext context) {
-        log.debug("Asserting SOAP fault ...");
+        LOG.debug("Asserting SOAP fault ...");
 
         try {
-            action.execute(context);
+            executeAction(action, context);
         } catch (SoapFaultClientException soapFaultException) {
-            log.debug("Validating SOAP fault ...");
+            LOG.debug("Validating SOAP fault ...");
 
             SoapFault controlFault = constructControlFault(context);
 
             validator.validateSoapFault(SoapFault.from(soapFaultException.getSoapFault()), controlFault, context, validationContext);
 
-            log.debug("Asserted SOAP fault as expected: " + soapFaultException.getFaultCode() + ": " + soapFaultException.getFaultStringOrReason());
-            log.info("Assert SOAP fault validation successful");
+            LOG.debug("Asserted SOAP fault as expected: " + soapFaultException.getFaultCode() + ": " + soapFaultException.getFaultStringOrReason());
+            LOG.info("Assert SOAP fault validation successful");
 
             return;
         } catch (Exception e) {

--- a/runtime/citrus-testng/src/test/java/com/consol/citrus/integration/container/CustomContainerJavaIT.java
+++ b/runtime/citrus-testng/src/test/java/com/consol/citrus/integration/container/CustomContainerJavaIT.java
@@ -51,7 +51,7 @@ public class CustomContainerJavaIT extends TestNGCitrusSpringSupport {
         @Override
         public void doExecute(TestContext context) {
             for (int i = getActions().size(); i > 0; i--) {
-                getActions().get(i - 1).execute(context);
+                executeAction(getActions().get(i - 1), context);
             }
         }
     }

--- a/vintage/citrus-java-dsl/src/test/java/com/consol/citrus/dsl/runner/CustomContainerTestRunnerTest.java
+++ b/vintage/citrus-java-dsl/src/test/java/com/consol/citrus/dsl/runner/CustomContainerTestRunnerTest.java
@@ -16,7 +16,6 @@
 
 package com.consol.citrus.dsl.runner;
 
-import com.consol.citrus.TestAction;
 import com.consol.citrus.TestActionBuilder;
 import com.consol.citrus.TestCase;
 import com.consol.citrus.actions.EchoAction;
@@ -96,8 +95,7 @@ public class CustomContainerTestRunnerTest extends UnitTestSupport {
                 context.setVariable("index", i);
 
                 for (TestActionBuilder<?> actionBuilder : actions) {
-                    TestAction action = actionBuilder.build();
-                    action.execute(context);
+                    executeAction(actionBuilder.build(), context);
                 }
             }
         }

--- a/vintage/citrus-java-dsl/src/test/java/com/consol/citrus/integration/design/CustomContainerJavaIT.java
+++ b/vintage/citrus-java-dsl/src/test/java/com/consol/citrus/integration/design/CustomContainerJavaIT.java
@@ -47,7 +47,7 @@ public class CustomContainerJavaIT extends TestNGCitrusTestDesigner {
         @Override
         public void doExecute(TestContext context) {
             for (int i = getActions().size(); i > 0; i--) {
-                getActions().get(i - 1).execute(context);
+                executeAction(getActions().get(i - 1), context);
             }
         }
     }

--- a/vintage/citrus-java-dsl/src/test/java/com/consol/citrus/integration/runner/CustomContainerTestRunnerIT.java
+++ b/vintage/citrus-java-dsl/src/test/java/com/consol/citrus/integration/runner/CustomContainerTestRunnerIT.java
@@ -43,11 +43,11 @@ public class CustomContainerTestRunnerIT extends TestNGCitrusTestRunner {
         return container(new ReverseActionContainer());
     }
 
-    private class ReverseActionContainer extends AbstractActionContainer {
+    private static class ReverseActionContainer extends AbstractActionContainer {
         @Override
         public void doExecute(TestContext context) {
             for (int i = getActions().size(); i > 0; i--) {
-                getActions().get(i - 1).execute(context);
+                executeAction(getActions().get(i - 1), context);
             }
         }
     }


### PR DESCRIPTION
… when evaluating test action done state

- Evaluation of done state visits all entries in the list of executed actions in order to verify that the action is done
- Concurrently some action may finish and as a result the action gets added to the list of executed actions which eventually causes concurrent modification exception
- Make sure to iterate over a copy of executed actions list to avoid concurrent modification exception
- Separate active action and executed actions handling where active action state is set before execution while action is added to the list of executed actions after execution
- Also use active action and executed action list in test containers to evaluate done state properly (e.g. when there is still an active action pending in execution)
- Properly account for disabled state in test action execution (the disabled state was only evaluated for top level test actions in a test case, nested test actions living in a test container did not properly check the disabled state before execution)

Fixes #879 