### PR TITLE
Fix: #900. Add dependency checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,3 +61,6 @@ jobs:
       - name: Build Citrus
         run: |
           ./mvnw --no-transfer-progress install
+      - name: Informative security dependency checks.
+        run: |
+          ./mvnw org.owasp:dependency-check-maven:check


### PR DESCRIPTION
## This PR

- adds informative owasp dependency checks in CI

## Note

you can enforce validation output and block deployment when insecure deps are found