### PR TITLE
Citrus w/ jUnit5: Neither an actual suite name nor groups are passed to BeforeSuites / AfterSuites shouldExecute method

### DIFF
--- a/runtime/citrus-junit5/src/main/java/com/consol/citrus/junit/jupiter/CitrusExtension.java
+++ b/runtime/citrus-junit5/src/main/java/com/consol/citrus/junit/jupiter/CitrusExtension.java
@@ -76,7 +76,20 @@ public class CitrusExtension implements BeforeAllCallback, InvocationInterceptor
 
         if (beforeSuite) {
             beforeSuite = false;
-            CitrusExtensionHelper.getCitrus(extensionContext).beforeSuite(SUITE_NAME);
+      // Assertion: If the beforeAll callback is called for a test, the annotated tags are currently
+      // included by the groups filter of surefire / failsafe or no specific filter is defined and
+      // all groups / tags will run anyway.
+      final String[] tags = extensionContext.getTags().toArray(new String[0]);
+      extensionContext.getTestClass().map(Class::getName).or(() ->
+          extensionContext.getTestMethod().map(method -> method.getDeclaringClass().getName()+":"+method.getName())
+      ).ifPresentOrElse(suiteName ->
+              CitrusExtensionHelper
+                  .getCitrus(extensionContext)
+                  .beforeSuite(suiteName, tags),
+          () -> CitrusExtensionHelper
+              .getCitrus(extensionContext)
+              .beforeSuite(SUITE_NAME, tags)
+      );
         }
     }
 
@@ -84,7 +97,20 @@ public class CitrusExtension implements BeforeAllCallback, InvocationInterceptor
     public void afterAll(ExtensionContext extensionContext) throws Exception {
         if (afterSuite) {
             afterSuite = false;
-            CitrusExtensionHelper.getCitrus(extensionContext).afterSuite(SUITE_NAME);
+      // Assertion: If the afterAll callback is called for a test, the annotated tags are currently
+      // included by the groups filter of surefire / failsafe or no specific filter is defined and
+      // all groups / tags did run anyway.
+      final String[] tags = extensionContext.getTags().toArray(new String[0]);
+      extensionContext.getTestClass().map(Class::getName).or(() ->
+          extensionContext.getTestMethod().map(meth -> meth.getDeclaringClass().getName()+":"+meth.getName())
+      ).ifPresentOrElse(suiteName ->
+              CitrusExtensionHelper
+                  .getCitrus(extensionContext)
+                  .afterSuite(suiteName, tags),
+          () -> CitrusExtensionHelper
+              .getCitrus(extensionContext)
+              .afterSuite(SUITE_NAME, tags)
+      );
         }
     }
 


### PR DESCRIPTION
Changed the suite name passed to beforeSuite and afterSuite callbacks to the actual class or method name and also passed the tags of the current test case or method to the call. The default Citrus suite name that comes from a constant will still be used as fallback.

Related issue: #934
