### PR TITLE
chore: Spring context improvements

### DIFF
--- a/core/citrus-base/src/main/java/com/consol/citrus/actions/PurgeEndpointAction.java
+++ b/core/citrus-base/src/main/java/com/consol/citrus/actions/PurgeEndpointAction.java
@@ -31,6 +31,7 @@ import com.consol.citrus.message.MessageSelectorBuilder;
 import com.consol.citrus.messaging.Consumer;
 import com.consol.citrus.messaging.SelectiveConsumer;
 import com.consol.citrus.spi.ReferenceResolver;
+import com.consol.citrus.spi.ReferenceResolverAware;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
@@ -214,7 +215,7 @@ public class PurgeEndpointAction extends AbstractTestAction {
     /**
      * Action builder.
      */
-    public static final class Builder extends AbstractTestActionBuilder<PurgeEndpointAction, Builder> {
+    public static final class Builder extends AbstractTestActionBuilder<PurgeEndpointAction, Builder> implements ReferenceResolverAware {
 
         private final List<String> endpointNames = new ArrayList<>();
         private final List<Endpoint> endpoints = new ArrayList<>();
@@ -344,6 +345,11 @@ public class PurgeEndpointAction extends AbstractTestAction {
         public Builder referenceResolver(ReferenceResolver referenceResolver) {
             this.referenceResolver = referenceResolver;
             return this;
+        }
+
+        @Override
+        public void setReferenceResolver(ReferenceResolver referenceResolver) {
+            this.referenceResolver = referenceResolver;
         }
 
         @Override

--- a/core/citrus-base/src/main/java/com/consol/citrus/endpoint/adapter/mapping/SimpleMappingStrategy.java
+++ b/core/citrus-base/src/main/java/com/consol/citrus/endpoint/adapter/mapping/SimpleMappingStrategy.java
@@ -40,7 +40,6 @@ public class SimpleMappingStrategy implements EndpointAdapterMappingStrategy {
             return adapterMappings.get(mappingKey);
         } else {
             throw new CitrusRuntimeException("Unable to find matching endpoint adapter with mapping key '" + mappingKey + "'");
-
         }
     }
 

--- a/core/citrus-spring/src/main/java/com/consol/citrus/config/CitrusSpringConfig.java
+++ b/core/citrus-spring/src/main/java/com/consol/citrus/config/CitrusSpringConfig.java
@@ -54,68 +54,68 @@ import org.springframework.context.annotation.ImportResource;
 @ImportResource(locations = "${systemProperties['citrus.spring.application.context']?:classpath*:citrus-context.xml}", reader = CitrusBeanDefinitionReader.class)
 public class CitrusSpringConfig {
 
-    @Bean
+    @Bean(name = "citrusTestContextFactory")
     public TestContextFactoryBean testContextFactory() {
         return new TestContextFactoryBean();
     }
 
-    @Bean
+    @Bean(name = "citrusEndpointFactory")
     public EndpointFactory endpointFactory() {
         return new DefaultEndpointFactory();
     }
 
-    @Bean
+    @Bean(name = "citrusReferenceResolver")
     public ReferenceResolver referenceResolver() {
         return new SpringBeanReferenceResolver();
     }
 
-    @Bean
+    @Bean(name = "citrusTypeConverter")
     public TypeConverter typeConverter() {
         return TypeConverter.lookupDefault(SpringBeanTypeConverter.INSTANCE);
     }
 
-    @Bean
+    @Bean(name = "citrusLogModifier")
     public LogModifier logModifier() {
         return new DefaultLogModifier();
     }
 
-    @Bean
+    @Bean(name = "citrusMessageProcessors")
     public MessageProcessorsFactory messageProcessors() {
         return new MessageProcessorsFactory();
     }
 
-    @Bean
+    @Bean(name = "citrusTestListeners")
     public TestListenersFactory testListeners() {
         return new TestListenersFactory();
     }
 
-    @Bean
+    @Bean(name = "citrusTestActionListeners")
     public TestActionListenersFactory testActionListeners() {
         return new TestActionListenersFactory();
     }
 
-    @Bean
+    @Bean(name = "citrusTestSuiteListeners")
     public TestSuiteListenersFactory testSuiteListeners() {
         return new TestSuiteListenersFactory();
     }
 
-    @Bean
+    @Bean(name = "citrusMessageListeners")
     public MessageListenersFactory messageListeners() {
         return new MessageListenersFactory();
     }
 
-    @Bean
+    @Bean(name = "citrusFailureStackTestListener")
     public FailureStackTestListener failureStackTestListener() {
         return new FailureStackTestListener();
     }
 
-    @Bean
+    @Bean(name = "citrusComponentInitializer")
     public ComponentLifecycleProcessor componentInitializer() {
         return new ComponentLifecycleProcessor();
     }
 
-    @Bean
-    public SegmentVariableExtractorRegistry segmentVariableExtractorRegistry() {
+    @Bean(name = "citrusVariableExtractorRegistry")
+    public SegmentVariableExtractorRegistry variableExtractorRegistry() {
         return new SegmentVariableExtractorRegistry();
     }
 }

--- a/core/citrus-spring/src/main/java/com/consol/citrus/functions/FunctionConfig.java
+++ b/core/citrus-spring/src/main/java/com/consol/citrus/functions/FunctionConfig.java
@@ -26,7 +26,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class FunctionConfig {
 
-    @Bean(name = "functionRegistry")
+    @Bean(name = "citrusFunctionRegistry")
     public FunctionRegistryFactory functionRegistry() {
         return new FunctionRegistryFactory();
     }

--- a/core/citrus-spring/src/main/java/com/consol/citrus/reporter/ReporterConfig.java
+++ b/core/citrus-spring/src/main/java/com/consol/citrus/reporter/ReporterConfig.java
@@ -12,22 +12,22 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class ReporterConfig {
 
-    @Bean
+    @Bean(name = "citrusLoggingReporter")
     public LoggingReporter loggingReporter() {
         return new LoggingReporter();
     }
 
-    @Bean
+    @Bean(name = "citrusHtmlReporter")
     public HtmlReporter htmlReporter() {
         return new HtmlReporter();
     }
 
-    @Bean
+    @Bean(name = "citrusJunitReporter")
     public JUnitReporter junitReporter() {
         return new JUnitReporter();
     }
 
-    @Bean
+    @Bean(name = "citrusTestReporters")
     public TestReportersFactory testReporters() {
         return new TestReportersFactory();
     }

--- a/core/citrus-spring/src/main/java/com/consol/citrus/validation/matcher/ValidationMatcherConfig.java
+++ b/core/citrus-spring/src/main/java/com/consol/citrus/validation/matcher/ValidationMatcherConfig.java
@@ -28,7 +28,7 @@ public class ValidationMatcherConfig {
 
     private ValidationMatcherLibrary validationMatcherLibrary = new DefaultValidationMatcherLibrary();
 
-    @Bean(name = "validationMatcherRegistry")
+    @Bean(name = "citrusValidationMatcherRegistry")
     public ValidationMatcherRegistryFactory validationMatcherRegistry() {
         return new ValidationMatcherRegistryFactory();
     }

--- a/core/citrus-spring/src/test/java/com/consol/citrus/TestSuiteTest.java
+++ b/core/citrus-spring/src/test/java/com/consol/citrus/TestSuiteTest.java
@@ -26,13 +26,23 @@ import com.consol.citrus.container.SequenceBeforeTest;
 import com.consol.citrus.context.TestContext;
 import com.consol.citrus.context.TestContextFactoryBean;
 import com.consol.citrus.exceptions.CitrusRuntimeException;
+import com.consol.citrus.functions.FunctionRegistry;
+import com.consol.citrus.log.LogModifier;
+import com.consol.citrus.report.MessageListeners;
+import com.consol.citrus.report.TestActionListeners;
 import com.consol.citrus.report.TestListeners;
+import com.consol.citrus.report.TestReporters;
 import com.consol.citrus.report.TestSuiteListener;
 import com.consol.citrus.report.TestSuiteListeners;
+import com.consol.citrus.spi.ReferenceResolver;
 import com.consol.citrus.testng.AbstractTestNGUnitTest;
+import com.consol.citrus.util.TypeConverter;
+import com.consol.citrus.validation.MessageValidatorRegistry;
+import com.consol.citrus.validation.matcher.ValidationMatcherRegistry;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.context.ApplicationContext;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
@@ -74,6 +84,17 @@ public class TestSuiteTest extends AbstractTestNGUnitTest {
         afterActions = new SequenceAfterSuite();
 
         when(testContextFactory.getObject()).thenReturn(context);
+
+        when(applicationContextMock.getBean(FunctionRegistry.class)).thenThrow(NoSuchBeanDefinitionException.class);
+        when(applicationContextMock.getBean(ValidationMatcherRegistry.class)).thenThrow(NoSuchBeanDefinitionException.class);
+        when(applicationContextMock.getBean(MessageValidatorRegistry.class)).thenThrow(NoSuchBeanDefinitionException.class);
+        when(applicationContextMock.getBean(MessageListeners.class)).thenThrow(NoSuchBeanDefinitionException.class);
+        when(applicationContextMock.getBean(TestActionListeners.class)).thenThrow(NoSuchBeanDefinitionException.class);
+        when(applicationContextMock.getBean(TestReporters.class)).thenThrow(NoSuchBeanDefinitionException.class);
+        when(applicationContextMock.getBean(ReferenceResolver.class)).thenThrow(NoSuchBeanDefinitionException.class);
+        when(applicationContextMock.getBean(TypeConverter.class)).thenThrow(NoSuchBeanDefinitionException.class);
+        when(applicationContextMock.getBean(LogModifier.class)).thenThrow(NoSuchBeanDefinitionException.class);
+
         when(applicationContextMock.getBean(TestContextFactoryBean.class)).thenReturn(testContextFactory);
         when(applicationContextMock.getBeansOfType(AfterSuite.class)).thenReturn(Collections.singletonMap("afterActions", afterActions));
         when(applicationContextMock.getBeansOfType(BeforeSuite.class)).thenReturn(Collections.singletonMap("beforeActions", beforeActions));


### PR DESCRIPTION
- Enable reference resolver in PurgeEndpointAction for bean postprocessing
- Use "citrus" prefix for all default beans in CitrusSpringConfig (avoid name clash with other libraries being loaded into the application context)
- Support building CitrusContext from application context that has no default Citrus beans configured (avoids NullpointerException in JUnit5 extension)