### PR TITLE
fix(#894): Avoid NullpointerException in citrus:env function

### DIFF
--- a/core/citrus-spring/src/main/java/com/consol/citrus/functions/DefaultFunctionLibraryFactory.java
+++ b/core/citrus-spring/src/main/java/com/consol/citrus/functions/DefaultFunctionLibraryFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.consol.citrus.functions;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.EnvironmentAware;
+import org.springframework.core.env.Environment;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class DefaultFunctionLibraryFactory implements FactoryBean<DefaultFunctionLibrary>, ApplicationContextAware, EnvironmentAware {
+
+    private ApplicationContext applicationContext;
+    private Environment environment;
+
+    private final DefaultFunctionLibrary library = new DefaultFunctionLibrary();
+
+    @Override
+    public DefaultFunctionLibrary getObject() throws Exception {
+        library.getMembers().forEach((key, member) -> {
+            if (member instanceof ApplicationContextAware) {
+                ((ApplicationContextAware) member).setApplicationContext(applicationContext);
+            }
+
+            if (member instanceof EnvironmentAware) {
+                ((EnvironmentAware) member).setEnvironment(environment);
+            }
+        });
+
+        applicationContext.getBeansOfType(Function.class)
+                .forEach((key, value) -> library.getMembers().put(key, value));
+
+        return library;
+    }
+
+    @Override
+    public Class<?> getObjectType() {
+        return DefaultFunctionLibrary.class;
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.applicationContext = applicationContext;
+    }
+
+    @Override
+    public void setEnvironment(Environment environment) {
+        this.environment = environment;
+    }
+}

--- a/core/citrus-spring/src/main/java/com/consol/citrus/functions/FunctionConfig.java
+++ b/core/citrus-spring/src/main/java/com/consol/citrus/functions/FunctionConfig.java
@@ -26,15 +26,13 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class FunctionConfig {
 
-    private final FunctionLibrary functionLibrary = new DefaultFunctionLibrary();
-
     @Bean(name = "functionRegistry")
     public FunctionRegistryFactory functionRegistry() {
         return new FunctionRegistryFactory();
     }
 
     @Bean(name="citrusFunctionLibrary")
-    public FunctionLibrary functionLibrary() {
-        return functionLibrary;
+    public DefaultFunctionLibraryFactory functionLibrary() {
+        return new DefaultFunctionLibraryFactory();
     }
 }

--- a/core/citrus-spring/src/main/java/com/consol/citrus/functions/core/EnvironmentPropertyFunction.java
+++ b/core/citrus-spring/src/main/java/com/consol/citrus/functions/core/EnvironmentPropertyFunction.java
@@ -31,7 +31,7 @@ import org.springframework.core.env.Environment;
 import org.springframework.util.CollectionUtils;
 
 /**
- * Function returns given string argument in lower case.
+ * Function to get environment variable settings.
  *
  * @author Christoph Deppisch
  */
@@ -55,12 +55,22 @@ public class EnvironmentPropertyFunction implements Function, EnvironmentAware {
             defaultValue = Optional.empty();
         }
 
-        return Optional.ofNullable(environment.getProperty(propertyName))
-                       .orElseGet(() -> defaultValue.orElseThrow(() -> new CitrusRuntimeException(String.format("Failed to resolve property '%s' in environment", propertyName))));
+        Optional<String> value;
+        if (environment != null) {
+            value = Optional.ofNullable(environment.getProperty(propertyName));
+        } else {
+            value = Optional.ofNullable(System.getenv(propertyName));
+        }
+
+        return value.orElseGet(() -> defaultValue.orElseThrow(() -> new CitrusRuntimeException(String.format("Failed to resolve property '%s' in environment", propertyName))));
     }
 
     @Override
     public void setEnvironment(Environment environment) {
         this.environment = environment;
+    }
+
+    public Environment getEnvironment() {
+        return environment;
     }
 }

--- a/core/citrus-spring/src/test/java/com/consol/citrus/functions/DefaultFunctionLibraryFactoryTest.java
+++ b/core/citrus-spring/src/test/java/com/consol/citrus/functions/DefaultFunctionLibraryFactoryTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.consol.citrus.functions;
+
+import com.consol.citrus.UnitTestSupport;
+import com.consol.citrus.functions.core.EnvironmentPropertyFunction;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class DefaultFunctionLibraryFactoryTest extends UnitTestSupport {
+
+    @Autowired
+    private DefaultFunctionLibrary library;
+
+    @Test
+    public void shouldKnowEnvironmentPropertyFunction() {
+        Assert.assertTrue(library.getMembers().containsKey("env"));
+        Assert.assertEquals(library.getMembers().get("env").getClass(), EnvironmentPropertyFunction.class);
+        Assert.assertNotNull(((EnvironmentPropertyFunction) library.getMembers().get("env")).getEnvironment());
+    }
+}

--- a/core/citrus-spring/src/test/java/com/consol/citrus/functions/core/EnvironmentPropertyFunctionTest.java
+++ b/core/citrus-spring/src/test/java/com/consol/citrus/functions/core/EnvironmentPropertyFunctionTest.java
@@ -41,8 +41,8 @@ import static org.mockito.Mockito.when;
  */
 public class EnvironmentPropertyFunctionTest extends AbstractTestNGUnitTest {
 
-    private Environment environment = Mockito.mock(Environment.class);
-    private EnvironmentPropertyFunction function = new EnvironmentPropertyFunction();
+    private final Environment environment = Mockito.mock(Environment.class);
+    private final EnvironmentPropertyFunction function = new EnvironmentPropertyFunction();
 
     @BeforeMethod
     public void setup() {


### PR DESCRIPTION
Make sure to properly set Spring environment and application context on all functions in default function library. Adding factory bean for default function library that is aware of application context and Spring environment for proper dependency injection. Also, automatically add all functions to the function library that live as Spring beans in the application context.

Use traditional system environment variable settings lookup as fallback when Spring environment is not set properly.

Fixes #894 