### PR TITLE
fix(#892): Support multiple jsonPath validations

### DIFF
--- a/validation/citrus-validation-json/src/main/java/com/consol/citrus/dsl/JsonSupport.java
+++ b/validation/citrus-validation-json/src/main/java/com/consol/citrus/dsl/JsonSupport.java
@@ -35,7 +35,13 @@ public class JsonSupport {
         return new JsonMessageValidationContext.Builder();
     }
 
-    public <T> JsonMappingValidationProcessor.Builder<T> validate(Class<T> type) {
+    /**
+     * Static entrance for Json mapping validation that uses object mapper to perform Json object validation.
+     * @param type
+     * @return
+     * @param <T>
+     */
+    public static <T> JsonMappingValidationProcessor.Builder<T> validate(Class<T> type) {
         return JsonMappingValidationProcessor.Builder.validate(type);
     }
 }

--- a/validation/citrus-validation-json/src/main/java/com/consol/citrus/validation/json/JsonMappingValidationProcessor.java
+++ b/validation/citrus-validation-json/src/main/java/com/consol/citrus/validation/json/JsonMappingValidationProcessor.java
@@ -28,6 +28,8 @@ import com.consol.citrus.spi.ReferenceResolverAware;
 import com.consol.citrus.validation.AbstractValidationProcessor;
 import com.consol.citrus.validation.GenericValidationProcessor;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.Assert;
 
 /**
@@ -35,6 +37,9 @@ import org.springframework.util.Assert;
  * @since 2.4
  */
 public abstract class JsonMappingValidationProcessor<T> extends AbstractValidationProcessor<T> {
+
+    /** Logger */
+    private static final Logger log = LoggerFactory.getLogger(JsonMappingValidationProcessor.class);
 
     /** JSON object mapper */
     private ObjectMapper mapper;
@@ -59,7 +64,11 @@ public abstract class JsonMappingValidationProcessor<T> extends AbstractValidati
 
     @Override
     public void validate(Message message, TestContext context) {
+        log.debug("Start JSON object validation ...");
+
         validate(readJson(message), message.getHeaders(), context);
+
+        log.info("JSON object validation successful: All values OK");
     }
 
     private T readJson(Message message) {

--- a/validation/citrus-validation-json/src/test/java/com/consol/citrus/integration/JsonMappingValidationProcessorIT.java
+++ b/validation/citrus-validation-json/src/test/java/com/consol/citrus/integration/JsonMappingValidationProcessorIT.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.consol.citrus.integration;
+
+import com.consol.citrus.annotations.CitrusEndpoint;
+import com.consol.citrus.annotations.CitrusTest;
+import com.consol.citrus.dsl.JsonSupport;
+import com.consol.citrus.endpoint.direct.DirectEndpoint;
+import com.consol.citrus.endpoint.direct.annotation.DirectEndpointConfig;
+import com.consol.citrus.exceptions.TestCaseFailedException;
+import com.consol.citrus.message.DefaultMessageQueue;
+import com.consol.citrus.message.MessageQueue;
+import com.consol.citrus.message.MessageType;
+import com.consol.citrus.spi.BindToRegistry;
+import com.consol.citrus.testng.spring.TestNGCitrusSpringSupport;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static com.consol.citrus.actions.ReceiveMessageAction.Builder.receive;
+import static com.consol.citrus.actions.SendMessageAction.Builder.send;
+
+/**
+ * @author Christoph Deppisch
+ * @since 3.3.1
+ */
+public class JsonMappingValidationProcessorIT extends TestNGCitrusSpringSupport {
+
+    @BindToRegistry
+    public MessageQueue test = new DefaultMessageQueue("test");
+
+    @CitrusEndpoint
+    @DirectEndpointConfig(
+        queue = "test"
+    )
+    public DirectEndpoint direct;
+
+    private static final String JSON_BODY = "{\"name\":\"christoph\", \"age\": 32}";
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    @CitrusTest
+    public void shouldPerformJsonMappingValidationProcessor() {
+        $(send(direct)
+                .message()
+                .type(MessageType.JSON)
+                .body(JSON_BODY)
+        );
+
+        $(receive(direct)
+                .message()
+                .validate(JsonSupport.validate(Person.class)
+                    .mapper(mapper)
+                    .validator((person, headers, context) -> {
+                        Assert.assertEquals(person.name, "christoph");
+                        Assert.assertTrue(person.age > 30);
+                    }).build())
+        );
+    }
+
+    @Test
+    @CitrusTest
+    public void shouldPerformMultipleJsonMappingValidationProcessor() {
+        $(send(direct)
+                .message()
+                .type(MessageType.JSON)
+                .body(JSON_BODY)
+        );
+
+        $(receive(direct)
+                .message()
+                .validate(JsonSupport.validate(Person.class)
+                    .mapper(mapper)
+                    .validator((person, headers, context) -> {
+                        Assert.assertEquals(person.name, "christoph");
+                    }).build())
+                .validate(JsonSupport.validate(Person.class)
+                    .mapper(mapper)
+                    .validator((person, headers, context) -> {
+                        Assert.assertTrue(person.age > 30);
+                    }).build())
+        );
+    }
+
+    @Test(expectedExceptions = TestCaseFailedException.class)
+    @CitrusTest
+    public void shouldFailOnJsonMultipleMappingValidationProcessor() {
+        $(send(direct)
+                .message()
+                .type(MessageType.JSON)
+                .body(JSON_BODY)
+        );
+
+        $(receive(direct)
+                .message()
+                .validate(JsonSupport.validate(Person.class)
+                        .mapper(mapper)
+                        .validator((person, headers, context) -> {
+                            Assert.assertTrue(person.age > 30);
+                        }).build())
+                .validate(JsonSupport.validate(Person.class)
+                        .mapper(mapper)
+                        .validator((person, headers, context) -> {
+                            Assert.assertEquals(person.name, "should fail");
+                        }).build())
+        );
+    }
+
+    @Test(expectedExceptions = TestCaseFailedException.class)
+    @CitrusTest
+    public void shouldFailOnJsonMappingValidationProcessor() {
+        $(send(direct)
+                .message()
+                .type(MessageType.JSON)
+                .body(JSON_BODY)
+        );
+
+        $(receive(direct)
+                .message()
+                .validate(JsonSupport.validate(Person.class)
+                        .mapper(mapper)
+                        .validator((person, headers, context) -> {
+                            Assert.assertEquals(person.name, "should fail");
+                        }).build())
+        );
+    }
+
+    private static class Person {
+        String name;
+        int age;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public int getAge() {
+            return age;
+        }
+
+        public void setAge(int age) {
+            this.age = age;
+        }
+    }
+}

--- a/validation/citrus-validation-json/src/test/java/com/consol/citrus/integration/JsonPathExpressionValidationIT.java
+++ b/validation/citrus-validation-json/src/test/java/com/consol/citrus/integration/JsonPathExpressionValidationIT.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.consol.citrus.integration;
+
+import com.consol.citrus.annotations.CitrusEndpoint;
+import com.consol.citrus.annotations.CitrusTest;
+import com.consol.citrus.endpoint.direct.DirectEndpoint;
+import com.consol.citrus.endpoint.direct.annotation.DirectEndpointConfig;
+import com.consol.citrus.exceptions.TestCaseFailedException;
+import com.consol.citrus.message.DefaultMessageQueue;
+import com.consol.citrus.message.MessageQueue;
+import com.consol.citrus.message.MessageType;
+import com.consol.citrus.spi.BindToRegistry;
+import com.consol.citrus.testng.spring.TestNGCitrusSpringSupport;
+import org.testng.annotations.Test;
+
+import static com.consol.citrus.actions.ReceiveMessageAction.Builder.receive;
+import static com.consol.citrus.actions.SendMessageAction.Builder.send;
+import static com.consol.citrus.dsl.JsonPathSupport.jsonPath;
+
+/**
+ * @author Christoph Deppisch
+ * @since 3.3.1
+ */
+public class JsonPathExpressionValidationIT extends TestNGCitrusSpringSupport {
+
+    @BindToRegistry
+    public MessageQueue test = new DefaultMessageQueue("test");
+
+    @CitrusEndpoint
+    @DirectEndpointConfig(
+        queue = "test"
+    )
+    public DirectEndpoint direct;
+
+    private static final String JSON_BODY = "{\"user\":\"christoph\", \"age\": 32}";
+
+    @Test
+    @CitrusTest
+    public void shouldPerformJsonPathValidation() {
+        $(send(direct)
+                .message()
+                .type(MessageType.JSON)
+                .body(JSON_BODY)
+        );
+
+        $(receive(direct)
+                .message()
+                .body("{\"user\":\"@ignore@\", \"age\": \"@ignore@\"}")
+                .validate(jsonPath()
+                            .expression("$.user", "christoph")
+                            .expression("$.age", 32))
+        );
+    }
+
+    @Test
+    @CitrusTest
+    public void shouldPerformJsonPathValidationWithMessageProcessing() {
+        $(send(direct)
+                .message()
+                .type(MessageType.JSON)
+                .body("{\"user\":\"?\", \"age\": 0}")
+                .process(jsonPath().expression("$.user", "christoph"))
+                .process(jsonPath().expression("$.age", 32))
+        );
+
+        $(receive(direct)
+                .message()
+                .type(MessageType.JSON)
+                .body("{\"user\":\"x\", \"age\": \"99\"}")
+                .process(jsonPath().expression("$.age", 32))
+                .process(jsonPath().expression("$.user", "christoph"))
+                .validate(jsonPath()
+                            .expression("$.user", "christoph")
+                            .expression("$.age", 32))
+        );
+    }
+
+    @Test(expectedExceptions = TestCaseFailedException.class)
+    @CitrusTest
+    public void shouldFailOnJsonPathValidation() {
+        $(send(direct)
+                .message()
+                .type(MessageType.JSON)
+                .body(JSON_BODY)
+        );
+
+        $(receive(direct)
+                .message()
+                .body("{\"user\":\"@ignore@\", \"age\": \"@ignore@\"}")
+                .validate(jsonPath().expression("$.user", "wrong"))
+        );
+    }
+
+    @Test
+    @CitrusTest
+    public void shouldPerformJsonPathValidationWithMultipleExpressions() {
+        $(send(direct)
+                .message()
+                .type(MessageType.JSON)
+                .body(JSON_BODY)
+        );
+
+        $(receive(direct)
+                .message()
+                .body("{\"user\":\"@ignore@\", \"age\": \"@ignore@\"}")
+                .validate(jsonPath().expression("$.user", "christoph"))
+                .validate(jsonPath().expression("$.age", 32))
+        );
+    }
+
+    @Test(expectedExceptions = TestCaseFailedException.class)
+    @CitrusTest
+    public void shouldFailOnJsonPathValidationWithMultipleExpressions() {
+        $(send(direct)
+                .message()
+                .type(MessageType.JSON)
+                .body(JSON_BODY)
+        );
+
+        $(receive(direct)
+                .message()
+                .body("{\"user\":\"@ignore@\", \"age\": \"@ignore@\"}")
+                .validate(jsonPath().expression("$.user", "christoph"))
+                .validate(jsonPath().expression("$.age", 0))
+        );
+    }
+}

--- a/validation/citrus-validation-json/src/test/java/com/consol/citrus/integration/JsonPathVariableExtractorIT.java
+++ b/validation/citrus-validation-json/src/test/java/com/consol/citrus/integration/JsonPathVariableExtractorIT.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.consol.citrus.integration;
+
+import com.consol.citrus.annotations.CitrusEndpoint;
+import com.consol.citrus.annotations.CitrusResource;
+import com.consol.citrus.annotations.CitrusTest;
+import com.consol.citrus.context.TestContext;
+import com.consol.citrus.endpoint.direct.DirectEndpoint;
+import com.consol.citrus.endpoint.direct.annotation.DirectEndpointConfig;
+import com.consol.citrus.exceptions.TestCaseFailedException;
+import com.consol.citrus.message.DefaultMessageQueue;
+import com.consol.citrus.message.MessageQueue;
+import com.consol.citrus.message.MessageType;
+import com.consol.citrus.spi.BindToRegistry;
+import com.consol.citrus.testng.spring.TestNGCitrusSpringSupport;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static com.consol.citrus.actions.ReceiveMessageAction.Builder.receive;
+import static com.consol.citrus.actions.SendMessageAction.Builder.send;
+import static com.consol.citrus.dsl.JsonPathSupport.jsonPath;
+
+/**
+ * @author Christoph Deppisch
+ * @since 3.3.1
+ */
+public class JsonPathVariableExtractorIT extends TestNGCitrusSpringSupport {
+
+    @BindToRegistry
+    public MessageQueue test = new DefaultMessageQueue("test");
+
+    @CitrusEndpoint
+    @DirectEndpointConfig(
+        queue = "test"
+    )
+    public DirectEndpoint direct;
+
+    @CitrusResource
+    private TestContext context;
+
+    private static final String JSON_BODY = "{\"user\":\"christoph\", \"age\": 32}";
+
+    @Test
+    @CitrusTest
+    public void shouldPerformJsonPathVariableExtract() {
+        $(send(direct)
+                .message()
+                .type(MessageType.JSON)
+                .body(JSON_BODY)
+        );
+
+        $(receive(direct)
+                .message()
+                .body(JSON_BODY)
+                .extract(jsonPath()
+                            .expression("$.user", "user")
+                            .expression("$.age", "age"))
+        );
+
+        Assert.assertEquals(context.getVariable("user"), "christoph");
+        Assert.assertEquals(context.getVariable("age", Long.class), 32L);
+    }
+
+    @Test(expectedExceptions = TestCaseFailedException.class)
+    @CitrusTest
+    public void shouldFailOnJsonPathVariableExtract() {
+        $(send(direct)
+                .message()
+                .type(MessageType.JSON)
+                .body(JSON_BODY)
+        );
+
+        $(receive(direct)
+                .message()
+                .body(JSON_BODY)
+                .extract(jsonPath().expression("$.wrong", "user"))
+        );
+    }
+
+    @Test
+    @CitrusTest
+    public void shouldPerformJsonPathValidationWithMultipleExpressions() {
+        $(send(direct)
+                .message()
+                .type(MessageType.JSON)
+                .body(JSON_BODY)
+        );
+
+        $(receive(direct)
+                .message()
+                .body(JSON_BODY)
+                .extract(jsonPath().expression("$.user", "user"))
+                .extract(jsonPath().expression("$.age", "age"))
+        );
+
+        Assert.assertEquals(context.getVariable("user"), "christoph");
+        Assert.assertEquals(context.getVariable("age", Long.class), 32L);
+    }
+}


### PR DESCRIPTION
- Make sure to also support multiple validate() calls in Java DSL in order to have multiple jsonPath validations
- Consolidate multiple validation contexts to single context in JsonPathMessageValidator
- Also apply same logic for xpath validation Java DSL
- Fix JsonSupport static entrance method for Json object mapping validation
- Add some unit tests

Fixes #892 
Closes #898 