### PR TITLE
fix(#924): Fix false positive test report in DefaultTestLoader

### DIFF
--- a/core/citrus-base/src/main/java/com/consol/citrus/DefaultTestCase.java
+++ b/core/citrus-base/src/main/java/com/consol/citrus/DefaultTestCase.java
@@ -88,8 +88,6 @@ public class DefaultTestCase extends AbstractActionContainer implements TestCase
             } catch (final Exception | AssertionError e) {
                 testResult = TestResult.failed(getName(), testClass.getName(), e);
                 throw new TestCaseFailedException(e);
-            } finally {
-                finish(context);
             }
         } else {
             testResult = TestResult.skipped(getName(), testClass.getName());
@@ -151,6 +149,10 @@ public class DefaultTestCase extends AbstractActionContainer implements TestCase
      * Usually used for clean up tasks.
      */
     public void finish(final TestContext context) {
+        if (getMetaInfo().getStatus().equals(TestCaseMetaInfo.Status.DISABLED)) {
+            return;
+        }
+
         try {
             CitrusRuntimeException contextException = null;
             if (testResult == null) {

--- a/core/citrus-base/src/main/java/com/consol/citrus/common/DefaultTestLoader.java
+++ b/core/citrus-base/src/main/java/com/consol/citrus/common/DefaultTestLoader.java
@@ -19,6 +19,10 @@
 
 package com.consol.citrus.common;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
 import com.consol.citrus.Citrus;
 import com.consol.citrus.CitrusContext;
 import com.consol.citrus.DefaultTestCase;
@@ -31,9 +35,6 @@ import com.consol.citrus.annotations.CitrusResource;
 import com.consol.citrus.context.TestContext;
 import com.consol.citrus.exceptions.CitrusRuntimeException;
 import com.consol.citrus.exceptions.TestCaseFailedException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Consumer;
 
 /**
  * Default test loader implementation takes case on test names/packages and initializes the test runner if applicable.
@@ -102,6 +103,8 @@ public class DefaultTestLoader implements TestLoader {
 
             testCase.setTestResult(TestResult.failed(testCase.getName(), testCase.getTestClass().getName(), e));
             throw new TestCaseFailedException(e);
+        }  finally {
+            runner.stop();
         }
     }
 
@@ -109,14 +112,10 @@ public class DefaultTestLoader implements TestLoader {
      * Subclasses are supposed to overwrite this method on order to add logic how to load the test case (e.g. from XML, Json, YAML).
      */
     protected void doLoad() {
-        try {
-            testCase = runner.getTestCase();
-            configurer.forEach(it -> it.accept(testCase));
-            runner.start();
-            handler.forEach(it -> it.accept(testCase));
-        } finally {
-            runner.stop();
-        }
+        testCase = runner.getTestCase();
+        configurer.forEach(it -> it.accept(testCase));
+        runner.start();
+        handler.forEach(it -> it.accept(testCase));
     }
 
     /**

--- a/core/citrus-base/src/test/java/com/consol/citrus/TestCaseTest.java
+++ b/core/citrus-base/src/test/java/com/consol/citrus/TestCaseTest.java
@@ -47,6 +47,7 @@ public class TestCaseTest extends UnitTestSupport {
         testcase.addTestAction(new EchoAction.Builder().build());
 
         testcase.execute(context);
+        testcase.finish(context);
     }
 
     @Test
@@ -67,6 +68,7 @@ public class TestCaseTest extends UnitTestSupport {
         });
 
         testcase.execute(context);
+        testcase.finish(context);
     }
 
     @Test(expectedExceptions = TestCaseFailedException.class,
@@ -89,6 +91,7 @@ public class TestCaseTest extends UnitTestSupport {
         });
 
         testcase.execute(context);
+        testcase.finish(context);
     }
 
     @Test
@@ -108,6 +111,7 @@ public class TestCaseTest extends UnitTestSupport {
         }).build());
 
         testcase.execute(context);
+        testcase.finish(context);
 
         // Make sure that waiting thread is completed
         final Map<Thread, StackTraceElement[]> threads = Thread.getAllStackTraces();
@@ -144,6 +148,7 @@ public class TestCaseTest extends UnitTestSupport {
         }));
 
         testcase.execute(context);
+        testcase.finish(context);
     }
 
     @Test(expectedExceptions = {TestCaseFailedException.class})
@@ -157,6 +162,7 @@ public class TestCaseTest extends UnitTestSupport {
         testcase.addTestAction(action(context -> Assert.assertEquals(context.getVariable("${unknown}"), message)));
 
         testcase.execute(context);
+        testcase.finish(context);
     }
 
     @Test(expectedExceptions = {TestCaseFailedException.class}, expectedExceptionsMessageRegExp = "This failed in forked action")
@@ -171,6 +177,7 @@ public class TestCaseTest extends UnitTestSupport {
         testcase.addTestAction(new EchoAction.Builder().message("Everything is fine!").build());
 
         testcase.execute(context);
+        testcase.finish(context);
     }
 
     @Test(expectedExceptions = {TestCaseFailedException.class})
@@ -181,6 +188,7 @@ public class TestCaseTest extends UnitTestSupport {
         testcase.addTestAction(action(context -> context.addException(new CitrusRuntimeException("This failed in forked action"))).build());
 
         testcase.execute(context);
+        testcase.finish(context);
     }
 
     @Test
@@ -192,6 +200,7 @@ public class TestCaseTest extends UnitTestSupport {
         testcase.addFinalAction(new EchoAction.Builder().build());
 
         testcase.execute(context);
+        testcase.finish(context);
     }
 
     @Test
@@ -204,6 +213,7 @@ public class TestCaseTest extends UnitTestSupport {
 
         //WHEN
         testcase.execute(context);
+        testcase.finish(context);
 
         //THEN
         final Map<Thread, StackTraceElement[]> threads = Thread.getAllStackTraces();

--- a/runtime/citrus-groovy/src/main/java/com/consol/citrus/groovy/GroovyTestLoader.java
+++ b/runtime/citrus-groovy/src/main/java/com/consol/citrus/groovy/GroovyTestLoader.java
@@ -19,14 +19,14 @@
 
 package com.consol.citrus.groovy;
 
+import java.io.File;
+import java.io.IOException;
+
 import com.consol.citrus.common.DefaultTestLoader;
 import com.consol.citrus.common.TestSourceAware;
-import com.consol.citrus.exceptions.CitrusRuntimeException;
 import com.consol.citrus.groovy.dsl.GroovyShellUtils;
 import com.consol.citrus.groovy.dsl.test.TestCaseScript;
 import com.consol.citrus.util.FileUtils;
-import java.io.File;
-import java.io.IOException;
 import org.codehaus.groovy.control.customizers.ImportCustomizer;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
@@ -57,9 +57,8 @@ public class GroovyTestLoader extends DefaultTestLoader implements TestSourceAwa
 
             handler.forEach(it -> it.accept(testCase));
         } catch (IOException e) {
-            throw new CitrusRuntimeException("Failed to load Groovy test source", e);
-        } finally {
-            runner.stop();
+            throw citrusContext.getTestContextFactory().getObject()
+                    .handleError(testName, packageName, "Failed to load Groovy test source '" + testName + "'", e);
         }
     }
 

--- a/vintage/citrus-java-dsl/src/main/java/com/consol/citrus/dsl/junit/JUnit4CitrusTest.java
+++ b/vintage/citrus-java-dsl/src/main/java/com/consol/citrus/dsl/junit/JUnit4CitrusTest.java
@@ -79,18 +79,17 @@ public class JUnit4CitrusTest extends AbstractJUnit4CitrusTest {
             try {
                 ReflectionUtils.invokeMethod(frameworkMethod.getMethod(), this,
                         resolveParameter(frameworkMethod, context));
+                citrus.run(testCase, context);
             } catch (TestCaseFailedException e) {
                 throw e;
             } catch (Exception | AssertionError e) {
                 testCase.setTestResult(TestResult.failed(testCase.getName(), testCase.getTestClass().getName(), e));
-                testCase.finish(context);
                 throw new TestCaseFailedException(e);
+            } finally {
+                testCase.finish(context);
             }
-
-            citrus.run(testCase, context);
         } else if (frameworkMethod.getAttribute(RUNNER_ATTRIBUTE) != null) {
             TestRunner testRunner = (TestRunner) frameworkMethod.getAttribute(RUNNER_ATTRIBUTE);
-
             try {
                 Object[] params = resolveParameter(frameworkMethod, context);
                 testRunner.start();

--- a/vintage/citrus-java-dsl/src/main/java/com/consol/citrus/dsl/junit/JUnit4CitrusTestDesigner.java
+++ b/vintage/citrus-java-dsl/src/main/java/com/consol/citrus/dsl/junit/JUnit4CitrusTestDesigner.java
@@ -16,10 +16,10 @@
 
 package com.consol.citrus.dsl.junit;
 
-import javax.sql.DataSource;
 import java.lang.reflect.Method;
 import java.util.Date;
 import java.util.Map;
+import javax.sql.DataSource;
 
 import com.consol.citrus.TestAction;
 import com.consol.citrus.TestActionBuilder;
@@ -27,25 +27,7 @@ import com.consol.citrus.TestActionContainerBuilder;
 import com.consol.citrus.TestCase;
 import com.consol.citrus.TestCaseMetaInfo;
 import com.consol.citrus.TestResult;
-import com.consol.citrus.actions.AntRunAction;
-import com.consol.citrus.actions.CreateVariablesAction;
-import com.consol.citrus.actions.EchoAction;
-import com.consol.citrus.actions.ExecutePLSQLAction;
-import com.consol.citrus.actions.ExecuteSQLAction;
-import com.consol.citrus.actions.ExecuteSQLQueryAction;
-import com.consol.citrus.actions.FailAction;
-import com.consol.citrus.actions.InputAction;
-import com.consol.citrus.actions.JavaAction;
-import com.consol.citrus.actions.LoadPropertiesAction;
-import com.consol.citrus.actions.PurgeEndpointAction;
-import com.consol.citrus.actions.ReceiveTimeoutAction;
-import com.consol.citrus.actions.SleepAction;
-import com.consol.citrus.actions.StartServerAction;
-import com.consol.citrus.actions.StopServerAction;
-import com.consol.citrus.actions.StopTimeAction;
-import com.consol.citrus.actions.StopTimerAction;
-import com.consol.citrus.actions.TraceVariablesAction;
-import com.consol.citrus.actions.TransformAction;
+import com.consol.citrus.actions.*;
 import com.consol.citrus.container.Assert;
 import com.consol.citrus.container.Async;
 import com.consol.citrus.container.Catch;
@@ -107,15 +89,15 @@ public class JUnit4CitrusTestDesigner extends JUnit4CitrusTest implements TestDe
         if (isConfigure(frameworkMethod.getMethod())) {
             try {
                 configure();
+                citrus.run(testCase, context);
             } catch (TestCaseFailedException e) {
                 throw e;
             } catch (Exception | AssertionError e) {
                 testCase.setTestResult(TestResult.failed(testCase.getName(), testCase.getTestClass().getName(), e));
-                testCase.finish(context);
                 throw new TestCaseFailedException(e);
+            } finally {
+                testCase.finish(context);
             }
-
-            citrus.run(testCase, context);
         } else {
             super.invokeTestMethod(frameworkMethod, testCase, context);
         }

--- a/vintage/citrus-java-dsl/src/main/java/com/consol/citrus/dsl/junit/jupiter/CitrusExtension.java
+++ b/vintage/citrus-java-dsl/src/main/java/com/consol/citrus/dsl/junit/jupiter/CitrusExtension.java
@@ -85,7 +85,11 @@ public class CitrusExtension extends CitrusBaseExtension implements ParameterRes
             if (isDesignerMethod(extensionContext.getRequiredTestMethod()) ||
                     isDesignerClass(extensionContext.getRequiredTestClass())) {
                 TestContext context = CitrusExtensionHelper.getTestContext(extensionContext);
-                CitrusExtensionHelper.getCitrus(extensionContext).run(testCase, context);
+                try {
+                    CitrusExtensionHelper.getCitrus(extensionContext).run(testCase, context);
+                } finally {
+                    testCase.finish(context);
+                }
             } else if (isRunnerMethod(extensionContext.getRequiredTestMethod()) ||
                     isRunnerClass(extensionContext.getRequiredTestClass())) {
                 getTestRunner(extensionContext).stop();
@@ -102,7 +106,13 @@ public class CitrusExtension extends CitrusBaseExtension implements ParameterRes
     @Override
     public void beforeTestExecution(ExtensionContext extensionContext) throws Exception {
         if (isSpringXmlTestMethod(extensionContext.getRequiredTestMethod())) {
-            CitrusExtensionHelper.getCitrus(extensionContext).run(getXmlTestCase(extensionContext), CitrusExtensionHelper.getTestContext(extensionContext));
+            TestCase testCase = getXmlTestCase(extensionContext);
+            TestContext context = CitrusExtensionHelper.getTestContext(extensionContext);
+            try {
+                CitrusExtensionHelper.getCitrus(extensionContext).run(testCase, context);
+            } finally {
+                testCase.finish(context);
+            }
         } else {
             CitrusDslAnnotations.injectTestDesigner(extensionContext.getRequiredTestInstance(), getTestDesigner(extensionContext));
             CitrusDslAnnotations.injectTestRunner(extensionContext.getRequiredTestInstance(), getTestRunner(extensionContext));

--- a/vintage/citrus-java-dsl/src/main/java/com/consol/citrus/dsl/testng/TestNGCitrusTest.java
+++ b/vintage/citrus-java-dsl/src/main/java/com/consol/citrus/dsl/testng/TestNGCitrusTest.java
@@ -123,18 +123,17 @@ public class TestNGCitrusTest extends AbstractTestNGCitrusTest {
             try {
                 ReflectionUtils.invokeMethod(method, this,
                         resolveParameter(testResult, method, testCase, context, invocationCount));
+                citrus.run(testCase, context);
             } catch (TestCaseFailedException e) {
                 throw e;
             } catch (Exception | AssertionError e) {
                 testCase.setTestResult(TestResult.failed(testCase.getName(), testCase.getTestClass().getName(), e));
-                testCase.finish(context);
                 throw new TestCaseFailedException(e);
+            } finally {
+                testCase.finish(context);
             }
-
-            citrus.run(testCase, context);
         } else if (testResult.getAttribute(RUNNER_ATTRIBUTE) != null) {
             TestRunner testRunner = (TestRunner) testResult.getAttribute(RUNNER_ATTRIBUTE);
-
             try {
                 Object[] params = resolveParameter(testResult, method, testCase, context, invocationCount);
                 testRunner.start();

--- a/vintage/citrus-java-dsl/src/main/java/com/consol/citrus/dsl/testng/TestNGCitrusTestDesigner.java
+++ b/vintage/citrus-java-dsl/src/main/java/com/consol/citrus/dsl/testng/TestNGCitrusTestDesigner.java
@@ -16,34 +16,16 @@
 
 package com.consol.citrus.dsl.testng;
 
-import javax.sql.DataSource;
 import java.lang.reflect.Method;
 import java.util.Date;
+import javax.sql.DataSource;
 
 import com.consol.citrus.TestAction;
 import com.consol.citrus.TestActionBuilder;
 import com.consol.citrus.TestActionContainerBuilder;
 import com.consol.citrus.TestCase;
 import com.consol.citrus.TestCaseMetaInfo;
-import com.consol.citrus.actions.AntRunAction;
-import com.consol.citrus.actions.CreateVariablesAction;
-import com.consol.citrus.actions.EchoAction;
-import com.consol.citrus.actions.ExecutePLSQLAction;
-import com.consol.citrus.actions.ExecuteSQLAction;
-import com.consol.citrus.actions.ExecuteSQLQueryAction;
-import com.consol.citrus.actions.FailAction;
-import com.consol.citrus.actions.InputAction;
-import com.consol.citrus.actions.JavaAction;
-import com.consol.citrus.actions.LoadPropertiesAction;
-import com.consol.citrus.actions.PurgeEndpointAction;
-import com.consol.citrus.actions.ReceiveTimeoutAction;
-import com.consol.citrus.actions.SleepAction;
-import com.consol.citrus.actions.StartServerAction;
-import com.consol.citrus.actions.StopServerAction;
-import com.consol.citrus.actions.StopTimeAction;
-import com.consol.citrus.actions.StopTimerAction;
-import com.consol.citrus.actions.TraceVariablesAction;
-import com.consol.citrus.actions.TransformAction;
+import com.consol.citrus.actions.*;
 import com.consol.citrus.container.Assert;
 import com.consol.citrus.container.Async;
 import com.consol.citrus.container.Catch;
@@ -101,8 +83,12 @@ public class TestNGCitrusTestDesigner extends TestNGCitrusTest implements TestDe
     @Override
     protected void invokeTestMethod(ITestResult testResult, Method method, TestCase testCase, TestContext context, int invocationCount) {
         if (isConfigure(method)) {
-            configure();
-            citrus.run(testCase, context);
+            try {
+                configure();
+                citrus.run(testCase, context);
+            } finally {
+                testCase.finish(context);
+            }
         } else {
             super.invokeTestMethod(testResult, method, testCase, context, invocationCount);
         }


### PR DESCRIPTION
- Avoid success reports for failing tests in DefaultTestLoader
- Makes sure to call `runner.stop()` after test result has been set on exception handling
- Avoid duplicate test reports when `test.execute()` and `runner.stop()` both calling `test.finish()`
- Move `test.finish()` invocation to test loader

Fixes #924 