### PR TITLE
chore(build): Fix flaky CI job tests

### DIFF
--- a/connectors/citrus-sql/src/test/java/com/consol/citrus/integration/actions/QueryDatabaseRetriesJavaIT.java
+++ b/connectors/citrus-sql/src/test/java/com/consol/citrus/integration/actions/QueryDatabaseRetriesJavaIT.java
@@ -43,19 +43,19 @@ public class QueryDatabaseRetriesJavaIT extends TestNGCitrusSpringSupport {
 
     @CitrusTest
     public void sqlQueryRetries() {
+        run(sql(dataSource)
+                .sqlResource("classpath:com/consol/citrus/integration/actions/script.sql"));
+
         run(parallel().actions(
-            sequential().actions(
-                sql(dataSource)
-                    .sqlResource("classpath:com/consol/citrus/integration/actions/script.sql"),
-                repeatOnError()
-                    .autoSleep(100).index("i").until("i = 5")
-                    .actions(query(dataSource)
-                        .statement("select COUNT(*) as customer_cnt from CUSTOMERS")
-                        .validate("CUSTOMER_CNT", "0")
-                )
+            repeatOnError()
+                .autoSleep(1000).index("i").until("i = 5")
+                .actions(query(dataSource)
+                    .statement("select COUNT(*) as customer_cnt from CUSTOMERS")
+                    .validate("CUSTOMER_CNT", "0")
             ),
+
             sequential().actions(
-                sleep().milliseconds(300),
+                sleep().milliseconds(3000),
                 sql(dataSource)
                     .statement("DELETE FROM CUSTOMERS")
             )

--- a/connectors/citrus-sql/src/test/resources/com/consol/citrus/integration/actions/QueryDatabaseRetriesIT.xml
+++ b/connectors/citrus-sql/src/test/resources/com/consol/citrus/integration/actions/QueryDatabaseRetriesIT.xml
@@ -1,40 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <spring:beans xmlns="http://www.citrusframework.org/schema/testcase" xmlns:spring="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.citrusframework.org/schema/testcase http://www.citrusframework.org/schema/testcase/citrus-testcase.xsd">
-    <testcase name="QueryDatabaseRetriesIT">
-		<meta-info>
-			<author>Christoph Deppisch</author>
-			<creationdate>2008-08-05</creationdate>
-			<status>FINAL</status>
-			<last-updated-by>Christoph Deppisch</last-updated-by>
-			<last-updated-on>2008-06-13T00:00:00</last-updated-on>
-		</meta-info>
+  <testcase name="QueryDatabaseRetriesIT">
+    <meta-info>
+      <author>Christoph Deppisch</author>
+      <creationdate>2008-08-05</creationdate>
+      <status>FINAL</status>
+      <last-updated-by>Christoph Deppisch</last-updated-by>
+      <last-updated-on>2008-06-13T00:00:00</last-updated-on>
+    </meta-info>
 
-        <description>
-			Test of retry functionality in sql action.
-            Sql action is configured so that it retries for 5 seconds with a pause of 1
-            second. The parallel task waits for 3 seconds and updates the database so
-            that the sql action succeeds.
-		</description>
-        <actions>
-			<parallel>
-				<sequential>
-                    <sql datasource="testDataSource">
-                        <resource file="classpath:com/consol/citrus/integration/actions/script.sql"/>
-                    </sql>
-                    <repeat-onerror-until-true auto-sleep="1000" condition="i = 5" index="i">
-            	        <sql datasource="testDataSource">
-                            <statement>select COUNT(*) as customer_cnt from CUSTOMERS</statement>
-                            <validate column="CUSTOMER_CNT" value="0"/>
-                        </sql>
-                    </repeat-onerror-until-true>
-				</sequential>
-				<sequential>
-                    <sleep milliseconds="3000"/>
-                    <sql datasource="testDataSource">
-                        <statement>DELETE FROM CUSTOMERS</statement>
-                    </sql>
-				</sequential>
-            </parallel>
-        </actions>
-    </testcase>
+    <description>
+      Test of retry functionality in sql action.
+      Sql action is configured so that it retries for 5 seconds with a pause of 1
+      second. The parallel task waits for 3 seconds and updates the database so
+      that the sql action succeeds.
+    </description>
+    <actions>
+      <sql datasource="testDataSource">
+        <resource file="classpath:com/consol/citrus/integration/actions/script.sql"/>
+      </sql>
+
+      <parallel>
+        <repeat-onerror-until-true auto-sleep="1000" condition="i = 5" index="i">
+          <sql datasource="testDataSource">
+            <statement>select COUNT(*) as customer_cnt from CUSTOMERS</statement>
+            <validate column="CUSTOMER_CNT" value="0"/>
+          </sql>
+        </repeat-onerror-until-true>
+
+        <sequential>
+          <sleep milliseconds="3000"/>
+          <sql datasource="testDataSource">
+            <statement>DELETE FROM CUSTOMERS</statement>
+          </sql>
+        </sequential>
+      </parallel>
+    </actions>
+  </testcase>
 </spring:beans>

--- a/endpoints/citrus-http/src/test/resources/citrus-context.xml
+++ b/endpoints/citrus-http/src/test/resources/citrus-context.xml
@@ -119,7 +119,7 @@
   </bean>
 
   <!-- Embedded ActiveMQ JMS broker -->
-  <amq:broker useJmx="false" persistent="false">
+  <amq:broker useJmx="false" persistent="false" advisorySupport="false" timeBeforePurgeTempDestinations="30000">
     <amq:transportConnectors>
       <amq:transportConnector uri="tcp://localhost:61616"/>
     </amq:transportConnectors>

--- a/endpoints/citrus-jms/src/test/resources/citrus-activemq-context.xml
+++ b/endpoints/citrus-jms/src/test/resources/citrus-activemq-context.xml
@@ -1,16 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xmlns:context="http://www.springframework.org/schema/context"
-     xmlns:util="http://www.springframework.org/schema/util"
      xmlns:amq="http://activemq.apache.org/schema/core"
      xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-                         http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-                         http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
                          http://activemq.apache.org/schema/core http://activemq.apache.org/schema/core/activemq-core.xsd">
 
   <!-- Embedded ActiveMQ JMS broker -->
-  <amq:broker useJmx="false" persistent="false">
+  <amq:broker useJmx="false" persistent="false" advisorySupport="false" timeBeforePurgeTempDestinations="30000">
     <amq:transportConnectors>
       <amq:transportConnector uri="${jms.broker.url}" />
     </amq:transportConnectors>
@@ -18,6 +14,7 @@
 
   <bean id="connectionFactory" class="org.apache.activemq.ActiveMQConnectionFactory">
     <property name="brokerURL" value="${jms.broker.url}" />
+    <property name="watchTopicAdvisories" value="false"/>
   </bean>
 
 </beans>

--- a/endpoints/citrus-ws/src/test/resources/citrus-context.xml
+++ b/endpoints/citrus-ws/src/test/resources/citrus-context.xml
@@ -59,7 +59,7 @@
   </citrus:namespace-context>
 
   <!-- Embedded ActiveMQ JMS broker -->
-  <amq:broker useJmx="false" persistent="false">
+  <amq:broker useJmx="false" persistent="false" advisorySupport="false" timeBeforePurgeTempDestinations="30000">
     <amq:transportConnectors>
       <amq:transportConnector uri="tcp://localhost:61616" />
     </amq:transportConnectors>

--- a/tools/archetypes/jms/src/main/resources/archetype-resources/src/test/resources/citrus-context.xml
+++ b/tools/archetypes/jms/src/main/resources/archetype-resources/src/test/resources/citrus-context.xml
@@ -47,7 +47,7 @@
   </bean>
 
   <!-- Embedded ActiveMQ JMS broker -->
-  <amq:broker useJmx="false" persistent="false">
+  <amq:broker useJmx="false" persistent="false" advisorySupport="false" timeBeforePurgeTempDestinations="30000">
     <amq:transportConnectors>
       <amq:transportConnector uri="${jms.broker.url}" />
     </amq:transportConnectors>

--- a/vintage/citrus-java-dsl/src/test/resources/citrus-context.xml
+++ b/vintage/citrus-java-dsl/src/test/resources/citrus-context.xml
@@ -31,7 +31,7 @@
     <context:component-scan base-package="com.consol.citrus.integration.runner.suite"/>
 
     <!-- Embedded ActiveMQ JMS broker -->
-    <amq:broker useJmx="false" persistent="false">
+    <amq:broker useJmx="false" persistent="false" advisorySupport="false" timeBeforePurgeTempDestinations="30000">
       <amq:transportConnectors>
         <amq:transportConnector uri="tcp://localhost:61616"/>
       </amq:transportConnectors>


### PR DESCRIPTION
For some reason temporary queues get deleted before the synchronous JMS consumer is able to send a reply message. The error can not be reproduced on local machines but only happens randomly on GitHub CI jobs. Try to overcome this by disabling advisory support and explicitly set the timeout for purging temporary destinations on the JMS broker.

Also fixed SQL query retries tests eliminating racing conditions when inserting/deleting entries from database.