### PR TITLE
fix(#846): Always debug log received message content

### DIFF
--- a/core/citrus-api/src/main/java/com/consol/citrus/CitrusSettings.java
+++ b/core/citrus-api/src/main/java/com/consol/citrus/CitrusSettings.java
@@ -147,6 +147,11 @@ public final class CitrusSettings {
     public static final String TYPE_CONVERTER_ENV = "CITRUS_TYPE_CONVERTER";
     public static final String TYPE_CONVERTER_DEFAULT = "default";
 
+    /** Flag to enable/disable message pretty print */
+    public static final String PRETTY_PRINT_PROPERTY = "citrus.message.pretty.print";
+    public static final String PRETTY_PRINT_ENV = "CITRUS_MESSAGE_PRETTY_PRINT";
+    public static final String PRETTY_PRINT_DEFAULT = Boolean.TRUE.toString();
+
     /** Flag to enable/disable log modifier */
     public static final String LOG_MODIFIER_PROPERTY = "citrus.log.modifier";
     public static final String LOG_MODIFIER_ENV = "CITRUS_LOG_MODIFIER";
@@ -210,6 +215,15 @@ public final class CitrusSettings {
     public static String getTypeConverter() {
         return System.getProperty(TYPE_CONVERTER_PROPERTY,  System.getenv(TYPE_CONVERTER_ENV) != null ?
                 System.getenv(TYPE_CONVERTER_ENV) : TYPE_CONVERTER_DEFAULT);
+    }
+
+    /**
+     * Gets the message payload pretty print enabled/disabled setting.
+     * @return
+     */
+    public static boolean isPrettyPrintEnabled() {
+        return Boolean.parseBoolean(System.getProperty(PRETTY_PRINT_PROPERTY,  System.getenv(PRETTY_PRINT_ENV) != null ?
+                System.getenv(PRETTY_PRINT_ENV) : PRETTY_PRINT_DEFAULT));
     }
 
     /**

--- a/core/citrus-api/src/main/java/com/consol/citrus/message/Message.java
+++ b/core/citrus-api/src/main/java/com/consol/citrus/message/Message.java
@@ -48,9 +48,9 @@ public interface Message extends Serializable {
      */
     default String print(String body, Map<String, Object> headers, List<String> headerData) {
         if (CollectionUtils.isEmpty(headerData)) {
-            return getClass().getSimpleName().toUpperCase() + " [id: " + getId() + ", payload: " + body + "][headers: " + Collections.unmodifiableMap(headers) + "]";
+            return getClass().getSimpleName().toUpperCase() + " [id: " + getId() + ", payload: " + MessagePayloadUtils.prettyPrint(body) + "][headers: " + Collections.unmodifiableMap(headers) + "]";
         } else {
-            return getClass().getSimpleName().toUpperCase() + " [id: " + getId() + ", payload: " + body + "][headers: " + Collections.unmodifiableMap(headers) + "][header-data: " + Collections.unmodifiableList(headerData) + "]";
+            return getClass().getSimpleName().toUpperCase() + " [id: " + getId() + ", payload: " + MessagePayloadUtils.prettyPrint(body) + "][headers: " + Collections.unmodifiableMap(headers) + "][header-data: " + Collections.unmodifiableList(headerData) + "]";
         }
     }
 

--- a/core/citrus-api/src/main/java/com/consol/citrus/message/MessagePayloadUtils.java
+++ b/core/citrus-api/src/main/java/com/consol/citrus/message/MessagePayloadUtils.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.consol.citrus.message;
+
+import com.consol.citrus.CitrusSettings;
+
+public class MessagePayloadUtils {
+
+    private static final boolean prettyPrint = CitrusSettings.isPrettyPrintEnabled();
+
+    /**
+     * Prevent instantiation of utility class.
+     */
+    private MessagePayloadUtils() {
+    }
+
+    /**
+     * Pretty print given message payload. Supports XML payloads.
+     * @param payload
+     * @return
+     */
+    public static String prettyPrint(String payload) {
+        if (!prettyPrint) {
+            return payload;
+        }
+
+        if (isXml(payload)) {
+            return prettyPrintXml(payload);
+        }
+
+        if (isJson(payload)) {
+            return prettyPrintJson(payload);
+        }
+
+        return payload;
+    }
+
+    /**
+     * Checks if given message payload is of XML nature.
+     * @param payload
+     * @return
+     */
+    public static boolean isXml(String payload) {
+        return payload.trim().startsWith("<");
+    }
+
+    /**
+     * Check if given message payload is of Json nature.
+     * @param payload
+     * @return
+     */
+    public static boolean isJson(String payload) {
+        return payload.trim().startsWith("{") || payload.trim().startsWith("[");
+    }
+
+    /**
+     * Pretty print given XML payload.
+     * @param payload
+     * @return
+     */
+    public static String prettyPrintXml(String payload) {
+        boolean singleLine = true;
+        int indentNum = 2;
+        int indent = 0;
+
+        String s = payload.trim();
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < s.length(); i++) {
+            char currentChar = s.charAt(i);
+
+            if (currentChar == '<') {
+                char nextChar = s.charAt(i + 1);
+                if (nextChar == '/') {
+                    indent -= indentNum;
+                }
+                if (!singleLine) {
+                    sb.append(" ".repeat(Math.max(0, indent)));
+                }
+                if (nextChar != '?' && nextChar != '!' && nextChar != '/') {
+                    indent += indentNum;
+                }
+                singleLine = false;
+            }
+            sb.append(currentChar);
+            if (currentChar == '>') {
+                if (s.charAt(i - 1) == '/') {
+                    indent -= indentNum;
+                    sb.append(System.lineSeparator());
+                } else {
+                    int nextStartElementPos = s.indexOf('<', i);
+                    if (nextStartElementPos > i + 1) {
+                        String textBetweenElements = s.substring(i + 1, nextStartElementPos);
+
+                        if (textBetweenElements.replaceAll("\\s", "").length() == 0) {
+                            sb.append(System.lineSeparator());
+                        } else {
+                            sb.append(textBetweenElements.trim());
+                            singleLine = true;
+                        }
+                        i = nextStartElementPos - 1;
+                    } else {
+                        sb.append(System.lineSeparator());
+                    }
+                }
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Pretty print given Json payload.
+     * @param payload
+     * @return
+     */
+    public static String prettyPrintJson(String payload) {
+        if ("{}".equals(payload) || "[]".equals(payload)) {
+            return payload;
+        }
+
+        int indentNum = 2;
+        int indent = 0;
+        boolean inQuote = false;
+        boolean isKey = true;
+        boolean inArray = false;
+
+        String s = payload.trim();
+        StringBuilder sb = new StringBuilder();
+        char previousChar = 0;
+        for (char currentChar : s.toCharArray()) {
+            switch (currentChar) {
+                case '"':
+                    if (!inQuote && isKey) {
+                        sb.append(" ".repeat(Math.max(0, indent)));
+                    }
+                    inQuote = !inQuote;
+                    sb.append(currentChar);
+                    break;
+                case ':':
+                    if (inQuote) {
+                        sb.append(currentChar);
+                    } else {
+                        isKey = false;
+                        sb.append(currentChar).append(" ");
+                    }
+                    break;
+                case ' ':
+                    if (inQuote) {
+                        sb.append(currentChar);
+                    }
+                    break;
+                case '{':
+                case '[':
+                    if (inQuote) {
+                        sb.append(currentChar);
+                    } else {
+                        if (isKey) {
+                            sb.append(" ".repeat(Math.max(0, indent)));
+                        } else {
+                            isKey = true;
+                        }
+                        sb.append(currentChar);
+                        sb.append(System.lineSeparator());
+                        indent += indentNum;
+                    }
+                    break;
+                case '}':
+                case ']':
+                    if (!inQuote) {
+                        if (previousChar == '"' || Character.isDigit(previousChar)) {
+                            isKey = true;
+                            sb.append(System.lineSeparator());
+                        } else if (previousChar == '}' || previousChar == ']') {
+                            sb.append(System.lineSeparator());
+                        }
+
+                        indent -= indentNum;
+                        sb.append(" ".repeat(Math.max(0, indent)));
+                    }
+                    sb.append(currentChar);
+                    break;
+                case ',':
+                    sb.append(currentChar);
+                    if (!inQuote) {
+                        isKey = true;
+                        sb.append(System.lineSeparator());
+                    }
+                    break;
+                default:
+                    if (inQuote || !System.lineSeparator().equals(String.valueOf(currentChar))) {
+                        sb.append(currentChar);
+                    }
+            }
+            if (inQuote || (!System.lineSeparator().equals(String.valueOf(currentChar)) && !(currentChar == ' '))) {
+                previousChar = currentChar;
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/core/citrus-api/src/main/java/com/consol/citrus/validation/DefaultEmptyMessageValidator.java
+++ b/core/citrus-api/src/main/java/com/consol/citrus/validation/DefaultEmptyMessageValidator.java
@@ -44,11 +44,6 @@ public class DefaultEmptyMessageValidator extends DefaultMessageValidator {
 
         log.debug("Start to verify empty message payload ...");
 
-        if (log.isDebugEnabled()) {
-            log.debug("Received message:\n" + receivedMessage.print(context));
-            log.debug("Control message:\n" + controlMessage.print(context));
-        }
-
         if (StringUtils.hasText(receivedMessage.getPayload(String.class))) {
             throw new ValidationException("Validation failed - received message content is not empty!") ;
         }

--- a/core/citrus-api/src/test/java/com/consol/citrus/message/MessagePayloadUtilsTest.java
+++ b/core/citrus-api/src/test/java/com/consol/citrus/message/MessagePayloadUtilsTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.consol.citrus.message;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class MessagePayloadUtilsTest {
+
+    @Test
+    public void shouldPrettyPrintJson() {
+        Assert.assertEquals(MessagePayloadUtils.prettyPrint(""), "");
+        Assert.assertEquals(MessagePayloadUtils.prettyPrint("{}"), "{}");
+        Assert.assertEquals(MessagePayloadUtils.prettyPrint("[]"), "[]");
+        Assert.assertEquals(MessagePayloadUtils.prettyPrint("{\"user\":\"citrus\"}"),
+                String.format("{%n  \"user\": \"citrus\"%n}"));
+        Assert.assertEquals(MessagePayloadUtils.prettyPrint("{\"text\":\"<?;,{}' '[]:>\"}"),
+                String.format("{%n  \"text\": \"<?;,{}' '[]:>\"%n}"));
+        Assert.assertEquals(MessagePayloadUtils.prettyPrint(String.format("%n%n  {  \"user\":%n%n \"citrus\"  }")),
+                String.format("{%n  \"user\": \"citrus\"%n}"));
+        Assert.assertEquals(MessagePayloadUtils.prettyPrint("{\"user\":\"citrus\",\"age\": 32}"),
+                String.format("{%n  \"user\": \"citrus\",%n  \"age\": 32%n}"));
+        Assert.assertEquals(MessagePayloadUtils.prettyPrint("[22, 32]"),
+                String.format("[%n22,%n32%n]"));
+        Assert.assertEquals(MessagePayloadUtils.prettyPrint("[{\"user\":\"citrus\",\"age\": 32}]"),
+                String.format("[%n  {%n    \"user\": \"citrus\",%n    \"age\": 32%n  }%n]"));
+        Assert.assertEquals(MessagePayloadUtils.prettyPrint("[{\"user\":\"citrus\",\"age\": 32}, {\"user\":\"foo\",\"age\": 99}]"),
+                String.format("[%n  {%n    \"user\": \"citrus\",%n    \"age\": 32%n  },%n  {%n    \"user\": \"foo\",%n    \"age\": 99%n  }%n]"));
+        Assert.assertEquals(MessagePayloadUtils.prettyPrint("{\"user\":\"citrus\",\"age\": 32,\"pet\":{\"name\": \"fluffy\", \"age\": 4}}"),
+                String.format("{%n  \"user\": \"citrus\",%n  \"age\": 32,%n  \"pet\": {%n    \"name\": \"fluffy\",%n    \"age\": 4%n  }%n}"));
+        Assert.assertEquals(MessagePayloadUtils.prettyPrint("{\"user\":\"citrus\",\"age\": 32,\"pets\":[\"fluffy\",\"hasso\"]}"),
+                String.format("{%n  \"user\": \"citrus\",%n  \"age\": 32,%n  \"pets\": [%n    \"fluffy\",%n    \"hasso\"%n  ]%n}"));
+        Assert.assertEquals(MessagePayloadUtils.prettyPrint("{\"user\":\"citrus\",\"pets\":[\"fluffy\",\"hasso\"],\"age\": 32}"),
+                String.format("{%n  \"user\": \"citrus\",%n  \"pets\": [%n    \"fluffy\",%n    \"hasso\"%n  ],%n  \"age\": 32%n}"));
+        Assert.assertEquals(MessagePayloadUtils.prettyPrint("{\"user\":\"citrus\",\"pets\":[{\"name\": \"fluffy\", \"age\": 4},{\"name\": \"hasso\", \"age\": 2}],\"age\": 32}"),
+                String.format("{%n  \"user\": \"citrus\",%n  \"pets\": [%n    {%n      \"name\": \"fluffy\",%n      \"age\": 4%n    },%n    {%n      \"name\": \"hasso\",%n      \"age\": 2%n    }%n  ],%n  \"age\": 32%n}"));
+    }
+
+    @Test
+    public void shouldPrettyPrintXml() {
+        Assert.assertEquals(MessagePayloadUtils.prettyPrint(""), "");
+        Assert.assertEquals(MessagePayloadUtils.prettyPrint("<root></root>"),
+                String.format("<root>%n</root>%n"));
+        Assert.assertEquals(MessagePayloadUtils.prettyPrint("<root><text>Citrus rocks!</text></root>"),
+                String.format("<root>%n  <text>Citrus rocks!</text>%n</root>%n"));
+        Assert.assertEquals(MessagePayloadUtils.prettyPrint("<?xml version=\"1.0\" encoding=\"UTF-8\"?><root><text>Citrus rocks!</text></root>"),
+                String.format("<?xml version=\"1.0\" encoding=\"UTF-8\"?>%n<root>%n  <text>Citrus rocks!</text>%n</root>%n"));
+        Assert.assertEquals(MessagePayloadUtils.prettyPrint(String.format("<root>%n<text>%nCitrus rocks!%n</text>%n</root>")),
+                String.format("<root>%n  <text>Citrus rocks!</text>%n</root>%n"));
+        Assert.assertEquals(MessagePayloadUtils.prettyPrint(String.format("<root>%n  <text language=\"eng\">%nCitrus rocks!%n  </text>%n</root>")),
+                String.format("<root>%n  <text language=\"eng\">Citrus rocks!</text>%n</root>%n"));
+        Assert.assertEquals(MessagePayloadUtils.prettyPrint(String.format("%n%n  <root><text language=\"eng\"><![CDATA[Citrus rocks!]]></text></root>")),
+                String.format("<root>%n  <text language=\"eng\">%n    <![CDATA[Citrus rocks!]]>%n  </text>%n</root>%n"));
+        Assert.assertEquals(MessagePayloadUtils.prettyPrint(String.format("<root><text language=\"eng\" important=\"true\"><![CDATA[%n  Citrus rocks!%n  ]]></text></root>")),
+                String.format("<root>%n  <text language=\"eng\" important=\"true\">%n    <![CDATA[%n  Citrus rocks!%n  ]]>%n  </text>%n</root>%n"));
+    }
+
+}

--- a/core/citrus-base/src/main/java/com/consol/citrus/actions/ReceiveTimeoutAction.java
+++ b/core/citrus-base/src/main/java/com/consol/citrus/actions/ReceiveTimeoutAction.java
@@ -56,7 +56,7 @@ public class ReceiveTimeoutAction extends AbstractTestAction {
     private final String messageSelector;
 
     /** Logger */
-    private static Logger log = LoggerFactory.getLogger(ReceiveTimeoutAction.class);
+    private static final Logger log = LoggerFactory.getLogger(ReceiveTimeoutAction.class);
 
     /**
      * Default constructor.
@@ -87,7 +87,7 @@ public class ReceiveTimeoutAction extends AbstractTestAction {
 
             if (receivedMessage != null) {
                 if (log.isDebugEnabled()) {
-                    log.debug("Received message: " + receivedMessage.getPayload());
+                    log.debug("Received message:\n" + receivedMessage.print(context));
                 }
 
                 throw new CitrusRuntimeException("Message timeout validation failed! " +

--- a/core/citrus-base/src/test/java/com/consol/citrus/message/DefaultMessageTest.java
+++ b/core/citrus-base/src/test/java/com/consol/citrus/message/DefaultMessageTest.java
@@ -38,7 +38,7 @@ public class DefaultMessageTest extends UnitTestSupport {
         String output = message.print();
         Assert.assertEquals(output, String.format("DEFAULTMESSAGE [" +
                     "id: %s, " +
-                    "payload: <credentials><password>foo</password></credentials>" +
+                    "payload: <credentials>%n  <password>foo</password>%n</credentials>%n" +
                 "][headers: {" +
                     "citrus_message_id=%s, citrus_message_timestamp=%s, operation=getCredentials, password=foo" +
                 "}]", message.getId(), message.getId(), message.getTimestamp()));
@@ -88,7 +88,7 @@ public class DefaultMessageTest extends UnitTestSupport {
         String output = message.print(context);
         Assert.assertEquals(output, String.format("DEFAULTMESSAGE [" +
                     "id: %s, " +
-                    "payload: <credentials><password>****</password></credentials>" +
+                    "payload: <credentials>%n  <password>****</password>%n</credentials>%n" +
                 "][headers: {" +
                     "citrus_message_id=%s, citrus_message_timestamp=%s, operation=getCredentials, password=****" +
                 "}]", message.getId(), message.getId(), message.getTimestamp()));
@@ -105,7 +105,7 @@ public class DefaultMessageTest extends UnitTestSupport {
         String output = message.print(context);
         Assert.assertEquals(output, String.format("DEFAULTMESSAGE [" +
                     "id: %s, " +
-                    "payload: { \"credentials\": { \"password\": \"****\", \"secretKey\": \"****\" }}" +
+                    "payload: {%n  \"credentials\": {%n    \"password\": \"****\",%n    \"secretKey\": \"****\"%n  }%n}" +
                 "][headers: {" +
                     "citrus_message_id=%s, citrus_message_timestamp=%s, operation=getCredentials, password=****, secretKey=****" +
                 "}]", message.getId(), message.getId(), message.getTimestamp()));

--- a/endpoints/citrus-http/src/test/java/com/consol/citrus/http/validation/TextEqualsMessageValidator.java
+++ b/endpoints/citrus-http/src/test/java/com/consol/citrus/http/validation/TextEqualsMessageValidator.java
@@ -45,11 +45,7 @@ public class TextEqualsMessageValidator extends DefaultMessageValidator {
             return;
         }
 
-        if (log.isDebugEnabled()) {
-            log.debug("Start text equals validation ...");
-            log.debug("Received message:\n" + receivedMessage.getPayload(String.class));
-            log.debug("Control message:\n" + controlMessage.getPayload(String.class));
-        }
+        log.debug("Start text equals validation ...");
 
         String controlPayload = controlMessage.getPayload(String.class);
         String receivedPayload = receivedMessage.getPayload(String.class);

--- a/runtime/citrus-groovy/src/test/java/com/consol/citrus/validation/TextEqualsMessageValidator.java
+++ b/runtime/citrus-groovy/src/test/java/com/consol/citrus/validation/TextEqualsMessageValidator.java
@@ -37,11 +37,7 @@ public class TextEqualsMessageValidator extends DefaultMessageValidator {
     public void validateMessage(Message receivedMessage, Message controlMessage, TestContext context, ValidationContext validationContext) {
         Logger log = LoggerFactory.getLogger("TextEqualsMessageValidator");
 
-        if (log.isDebugEnabled()) {
-            log.debug("Start text equals validation ...");
-            log.debug("Received message:\n" + receivedMessage.getPayload(String.class));
-            log.debug("Control message:\n" + controlMessage.getPayload(String.class));
-        }
+        log.debug("Start text equals validation ...");
 
         Assert.assertEquals(receivedMessage.getPayload(String.class), controlMessage.getPayload(String.class), "Validation failed - " +
                 "expected message contents not equal!");

--- a/runtime/citrus-xml/src/test/java/com/consol/citrus/validation/TextEqualsMessageValidator.java
+++ b/runtime/citrus-xml/src/test/java/com/consol/citrus/validation/TextEqualsMessageValidator.java
@@ -44,11 +44,7 @@ public class TextEqualsMessageValidator extends DefaultMessageValidator {
             return;
         }
 
-        if (log.isDebugEnabled()) {
-            log.debug("Start text equals validation ...");
-            log.debug("Received message:\n" + receivedMessage.getPayload(String.class));
-            log.debug("Control message:\n" + controlMessage.getPayload(String.class));
-        }
+        log.debug("Start text equals validation ...");
 
         String controlPayload = controlMessage.getPayload(String.class);
         String receivedPayload = receivedMessage.getPayload(String.class);

--- a/runtime/citrus-yaml/src/test/java/com/consol/citrus/validation/TextEqualsMessageValidator.java
+++ b/runtime/citrus-yaml/src/test/java/com/consol/citrus/validation/TextEqualsMessageValidator.java
@@ -44,11 +44,7 @@ public class TextEqualsMessageValidator extends DefaultMessageValidator {
             return;
         }
 
-        if (log.isDebugEnabled()) {
-            log.debug("Start text equals validation ...");
-            log.debug("Received message:\n" + receivedMessage.getPayload(String.class));
-            log.debug("Control message:\n" + controlMessage.getPayload(String.class));
-        }
+        log.debug("Start text equals validation ...");
 
         String controlPayload = controlMessage.getPayload(String.class);
         String receivedPayload = receivedMessage.getPayload(String.class);

--- a/validation/citrus-validation-json/src/main/java/com/consol/citrus/validation/json/JsonTextMessageValidator.java
+++ b/validation/citrus-validation-json/src/main/java/com/consol/citrus/validation/json/JsonTextMessageValidator.java
@@ -34,7 +34,6 @@ import com.consol.citrus.validation.AbstractMessageValidator;
 import com.consol.citrus.validation.ValidationUtils;
 import com.consol.citrus.validation.json.schema.JsonSchemaValidation;
 import com.consol.citrus.validation.matcher.ValidationMatcherUtils;
-import com.github.fge.jsonschema.core.report.ProcessingReport;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.ReadContext;
 import net.minidev.json.JSONArray;
@@ -80,11 +79,6 @@ public class JsonTextMessageValidator extends AbstractMessageValidator<JsonMessa
 
         if (validationContext.isSchemaValidationEnabled()) {
             jsonSchemaValidation.validate(receivedMessage, context, validationContext);
-        }
-
-        if (log.isDebugEnabled()) {
-            log.debug("Received message:\n" + receivedMessage.print(context));
-            log.debug("Control message:\n" + controlMessage.print(context));
         }
 
         String receivedJsonText = receivedMessage.getPayload(String.class);

--- a/validation/citrus-validation-text/src/main/java/com/consol/citrus/validation/text/PlainTextMessageValidator.java
+++ b/validation/citrus-validation-text/src/main/java/com/consol/citrus/validation/text/PlainTextMessageValidator.java
@@ -57,11 +57,6 @@ public class PlainTextMessageValidator extends DefaultMessageValidator {
 
         log.debug("Start text message validation");
 
-        if (log.isDebugEnabled()) {
-            log.debug("Received message:\n" + receivedMessage.print(context));
-            log.debug("Control message:\n" + controlMessage.print(context));
-        }
-
         try {
             String resultValue = normalizeWhitespace(receivedMessage.getPayload(String.class).trim());
             String controlValue = normalizeWhitespace(context.replaceDynamicContentInString(controlMessage.getPayload(String.class).trim()));

--- a/validation/citrus-validation-xml/src/main/java/com/consol/citrus/validation/xml/DomXmlMessageValidator.java
+++ b/validation/citrus-validation-xml/src/main/java/com/consol/citrus/validation/xml/DomXmlMessageValidator.java
@@ -16,11 +16,11 @@
 
 package com.consol.citrus.validation.xml;
 
-import javax.xml.XMLConstants;
-import javax.xml.namespace.NamespaceContext;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import javax.xml.XMLConstants;
+import javax.xml.namespace.NamespaceContext;
 
 import com.consol.citrus.CitrusSettings;
 import com.consol.citrus.XmlValidationHelper;
@@ -225,11 +225,6 @@ public class DomXmlMessageValidator extends AbstractMessageValidator<XmlMessageV
 
         XMLUtils.stripWhitespaceNodes(received);
         XMLUtils.stripWhitespaceNodes(source);
-
-        if (LOG.isDebugEnabled()) {
-            log.debug("Received message:\n" + context.getLogModifier().mask(XMLUtils.serialize(received)));
-            log.debug("Control message:\n" + context.getLogModifier().mask(XMLUtils.serialize(source)));
-        }
 
         validateXmlTree(received, source, validationContext, getNamespaceContextBuilder(context)
                 .buildContext(receivedMessage, validationContext.getNamespaces()), context);


### PR DESCRIPTION
- Make sure to log received message content independently of validator applied
- Remove message content logging from validator implementations and move to receive message action
- Also makes sure to always apply log modifier (e.g. masking sensitive data such as passwords)
- Pretty print XML and Json payload with just pure Java tooling

Fixes #846 
Closes #891 