### PR TITLE
chore(#922): Add unit test coverage from removed java-dsl module

### DIFF
--- a/connectors/citrus-docker/src/test/java/org/citrusframework/docker/UnitTestSupport.java
+++ b/connectors/citrus-docker/src/test/java/org/citrusframework/docker/UnitTestSupport.java
@@ -1,0 +1,32 @@
+package org.citrusframework.docker;
+
+import org.citrusframework.context.TestContext;
+import org.citrusframework.context.TestContextFactory;
+import org.citrusframework.functions.DefaultFunctionLibrary;
+import org.citrusframework.validation.matcher.DefaultValidationMatcherLibrary;
+import org.testng.annotations.BeforeMethod;
+
+/**
+ * @author Christoph Deppisch
+ */
+public abstract class UnitTestSupport {
+
+    protected TestContextFactory testContextFactory;
+    protected TestContext context;
+
+    /**
+     * Setup test execution.
+     */
+    @BeforeMethod
+    public void prepareTest() {
+        testContextFactory = createTestContextFactory();
+        context = testContextFactory.getObject();
+    }
+
+    protected TestContextFactory createTestContextFactory() {
+        TestContextFactory factory = TestContextFactory.newInstance();
+        factory.getFunctionRegistry().addFunctionLibrary(new DefaultFunctionLibrary());
+        factory.getValidationMatcherRegistry().addValidationMatcherLibrary(new DefaultValidationMatcherLibrary());
+        return factory;
+    }
+}

--- a/connectors/citrus-docker/src/test/java/org/citrusframework/docker/actions/dsl/DockerTestActionBuilderTest.java
+++ b/connectors/citrus-docker/src/test/java/org/citrusframework/docker/actions/dsl/DockerTestActionBuilderTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.docker.actions.dsl;
+
+import java.util.UUID;
+
+import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.github.dockerjava.api.command.CreateContainerResponse;
+import com.github.dockerjava.api.command.InfoCmd;
+import com.github.dockerjava.api.command.InspectContainerCmd;
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.github.dockerjava.api.command.PingCmd;
+import com.github.dockerjava.api.command.VersionCmd;
+import com.github.dockerjava.api.model.Info;
+import com.github.dockerjava.api.model.Version;
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.docker.UnitTestSupport;
+import org.citrusframework.docker.actions.DockerExecuteAction;
+import org.citrusframework.docker.client.DockerClient;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.docker.actions.DockerExecuteAction.Builder.docker;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ * @since 2.4
+ */
+public class DockerTestActionBuilderTest extends UnitTestSupport {
+
+    private com.github.dockerjava.api.DockerClient dockerClient = Mockito.mock(com.github.dockerjava.api.DockerClient.class);
+
+    @Test
+    public void testDockerBuilder() {
+        InfoCmd infoCmd = Mockito.mock(InfoCmd.class);
+        PingCmd pingCmd = Mockito.mock(PingCmd.class);
+        VersionCmd versionCmd = Mockito.mock(VersionCmd.class);
+        CreateContainerCmd createCmd = Mockito.mock(CreateContainerCmd.class);
+        InspectContainerCmd inspectCmd = Mockito.mock(InspectContainerCmd.class);
+
+        CreateContainerResponse response = new CreateContainerResponse();
+        response.setId(UUID.randomUUID().toString());
+
+        reset(dockerClient, infoCmd, pingCmd, versionCmd, createCmd, inspectCmd);
+
+        when(dockerClient.infoCmd()).thenReturn(infoCmd);
+        when(infoCmd.exec()).thenReturn(new Info());
+
+        when(dockerClient.pingCmd()).thenReturn(pingCmd);
+        doNothing().when(pingCmd).exec();
+
+        when(dockerClient.versionCmd()).thenReturn(versionCmd);
+        when(versionCmd.exec()).thenReturn(new Version());
+
+        when(dockerClient.createContainerCmd("new_image")).thenReturn(createCmd);
+        when(createCmd.withName("my_container")).thenReturn(createCmd);
+        when(createCmd.exec()).thenReturn(response);
+
+        when(dockerClient.inspectContainerCmd("my_container")).thenReturn(inspectCmd);
+        when(inspectCmd.exec()).thenReturn(new InspectContainerResponse());
+
+        final DockerClient client = new DockerClient();
+        client.getEndpointConfiguration().setDockerClient(dockerClient);
+
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(docker().client(client)
+                    .info());
+
+        builder.$(docker().client(client)
+                    .ping());
+
+        builder.$(docker().client(client)
+                    .version()
+                    .validateCommandResult((result, context) -> {
+                        Assert.assertNotNull(result);
+                    }));
+
+        builder.$(docker().client(client)
+                    .create("new_image")
+                        .name("my_container"));
+
+        builder.$(docker().client(client)
+                    .inspectContainer("my_container"));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 5);
+        Assert.assertEquals(test.getActions().get(0).getClass(), DockerExecuteAction.class);
+        Assert.assertEquals(test.getActiveAction().getClass(), DockerExecuteAction.class);
+
+        DockerExecuteAction action = (DockerExecuteAction)test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "docker-execute");
+        Assert.assertEquals(action.getCommand().getClass(), org.citrusframework.docker.command.Info.class);
+
+        action = (DockerExecuteAction)test.getActions().get(1);
+        Assert.assertEquals(action.getName(), "docker-execute");
+        Assert.assertEquals(action.getCommand().getClass(), org.citrusframework.docker.command.Ping.class);
+
+        action = (DockerExecuteAction)test.getActions().get(2);
+        Assert.assertEquals(action.getName(), "docker-execute");
+        Assert.assertEquals(action.getCommand().getClass(), org.citrusframework.docker.command.Version.class);
+        Assert.assertNotNull(action.getCommand().getResultCallback());
+
+        action = (DockerExecuteAction)test.getActions().get(3);
+        Assert.assertEquals(action.getName(), "docker-execute");
+        Assert.assertEquals(action.getCommand().getClass(), org.citrusframework.docker.command.ContainerCreate.class);
+
+        action = (DockerExecuteAction)test.getActions().get(4);
+        Assert.assertEquals(action.getName(), "docker-execute");
+        Assert.assertEquals(action.getCommand().getClass(), org.citrusframework.docker.command.ContainerInspect.class);
+
+    }
+}

--- a/connectors/citrus-kubernetes/pom.xml
+++ b/connectors/citrus-kubernetes/pom.xml
@@ -108,6 +108,11 @@
 
     <!-- Test scoped dependencies -->
     <dependency>
+      <groupId>com.github.docker-java</groupId>
+      <artifactId>docker-java</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.citrusframework</groupId>
       <artifactId>citrus-test-support</artifactId>
       <version>${project.version}</version>

--- a/connectors/citrus-kubernetes/src/test/java/org/citrusframework/kubernetes/UnitTestSupport.java
+++ b/connectors/citrus-kubernetes/src/test/java/org/citrusframework/kubernetes/UnitTestSupport.java
@@ -1,0 +1,32 @@
+package org.citrusframework.kubernetes;
+
+import org.citrusframework.context.TestContext;
+import org.citrusframework.context.TestContextFactory;
+import org.citrusframework.functions.DefaultFunctionLibrary;
+import org.citrusframework.validation.matcher.DefaultValidationMatcherLibrary;
+import org.testng.annotations.BeforeMethod;
+
+/**
+ * @author Christoph Deppisch
+ */
+public abstract class UnitTestSupport {
+
+    protected TestContextFactory testContextFactory;
+    protected TestContext context;
+
+    /**
+     * Setup test execution.
+     */
+    @BeforeMethod
+    public void prepareTest() {
+        testContextFactory = createTestContextFactory();
+        context = testContextFactory.getObject();
+    }
+
+    protected TestContextFactory createTestContextFactory() {
+        TestContextFactory factory = TestContextFactory.newInstance();
+        factory.getFunctionRegistry().addFunctionLibrary(new DefaultFunctionLibrary());
+        factory.getValidationMatcherRegistry().addValidationMatcherLibrary(new DefaultValidationMatcherLibrary());
+        return factory;
+    }
+}

--- a/connectors/citrus-kubernetes/src/test/java/org/citrusframework/kubernetes/actions/dsl/KubernetesTestActionBuilderTest.java
+++ b/connectors/citrus-kubernetes/src/test/java/org/citrusframework/kubernetes/actions/dsl/KubernetesTestActionBuilderTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2006-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.kubernetes.actions.dsl;
+
+import java.net.URL;
+import java.util.UUID;
+
+import com.github.dockerjava.api.command.CreateContainerResponse;
+import io.fabric8.kubernetes.api.model.NamespaceList;
+import io.fabric8.kubernetes.api.model.Node;
+import io.fabric8.kubernetes.api.model.NodeList;
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.dsl.ClientMixedOperation;
+import io.fabric8.kubernetes.client.dsl.ClientNonNamespaceOperation;
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.kubernetes.UnitTestSupport;
+import org.citrusframework.kubernetes.actions.KubernetesExecuteAction;
+import org.citrusframework.kubernetes.client.KubernetesClient;
+import org.citrusframework.kubernetes.command.Info;
+import org.citrusframework.kubernetes.command.ListNamespaces;
+import org.citrusframework.kubernetes.command.ListNodes;
+import org.citrusframework.kubernetes.command.ListPods;
+import org.citrusframework.kubernetes.command.WatchEventResult;
+import org.citrusframework.kubernetes.command.WatchNodes;
+import org.citrusframework.kubernetes.command.WatchServices;
+import org.citrusframework.kubernetes.message.KubernetesMessageHeaders;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.kubernetes.actions.KubernetesExecuteAction.Builder.kubernetes;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ * @since 2.7
+ */
+public class KubernetesTestActionBuilderTest extends UnitTestSupport {
+
+    private final io.fabric8.kubernetes.client.KubernetesClient k8sClient = Mockito.mock(io.fabric8.kubernetes.client.KubernetesClient.class);
+
+    @Test
+    public void testKubernetesBuilder() throws Exception {
+        ClientMixedOperation podsOperation = Mockito.mock(ClientMixedOperation.class);
+        ClientNonNamespaceOperation namespacesOperation = Mockito.mock(ClientNonNamespaceOperation.class);
+        ClientNonNamespaceOperation nodesOperation = Mockito.mock(ClientNonNamespaceOperation.class);
+        ClientMixedOperation servicesOperation = Mockito.mock(ClientMixedOperation.class);
+
+        Watch watch = Mockito.mock(Watch.class);
+
+        CreateContainerResponse response = new CreateContainerResponse();
+        response.setId(UUID.randomUUID().toString());
+
+        reset(k8sClient, podsOperation, namespacesOperation, nodesOperation, servicesOperation);
+
+        when(k8sClient.getApiVersion()).thenReturn("v1");
+        when(k8sClient.getMasterUrl()).thenReturn(new URL("https://localhost:8443"));
+        when(k8sClient.getNamespace()).thenReturn("test");
+
+        when(k8sClient.pods()).thenReturn(podsOperation);
+        when(podsOperation.list()).thenReturn(new PodList());
+        when(podsOperation.inNamespace("myNamespace")).thenReturn(podsOperation);
+
+        when(k8sClient.namespaces()).thenReturn(namespacesOperation);
+        when(namespacesOperation.list()).thenReturn(new NamespaceList());
+
+        when(k8sClient.nodes()).thenReturn(nodesOperation);
+        when(nodesOperation.list()).thenReturn(new NodeList());
+        when(nodesOperation.watch(any(Watcher.class))).thenAnswer(invocationOnMock -> {
+            ((Watcher) invocationOnMock.getArguments()[0]).eventReceived(Watcher.Action.ADDED, new Node());
+            return watch;
+        });
+
+        when(k8sClient.services()).thenReturn(servicesOperation);
+        when(servicesOperation.watch(any(Watcher.class))).thenAnswer(invocationOnMock -> {
+            ((Watcher) invocationOnMock.getArguments()[0]).eventReceived(Watcher.Action.MODIFIED, new Service());
+            return watch;
+        });
+        when(servicesOperation.withName("myService")).thenReturn(servicesOperation);
+        when(servicesOperation.inNamespace("myNamespace")).thenReturn(servicesOperation);
+
+        final KubernetesClient client = new KubernetesClient();
+        client.getEndpointConfiguration().setKubernetesClient(k8sClient);
+
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(kubernetes().client(client)
+            .info()
+            .validate((commandResult, context) -> {
+                Assert.assertEquals(commandResult.getResult().getApiVersion(), "v1");
+                Assert.assertEquals(commandResult.getResult().getMasterUrl(), "https://localhost:8443");
+                Assert.assertEquals(commandResult.getResult().getNamespace(), "test");
+            }));
+
+        builder.$(kubernetes().client(client)
+            .pods()
+            .list()
+            .label("active")
+            .namespace("myNamespace"));
+
+        builder.$(kubernetes().client(client)
+            .nodes()
+            .list()
+            .validate((nodes, context) -> {
+                Assert.assertNotNull(nodes.getResult());
+            }));
+
+        builder.$(kubernetes().client(client)
+            .namespaces()
+            .list()
+            .validate((namespaces, context) -> {
+                Assert.assertNotNull(namespaces.getResult());
+            }));
+
+        builder.$(kubernetes().client(client)
+            .nodes()
+            .watch()
+            .label("new"));
+
+        builder.$(kubernetes().client(client)
+            .services()
+            .watch()
+            .name("myService")
+            .namespace("myNamespace")
+            .validate((services, context) -> {
+                Assert.assertNotNull(services);
+                Assert.assertNotNull(services.getResult());
+                Assert.assertEquals(((WatchEventResult) services).getAction(), Watcher.Action.MODIFIED);
+            }));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 6);
+        Assert.assertEquals(test.getActions().get(0).getClass(), KubernetesExecuteAction.class);
+        Assert.assertEquals(test.getActiveAction().getClass(), KubernetesExecuteAction.class);
+
+        KubernetesExecuteAction action = (KubernetesExecuteAction)test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "kubernetes-execute");
+        Assert.assertEquals(action.getCommand().getClass(), Info.class);
+
+        action = (KubernetesExecuteAction)test.getActions().get(1);
+        Assert.assertEquals(action.getName(), "kubernetes-execute");
+        Assert.assertEquals(action.getCommand().getClass(), ListPods.class);
+        Assert.assertEquals(action.getCommand().getParameters().get(KubernetesMessageHeaders.NAMESPACE), "myNamespace");
+        Assert.assertEquals(action.getCommand().getParameters().get(KubernetesMessageHeaders.LABEL), "active");
+
+        action = (KubernetesExecuteAction)test.getActions().get(2);
+        Assert.assertEquals(action.getName(), "kubernetes-execute");
+        Assert.assertEquals(action.getCommand().getClass(), ListNodes.class);
+        Assert.assertNotNull(action.getCommand().getResultCallback());
+
+        action = (KubernetesExecuteAction)test.getActions().get(3);
+        Assert.assertEquals(action.getName(), "kubernetes-execute");
+        Assert.assertEquals(action.getCommand().getClass(), ListNamespaces.class);
+
+        action = (KubernetesExecuteAction)test.getActions().get(4);
+        Assert.assertEquals(action.getName(), "kubernetes-execute");
+        Assert.assertEquals(action.getCommand().getClass(), WatchNodes.class);
+        Assert.assertEquals(action.getCommand().getParameters().get(KubernetesMessageHeaders.LABEL), "new");
+
+        action = (KubernetesExecuteAction)test.getActions().get(5);
+        Assert.assertEquals(action.getName(), "kubernetes-execute");
+        Assert.assertEquals(action.getCommand().getClass(), WatchServices.class);
+        Assert.assertEquals(action.getCommand().getParameters().get(KubernetesMessageHeaders.NAME), "myService");
+        Assert.assertEquals(action.getCommand().getParameters().get(KubernetesMessageHeaders.NAMESPACE), "myNamespace");
+
+        verify(watch, atLeastOnce()).close();
+    }
+}

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/UnitTestSupport.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/UnitTestSupport.java
@@ -1,0 +1,32 @@
+package org.citrusframework.selenium;
+
+import org.citrusframework.context.TestContext;
+import org.citrusframework.context.TestContextFactory;
+import org.citrusframework.functions.DefaultFunctionLibrary;
+import org.citrusframework.validation.matcher.DefaultValidationMatcherLibrary;
+import org.testng.annotations.BeforeMethod;
+
+/**
+ * @author Christoph Deppisch
+ */
+public abstract class UnitTestSupport {
+
+    protected TestContextFactory testContextFactory;
+    protected TestContext context;
+
+    /**
+     * Setup test execution.
+     */
+    @BeforeMethod
+    public void prepareTest() {
+        testContextFactory = createTestContextFactory();
+        context = testContextFactory.getObject();
+    }
+
+    protected TestContextFactory createTestContextFactory() {
+        TestContextFactory factory = TestContextFactory.newInstance();
+        factory.getFunctionRegistry().addFunctionLibrary(new DefaultFunctionLibrary());
+        factory.getValidationMatcherRegistry().addValidationMatcherLibrary(new DefaultValidationMatcherLibrary());
+        return factory;
+    }
+}

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/dsl/SeleniumTestActionBuilderTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/dsl/SeleniumTestActionBuilderTest.java
@@ -1,0 +1,303 @@
+/*
+ * Copyright 2006-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.selenium.actions.dsl;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.container.SequenceAfterTest;
+import org.citrusframework.container.SequenceBeforeTest;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.report.TestActionListeners;
+import org.citrusframework.selenium.UnitTestSupport;
+import org.citrusframework.selenium.actions.*;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+import org.citrusframework.selenium.endpoint.SeleniumBrowserConfiguration;
+import org.citrusframework.selenium.endpoint.SeleniumHeaders;
+import org.citrusframework.spi.ReferenceResolver;
+import org.mockito.Mockito;
+import org.openqa.selenium.Alert;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.interactions.Coordinates;
+import org.openqa.selenium.remote.Browser;
+import org.openqa.selenium.remote.RemoteWebElement;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.selenium.actions.SeleniumActionBuilder.selenium;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ * @since 2.7
+ */
+public class SeleniumTestActionBuilderTest extends UnitTestSupport {
+
+    private final SeleniumBrowser seleniumBrowser = Mockito.mock(SeleniumBrowser.class);
+    private final SeleniumBrowserConfiguration seleniumBrowserConfiguration = Mockito.mock(SeleniumBrowserConfiguration.class);
+    private final ChromeDriver webDriver = Mockito.mock(ChromeDriver.class);
+    private final ReferenceResolver referenceResolver = Mockito.mock(ReferenceResolver.class);
+    private final WebElement element = Mockito.mock(WebElement.class);
+    private final WebElement button = Mockito.mock(WebElement.class);
+    private final RemoteWebElement link = Mockito.mock(RemoteWebElement.class);
+    private final WebElement input = Mockito.mock(WebElement.class);
+    private final WebElement checkbox = Mockito.mock(WebElement.class);
+    private final WebElement hidden = Mockito.mock(WebElement.class);
+    private final Alert alert = Mockito.mock(Alert.class);
+    private final WebDriver.Navigation navigation = Mockito.mock(WebDriver.Navigation.class);
+    private final WebDriver.TargetLocator locator = Mockito.mock(WebDriver.TargetLocator.class);
+    private final WebDriver.Options options = Mockito.mock(WebDriver.Options.class);
+
+    private final Coordinates coordinates = Mockito.mock(Coordinates.class);
+
+    @Test
+    public void testSeleniumBuilder() {
+        when(referenceResolver.resolve(TestContext.class)).thenReturn(context);
+        when(referenceResolver.resolve(TestActionListeners.class)).thenReturn(new TestActionListeners());
+        when(referenceResolver.resolveAll(SequenceBeforeTest.class)).thenReturn(new HashMap<>());
+        when(referenceResolver.resolveAll(SequenceAfterTest.class)).thenReturn(new HashMap<>());
+
+        when(seleniumBrowser.getEndpointConfiguration()).thenReturn(seleniumBrowserConfiguration);
+        when(seleniumBrowserConfiguration.getBrowserType()).thenReturn(Browser.CHROME.browserName());
+        when(seleniumBrowser.getWebDriver()).thenReturn(webDriver);
+
+        when(seleniumBrowser.getName()).thenReturn("mockBrowser");
+        when(referenceResolver.resolve("mockBrowser", SeleniumBrowser.class)).thenReturn(seleniumBrowser);
+
+        when(webDriver.navigate()).thenReturn(navigation);
+        when(webDriver.manage()).thenReturn(options);
+        when(webDriver.switchTo()).thenReturn(locator);
+        when(locator.alert()).thenReturn(alert);
+        when(alert.getText()).thenReturn("Hello!");
+
+        when(webDriver.findElement(By.id("header"))).thenReturn(element);
+        when(element.getTagName()).thenReturn("h1");
+        when(element.isEnabled()).thenReturn(true);
+        when(element.isDisplayed()).thenReturn(true);
+
+        when(webDriver.findElement(By.linkText("Click Me!"))).thenReturn(link);
+        when(link.getTagName()).thenReturn("a");
+        when(link.isEnabled()).thenReturn(true);
+        when(link.isDisplayed()).thenReturn(true);
+
+        when(webDriver.findElement(By.linkText("Hover Me!"))).thenReturn(link);
+
+        when(link.getCoordinates()).thenReturn(coordinates);
+
+        when(webDriver.findElement(By.name("username"))).thenReturn(input);
+        when(input.getTagName()).thenReturn("input");
+        when(input.isEnabled()).thenReturn(true);
+        when(input.isDisplayed()).thenReturn(true);
+
+        when(webDriver.findElement(By.name("hiddenButton"))).thenReturn(hidden);
+        when(hidden.getTagName()).thenReturn("input");
+        when(hidden.isEnabled()).thenReturn(true);
+        when(hidden.isDisplayed()).thenReturn(false);
+
+        when(webDriver.findElement(By.xpath("//input[@type='checkbox']"))).thenReturn(checkbox);
+        when(checkbox.getTagName()).thenReturn("input");
+        when(checkbox.isEnabled()).thenReturn(true);
+        when(checkbox.isDisplayed()).thenReturn(true);
+        when(checkbox.isSelected()).thenReturn(false);
+
+        when(webDriver.executeScript(anyString())).thenReturn(Collections.singletonList("This went wrong!"));
+
+        when(webDriver.findElement(By.className("btn"))).thenReturn(button);
+        when(button.getTagName()).thenReturn("button");
+        when(button.isEnabled()).thenReturn(false);
+        when(button.isDisplayed()).thenReturn(false);
+        when(button.getText()).thenReturn("Click Me!");
+        when(button.getAttribute("type")).thenReturn("submit");
+        when(button.getCssValue("color")).thenReturn("red");
+
+        when(seleniumBrowser.getStoredFile("file.txt")).thenReturn("file.txt");
+        Set<String> windows = new HashSet<>();
+        windows.add("last_window");
+        windows.add("new_window");
+        when(webDriver.getWindowHandles()).thenReturn(Collections.singleton("last_window")).thenReturn(windows);
+        when(webDriver.getWindowHandle()).thenReturn("last_window");
+
+        context.setVariable("cssClass", "btn");
+
+        context.setReferenceResolver(referenceResolver);
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(selenium().start(seleniumBrowser));
+
+        builder.$(selenium().navigate("http://localhost:9090"));
+
+        builder.$(selenium().find().element(By.id("header")));
+        builder.$(selenium().find().element("class-name", "${cssClass}")
+                    .tagName("button")
+                    .enabled(false)
+                    .displayed(false)
+                    .text("Click Me!")
+                    .style("color", "red")
+                    .attribute("type", "submit"));
+
+        builder.$(selenium().click().element(By.linkText("Click Me!")));
+        builder.$(selenium().hover().element(By.linkText("Hover Me!")));
+
+        builder.$(selenium().setInput("Citrus").element(By.name("username")));
+        builder.$(selenium().checkInput(false).element(By.xpath("//input[@type='checkbox']")));
+
+        builder.$(selenium().javascript("alert('Hello!')")
+                    .errors("This went wrong!"));
+
+        builder.$(selenium().alert().text("Hello!").accept());
+
+        builder.$(selenium().clearCache());
+
+        builder.$(selenium().store("classpath:download/file.txt"));
+        builder.$(selenium().getStored("file.txt"));
+
+        builder.$(selenium().open().window("my_window"));
+        builder.$(selenium().focus().window("my_window"));
+        builder.$(selenium().close().window("my_window"));
+
+        builder.$(selenium().waitUntil().hidden().element(By.name("hiddenButton")));
+
+        builder.$(selenium().stop(seleniumBrowser));
+
+        TestCase test = builder.getTestCase();
+        int actionIndex = 0;
+        Assert.assertEquals(test.getActionCount(), 18);
+
+        Assert.assertEquals(test.getActions().get(actionIndex).getClass(), StartBrowserAction.class);
+        StartBrowserAction startBrowserAction = (StartBrowserAction) test.getActions().get(actionIndex++);
+        Assert.assertEquals(startBrowserAction.getName(), "selenium:start");
+        Assert.assertNotNull(startBrowserAction.getBrowser());
+
+        Assert.assertEquals(test.getActions().get(actionIndex).getClass(), NavigateAction.class);
+        NavigateAction navigateAction = (NavigateAction) test.getActions().get(actionIndex++);
+        Assert.assertEquals(navigateAction.getName(), "selenium:navigate");
+        Assert.assertEquals(navigateAction.getPage(), "http://localhost:9090");
+
+        Assert.assertEquals(test.getActions().get(actionIndex).getClass(), FindElementAction.class);
+        FindElementAction findElementAction = (FindElementAction) test.getActions().get(actionIndex++);
+        Assert.assertEquals(findElementAction.getName(), "selenium:find");
+        Assert.assertEquals(findElementAction.getBy(), By.id("header"));
+
+        Assert.assertEquals(test.getActions().get(actionIndex).getClass(), FindElementAction.class);
+        findElementAction = (FindElementAction) test.getActions().get(actionIndex++);
+        Assert.assertEquals(findElementAction.getName(), "selenium:find");
+        Assert.assertEquals(findElementAction.getProperty(), "class-name");
+        Assert.assertEquals(findElementAction.getPropertyValue(), "${cssClass}");
+        Assert.assertEquals(findElementAction.getTagName(), "button");
+        Assert.assertEquals(findElementAction.getText(), "Click Me!");
+        Assert.assertFalse(findElementAction.isEnabled());
+        Assert.assertFalse(findElementAction.isDisplayed());
+        Assert.assertEquals(findElementAction.getStyles().size(), 1L);
+        Assert.assertEquals(findElementAction.getStyles().get("color"), "red");
+        Assert.assertEquals(findElementAction.getAttributes().size(), 1L);
+        Assert.assertEquals(findElementAction.getAttributes().get("type"), "submit");
+
+        Assert.assertEquals(test.getActions().get(actionIndex).getClass(), ClickAction.class);
+        ClickAction clickAction = (ClickAction) test.getActions().get(actionIndex++);
+        Assert.assertEquals(clickAction.getName(), "selenium:click");
+        Assert.assertEquals(clickAction.getBy(), By.linkText("Click Me!"));
+
+        Assert.assertEquals(test.getActions().get(actionIndex).getClass(), HoverAction.class);
+        HoverAction hoverAction = (HoverAction) test.getActions().get(actionIndex++);
+        Assert.assertEquals(hoverAction.getName(), "selenium:hover");
+        Assert.assertEquals(hoverAction.getBy(), By.linkText("Hover Me!"));
+
+        Assert.assertEquals(test.getActions().get(actionIndex).getClass(), SetInputAction.class);
+        SetInputAction setInputAction = (SetInputAction) test.getActions().get(actionIndex++);
+        Assert.assertEquals(setInputAction.getName(), "selenium:set-input");
+        Assert.assertEquals(setInputAction.getBy(), By.name("username"));
+        Assert.assertEquals(setInputAction.getValue(), "Citrus");
+
+        Assert.assertEquals(test.getActions().get(actionIndex).getClass(), CheckInputAction.class);
+        CheckInputAction checkInputAction = (CheckInputAction) test.getActions().get(actionIndex++);
+        Assert.assertEquals(checkInputAction.getName(), "selenium:check-input");
+        Assert.assertEquals(checkInputAction.getBy(), By.xpath("//input[@type='checkbox']"));
+        Assert.assertFalse(checkInputAction.isChecked());
+
+        Assert.assertEquals(test.getActions().get(actionIndex).getClass(), JavaScriptAction.class);
+        JavaScriptAction javaScriptAction = (JavaScriptAction) test.getActions().get(actionIndex++);
+        Assert.assertEquals(javaScriptAction.getName(), "selenium:javascript");
+        Assert.assertEquals(javaScriptAction.getScript(), "alert('Hello!')");
+        Assert.assertEquals(javaScriptAction.getExpectedErrors().size(), 1L);
+        Assert.assertEquals(javaScriptAction.getExpectedErrors().get(0), "This went wrong!");
+
+        Assert.assertEquals(test.getActions().get(actionIndex).getClass(), AlertAction.class);
+        AlertAction alertAction = (AlertAction) test.getActions().get(actionIndex++);
+        Assert.assertEquals(alertAction.getName(), "selenium:alert");
+        Assert.assertEquals(alertAction.getText(), "Hello!");
+
+        Assert.assertEquals(test.getActions().get(actionIndex).getClass(), ClearBrowserCacheAction.class);
+        ClearBrowserCacheAction clearBrowserCacheAction = (ClearBrowserCacheAction) test.getActions().get(actionIndex++);
+        Assert.assertEquals(clearBrowserCacheAction.getName(), "selenium:clear-cache");
+
+        Assert.assertEquals(test.getActions().get(actionIndex).getClass(), StoreFileAction.class);
+        StoreFileAction storeFileAction = (StoreFileAction) test.getActions().get(actionIndex++);
+        Assert.assertEquals(storeFileAction.getName(), "selenium:store-file");
+        Assert.assertEquals(storeFileAction.getFilePath(), "classpath:download/file.txt");
+
+        Assert.assertEquals(test.getActions().get(actionIndex).getClass(), GetStoredFileAction.class);
+        GetStoredFileAction getStoredFileAction = (GetStoredFileAction) test.getActions().get(actionIndex++);
+        Assert.assertEquals(getStoredFileAction.getName(), "selenium:get-stored-file");
+        Assert.assertEquals(getStoredFileAction.getFileName(), "file.txt");
+
+        Assert.assertEquals(test.getActions().get(actionIndex).getClass(), OpenWindowAction.class);
+        OpenWindowAction openWindowAction = (OpenWindowAction) test.getActions().get(actionIndex++);
+        Assert.assertEquals(openWindowAction.getName(), "selenium:open-window");
+        Assert.assertEquals(openWindowAction.getWindowName(), "my_window");
+
+        Assert.assertEquals(test.getActions().get(actionIndex).getClass(), SwitchWindowAction.class);
+        SwitchWindowAction switchWindowAction = (SwitchWindowAction) test.getActions().get(actionIndex++);
+        Assert.assertEquals(switchWindowAction.getName(), "selenium:switch-window");
+        Assert.assertEquals(switchWindowAction.getWindowName(), "my_window");
+
+        Assert.assertEquals(test.getActions().get(actionIndex).getClass(), CloseWindowAction.class);
+        CloseWindowAction closeWindowAction = (CloseWindowAction) test.getActions().get(actionIndex++);
+        Assert.assertEquals(closeWindowAction.getName(), "selenium:close-window");
+        Assert.assertEquals(closeWindowAction.getWindowName(), "my_window");
+
+        Assert.assertEquals(test.getActions().get(actionIndex).getClass(), WaitUntilAction.class);
+        WaitUntilAction waitUntilAction = (WaitUntilAction) test.getActions().get(actionIndex++);
+        Assert.assertEquals(waitUntilAction.getName(), "selenium:wait");
+        Assert.assertEquals(waitUntilAction.getBy(), By.name("hiddenButton"));
+        Assert.assertEquals(waitUntilAction.getCondition(), "hidden");
+
+        Assert.assertEquals(test.getActions().get(actionIndex).getClass(), StopBrowserAction.class);
+        StopBrowserAction stopBrowserAction = (StopBrowserAction) test.getActions().get(actionIndex);
+        Assert.assertEquals(stopBrowserAction.getName(), "selenium:stop");
+        Assert.assertNotNull(stopBrowserAction.getBrowser());
+
+        Assert.assertEquals(context.getVariable(SeleniumHeaders.SELENIUM_ALERT_TEXT), "Hello!");
+        Assert.assertEquals(context.getVariable(SeleniumHeaders.SELENIUM_DOWNLOAD_FILE), "file.txt");
+        Assert.assertEquals(context.getVariable(SeleniumHeaders.SELENIUM_LAST_WINDOW), "last_window");
+        Assert.assertEquals(context.getVariable(SeleniumHeaders.SELENIUM_ACTIVE_WINDOW), "new_window");
+        Assert.assertEquals(context.getVariable("my_window"), "new_window");
+
+        verify(alert).accept();
+        verify(options).deleteAllCookies();
+        verify(link).click();
+        verify(input).clear();
+        verify(input).sendKeys("Citrus");
+    }
+}

--- a/connectors/citrus-sql/src/main/java/org/citrusframework/actions/ExecutePLSQLAction.java
+++ b/connectors/citrus-sql/src/main/java/org/citrusframework/actions/ExecutePLSQLAction.java
@@ -16,12 +16,12 @@
 
 package org.citrusframework.actions;
 
-import javax.sql.DataSource;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.StringTokenizer;
+import javax.sql.DataSource;
 
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;
@@ -171,6 +171,10 @@ public class ExecutePLSQLAction extends AbstractDatabaseConnectingTestAction {
 
         private boolean ignoreErrors = false;
         private String script;
+
+        public static Builder plsql() {
+            return new Builder();
+        }
 
         public static Builder plsql(DataSource dataSource) {
             Builder builder = new Builder();

--- a/connectors/citrus-sql/src/main/java/org/citrusframework/actions/ExecuteSQLAction.java
+++ b/connectors/citrus-sql/src/main/java/org/citrusframework/actions/ExecuteSQLAction.java
@@ -16,8 +16,8 @@
 
 package org.citrusframework.actions;
 
-import javax.sql.DataSource;
 import java.util.List;
+import javax.sql.DataSource;
 
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;
@@ -121,6 +121,10 @@ public class ExecuteSQLAction extends AbstractDatabaseConnectingTestAction {
     public static final class Builder extends AbstractDatabaseConnectingTestAction.Builder<ExecuteSQLAction, Builder> {
 
         private boolean ignoreErrors = false;
+
+        public static Builder sql() {
+            return new Builder();
+        }
 
         public static Builder sql(DataSource dataSource) {
             Builder builder = new Builder();

--- a/connectors/citrus-sql/src/main/java/org/citrusframework/actions/ExecuteSQLQueryAction.java
+++ b/connectors/citrus-sql/src/main/java/org/citrusframework/actions/ExecuteSQLQueryAction.java
@@ -16,7 +16,6 @@
 
 package org.citrusframework.actions;
 
-import javax.sql.DataSource;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
@@ -26,7 +25,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import javax.sql.DataSource;
 
+import org.apache.commons.codec.binary.Base64;
 import org.citrusframework.CitrusSettings;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;
@@ -37,7 +38,6 @@ import org.citrusframework.util.FileUtils;
 import org.citrusframework.validation.matcher.ValidationMatcherUtils;
 import org.citrusframework.validation.script.ScriptValidationContext;
 import org.citrusframework.validation.script.sql.SqlResultSetScriptValidator;
-import org.apache.commons.codec.binary.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.Resource;
@@ -432,6 +432,10 @@ public class ExecuteSQLQueryAction extends AbstractDatabaseConnectingTestAction 
         private final Map<String, String> extractVariables = new HashMap<>();
         private ScriptValidationContext scriptValidationContext;
         private SqlResultSetScriptValidator validator;
+
+        public static Builder query() {
+            return new Builder();
+        }
 
         public static Builder query(DataSource dataSource) {
             Builder builder = new Builder();

--- a/connectors/citrus-sql/src/test/java/org/citrusframework/actions/dsl/ExecutePLSQLTestActionBuilderTest.java
+++ b/connectors/citrus-sql/src/test/java/org/citrusframework/actions/dsl/ExecutePLSQLTestActionBuilderTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.actions.dsl;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.actions.ExecutePLSQLAction;
+import org.mockito.Mockito;
+import org.springframework.core.io.Resource;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.ExecutePLSQLAction.Builder.plsql;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ * @since 2.3
+ */
+public class ExecutePLSQLTestActionBuilderTest extends UnitTestSupport {
+    private final JdbcTemplate jdbcTemplate = Mockito.mock(JdbcTemplate.class);
+    private final PlatformTransactionManager transactionManager = Mockito.mock(PlatformTransactionManager.class);
+    private final Resource sqlResource = Mockito.mock(Resource.class);
+
+    @Test
+    public void testExecutePLSQLBuilderWithStatement() {
+        reset(jdbcTemplate);
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(plsql().jdbcTemplate(jdbcTemplate)
+                        .statement("TEST_STMT_1")
+                        .statement("TEST_STMT_2")
+                        .statement("TEST_STMT_3"));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ExecutePLSQLAction.class);
+        Assert.assertEquals(test.getActiveAction().getClass(), ExecutePLSQLAction.class);
+
+        ExecutePLSQLAction action = (ExecutePLSQLAction)test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "plsql");
+        Assert.assertFalse(action.isIgnoreErrors());
+        Assert.assertEquals(action.getStatements().toString(), "[TEST_STMT_1, TEST_STMT_2, TEST_STMT_3]");
+        Assert.assertNull(action.getScript());
+        Assert.assertNull(action.getSqlResourcePath());
+        Assert.assertEquals(action.getJdbcTemplate(), jdbcTemplate);
+
+        verify(jdbcTemplate).execute("TEST_STMT_1");
+        verify(jdbcTemplate).execute("TEST_STMT_2");
+        verify(jdbcTemplate).execute("TEST_STMT_3");
+    }
+
+    @Test
+    public void testExecutePLSQLBuilderWithTransaction() {
+        reset(jdbcTemplate, transactionManager);
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(plsql().jdbcTemplate(jdbcTemplate)
+                        .transactionManager(transactionManager)
+                        .transactionTimeout(5000)
+                        .transactionIsolationLevel("ISOLATION_READ_COMMITTED")
+                        .statement("TEST_STMT_1")
+                        .statement("TEST_STMT_2")
+                        .statement("TEST_STMT_3"));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ExecutePLSQLAction.class);
+        Assert.assertEquals(test.getActiveAction().getClass(), ExecutePLSQLAction.class);
+
+        ExecutePLSQLAction action = (ExecutePLSQLAction)test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "plsql");
+        Assert.assertFalse(action.isIgnoreErrors());
+        Assert.assertEquals(action.getStatements().toString(), "[TEST_STMT_1, TEST_STMT_2, TEST_STMT_3]");
+        Assert.assertNull(action.getScript());
+        Assert.assertNull(action.getSqlResourcePath());
+        Assert.assertEquals(action.getJdbcTemplate(), jdbcTemplate);
+        Assert.assertEquals(action.getTransactionManager(), transactionManager);
+        Assert.assertEquals(action.getTransactionTimeout(), "5000");
+        Assert.assertEquals(action.getTransactionIsolationLevel(), "ISOLATION_READ_COMMITTED");
+
+        verify(jdbcTemplate).execute("TEST_STMT_1");
+        verify(jdbcTemplate).execute("TEST_STMT_2");
+        verify(jdbcTemplate).execute("TEST_STMT_3");
+    }
+
+    @Test
+    public void testExecutePLSQLBuilderWithSQLResource() throws IOException {
+        reset(jdbcTemplate, sqlResource);
+        when(sqlResource.getInputStream()).thenReturn(new ByteArrayInputStream(("TEST_STMT_1\n" +
+                "/\n" +
+                "TEST_STMT_2\n" +
+                "/\n" +
+                "TEST_STMT_3\n" +
+                "/").getBytes()));
+
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(plsql().jdbcTemplate(jdbcTemplate)
+                        .sqlResource(sqlResource));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ExecutePLSQLAction.class);
+        Assert.assertEquals(test.getActiveAction().getClass(), ExecutePLSQLAction.class);
+
+        ExecutePLSQLAction action = (ExecutePLSQLAction)test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "plsql");
+        Assert.assertFalse(action.isIgnoreErrors());
+        Assert.assertEquals(action.getStatements().size(), 0L);
+        Assert.assertEquals(action.getScript(), ("TEST_STMT_1\n" +
+                "/\n" +
+                "TEST_STMT_2\n" +
+                "/\n" +
+                "TEST_STMT_3\n" +
+                "/"));
+        Assert.assertEquals(action.getJdbcTemplate(), jdbcTemplate);
+
+        verify(jdbcTemplate).execute("TEST_STMT_1");
+        verify(jdbcTemplate).execute("TEST_STMT_2");
+        verify(jdbcTemplate).execute("TEST_STMT_3");
+    }
+
+    @Test
+    public void testExecutePLSQLBuilderWithSQLResourcePath() throws IOException {
+        reset(jdbcTemplate);
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(plsql().jdbcTemplate(jdbcTemplate)
+                        .sqlResource("classpath:org/citrusframework/actions/dsl/plsql.sql"));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ExecutePLSQLAction.class);
+        Assert.assertEquals(test.getActiveAction().getClass(), ExecutePLSQLAction.class);
+
+        ExecutePLSQLAction action = (ExecutePLSQLAction)test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "plsql");
+        Assert.assertFalse(action.isIgnoreErrors());
+        Assert.assertEquals(action.getStatements().size(), 0L);
+        Assert.assertNull(action.getScript());
+        Assert.assertEquals(action.getSqlResourcePath(), "classpath:org/citrusframework/actions/dsl/plsql.sql");
+        Assert.assertEquals(action.getJdbcTemplate(), jdbcTemplate);
+
+        verify(jdbcTemplate).execute("TEST_STMT_1");
+        verify(jdbcTemplate).execute("TEST_STMT_2");
+        verify(jdbcTemplate).execute("TEST_STMT_3");
+    }
+
+    @Test
+    public void testExecutePLSQLBuilderWithInlineScript() {
+        reset(jdbcTemplate);
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(plsql().jdbcTemplate(jdbcTemplate)
+                        .ignoreErrors(true)
+                        .sqlScript(("TEST_STMT_1\n" +
+                                "/\n" +
+                                "TEST_STMT_2\n" +
+                                "/")));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ExecutePLSQLAction.class);
+        Assert.assertEquals(test.getActiveAction().getClass(), ExecutePLSQLAction.class);
+
+        ExecutePLSQLAction action = (ExecutePLSQLAction)test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "plsql");
+        Assert.assertTrue(action.isIgnoreErrors());
+        Assert.assertEquals(action.getStatements().size(), 0L);
+        Assert.assertNull(action.getSqlResourcePath());
+        Assert.assertEquals(action.getScript(), ("TEST_STMT_1\n" +
+                "/\n" +
+                "TEST_STMT_2\n" +
+                "/"));
+        Assert.assertEquals(action.getJdbcTemplate(), jdbcTemplate);
+
+        verify(jdbcTemplate).execute("TEST_STMT_1");
+        verify(jdbcTemplate).execute("TEST_STMT_2");
+    }
+}

--- a/connectors/citrus-sql/src/test/java/org/citrusframework/actions/dsl/ExecuteSQLQueryTestActionBuilderTest.java
+++ b/connectors/citrus-sql/src/test/java/org/citrusframework/actions/dsl/ExecuteSQLQueryTestActionBuilderTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.actions.dsl;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.actions.ExecuteSQLQueryAction;
+import org.citrusframework.validation.script.sql.SqlResultSetScriptValidator;
+import org.mockito.Mockito;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.ExecuteSQLQueryAction.Builder.query;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ * @since 2.3
+ */
+public class ExecuteSQLQueryTestActionBuilderTest extends UnitTestSupport {
+
+    private final JdbcTemplate jdbcTemplate = Mockito.mock(JdbcTemplate.class);
+    private final PlatformTransactionManager transactionManager = Mockito.mock(PlatformTransactionManager.class);
+    private final Resource resource = Mockito.mock(Resource.class);
+
+    private final SqlResultSetScriptValidator validator = Mockito.mock(SqlResultSetScriptValidator.class);
+
+    @Test
+    public void testExecuteSQLQueryWithResource() throws IOException {
+        List<Map<String, Object>> results = new ArrayList<>();
+        results.add(Collections.<String, Object>singletonMap("NAME", "Leonard"));
+
+        reset(jdbcTemplate);
+
+        when(jdbcTemplate.queryForList(anyString())).thenReturn(results)
+                                                    .thenReturn(Collections.singletonList(Collections.<String, Object>singletonMap("CNT_EPISODES", "100000")));
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.variable("episodeId", "citrus:randomNumber(5)");
+
+        builder.$(query().jdbcTemplate(jdbcTemplate)
+                .sqlResource(new ClassPathResource("org/citrusframework/actions/dsl/query-script.sql"))
+                .validate("NAME", "Leonard")
+                .validate("CNT_EPISODES", "100000")
+                .extract("NAME", "actorName"));
+
+        Assert.assertNotNull(context.getVariable("NAME"));
+        Assert.assertNotNull(context.getVariable("actorName"));
+        Assert.assertNotNull(context.getVariable("CNT_EPISODES"));
+        Assert.assertEquals(context.getVariable("NAME"), "Leonard");
+        Assert.assertEquals(context.getVariable("actorName"), "Leonard");
+        Assert.assertEquals(context.getVariable("CNT_EPISODES"), "100000");
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ExecuteSQLQueryAction.class);
+
+        ExecuteSQLQueryAction action = (ExecuteSQLQueryAction)test.getActions().get(0);
+
+        Assert.assertEquals(action.getName(), "sql-query");
+        Assert.assertEquals(action.getControlResultSet().size(), 2);
+        Set<Map.Entry<String, List<String>>> rows = action.getControlResultSet().entrySet();
+        Assert.assertEquals(getRow("NAME", rows).toString(), "NAME=[Leonard]");
+        Assert.assertEquals(getRow("CNT_EPISODES", rows).toString(), "CNT_EPISODES=[100000]");
+        Assert.assertEquals(action.getExtractVariables().size(), 1);
+        Assert.assertEquals(action.getExtractVariables().entrySet().iterator().next().toString(), "NAME=actorName");
+        Assert.assertNull(action.getScriptValidationContext());
+        Assert.assertEquals(action.getJdbcTemplate(), jdbcTemplate);
+        Assert.assertEquals(action.getStatements().size(), 2);
+        Assert.assertNull(action.getSqlResourcePath());
+        Assert.assertNull(action.getValidator());
+    }
+
+    @Test
+    public void testExecuteSQLQueryWithStatements() {
+        List<Map<String, Object>> results = new ArrayList<>();
+        results.add(Collections.<String, Object>singletonMap("NAME", "Penny"));
+        results.add(Collections.<String, Object>singletonMap("NAME", "Sheldon"));
+
+        reset(jdbcTemplate);
+        when(jdbcTemplate.queryForList("SELECT NAME FROM ACTORS")).thenReturn(results);
+        when(jdbcTemplate.queryForList("SELECT COUNT(*) as CNT_EPISODES FROM EPISODES")).thenReturn(Collections.singletonList(Collections.<String, Object>singletonMap("CNT_EPISODES", "9999")));
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(query().jdbcTemplate(jdbcTemplate)
+            .statement("SELECT NAME FROM ACTORS")
+            .statement("SELECT COUNT(*) as CNT_EPISODES FROM EPISODES")
+            .validate("NAME", "Penny", "Sheldon")
+            .validate("CNT_EPISODES", "9999")
+            .extract("CNT_EPISODES", "cntEpisodes"));
+
+        Assert.assertNotNull(context.getVariable("NAME"));
+        Assert.assertNotNull(context.getVariable("CNT_EPISODES"));
+        Assert.assertNotNull(context.getVariable("cntEpisodes"));
+        Assert.assertEquals(context.getVariable("NAME"), "Penny");
+        Assert.assertEquals(context.getVariable("CNT_EPISODES"), "9999");
+        Assert.assertEquals(context.getVariable("cntEpisodes"), "9999");
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ExecuteSQLQueryAction.class);
+
+        ExecuteSQLQueryAction action = (ExecuteSQLQueryAction)test.getActions().get(0);
+
+        Assert.assertEquals(action.getName(), "sql-query");
+        Assert.assertEquals(action.getControlResultSet().size(), 2);
+        Set<Map.Entry<String, List<String>>> rows = action.getControlResultSet().entrySet();
+        Assert.assertEquals(getRow("NAME", rows).toString(), "NAME=[Penny, Sheldon]");
+        Assert.assertEquals(getRow("CNT_EPISODES", rows).toString(), "CNT_EPISODES=[9999]");
+        Assert.assertEquals(action.getExtractVariables().size(), 1);
+        Assert.assertEquals(action.getExtractVariables().entrySet().iterator().next().toString(), "CNT_EPISODES=cntEpisodes");
+        Assert.assertEquals(action.getStatements().size(), 2);
+        Assert.assertEquals(action.getStatements().toString(), "[SELECT NAME FROM ACTORS, SELECT COUNT(*) as CNT_EPISODES FROM EPISODES]");
+        Assert.assertNull(action.getScriptValidationContext());
+        Assert.assertEquals(action.getJdbcTemplate(), jdbcTemplate);
+        Assert.assertNull(action.getValidator());
+
+    }
+
+    @Test
+    public void testExecuteSQLQueryWithTransaction() {
+        List<Map<String, Object>> results = new ArrayList<>();
+        results.add(Collections.<String, Object>singletonMap("NAME", "Penny"));
+        results.add(Collections.<String, Object>singletonMap("NAME", "Sheldon"));
+
+        reset(jdbcTemplate, transactionManager);
+        when(jdbcTemplate.queryForList("SELECT NAME FROM ACTORS")).thenReturn(results);
+        when(jdbcTemplate.queryForList("SELECT COUNT(*) as CNT_EPISODES FROM EPISODES")).thenReturn(Collections.singletonList(Collections.<String, Object>singletonMap("CNT_EPISODES", "9999")));
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(query().jdbcTemplate(jdbcTemplate)
+            .transactionManager(transactionManager)
+            .transactionTimeout(5000)
+            .transactionIsolationLevel("ISOLATION_READ_COMMITTED")
+            .statement("SELECT NAME FROM ACTORS")
+            .statement("SELECT COUNT(*) as CNT_EPISODES FROM EPISODES")
+            .validate("NAME", "Penny", "Sheldon")
+            .validate("CNT_EPISODES", "9999")
+            .extract("CNT_EPISODES", "cntEpisodes"));
+
+        Assert.assertNotNull(context.getVariable("NAME"));
+        Assert.assertNotNull(context.getVariable("CNT_EPISODES"));
+        Assert.assertNotNull(context.getVariable("cntEpisodes"));
+        Assert.assertEquals(context.getVariable("NAME"), "Penny");
+        Assert.assertEquals(context.getVariable("CNT_EPISODES"), "9999");
+        Assert.assertEquals(context.getVariable("cntEpisodes"), "9999");
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ExecuteSQLQueryAction.class);
+
+        ExecuteSQLQueryAction action = (ExecuteSQLQueryAction)test.getActions().get(0);
+
+        Assert.assertEquals(action.getName(), "sql-query");
+        Assert.assertEquals(action.getControlResultSet().size(), 2);
+        Set<Map.Entry<String, List<String>>> rows = action.getControlResultSet().entrySet();
+        Assert.assertEquals(getRow("NAME", rows).toString(), "NAME=[Penny, Sheldon]");
+        Assert.assertEquals(getRow("CNT_EPISODES", rows).toString(), "CNT_EPISODES=[9999]");
+        Assert.assertEquals(action.getExtractVariables().size(), 1);
+        Assert.assertEquals(action.getExtractVariables().entrySet().iterator().next().toString(), "CNT_EPISODES=cntEpisodes");
+        Assert.assertEquals(action.getStatements().size(), 2);
+        Assert.assertEquals(action.getStatements().toString(), "[SELECT NAME FROM ACTORS, SELECT COUNT(*) as CNT_EPISODES FROM EPISODES]");
+        Assert.assertNull(action.getScriptValidationContext());
+        Assert.assertEquals(action.getJdbcTemplate(), jdbcTemplate);
+        Assert.assertEquals(action.getTransactionManager(), transactionManager);
+        Assert.assertEquals(action.getTransactionTimeout(), "5000");
+        Assert.assertEquals(action.getTransactionIsolationLevel(), "ISOLATION_READ_COMMITTED");
+        Assert.assertNull(action.getValidator());
+    }
+
+    /**
+     * Gets row from result set with given column name.
+     * @param columnName
+     * @param rows
+     * @return
+     */
+    private Map.Entry<String, List<String>> getRow(String columnName, Set<Map.Entry<String, List<String>>> rows) {
+        for (Map.Entry<String, List<String>> row : rows) {
+            if (row.getKey().equals(columnName)) {
+                return row;
+            }
+        }
+
+        throw new AssertionError(String.format("Missing column in result set for name '%s'", columnName));
+    }
+}

--- a/connectors/citrus-sql/src/test/java/org/citrusframework/actions/dsl/ExecuteSQLTestActionBuilderTest.java
+++ b/connectors/citrus-sql/src/test/java/org/citrusframework/actions/dsl/ExecuteSQLTestActionBuilderTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.actions.dsl;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.actions.ExecuteSQLAction;
+import org.mockito.Mockito;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.ExecuteSQLAction.Builder.sql;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author Christoph Deppisch
+ * @since 2.3
+ */
+public class ExecuteSQLTestActionBuilderTest extends UnitTestSupport {
+    private final JdbcTemplate jdbcTemplate = Mockito.mock(JdbcTemplate.class);
+    private final PlatformTransactionManager transactionManager = Mockito.mock(PlatformTransactionManager.class);
+    private final Resource resource = Mockito.mock(Resource.class);
+    private final File file = Mockito.mock(File.class);
+
+    @Test
+    public void testExecuteSQLBuilderWithStatement() {
+        reset(jdbcTemplate);
+
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(sql().jdbcTemplate(jdbcTemplate)
+            .statement("TEST_STMT_1")
+            .statement("TEST_STMT_2")
+            .statement("TEST_STMT_3")
+            .ignoreErrors(false));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ExecuteSQLAction.class);
+        Assert.assertEquals(test.getActiveAction().getClass(), ExecuteSQLAction.class);
+
+        ExecuteSQLAction action = (ExecuteSQLAction)test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "sql");
+        Assert.assertEquals(action.getStatements().toString(), "[TEST_STMT_1, TEST_STMT_2, TEST_STMT_3]");
+        Assert.assertFalse(action.isIgnoreErrors());
+        Assert.assertEquals(action.getJdbcTemplate(), jdbcTemplate);
+
+        verify(jdbcTemplate).execute("TEST_STMT_1");
+        verify(jdbcTemplate).execute("TEST_STMT_2");
+        verify(jdbcTemplate).execute("TEST_STMT_3");
+    }
+
+    @Test
+    public void testExecuteSQLBuilderWithTransaction() {
+        reset(jdbcTemplate, transactionManager);
+
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(sql().jdbcTemplate(jdbcTemplate)
+                .transactionManager(transactionManager)
+                .transactionTimeout(5000)
+                .transactionIsolationLevel("ISOLATION_READ_COMMITTED")
+                .statement("TEST_STMT_1")
+                .statement("TEST_STMT_2")
+                .statement("TEST_STMT_3")
+                .ignoreErrors(false));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ExecuteSQLAction.class);
+        Assert.assertEquals(test.getActiveAction().getClass(), ExecuteSQLAction.class);
+
+        ExecuteSQLAction action = (ExecuteSQLAction)test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "sql");
+        Assert.assertEquals(action.getStatements().toString(), "[TEST_STMT_1, TEST_STMT_2, TEST_STMT_3]");
+        Assert.assertFalse(action.isIgnoreErrors());
+        Assert.assertEquals(action.getJdbcTemplate(), jdbcTemplate);
+        Assert.assertEquals(action.getTransactionManager(), transactionManager);
+        Assert.assertEquals(action.getTransactionTimeout(), "5000");
+        Assert.assertEquals(action.getTransactionIsolationLevel(), "ISOLATION_READ_COMMITTED");
+
+        verify(jdbcTemplate).execute("TEST_STMT_1");
+        verify(jdbcTemplate).execute("TEST_STMT_2");
+        verify(jdbcTemplate).execute("TEST_STMT_3");
+    }
+
+    @Test
+    public void testExecuteSQLBuilderWithResource() throws IOException {
+        reset(jdbcTemplate);
+
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(sql().jdbcTemplate(jdbcTemplate)
+            .sqlResource(new ClassPathResource("org/citrusframework/actions/dsl/script.sql"))
+            .ignoreErrors(true));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ExecuteSQLAction.class);
+        Assert.assertEquals(test.getActiveAction().getClass(), ExecuteSQLAction.class);
+
+        ExecuteSQLAction action = (ExecuteSQLAction)test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "sql");
+        Assert.assertTrue(action.isIgnoreErrors());
+        Assert.assertEquals(action.getJdbcTemplate(), jdbcTemplate);
+        Assert.assertEquals(action.getStatements().size(), 3);
+        Assert.assertNull(action.getSqlResourcePath());
+
+        verify(jdbcTemplate).execute("TEST_STMT_1");
+        verify(jdbcTemplate).execute("TEST_STMT_2");
+        verify(jdbcTemplate).execute("TEST_STMT_3");
+    }
+
+    @Test
+    public void testExecuteSQLBuilderWithResourcePath() throws IOException {
+        reset(jdbcTemplate);
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(sql().jdbcTemplate(jdbcTemplate)
+            .sqlResource("classpath:org/citrusframework/actions/dsl/script.sql"));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ExecuteSQLAction.class);
+        Assert.assertEquals(test.getActiveAction().getClass(), ExecuteSQLAction.class);
+
+        ExecuteSQLAction action = (ExecuteSQLAction)test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "sql");
+        Assert.assertFalse(action.isIgnoreErrors());
+        Assert.assertEquals(action.getJdbcTemplate(), jdbcTemplate);
+        Assert.assertEquals(action.getSqlResourcePath(), "classpath:org/citrusframework/actions/dsl/script.sql");
+
+        verify(jdbcTemplate).execute("TEST_STMT_1");
+        verify(jdbcTemplate).execute("TEST_STMT_2");
+        verify(jdbcTemplate).execute("TEST_STMT_3");
+    }
+}

--- a/connectors/citrus-sql/src/test/resources/org/citrusframework/actions/dsl/plsql.sql
+++ b/connectors/citrus-sql/src/test/resources/org/citrusframework/actions/dsl/plsql.sql
@@ -1,0 +1,6 @@
+TEST_STMT_1
+/
+TEST_STMT_2
+/
+TEST_STMT_3
+/

--- a/connectors/citrus-sql/src/test/resources/org/citrusframework/actions/dsl/query-script.sql
+++ b/connectors/citrus-sql/src/test/resources/org/citrusframework/actions/dsl/query-script.sql
@@ -1,0 +1,6 @@
+select NAME
+from ACTORS
+where EPISODE_ID='${episodeId}';
+
+select COUNT(1) as CNT_EPISODES
+from EPISODES;

--- a/connectors/citrus-sql/src/test/resources/org/citrusframework/actions/dsl/script.sql
+++ b/connectors/citrus-sql/src/test/resources/org/citrusframework/actions/dsl/script.sql
@@ -1,0 +1,6 @@
+-- Test stetments
+TEST_STMT_1;
+TEST_STMT_2;
+
+-- Insert data
+TEST_STMT_3;

--- a/core/citrus-base/src/main/java/org/citrusframework/actions/ReceiveTimeoutAction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/actions/ReceiveTimeoutAction.java
@@ -167,6 +167,10 @@ public class ReceiveTimeoutAction extends AbstractTestAction {
         private Map<String, Object> messageSelectorMap = new HashMap<>();
         private String messageSelector;
 
+        public static Builder expectTimeout() {
+            return new Builder();
+        }
+
         /**
          * Fluent API action building entry method used in Java DSL.
          * @param endpointUri

--- a/core/citrus-base/src/main/java/org/citrusframework/container/Template.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/container/Template.java
@@ -33,6 +33,7 @@ import org.citrusframework.actions.NoopTestAction;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.functions.FunctionUtils;
 import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.spi.ReferenceResolverAware;
 import org.citrusframework.variable.GlobalVariables;
 import org.citrusframework.variable.VariableUtils;
 import org.slf4j.Logger;
@@ -203,7 +204,7 @@ public class Template extends AbstractTestAction {
     /**
      * Action builder.
      */
-    public static abstract class AbstractTemplateBuilder<T extends Template, B extends AbstractTemplateBuilder<T, B>> extends AbstractTestActionBuilder<T, B> {
+    public static abstract class AbstractTemplateBuilder<T extends Template, B extends AbstractTemplateBuilder<T, B>> extends AbstractTestActionBuilder<T, B> implements ReferenceResolverAware {
 
         private String templateName;
         private final List<TestActionBuilder<?>> actions = new ArrayList<>();
@@ -297,6 +298,11 @@ public class Template extends AbstractTestAction {
         public B withReferenceResolver(ReferenceResolver referenceResolver) {
             this.referenceResolver = referenceResolver;
             return self;
+        }
+
+        @Override
+        public void setReferenceResolver(ReferenceResolver referenceResolver) {
+            this.referenceResolver = referenceResolver;
         }
 
         /**

--- a/core/citrus-base/src/main/java/org/citrusframework/validation/json/JsonMessageValidationContext.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/validation/json/JsonMessageValidationContext.java
@@ -81,6 +81,15 @@ public class JsonMessageValidationContext extends DefaultValidationContext imple
             return new Builder();
         }
 
+        public JsonPathMessageValidationContext.Builder expressions() {
+            return new JsonPathMessageValidationContext.Builder();
+        }
+
+        public JsonPathMessageValidationContext.Builder expression(String path, Object expectedValue) {
+            return new JsonPathMessageValidationContext.Builder()
+                    .expression(path, expectedValue);
+        }
+
         /**
          * Sets schema validation enabled/disabled for this message.
          *
@@ -135,8 +144,6 @@ public class JsonMessageValidationContext extends DefaultValidationContext imple
             this.ignoreExpressions.addAll(paths);
             return this;
         }
-
-
 
         @Override
         public JsonMessageValidationContext build() {

--- a/core/citrus-base/src/main/java/org/citrusframework/validation/xml/XmlMessageValidationContext.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/validation/xml/XmlMessageValidationContext.java
@@ -89,6 +89,14 @@ public class XmlMessageValidationContext extends DefaultValidationContext implem
             return new Builder();
         }
 
+        public XpathMessageValidationContext.Builder expressions() {
+            return new XpathMessageValidationContext.Builder();
+        }
+
+        public XpathMessageValidationContext.Builder expression(String path, Object expectedValue) {
+            return new XpathMessageValidationContext.Builder().expression(path, expectedValue);
+        }
+
         /**
          * Convert to Xpath message validation context builder.
          * @return

--- a/core/citrus-spring/src/main/java/org/citrusframework/endpoint/adapter/TestBehaviorExecutingEndpointAdapter.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/endpoint/adapter/TestBehaviorExecutingEndpointAdapter.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2006-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.endpoint.adapter;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestBehavior;
+import org.citrusframework.TestCase;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.message.Message;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+
+/**
+ * Test executing endpoint adapter specialization executes a Java DSL test designer or test runner loaded from
+ * Spring application context by bean name mapping.
+ *
+ * @author Christoph Deppisch
+ * @since 1.3.1
+ */
+public class TestBehaviorExecutingEndpointAdapter extends XmlTestExecutingEndpointAdapter {
+
+    @Override
+    public Message dispatchMessage(final Message request, String mappingName) {
+        final TestBehavior behavior;
+
+        try {
+            behavior = getApplicationContext().getBean(mappingName, TestBehavior.class);
+        } catch (NoSuchBeanDefinitionException e) {
+            throw new CitrusRuntimeException("Unable to find test behavior with name '" +
+                    mappingName + "' in Spring bean context", e);
+        }
+
+        getTaskExecutor().execute(() -> {
+            prepareExecution(request, behavior);
+            TestContext context = getTestContext();
+            DefaultTestCaseRunner testCaseRunner = new DefaultTestCaseRunner(context);
+            behavior.apply(testCaseRunner);
+        });
+
+        return getResponseEndpointAdapter().handleMessage(request);
+    }
+
+    /**
+     * Prepares the test behavior instance before execution. Subclasses may add custom properties to test behavior
+     * here.
+     * @param request the triggering request message.
+     * @param behavior the found test behavior.
+     */
+    protected void prepareExecution(Message request, TestBehavior behavior) {
+    }
+
+    @Override
+    protected final void prepareExecution(Message request, TestCase testCase) {
+        super.prepareExecution(request, testCase);
+    }
+}

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelActionBuilder.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelActionBuilder.java
@@ -31,8 +31,6 @@ import org.springframework.util.Assert;
  */
 public class CamelActionBuilder implements TestActionBuilder.DelegatingTestActionBuilder<TestAction>, ReferenceResolverAware {
 
-    /** Bean reference resolver */
-    private ReferenceResolver referenceResolver;
     private CamelContext camelContext;
 
     private TestActionBuilder<?> delegate;
@@ -81,7 +79,7 @@ public class CamelActionBuilder implements TestActionBuilder.DelegatingTestActio
      * @param referenceResolver
      */
     public CamelActionBuilder withReferenceResolver(ReferenceResolver referenceResolver) {
-        this.referenceResolver = referenceResolver;
+        setReferenceResolver(referenceResolver);
         return this;
     }
 
@@ -103,8 +101,6 @@ public class CamelActionBuilder implements TestActionBuilder.DelegatingTestActio
     @Override
     public void setReferenceResolver(ReferenceResolver referenceResolver) {
         if (referenceResolver == null) {
-            this.referenceResolver = referenceResolver;
-
             if (delegate instanceof ReferenceResolverAware) {
                 ((ReferenceResolverAware) delegate).setReferenceResolver(referenceResolver);
             }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelControlBusAction.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelControlBusAction.java
@@ -221,7 +221,7 @@ public class CamelControlBusAction extends AbstractCamelRouteAction {
         }
 
         @Override
-        public CamelControlBusAction build() {
+        public CamelControlBusAction doBuild() {
             return new CamelControlBusAction(this);
         }
 

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelRouteActionBuilder.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelRouteActionBuilder.java
@@ -65,12 +65,12 @@ public class CamelRouteActionBuilder implements TestActionBuilder.DelegatingTest
      * @return
      */
     public CreateCamelRouteAction.Builder create(RouteBuilder routeBuilder) {
-        if (getCamelContext() == null) {
+        if (camelContext == null) {
             context(routeBuilder.getContext());
         }
 
         CreateCamelRouteAction.Builder builder = new CreateCamelRouteAction.Builder()
-                .context(getCamelContext())
+                .context(camelContext)
                 .route(routeBuilder);
 
         this.delegate = builder;
@@ -84,7 +84,7 @@ public class CamelRouteActionBuilder implements TestActionBuilder.DelegatingTest
      */
     public CreateCamelRouteAction.Builder create(String routeContext) {
         CreateCamelRouteAction.Builder builder = new CreateCamelRouteAction.Builder()
-                .context(getCamelContext())
+                .context(camelContext)
                 .routeContext(routeContext);
 
         this.delegate = builder;
@@ -97,7 +97,7 @@ public class CamelRouteActionBuilder implements TestActionBuilder.DelegatingTest
      */
     public CamelControlBusAction.Builder controlBus() {
         CamelControlBusAction.Builder builder = new CamelControlBusAction.Builder()
-                .context(getCamelContext());
+                .context(camelContext);
 
         this.delegate = builder;
         return builder;
@@ -108,7 +108,7 @@ public class CamelRouteActionBuilder implements TestActionBuilder.DelegatingTest
      */
     public StartCamelRouteAction.Builder start(String ... routes) {
         StartCamelRouteAction.Builder builder = new StartCamelRouteAction.Builder()
-                .context(getCamelContext())
+                .context(camelContext)
                 .routes(routes);
 
         this.delegate = builder;
@@ -120,7 +120,7 @@ public class CamelRouteActionBuilder implements TestActionBuilder.DelegatingTest
      */
     public StopCamelRouteAction.Builder stop(String ... routes) {
         StopCamelRouteAction.Builder builder = new StopCamelRouteAction.Builder()
-                .context(getCamelContext())
+                .context(camelContext)
                 .routes(routes);
 
         this.delegate = builder;
@@ -132,7 +132,7 @@ public class CamelRouteActionBuilder implements TestActionBuilder.DelegatingTest
      */
     public RemoveCamelRouteAction.Builder remove(String ... routes) {
         RemoveCamelRouteAction.Builder builder = new RemoveCamelRouteAction.Builder()
-                .context(getCamelContext())
+                .context(camelContext)
                 .routes(routes);
 
         this.delegate = builder;
@@ -146,25 +146,6 @@ public class CamelRouteActionBuilder implements TestActionBuilder.DelegatingTest
     public CamelRouteActionBuilder withReferenceResolver(ReferenceResolver referenceResolver) {
         this.referenceResolver = referenceResolver;
         return this;
-    }
-
-    /**
-     * Gets the camel context either explicitly set before or default
-     * context from Spring application context.
-     * @return
-     */
-    protected CamelContext getCamelContext() {
-        if (camelContext == null) {
-            Assert.notNull(referenceResolver, "Citrus bean reference resolver is not initialized!");
-
-            if (referenceResolver.isResolvable("citrusCamelContext")) {
-                camelContext = referenceResolver.resolve("citrusCamelContext", ModelCamelContext.class);
-            } else {
-                camelContext = referenceResolver.resolve(ModelCamelContext.class);
-            }
-        }
-
-        return camelContext;
     }
 
     @Override

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CreateCamelRouteAction.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CreateCamelRouteAction.java
@@ -176,7 +176,7 @@ public class CreateCamelRouteAction extends AbstractCamelRouteAction {
         }
 
         @Override
-        public CreateCamelRouteAction build() {
+        public CreateCamelRouteAction doBuild() {
             return new CreateCamelRouteAction(this);
         }
     }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/RemoveCamelRouteAction.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/RemoveCamelRouteAction.java
@@ -67,7 +67,7 @@ public class RemoveCamelRouteAction extends AbstractCamelRouteAction {
      */
     public static final class Builder extends AbstractCamelRouteAction.Builder<RemoveCamelRouteAction, Builder> {
         @Override
-        public RemoveCamelRouteAction build() {
+        public RemoveCamelRouteAction doBuild() {
             return new RemoveCamelRouteAction(this);
         }
     }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/StartCamelRouteAction.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/StartCamelRouteAction.java
@@ -57,7 +57,7 @@ public class StartCamelRouteAction extends AbstractCamelRouteAction {
      */
     public static final class Builder extends AbstractCamelRouteAction.Builder<StartCamelRouteAction, Builder> {
         @Override
-        public StartCamelRouteAction build() {
+        public StartCamelRouteAction doBuild() {
             return new StartCamelRouteAction(this);
         }
     }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/StopCamelRouteAction.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/StopCamelRouteAction.java
@@ -57,7 +57,7 @@ public class StopCamelRouteAction extends AbstractCamelRouteAction {
      */
     public static final class Builder extends AbstractCamelRouteAction.Builder<StopCamelRouteAction, Builder> {
         @Override
-        public StopCamelRouteAction build() {
+        public StopCamelRouteAction doBuild() {
             return new StopCamelRouteAction(this);
         }
     }

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/UnitTestSupport.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/UnitTestSupport.java
@@ -1,0 +1,32 @@
+package org.citrusframework.camel;
+
+import org.citrusframework.context.TestContext;
+import org.citrusframework.context.TestContextFactory;
+import org.citrusframework.functions.DefaultFunctionLibrary;
+import org.citrusframework.validation.matcher.DefaultValidationMatcherLibrary;
+import org.testng.annotations.BeforeMethod;
+
+/**
+ * @author Christoph Deppisch
+ */
+public abstract class UnitTestSupport {
+
+    protected TestContextFactory testContextFactory;
+    protected TestContext context;
+
+    /**
+     * Setup test execution.
+     */
+    @BeforeMethod
+    public void prepareTest() {
+        testContextFactory = createTestContextFactory();
+        context = testContextFactory.getObject();
+    }
+
+    protected TestContextFactory createTestContextFactory() {
+        TestContextFactory factory = TestContextFactory.newInstance();
+        factory.getFunctionRegistry().addFunctionLibrary(new DefaultFunctionLibrary());
+        factory.getValidationMatcherRegistry().addValidationMatcherLibrary(new DefaultValidationMatcherLibrary());
+        return factory;
+    }
+}

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/actions/dsl/CamelRouteTestActionRunnerTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/actions/dsl/CamelRouteTestActionRunnerTest.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.actions.dsl;
+
+import org.apache.camel.ServiceStatus;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.camel.UnitTestSupport;
+import org.citrusframework.camel.actions.CamelControlBusAction;
+import org.citrusframework.camel.actions.CreateCamelRouteAction;
+import org.citrusframework.camel.actions.RemoveCamelRouteAction;
+import org.citrusframework.camel.actions.StopCamelRouteAction;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.camel.dsl.CamelSupport.camel;
+
+/**
+ * @author Christoph Deppisch
+ * @since 2.4
+ */
+public class CamelRouteTestActionRunnerTest extends UnitTestSupport {
+
+    private DefaultCamelContext camelContext;
+
+    @BeforeMethod
+    public void setupCamelContext() throws Exception {
+        camelContext = new DefaultCamelContext();
+        camelContext.start();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void clearCamelContext() throws Exception {
+        if (camelContext != null) {
+            camelContext.shutdown();
+        }
+    }
+
+    @Test
+    public void testCreateCamelRouteBuilder() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+
+        builder.$(camel().camelContext(camelContext)
+                .route()
+                .create(new RouteBuilder(camelContext) {
+            @Override
+            public void configure() throws Exception {
+                from("direct:news")
+                        .routeId("route_1")
+                        .setHeader("headline", simple("This is BIG news!"))
+                        .to("mock:news");
+
+                from("direct:rumors")
+                        .routeId("route_2")
+                        .setHeader("headline", simple("This is just a rumor!"))
+                        .to("mock:rumors");
+            }
+        }));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), CreateCamelRouteAction.class);
+        Assert.assertEquals(test.getActiveAction().getClass(), CreateCamelRouteAction.class);
+
+        CreateCamelRouteAction action = (CreateCamelRouteAction) test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "create-routes");
+        Assert.assertEquals(action.getRoutes().size(), 2);
+
+        Assert.assertEquals(camelContext.getRouteDefinitions().size(), 2);
+    }
+
+    @Test
+    public void testStartCamelRouteBuilder() throws Exception {
+        camelContext.addRoutes(new RouteBuilder(camelContext) {
+            @Override
+            public void configure() throws Exception {
+                from("direct:news")
+                        .routeId("route_1")
+                        .autoStartup(false)
+                        .setHeader("headline", simple("This is BIG news!"))
+                        .to("mock:news");
+
+                from("direct:rumors")
+                        .routeId("route_2")
+                        .autoStartup(false)
+                        .setHeader("headline", simple("This is just a rumor!"))
+                        .to("mock:rumors");
+            }
+        });
+
+        Assert.assertEquals(camelContext.getRouteStatus("route_1"), ServiceStatus.Stopped);
+        Assert.assertEquals(camelContext.getRouteStatus("route_2"), ServiceStatus.Stopped);
+
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(camel().camelContext(camelContext).route().start("route_1", "route_2"));
+        builder = new DefaultTestCaseRunner(context);
+        builder.$(camel().camelContext(camelContext).route().stop("route_1", "route_2"));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), StopCamelRouteAction.class);
+        Assert.assertEquals(test.getActiveAction().getClass(), StopCamelRouteAction.class);
+
+        StopCamelRouteAction action = (StopCamelRouteAction) test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "stop-routes");
+        Assert.assertEquals(action.getRouteIds().size(), 2);
+
+        Assert.assertEquals(camelContext.getRouteDefinitions().size(), 2);
+        Assert.assertEquals(camelContext.getRouteStatus("route_1"), ServiceStatus.Stopped);
+        Assert.assertEquals(camelContext.getRouteStatus("route_2"), ServiceStatus.Stopped);
+    }
+
+    @Test
+    public void testRemoveCamelRouteBuilder() throws Exception {
+        camelContext.addRoutes(new RouteBuilder(camelContext) {
+            @Override
+            public void configure() throws Exception {
+                from("direct:news")
+                        .routeId("route_1")
+                        .autoStartup(false)
+                        .setHeader("headline", simple("This is BIG news!"))
+                        .to("mock:news");
+
+                from("direct:rumors")
+                        .routeId("route_2")
+                        .autoStartup(false)
+                        .setHeader("headline", simple("This is just a rumor!"))
+                        .to("mock:rumors");
+            }
+        });
+
+        Assert.assertEquals(camelContext.getRouteDefinitions().size(), 2);
+        Assert.assertEquals(camelContext.getRouteStatus("route_1"), ServiceStatus.Stopped);
+        Assert.assertEquals(camelContext.getRouteStatus("route_2"), ServiceStatus.Stopped);
+
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(camel().camelContext(camelContext).route().remove("route_1", "route_2"));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), RemoveCamelRouteAction.class);
+        Assert.assertEquals(test.getActiveAction().getClass(), RemoveCamelRouteAction.class);
+
+        RemoveCamelRouteAction action = (RemoveCamelRouteAction) test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "remove-routes");
+        Assert.assertEquals(action.getRouteIds().size(), 2);
+
+        Assert.assertEquals(camelContext.getRouteDefinitions().size(), 0);
+    }
+
+    @Test
+    public void testDefaultCamelContextBuilder() {
+        context.getReferenceResolver().bind("camelContext", camelContext);
+
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(camel().route().create(new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("direct:news")
+                        .routeId("route_1")
+                        .setHeader("headline", simple("This is BIG news!"))
+                        .to("mock:news");
+
+                from("direct:rumors")
+                        .routeId("route_2")
+                        .setHeader("headline", simple("This is just a rumor!"))
+                        .to("mock:rumors");
+            }
+        }));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), CreateCamelRouteAction.class);
+        Assert.assertEquals(test.getActiveAction().getClass(), CreateCamelRouteAction.class);
+
+        CreateCamelRouteAction action = (CreateCamelRouteAction) test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "create-routes");
+        Assert.assertEquals(action.getRoutes().size(), 2);
+
+        Assert.assertEquals(camelContext.getRoutes().size(), 2);
+    }
+
+    @Test
+    public void testCamelControlBusBuilder() throws Exception {
+        camelContext.addRoutes(new RouteBuilder(camelContext) {
+            @Override
+            public void configure() throws Exception {
+                from("direct:news")
+                        .routeId("route_1")
+                        .autoStartup(false)
+                        .setHeader("headline", simple("This is BIG news!"))
+                        .to("mock:news");
+
+                from("direct:rumors")
+                        .routeId("route_2")
+                        .autoStartup(false)
+                        .setHeader("headline", simple("This is just a rumor!"))
+                        .to("mock:rumors");
+            }
+        });
+
+        Assert.assertEquals(camelContext.getRouteStatus("route_1"), ServiceStatus.Stopped);
+        Assert.assertEquals(camelContext.getRouteStatus("route_2"), ServiceStatus.Stopped);
+
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(camel().camelContext(camelContext)
+                .controlBus()
+                    .route("route_1", "status")
+                    .result(ServiceStatus.Stopped));
+
+        builder.$(camel().camelContext(camelContext)
+                .controlBus()
+                .route("route_1", "start"));
+
+        builder.$(camel().camelContext(camelContext)
+                .controlBus()
+                .language("${camelContext.getRouteStatus('route_1')}")
+                .result(ServiceStatus.Started));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 3);
+        Assert.assertEquals(test.getActions().get(0).getClass(), CamelControlBusAction.class);
+        Assert.assertEquals(test.getActiveAction().getClass(), CamelControlBusAction.class);
+
+        CamelControlBusAction action = (CamelControlBusAction) test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "controlbus");
+        Assert.assertEquals(action.getRouteId(), "route_1");
+        Assert.assertEquals(action.getAction(), "status");
+        Assert.assertEquals(action.getResult(), "Stopped");
+
+        action = (CamelControlBusAction) test.getActions().get(1);
+        Assert.assertEquals(action.getName(), "controlbus");
+        Assert.assertEquals(action.getRouteId(), "route_1");
+        Assert.assertEquals(action.getAction(), "start");
+        Assert.assertNull(action.getResult());
+
+        action = (CamelControlBusAction) test.getActions().get(2);
+        Assert.assertEquals(action.getName(), "controlbus");
+        Assert.assertEquals(action.getLanguageType(), "simple");
+        Assert.assertEquals(action.getLanguageExpression(), "${camelContext.getRouteStatus('route_1')}");
+        Assert.assertEquals(action.getResult(), "Started");
+
+        Assert.assertEquals(camelContext.getRouteDefinitions().size(), 2);
+        Assert.assertEquals(camelContext.getRouteStatus("route_1"), ServiceStatus.Started);
+        Assert.assertEquals(camelContext.getRouteStatus("route_2"), ServiceStatus.Stopped);
+    }
+}

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/actions/HttpServerRequestActionBuilder.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/actions/HttpServerRequestActionBuilder.java
@@ -16,9 +16,9 @@
 
 package org.citrusframework.http.actions;
 
-import jakarta.servlet.http.Cookie;
 import java.util.Optional;
 
+import jakarta.servlet.http.Cookie;
 import org.citrusframework.actions.ReceiveMessageAction;
 import org.citrusframework.http.message.HttpMessage;
 import org.citrusframework.http.message.HttpMessageBuilder;

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/UnitTestSupport.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/UnitTestSupport.java
@@ -1,0 +1,35 @@
+package org.citrusframework.http;
+
+import org.citrusframework.context.TestContext;
+import org.citrusframework.context.TestContextFactory;
+import org.citrusframework.functions.DefaultFunctionLibrary;
+import org.citrusframework.validation.matcher.DefaultValidationMatcherLibrary;
+import org.citrusframework.validation.xml.DomXmlMessageValidator;
+import org.testng.annotations.BeforeMethod;
+
+/**
+ * @author Christoph Deppisch
+ */
+public abstract class UnitTestSupport {
+
+    protected TestContextFactory testContextFactory;
+    protected TestContext context;
+
+    /**
+     * Setup test execution.
+     */
+    @BeforeMethod
+    public void prepareTest() {
+        testContextFactory = createTestContextFactory();
+        context = testContextFactory.getObject();
+    }
+
+    protected TestContextFactory createTestContextFactory() {
+        TestContextFactory factory = TestContextFactory.newInstance();
+        factory.getFunctionRegistry().addFunctionLibrary(new DefaultFunctionLibrary());
+        factory.getValidationMatcherRegistry().addValidationMatcherLibrary(new DefaultValidationMatcherLibrary());
+
+        factory.getMessageValidatorRegistry().addMessageValidator("xml", new DomXmlMessageValidator());
+        return factory;
+    }
+}

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/actions/dsl/ReceiveHttpMessageTestActionBuilderTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/actions/dsl/ReceiveHttpMessageTestActionBuilderTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.http.actions.dsl;
+
+import org.apache.hc.core5.http.ContentType;
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.actions.ReceiveMessageAction;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.endpoint.resolver.EndpointUriResolver;
+import org.citrusframework.http.UnitTestSupport;
+import org.citrusframework.http.client.HttpClient;
+import org.citrusframework.http.client.HttpEndpointConfiguration;
+import org.citrusframework.http.message.HttpMessage;
+import org.citrusframework.http.message.HttpMessageBuilder;
+import org.citrusframework.http.message.HttpMessageHeaders;
+import org.citrusframework.http.server.HttpServer;
+import org.citrusframework.message.MessageHeaders;
+import org.citrusframework.messaging.SelectiveConsumer;
+import org.citrusframework.validation.context.HeaderValidationContext;
+import org.citrusframework.validation.json.JsonMessageValidationContext;
+import org.citrusframework.validation.xml.XmlMessageValidationContext;
+import org.mockito.Mockito;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.http.actions.HttpActionBuilder.http;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class ReceiveHttpMessageTestActionBuilderTest extends UnitTestSupport {
+
+    private final SelectiveConsumer messageConsumer = Mockito.mock(SelectiveConsumer.class);
+    private final HttpEndpointConfiguration configuration = Mockito.mock(HttpEndpointConfiguration.class);
+    private final HttpClient httpClient = Mockito.mock(HttpClient.class);
+    private final HttpServer httpServer = Mockito.mock(HttpServer.class);
+
+    @Test
+    public void testHttpRequestProperties() {
+        reset(httpServer, messageConsumer, configuration);
+        when(httpServer.createConsumer()).thenReturn(messageConsumer);
+        when(httpServer.getEndpointConfiguration()).thenReturn(configuration);
+        when(configuration.getTimeout()).thenReturn(100L);
+        when(httpServer.getActor()).thenReturn(null);
+        when(messageConsumer.receive(any(TestContext.class), anyLong())).thenReturn(new HttpMessage("<TestRequest><Message>Hello World!</Message></TestRequest>")
+                .method(HttpMethod.GET)
+                .path("/test/foo")
+                .queryParam("noValue", null)
+                .queryParam("param1", "value1")
+                .queryParam("param2", "value2"));
+
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(http().server(httpServer)
+            .receive()
+            .get("/test/foo")
+            .queryParam("noValue", null)
+            .queryParam("param1", "value1")
+            .queryParam("param2", "value2")
+            .message()
+            .body("<TestRequest><Message>Hello World!</Message></TestRequest>"));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ReceiveMessageAction.class);
+
+        ReceiveMessageAction action = (ReceiveMessageAction) test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "receive");
+
+        Assert.assertEquals(action.getEndpoint(), httpServer);
+        Assert.assertEquals(action.getValidationContexts().size(), 3L);
+        Assert.assertEquals(action.getValidationContexts().get(0).getClass(), HeaderValidationContext.class);
+        Assert.assertEquals(action.getValidationContexts().get(1).getClass(), XmlMessageValidationContext.class);
+        Assert.assertEquals(action.getValidationContexts().get(2).getClass(), JsonMessageValidationContext.class);
+
+        HttpMessageBuilder messageBuilder = (HttpMessageBuilder) action.getMessageBuilder();
+        Assert.assertEquals(messageBuilder.buildMessagePayload(context, action.getMessageType()), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 5L);
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get(HttpMessageHeaders.HTTP_REQUEST_METHOD), HttpMethod.GET.name());
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get(HttpMessageHeaders.HTTP_REQUEST_URI), "/test/foo");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get(HttpMessageHeaders.HTTP_QUERY_PARAMS), "noValue,param1=value1,param2=value2");
+    }
+
+    @Test
+    public void testMessageObjectOverride() {
+        reset(httpServer, messageConsumer, configuration);
+        when(httpServer.createConsumer()).thenReturn(messageConsumer);
+        when(httpServer.getEndpointConfiguration()).thenReturn(configuration);
+        when(configuration.getTimeout()).thenReturn(100L);
+        when(httpServer.getActor()).thenReturn(null);
+        when(messageConsumer.receive(any(TestContext.class), anyLong())).thenReturn(new HttpMessage("<TestRequest><Message>Hello World!</Message></TestRequest>")
+                .method(HttpMethod.GET)
+                .path("/test/foo")
+                .header("X-Foo", "foo")
+                .header("X-Bar", "bar")
+                .contentType(ContentType.APPLICATION_XML.getMimeType())
+                .queryParam("param1", "value1"));
+
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(http().server(httpServer)
+                        .receive()
+                        .get("/test/foo")
+                        .queryParam("param1", "value1")
+                        .message(new HttpMessage("<TestRequest><Message>Hello World!</Message></TestRequest>"))
+                        .header("X-Foo", "foo")
+                        .header("X-Bar", "bar")
+                        .contentType(ContentType.APPLICATION_XML.getMimeType()));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ReceiveMessageAction.class);
+
+        ReceiveMessageAction action = (ReceiveMessageAction) test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "receive");
+
+        Assert.assertEquals(action.getEndpoint(), httpServer);
+        Assert.assertEquals(action.getValidationContexts().size(), 3L);
+        Assert.assertEquals(action.getValidationContexts().get(0).getClass(), HeaderValidationContext.class);
+        Assert.assertEquals(action.getValidationContexts().get(1).getClass(), XmlMessageValidationContext.class);
+        Assert.assertEquals(action.getValidationContexts().get(2).getClass(), JsonMessageValidationContext.class);
+
+        HttpMessageBuilder messageBuilder = (HttpMessageBuilder) action.getMessageBuilder();
+        Assert.assertEquals(messageBuilder.buildMessagePayload(context, action.getMessageType()), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 9L);
+        Assert.assertNotNull(messageBuilder.getMessage().getHeader(MessageHeaders.ID));
+        Assert.assertNotNull(messageBuilder.getMessage().getHeader(MessageHeaders.TIMESTAMP));
+        Assert.assertNotNull(messageBuilder.buildMessageHeaders(context).get(MessageHeaders.MESSAGE_TYPE), action.getMessageType());
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get(HttpMessageHeaders.HTTP_REQUEST_METHOD), HttpMethod.GET.name());
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get(HttpMessageHeaders.HTTP_REQUEST_URI), "/test/foo");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get(EndpointUriResolver.REQUEST_PATH_HEADER_NAME), "/test/foo");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get(HttpMessageHeaders.HTTP_QUERY_PARAMS), "param1=value1");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get(EndpointUriResolver.QUERY_PARAM_HEADER_NAME), "param1=value1");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get(HttpMessageHeaders.HTTP_CONTENT_TYPE), ContentType.APPLICATION_XML.getMimeType());
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get("X-Foo"), "foo");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get("X-Bar"), "bar");
+    }
+
+    @Test
+    public void testHttpResponseProperties() {
+        reset(httpClient, messageConsumer, configuration);
+        when(httpClient.createConsumer()).thenReturn(messageConsumer);
+        when(httpClient.getEndpointConfiguration()).thenReturn(configuration);
+        when(configuration.getTimeout()).thenReturn(100L);
+        when(httpClient.getActor()).thenReturn(null);
+        when(messageConsumer.receive(any(TestContext.class), anyLong())).thenReturn(new HttpMessage("<TestRequest><Message>Hello World!</Message></TestRequest>")
+                .method(HttpMethod.GET)
+                .uri("/test")
+                .status(HttpStatus.OK)
+                .version("HTTP/1.1"));
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(http().client(httpClient)
+                        .receive()
+                        .response(HttpStatus.OK)
+                        .message()
+                        .version("HTTP/1.1")
+                        .body("<TestRequest><Message>Hello World!</Message></TestRequest>"));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ReceiveMessageAction.class);
+
+        ReceiveMessageAction action = (ReceiveMessageAction) test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "receive");
+
+        Assert.assertEquals(action.getEndpoint(), httpClient);
+        Assert.assertEquals(action.getValidationContexts().size(), 3L);
+        Assert.assertEquals(action.getValidationContexts().get(0).getClass(), HeaderValidationContext.class);
+        Assert.assertEquals(action.getValidationContexts().get(1).getClass(), XmlMessageValidationContext.class);
+        Assert.assertEquals(action.getValidationContexts().get(2).getClass(), JsonMessageValidationContext.class);
+
+        HttpMessageBuilder messageBuilder = (HttpMessageBuilder) action.getMessageBuilder();
+        Assert.assertEquals(messageBuilder.buildMessagePayload(context, action.getMessageType()), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 3L);
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get(HttpMessageHeaders.HTTP_STATUS_CODE), 200);
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get(HttpMessageHeaders.HTTP_REASON_PHRASE), "OK");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get(HttpMessageHeaders.HTTP_VERSION), "HTTP/1.1");
+    }
+
+}

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/actions/dsl/SendHttpMessageTestActionBuilderTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/actions/dsl/SendHttpMessageTestActionBuilderTest.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.http.actions.dsl;
+
+import jakarta.servlet.http.Cookie;
+import org.apache.hc.core5.http.ContentType;
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.actions.SendMessageAction;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.endpoint.resolver.EndpointUriResolver;
+import org.citrusframework.http.UnitTestSupport;
+import org.citrusframework.http.client.HttpClient;
+import org.citrusframework.http.message.HttpMessage;
+import org.citrusframework.http.message.HttpMessageBuilder;
+import org.citrusframework.http.message.HttpMessageHeaders;
+import org.citrusframework.message.DefaultMessage;
+import org.citrusframework.message.Message;
+import org.citrusframework.message.MessageHeaders;
+import org.citrusframework.message.MessageType;
+import org.citrusframework.messaging.Producer;
+import org.mockito.Mockito;
+import org.springframework.http.HttpMethod;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.http.actions.HttpActionBuilder.http;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class SendHttpMessageTestActionBuilderTest extends UnitTestSupport {
+
+    private final HttpClient httpClient = Mockito.mock(HttpClient.class);
+    private final Producer messageProducer = Mockito.mock(Producer.class);
+
+    @Test
+    public void testFork() {
+        reset(httpClient, messageProducer);
+        when(httpClient.createProducer()).thenReturn(messageProducer);
+        when(httpClient.getActor()).thenReturn(null);
+        doAnswer(invocation -> {
+            Message message = (Message) invocation.getArguments()[0];
+            Assert.assertEquals(message.getPayload(String.class), "Foo");
+            return null;
+        }).doAnswer(invocation -> {
+            Message message = (Message) invocation.getArguments()[0];
+            Assert.assertEquals(message.getPayload(String.class), "Bar");
+            return null;
+        }).when(messageProducer).send(any(Message.class), any(TestContext.class));
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(http().client(httpClient)
+                        .send()
+                        .get()
+                        .message(new DefaultMessage("Foo").setHeader("operation", "foo"))
+                        .type(MessageType.PLAINTEXT)
+                        .header("additional", "additionalValue"));
+
+        builder.$(http().client(httpClient)
+                .send()
+                .post()
+                .message(new DefaultMessage("Bar").setHeader("operation", "bar"))
+                .type(MessageType.PLAINTEXT)
+                .fork(true));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 2);
+        Assert.assertEquals(test.getActions().get(0).getClass(), SendMessageAction.class);
+        Assert.assertEquals(test.getActions().get(1).getClass(), SendMessageAction.class);
+
+        SendMessageAction action = ((SendMessageAction)(test.getActions().get(0)));
+        Assert.assertEquals(action.getName(), "send");
+
+        Assert.assertEquals(action.getEndpoint(), httpClient);
+        Assert.assertEquals(action.getMessageBuilder().getClass(), HttpMessageBuilder.class);
+
+        HttpMessageBuilder messageBuilder = (HttpMessageBuilder) action.getMessageBuilder();
+        Assert.assertEquals(messageBuilder.getMessage().getPayload(String.class), "Foo");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 4L);
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get(MessageHeaders.MESSAGE_TYPE), MessageType.PLAINTEXT.name());
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get(HttpMessageHeaders.HTTP_REQUEST_METHOD), HttpMethod.GET.name());
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get("operation"), "foo");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get("additional"), "additionalValue");
+
+        Assert.assertFalse(action.isForkMode());
+
+        action = ((SendMessageAction)test.getActions().get(1));
+        Assert.assertEquals(action.getName(), "send");
+
+        messageBuilder = (HttpMessageBuilder) action.getMessageBuilder();
+        Assert.assertEquals(action.getEndpoint(), httpClient);
+        Assert.assertEquals(action.getMessageBuilder().getClass(), HttpMessageBuilder.class);
+        Assert.assertEquals(messageBuilder.getMessage().getPayload(String.class), "Bar");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 3L);
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get(MessageHeaders.MESSAGE_TYPE), MessageType.PLAINTEXT.name());
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get(HttpMessageHeaders.HTTP_REQUEST_METHOD), HttpMethod.POST.name());
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get("operation"), "bar");
+
+        Assert.assertTrue(action.isForkMode());
+    }
+
+    @Test
+    public void testMessageObjectOverride() {
+        reset(httpClient, messageProducer);
+        when(httpClient.createProducer()).thenReturn(messageProducer);
+        when(httpClient.getActor()).thenReturn(null);
+        doAnswer(invocation -> {
+            Message message = (Message) invocation.getArguments()[0];
+            Assert.assertEquals(message.getPayload(String.class), "Foo");
+            return null;
+        }).when(messageProducer).send(any(Message.class), any(TestContext.class));
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(http().client(httpClient)
+            .send()
+            .get()
+            .message(new HttpMessage("Foo")
+                    .cookie(new Cookie("Bar", "987654"))
+                    .setHeader("operation", "foo"))
+            .cookie(new Cookie("Foo", "123456"))
+            .contentType(ContentType.APPLICATION_JSON.getMimeType())
+            .type(MessageType.PLAINTEXT)
+            .header("additional", "additionalValue"));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), SendMessageAction.class);
+
+        SendMessageAction action = ((SendMessageAction)(test.getActions().get(0)));
+        Assert.assertEquals(action.getName(), "send");
+
+        Assert.assertEquals(action.getEndpoint(), httpClient);
+        Assert.assertEquals(action.getMessageBuilder().getClass(), HttpMessageBuilder.class);
+
+        HttpMessageBuilder messageBuilder = (HttpMessageBuilder) action.getMessageBuilder();
+        Assert.assertEquals(messageBuilder.getMessage().getPayload(String.class), "Foo");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 7L);
+        Assert.assertNotEquals(messageBuilder.buildMessageHeaders(context).get(MessageHeaders.MESSAGE_TYPE), MessageType.PLAINTEXT);
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get(HttpMessageHeaders.HTTP_REQUEST_METHOD), HttpMethod.GET.name());
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get("Content-Type"), ContentType.APPLICATION_JSON.getMimeType());
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get("operation"), "foo");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get("additional"), "additionalValue");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get(HttpMessageHeaders.HTTP_COOKIE_PREFIX + "Foo"), "Foo=123456");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get(HttpMessageHeaders.HTTP_COOKIE_PREFIX + "Bar"), "Bar=987654");
+        Assert.assertEquals(((HttpMessage) messageBuilder.getMessage()).getCookies().size(), 2L);
+        Assert.assertTrue(((HttpMessage) messageBuilder.getMessage()).getCookies().stream().anyMatch(cookie -> cookie.getName().equals("Foo")));
+        Assert.assertTrue(((HttpMessage) messageBuilder.getMessage()).getCookies().stream().anyMatch(cookie -> cookie.getName().equals("Bar")));
+    }
+
+    @Test
+    public void testHttpMethod() {
+        reset(httpClient, messageProducer);
+        when(httpClient.createProducer()).thenReturn(messageProducer);
+        when(httpClient.getActor()).thenReturn(null);
+        doAnswer(invocation -> {
+            Message message = (Message) invocation.getArguments()[0];
+            Assert.assertEquals(message.getPayload(String.class), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+            Assert.assertEquals(message.getHeader(HttpMessageHeaders.HTTP_REQUEST_METHOD), HttpMethod.GET.name());
+            return null;
+        }).when(messageProducer).send(any(Message.class), any(TestContext.class));
+
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(http().client(httpClient)
+                        .send()
+                        .get()
+                        .message()
+                        .body("<TestRequest><Message>Hello World!</Message></TestRequest>"));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), SendMessageAction.class);
+
+        SendMessageAction action = ((SendMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "send");
+
+        Assert.assertEquals(action.getEndpoint(), httpClient);
+        Assert.assertEquals(action.getMessageBuilder().getClass(), HttpMessageBuilder.class);
+
+        HttpMessageBuilder messageBuilder = (HttpMessageBuilder) action.getMessageBuilder();
+        Assert.assertEquals(messageBuilder.getMessage().getPayload(), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 1L);
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get(HttpMessageHeaders.HTTP_REQUEST_METHOD), HttpMethod.GET.name());
+    }
+
+    @Test
+    public void testHttpRequestUriAndPath() {
+        reset(httpClient, messageProducer);
+        when(httpClient.createProducer()).thenReturn(messageProducer);
+        when(httpClient.getActor()).thenReturn(null);
+        doAnswer(invocation -> {
+            Message message = (Message) invocation.getArguments()[0];
+            Assert.assertEquals(message.getPayload(String.class), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+            Assert.assertEquals(message.getHeader(EndpointUriResolver.ENDPOINT_URI_HEADER_NAME), "http://localhost:8080/");
+            Assert.assertEquals(message.getHeader(EndpointUriResolver.REQUEST_PATH_HEADER_NAME), "/test");
+            return null;
+        }).when(messageProducer).send(any(Message.class), any(TestContext.class));
+
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(http().client(httpClient)
+                        .send()
+                        .get("/test")
+                        .uri("http://localhost:8080/")
+                        .message()
+                        .body("<TestRequest><Message>Hello World!</Message></TestRequest>"));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), SendMessageAction.class);
+
+        SendMessageAction action = ((SendMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "send");
+
+        Assert.assertEquals(action.getEndpoint(), httpClient);
+        Assert.assertEquals(action.getMessageBuilder().getClass(), HttpMessageBuilder.class);
+
+        HttpMessageBuilder messageBuilder = (HttpMessageBuilder) action.getMessageBuilder();
+        Assert.assertEquals(messageBuilder.getMessage().getPayload(), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 4L);
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get(HttpMessageHeaders.HTTP_REQUEST_METHOD), "GET");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get(HttpMessageHeaders.HTTP_REQUEST_URI), "http://localhost:8080/");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get(EndpointUriResolver.ENDPOINT_URI_HEADER_NAME), "http://localhost:8080/");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get(EndpointUriResolver.REQUEST_PATH_HEADER_NAME), "/test");
+    }
+
+    @Test
+    public void testHttpRequestUriAndQueryParams() {
+        reset(httpClient, messageProducer);
+        when(httpClient.createProducer()).thenReturn(messageProducer);
+        when(httpClient.getActor()).thenReturn(null);
+        doAnswer(invocation -> {
+            Message message = (Message) invocation.getArguments()[0];
+            Assert.assertEquals(message.getPayload(String.class), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+            Assert.assertEquals(message.getHeader(EndpointUriResolver.ENDPOINT_URI_HEADER_NAME), "http://localhost:8080/");
+            Assert.assertEquals(message.getHeader(EndpointUriResolver.QUERY_PARAM_HEADER_NAME), "param1=value1,param2=value2");
+            return null;
+        }).when(messageProducer).send(any(Message.class), any(TestContext.class));
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(http().client(httpClient)
+                        .send()
+                        .get()
+                        .uri("http://localhost:8080/")
+                        .queryParam("param1", "value1")
+                        .queryParam("param2", "value2")
+                        .message()
+                        .body("<TestRequest><Message>Hello World!</Message></TestRequest>"));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), SendMessageAction.class);
+
+        SendMessageAction action = ((SendMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "send");
+
+        Assert.assertEquals(action.getEndpoint(), httpClient);
+        Assert.assertEquals(action.getMessageBuilder().getClass(), HttpMessageBuilder.class);
+
+        HttpMessageBuilder messageBuilder = (HttpMessageBuilder) action.getMessageBuilder();
+        Assert.assertEquals(messageBuilder.getMessage().getPayload(), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 5L);
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get(HttpMessageHeaders.HTTP_REQUEST_METHOD), "GET");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get(HttpMessageHeaders.HTTP_REQUEST_URI), "http://localhost:8080/");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get(HttpMessageHeaders.HTTP_QUERY_PARAMS), "param1=value1,param2=value2");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get(EndpointUriResolver.ENDPOINT_URI_HEADER_NAME), "http://localhost:8080/");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get(EndpointUriResolver.QUERY_PARAM_HEADER_NAME), "param1=value1,param2=value2");
+    }
+
+}

--- a/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/UnitTestSupport.java
+++ b/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/UnitTestSupport.java
@@ -1,0 +1,32 @@
+package org.citrusframework.jms;
+
+import org.citrusframework.context.TestContext;
+import org.citrusframework.context.TestContextFactory;
+import org.citrusframework.functions.DefaultFunctionLibrary;
+import org.citrusframework.validation.matcher.DefaultValidationMatcherLibrary;
+import org.testng.annotations.BeforeMethod;
+
+/**
+ * @author Christoph Deppisch
+ */
+public abstract class UnitTestSupport {
+
+    protected TestContextFactory testContextFactory;
+    protected TestContext context;
+
+    /**
+     * Setup test execution.
+     */
+    @BeforeMethod
+    public void prepareTest() {
+        testContextFactory = createTestContextFactory();
+        context = testContextFactory.getObject();
+    }
+
+    protected TestContextFactory createTestContextFactory() {
+        TestContextFactory factory = TestContextFactory.newInstance();
+        factory.getFunctionRegistry().addFunctionLibrary(new DefaultFunctionLibrary());
+        factory.getValidationMatcherRegistry().addValidationMatcherLibrary(new DefaultValidationMatcherLibrary());
+        return factory;
+    }
+}

--- a/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/actions/dsl/PurgeJmsQueueTestActionBuilderTest.java
+++ b/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/actions/dsl/PurgeJmsQueueTestActionBuilderTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.jms.actions.dsl;
+
+import jakarta.jms.Connection;
+import jakarta.jms.ConnectionFactory;
+import jakarta.jms.Destination;
+import jakarta.jms.JMSException;
+import jakarta.jms.MessageConsumer;
+import jakarta.jms.Queue;
+import jakarta.jms.Session;
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.jms.UnitTestSupport;
+import org.citrusframework.jms.actions.PurgeJmsQueuesAction;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.jms.actions.PurgeJmsQueuesAction.Builder.purgeQueues;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ * @since 2.3
+ */
+public class PurgeJmsQueueTestActionBuilderTest extends UnitTestSupport {
+    private final ConnectionFactory connectionFactory = Mockito.mock(ConnectionFactory.class);
+    private final Connection connection = Mockito.mock(Connection.class);
+    private final Session session = Mockito.mock(Session.class);
+    private final MessageConsumer messageConsumer = Mockito.mock(MessageConsumer.class);
+    private final Queue queue1 = Mockito.mock(Queue.class);
+    private final Queue queue2 = Mockito.mock(Queue.class);
+    private final Queue queue3 = Mockito.mock(Queue.class);
+    private final Queue queue4 = Mockito.mock(Queue.class);
+
+    @Test
+    public void testPurgeJmsQueuesBuilderWithQueueNames() throws JMSException {
+        reset(connectionFactory, connection, session, messageConsumer, queue1, queue2, queue3, queue4);
+        when(connectionFactory.createConnection()).thenReturn(connection);
+        when(connection.createSession(false, Session.AUTO_ACKNOWLEDGE)).thenReturn(session);
+        when(session.createConsumer(any(Destination.class))).thenReturn(messageConsumer);
+
+        when(session.createQueue("q1")).thenReturn(queue1);
+        when(session.createQueue("q2")).thenReturn(queue2);
+        when(session.createQueue("q3")).thenReturn(queue3);
+        when(session.createQueue("q4")).thenReturn(queue4);
+
+        when(messageConsumer.receive(200L)).thenReturn(null);
+
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(purgeQueues().connectionFactory(connectionFactory)
+            .queueNames("q1", "q2", "q3")
+            .queue("q4")
+            .timeout(200L)
+            .sleep(150L));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), PurgeJmsQueuesAction.class);
+        Assert.assertEquals(test.getActions().get(0).getName(), "purge-queue");
+
+        PurgeJmsQueuesAction action = (PurgeJmsQueuesAction)test.getActions().get(0);
+        Assert.assertEquals(action.getReceiveTimeout(), 200L);
+        Assert.assertEquals(action.getSleepTime(), 150L);
+        Assert.assertEquals(action.getConnectionFactory(), connectionFactory);
+        Assert.assertEquals(action.getQueueNames().size(), 4);
+        Assert.assertEquals(action.getQueueNames().toString(), "[q1, q2, q3, q4]");
+        Assert.assertEquals(action.getQueues().size(), 0);
+
+        verify(connection).start();
+    }
+
+    @Test
+    public void testPurgeJmsQueuesBuilderWithQueues() throws JMSException {
+        reset(connectionFactory, connection, session, messageConsumer, queue1, queue2, queue3, queue4);
+        when(connectionFactory.createConnection()).thenReturn(connection);
+        when(connection.createSession(false, Session.AUTO_ACKNOWLEDGE)).thenReturn(session);
+        when(session.createConsumer(any(Destination.class))).thenReturn(messageConsumer);
+
+        when(queue1.getQueueName()).thenReturn("q1");
+        when(queue2.getQueueName()).thenReturn("q2");
+        when(queue3.getQueueName()).thenReturn("q3");
+
+        when(messageConsumer.receive(200L)).thenReturn(null);
+
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(purgeQueues().connectionFactory(connectionFactory)
+            .queues(queue1, queue2)
+            .queue(queue3)
+            .timeout(200L)
+            .sleep(150L));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), PurgeJmsQueuesAction.class);
+
+        PurgeJmsQueuesAction action = (PurgeJmsQueuesAction)test.getActions().get(0);
+        Assert.assertEquals(action.getReceiveTimeout(), 200L);
+        Assert.assertEquals(action.getSleepTime(), 150L);
+        Assert.assertEquals(action.getConnectionFactory(), connectionFactory);
+        Assert.assertEquals(action.getQueueNames().size(), 0);
+        Assert.assertEquals(action.getQueues().size(), 3);
+        Assert.assertEquals(action.getQueues().toString(), "[" + queue1.toString() + ", " + queue2.toString() + ", " + queue3.toString() + "]");
+
+        verify(connection).start();
+    }
+
+}

--- a/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/actions/PurgeMessageChannelAction.java
+++ b/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/actions/PurgeMessageChannelAction.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.citrusframework.AbstractTestActionBuilder;
 import org.citrusframework.spi.ReferenceResolver;
 import org.citrusframework.context.TestContext;
+import org.citrusframework.spi.ReferenceResolverAware;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.BeanFactory;
@@ -128,7 +129,7 @@ public class PurgeMessageChannelAction extends AbstractTestAction {
 
     /**
      * Gets the channelNames.
-     * @return the channelNames the channelNames to get.
+     * @return the channelNames to get.
      */
     public List<String> getChannelNames() {
         return channelNames;
@@ -136,7 +137,7 @@ public class PurgeMessageChannelAction extends AbstractTestAction {
 
     /**
      * Gets the channels.
-     * @return the channels the channels to get.
+     * @return the channels to get.
      */
     public List<MessageChannel> getChannels() {
         return channels;
@@ -144,7 +145,7 @@ public class PurgeMessageChannelAction extends AbstractTestAction {
 
     /**
      * Gets the messageSelector.
-     * @return the messageSelector the messageSelector to get.
+     * @return the messageSelector to get.
      */
     public MessageSelector getMessageSelector() {
         return messageSelector;
@@ -152,7 +153,7 @@ public class PurgeMessageChannelAction extends AbstractTestAction {
 
     /**
      * Gets the channelResolver.
-     * @return the channelResolver the channelResolver to get.
+     * @return the channelResolver to get.
      */
     public DestinationResolver<MessageChannel> getChannelResolver() {
         return channelResolver;
@@ -161,13 +162,15 @@ public class PurgeMessageChannelAction extends AbstractTestAction {
     /**
      * Action builder.
      */
-    public static final class Builder extends AbstractTestActionBuilder<PurgeMessageChannelAction, Builder> {
+    public static final class Builder extends AbstractTestActionBuilder<PurgeMessageChannelAction, Builder> implements ReferenceResolverAware {
 
-        private List<String> channelNames = new ArrayList<>();
-        private List<MessageChannel> channels = new ArrayList<>();
+        private final List<String> channelNames = new ArrayList<>();
+        private final List<MessageChannel> channels = new ArrayList<>();
         private BeanFactory beanFactory;
         private DestinationResolver<MessageChannel> channelResolver;
         private MessageSelector messageSelector = new AllAcceptingMessageSelector();
+
+        private ReferenceResolver referenceResolver;
 
         /**
          * Fluent API action building entry method used in Java DSL.
@@ -279,8 +282,22 @@ public class PurgeMessageChannelAction extends AbstractTestAction {
             return this;
         }
 
+        public Builder withReferenceResolver(ReferenceResolver referenceResolver) {
+            this.referenceResolver = referenceResolver;
+            return this;
+        }
+
+        @Override
+        public void setReferenceResolver(ReferenceResolver referenceResolver) {
+            this.referenceResolver = referenceResolver;
+        }
+
         @Override
         public PurgeMessageChannelAction build() {
+            if (!channelNames.isEmpty() && channelResolver == null && referenceResolver != null) {
+                this.channelResolver = channelName -> referenceResolver.resolve(channelName, MessageChannel.class);
+            }
+
             return new PurgeMessageChannelAction(this);
         }
     }

--- a/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/actions/dsl/PurgeMessageChannelTestActionBuilderTest.java
+++ b/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/actions/dsl/PurgeMessageChannelTestActionBuilderTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.actions.dsl;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.actions.PurgeMessageChannelAction;
+import org.citrusframework.container.SequenceAfterTest;
+import org.citrusframework.container.SequenceBeforeTest;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.report.TestActionListeners;
+import org.citrusframework.spi.ReferenceResolver;
+import org.mockito.Mockito;
+import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.core.MessageSelector;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.core.DestinationResolver;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.PurgeMessageChannelAction.Builder.purgeChannels;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ * @since 2.3
+ */
+public class PurgeMessageChannelTestActionBuilderTest extends UnitTestSupport {
+
+    private final MessageSelector messageSelector = Mockito.mock(MessageSelector.class);
+    private final DestinationResolver channelResolver = Mockito.mock(DestinationResolver.class);
+
+    private final QueueChannel channel1 = Mockito.mock(QueueChannel.class);
+    private final QueueChannel channel2 = Mockito.mock(QueueChannel.class);
+    private final QueueChannel channel3 = Mockito.mock(QueueChannel.class);
+    private final MessageChannel channel4 = Mockito.mock(MessageChannel.class);
+
+    private final ReferenceResolver referenceResolver = Mockito.mock(ReferenceResolver.class);
+
+    @Test
+    public void testPurgeChannelsBuilderWithChannels() {
+        reset(channel1, channel2, channel3, channel4);
+
+        when(channel1.purge(any(MessageSelector.class))).thenReturn(new ArrayList<>());
+        when(channel2.purge(any(MessageSelector.class))).thenReturn(new ArrayList<>());
+        when(channel3.purge(any(MessageSelector.class))).thenReturn(new ArrayList<>());
+
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(purgeChannels().channels(channel1, channel2)
+                        .channel(channel3));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), PurgeMessageChannelAction.class);
+        Assert.assertEquals(test.getActions().get(0).getName(), "purge-channel");
+
+        PurgeMessageChannelAction action = (PurgeMessageChannelAction) test.getActions().get(0);
+        Assert.assertEquals(action.getChannels().size(), 3);
+        Assert.assertEquals(action.getChannels().toString(), "[" + channel1.toString() + ", " + channel2.toString() + ", " + channel3.toString() + "]");
+        Assert.assertNotNull(action.getMessageSelector());
+        Assert.assertEquals(action.getMessageSelector().getClass(), PurgeMessageChannelAction.AllAcceptingMessageSelector.class);
+    }
+
+    @Test
+    public void testPurgeChannelBuilderWithNames() {
+        reset(referenceResolver, channel1, channel2, channel3, channel4);
+
+        when(referenceResolver.resolve(TestContext.class)).thenReturn(context);
+        when(referenceResolver.resolve(TestActionListeners.class)).thenReturn(new TestActionListeners());
+        when(referenceResolver.resolveAll(SequenceBeforeTest.class)).thenReturn(new HashMap<>());
+        when(referenceResolver.resolveAll(SequenceAfterTest.class)).thenReturn(new HashMap<>());
+        when(referenceResolver.resolve("ch1", MessageChannel.class)).thenReturn(channel1);
+        when(referenceResolver.resolve("ch2", MessageChannel.class)).thenReturn(channel2);
+        when(referenceResolver.resolve("ch3", MessageChannel.class)).thenReturn(channel3);
+        when(referenceResolver.resolve("ch4", MessageChannel.class)).thenReturn(channel4);
+
+        when(channel1.purge(any(MessageSelector.class))).thenReturn(new ArrayList<>());
+        when(channel2.purge(any(MessageSelector.class))).thenReturn(new ArrayList<>());
+        when(channel3.purge(any(MessageSelector.class))).thenReturn(new ArrayList<>());
+
+        context.setReferenceResolver(referenceResolver);
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(purgeChannels().channelNames("ch1", "ch2", "ch3")
+                        .channel("ch4")
+                        .selector(messageSelector));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), PurgeMessageChannelAction.class);
+
+        PurgeMessageChannelAction action = (PurgeMessageChannelAction) test.getActions().get(0);
+        Assert.assertEquals(action.getChannelNames().size(), 4);
+        Assert.assertEquals(action.getChannelNames().toString(), "[ch1, ch2, ch3, ch4]");
+        Assert.assertNotNull(action.getChannelResolver());
+        Assert.assertEquals(action.getMessageSelector(), messageSelector);
+    }
+
+    @Test
+    public void testCustomChannelResolver() {
+        reset(referenceResolver, channelResolver, channel1);
+
+        when(referenceResolver.resolve(TestContext.class)).thenReturn(context);
+        when(referenceResolver.resolve(TestActionListeners.class)).thenReturn(new TestActionListeners());
+        when(referenceResolver.resolveAll(SequenceBeforeTest.class)).thenReturn(new HashMap<>());
+        when(referenceResolver.resolveAll(SequenceAfterTest.class)).thenReturn(new HashMap<>());
+
+        when(channelResolver.resolveDestination("ch1")).thenReturn(channel1);
+        when(channel1.purge(any(MessageSelector.class))).thenReturn(new ArrayList<>());
+
+        context.setReferenceResolver(referenceResolver);
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(purgeChannels().channel("ch1")
+                        .channelResolver(channelResolver));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), PurgeMessageChannelAction.class);
+
+        PurgeMessageChannelAction action = (PurgeMessageChannelAction) test.getActions().get(0);
+        Assert.assertEquals(action.getChannelNames().size(), 1);
+        Assert.assertEquals(action.getChannelNames().toString(), "[ch1]");
+        Assert.assertNotNull(action.getChannelResolver());
+        Assert.assertEquals(action.getChannelResolver(), channelResolver);
+    }
+}

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/TextEqualsMessageValidator.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/TextEqualsMessageValidator.java
@@ -1,0 +1,38 @@
+package org.citrusframework.ws;
+
+import org.citrusframework.context.TestContext;
+import org.citrusframework.message.Message;
+import org.citrusframework.message.MessageType;
+import org.citrusframework.validation.DefaultMessageValidator;
+import org.citrusframework.validation.context.ValidationContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+
+/**
+ * Basic message validator performs String equals on received message payloads. We add this validator in order to have a
+ * matching message validation strategy for integration tests in this module.
+ * @author Christoph Deppisch
+ */
+public class TextEqualsMessageValidator extends DefaultMessageValidator {
+
+    @Override
+    public void validateMessage(Message receivedMessage, Message controlMessage, TestContext context, ValidationContext validationContext) {
+        Logger log = LoggerFactory.getLogger("TextEqualsMessageValidator");
+
+        if (controlMessage.getPayload(String.class).isBlank()) {
+            log.info("Skip text validation as no control message payload specified");
+            return;
+        }
+
+        Assert.assertEquals(receivedMessage.getPayload(String.class), controlMessage.getPayload(String.class), "Validation failed - " +
+                "expected message contents not equal!");
+
+        log.info("Text validation successful: All values OK");
+    }
+
+    @Override
+    public boolean supportsMessageType(String messageType, Message message) {
+        return messageType.equalsIgnoreCase(MessageType.PLAINTEXT.toString());
+    }
+}

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/UnitTestSupport.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/UnitTestSupport.java
@@ -4,6 +4,7 @@ import org.citrusframework.context.TestContextFactory;
 import org.citrusframework.functions.DefaultFunctionLibrary;
 import org.citrusframework.testng.AbstractTestNGUnitTest;
 import org.citrusframework.validation.matcher.DefaultValidationMatcherLibrary;
+import org.citrusframework.validation.xml.DomXmlMessageValidator;
 
 /**
  * @author Christoph Deppisch
@@ -15,6 +16,9 @@ public abstract class UnitTestSupport extends AbstractTestNGUnitTest {
         TestContextFactory factory = super.createTestContextFactory();
         factory.getFunctionRegistry().addFunctionLibrary(new DefaultFunctionLibrary());
         factory.getValidationMatcherRegistry().addValidationMatcherLibrary(new DefaultValidationMatcherLibrary());
+
+        factory.getMessageValidatorRegistry().addMessageValidator("xml", new DomXmlMessageValidator());
+        factory.getMessageValidatorRegistry().addMessageValidator("text", new TextEqualsMessageValidator());
         return factory;
     }
 }

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/actions/dsl/ReceiveSoapMessageTestActionBuilderTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/actions/dsl/ReceiveSoapMessageTestActionBuilderTest.java
@@ -1,0 +1,360 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.ws.actions.dsl;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.HashMap;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.container.SequenceAfterTest;
+import org.citrusframework.container.SequenceBeforeTest;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.endpoint.Endpoint;
+import org.citrusframework.endpoint.EndpointConfiguration;
+import org.citrusframework.message.DefaultMessage;
+import org.citrusframework.message.MessageType;
+import org.citrusframework.messaging.Consumer;
+import org.citrusframework.report.TestActionListeners;
+import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.validation.builder.StaticMessageBuilder;
+import org.citrusframework.validation.context.HeaderValidationContext;
+import org.citrusframework.validation.json.JsonMessageValidationContext;
+import org.citrusframework.validation.xml.XmlMessageValidationContext;
+import org.citrusframework.ws.UnitTestSupport;
+import org.citrusframework.ws.actions.ReceiveSoapMessageAction;
+import org.citrusframework.ws.message.SoapAttachment;
+import org.citrusframework.ws.message.SoapMessage;
+import org.citrusframework.ws.server.WebServiceServer;
+import org.mockito.Mockito;
+import org.springframework.core.io.Resource;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.ws.actions.SoapActionBuilder.soap;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class ReceiveSoapMessageTestActionBuilderTest extends UnitTestSupport {
+
+    private final Consumer messageConsumer = Mockito.mock(Consumer.class);
+    private final EndpointConfiguration configuration = Mockito.mock(EndpointConfiguration.class);
+    private final WebServiceServer server = Mockito.mock(WebServiceServer.class);
+    private final ReferenceResolver referenceResolver = Mockito.mock(ReferenceResolver.class);
+    private final Resource resource = Mockito.mock(Resource.class);
+
+    private final SoapAttachment testAttachment = new SoapAttachment();
+
+    /**
+     * Setup test attachment.
+     */
+    @BeforeClass
+    public void setup() {
+        testAttachment.setContentId("attachment01");
+        testAttachment.setContent("This is an attachment");
+        testAttachment.setContentType("text/plain");
+        testAttachment.setCharsetName("UTF-8");
+    }
+
+    @Test
+    public void testWebServiceServerReceive() {
+        reset(server, messageConsumer, configuration);
+        when(server.createConsumer()).thenReturn(messageConsumer);
+        when(server.getEndpointConfiguration()).thenReturn(configuration);
+        when(configuration.getTimeout()).thenReturn(100L);
+        when(server.getActor()).thenReturn(null);
+        when(messageConsumer.receive(any(TestContext.class), anyLong())).thenReturn(new SoapMessage("Foo")
+                .setHeader("operation","foo")
+                .addAttachment(testAttachment));
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(soap().server(server)
+                        .receive()
+                        .message(new DefaultMessage("Foo").setHeader("operation", "foo"))
+                        .attachment(testAttachment));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ReceiveSoapMessageAction.class);
+
+        ReceiveSoapMessageAction action = ((ReceiveSoapMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "receive");
+
+        Assert.assertEquals(action.getMessageType(), MessageType.PLAINTEXT.name());
+        Assert.assertEquals(action.getEndpoint(), server);
+        Assert.assertEquals(action.getValidationContexts().size(), 3);
+        Assert.assertEquals(action.getValidationContexts().get(0).getClass(), HeaderValidationContext.class);
+        Assert.assertEquals(action.getValidationContexts().get(1).getClass(), XmlMessageValidationContext.class);
+        Assert.assertEquals(action.getValidationContexts().get(2).getClass(), JsonMessageValidationContext.class);
+
+        Assert.assertTrue(action.getMessageBuilder() instanceof StaticMessageBuilder);
+        Assert.assertEquals(((StaticMessageBuilder)action.getMessageBuilder()).buildMessagePayload(context, action.getMessageType()), "Foo");
+        Assert.assertNotNull(((StaticMessageBuilder)action.getMessageBuilder()).getMessage().getHeader("operation"));
+
+        Assert.assertEquals(action.getAttachments().size(), 1L);
+        Assert.assertNull(action.getAttachments().get(0).getContentResourcePath());
+        Assert.assertEquals(action.getAttachments().get(0).getContent(), testAttachment.getContent());
+        Assert.assertEquals(action.getAttachments().get(0).getContentId(), testAttachment.getContentId());
+        Assert.assertEquals(action.getAttachments().get(0).getContentType(), testAttachment.getContentType());
+        Assert.assertEquals(action.getAttachments().get(0).getCharsetName(), testAttachment.getCharsetName());
+    }
+
+    @Test
+    public void testSoapAttachment() {
+        reset(server, messageConsumer, configuration);
+        when(server.createConsumer()).thenReturn(messageConsumer);
+        when(server.getEndpointConfiguration()).thenReturn(configuration);
+        when(configuration.getTimeout()).thenReturn(100L);
+        when(server.getActor()).thenReturn(null);
+        when(messageConsumer.receive(any(TestContext.class), anyLong())).thenReturn(new SoapMessage("<TestRequest><Message>Hello World!</Message></TestRequest>")
+                .setHeader("operation","foo")
+                .addAttachment(testAttachment));
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(soap().server(server)
+                        .receive()
+                        .message(new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>").setHeader("operation", "foo"))
+                        .attachment(testAttachment));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ReceiveSoapMessageAction.class);
+
+        ReceiveSoapMessageAction action = ((ReceiveSoapMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "receive");
+
+        Assert.assertEquals(action.getMessageType(), MessageType.XML.name());
+        Assert.assertEquals(action.getEndpoint(), server);
+        Assert.assertEquals(action.getValidationContexts().size(), 3);
+        Assert.assertEquals(action.getValidationContexts().get(0).getClass(), HeaderValidationContext.class);
+        Assert.assertEquals(action.getValidationContexts().get(1).getClass(), XmlMessageValidationContext.class);
+        Assert.assertEquals(action.getValidationContexts().get(2).getClass(), JsonMessageValidationContext.class);
+
+        Assert.assertTrue(action.getMessageBuilder() instanceof StaticMessageBuilder);
+        Assert.assertEquals(((StaticMessageBuilder)action.getMessageBuilder()).buildMessagePayload(context, action.getMessageType()), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+        Assert.assertNotNull(((StaticMessageBuilder)action.getMessageBuilder()).getMessage().getHeader("operation"));
+
+        Assert.assertEquals(action.getAttachments().size(), 1L);
+        Assert.assertNull(action.getAttachments().get(0).getContentResourcePath());
+        Assert.assertEquals(action.getAttachments().get(0).getContent(), testAttachment.getContent());
+        Assert.assertEquals(action.getAttachments().get(0).getContentId(), testAttachment.getContentId());
+        Assert.assertEquals(action.getAttachments().get(0).getContentType(), testAttachment.getContentType());
+        Assert.assertEquals(action.getAttachments().get(0).getCharsetName(), testAttachment.getCharsetName());
+    }
+
+    @Test
+    public void testSoapAttachmentData() {
+        reset(server, messageConsumer, configuration);
+        when(server.createConsumer()).thenReturn(messageConsumer);
+        when(server.getEndpointConfiguration()).thenReturn(configuration);
+        when(configuration.getTimeout()).thenReturn(100L);
+        when(server.getActor()).thenReturn(null);
+        when(messageConsumer.receive(any(TestContext.class), anyLong())).thenReturn(new SoapMessage("<TestRequest><Message>Hello World!</Message></TestRequest>")
+                .setHeader("operation","foo")
+                .addAttachment(testAttachment));
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(soap().server(server)
+                        .receive()
+                        .message()
+                        .body("<TestRequest><Message>Hello World!</Message></TestRequest>")
+                        .attachment(testAttachment.getContentId(), testAttachment.getContentType(), testAttachment.getContent()));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ReceiveSoapMessageAction.class);
+
+        ReceiveSoapMessageAction action = ((ReceiveSoapMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "receive");
+
+        Assert.assertEquals(action.getMessageType(), MessageType.XML.name());
+        Assert.assertEquals(action.getEndpoint(), server);
+        Assert.assertEquals(action.getValidationContexts().size(), 3);
+        Assert.assertEquals(action.getValidationContexts().get(0).getClass(), HeaderValidationContext.class);
+        Assert.assertEquals(action.getValidationContexts().get(1).getClass(), XmlMessageValidationContext.class);
+        Assert.assertEquals(action.getValidationContexts().get(2).getClass(), JsonMessageValidationContext.class);
+
+        Assert.assertTrue(action.getMessageBuilder() instanceof StaticMessageBuilder);
+        Assert.assertEquals(((StaticMessageBuilder)action.getMessageBuilder()).buildMessagePayload(context, action.getMessageType()), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+
+        Assert.assertEquals(action.getAttachments().size(), 1L);
+        Assert.assertNull(action.getAttachments().get(0).getContentResourcePath());
+        Assert.assertEquals(action.getAttachments().get(0).getContent(), testAttachment.getContent());
+        Assert.assertEquals(action.getAttachments().get(0).getContentId(), testAttachment.getContentId());
+        Assert.assertEquals(action.getAttachments().get(0).getContentType(), testAttachment.getContentType());
+        Assert.assertEquals(action.getAttachments().get(0).getCharsetName(), testAttachment.getCharsetName());
+    }
+
+    @Test
+    public void testSoapAttachmentResource() throws IOException {
+        final Resource attachmentResource = Mockito.mock(Resource.class);
+
+        reset(server, messageConsumer, configuration, resource, attachmentResource);
+        when(server.createConsumer()).thenReturn(messageConsumer);
+        when(server.getEndpointConfiguration()).thenReturn(configuration);
+        when(configuration.getTimeout()).thenReturn(100L);
+        when(server.getActor()).thenReturn(null);
+        when(messageConsumer.receive(any(TestContext.class), anyLong())).thenReturn(new SoapMessage("<TestRequest><Message>Hello World!</Message></TestRequest>")
+                .setHeader("operation","foo")
+                .addAttachment(testAttachment));
+
+        when(resource.getInputStream()).thenReturn(new ByteArrayInputStream("<TestRequest><Message>Hello World!</Message></TestRequest>".getBytes()));
+        when(attachmentResource.getInputStream()).thenReturn(new ByteArrayInputStream("This is an attachment".getBytes()));
+
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(soap().server(server)
+                        .receive()
+                        .message()
+                        .body(resource)
+                        .attachment(testAttachment.getContentId(), testAttachment.getContentType(), attachmentResource, Charset.forName("UTF-8")));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ReceiveSoapMessageAction.class);
+
+        ReceiveSoapMessageAction action = ((ReceiveSoapMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "receive");
+
+        Assert.assertEquals(action.getMessageType(), MessageType.XML.name());
+        Assert.assertEquals(action.getEndpoint(), server);
+        Assert.assertEquals(action.getValidationContexts().size(), 3);
+        Assert.assertEquals(action.getValidationContexts().get(0).getClass(), HeaderValidationContext.class);
+        Assert.assertEquals(action.getValidationContexts().get(1).getClass(), XmlMessageValidationContext.class);
+        Assert.assertEquals(action.getValidationContexts().get(2).getClass(), JsonMessageValidationContext.class);
+
+        Assert.assertTrue(action.getMessageBuilder() instanceof StaticMessageBuilder);
+        Assert.assertEquals(((StaticMessageBuilder)action.getMessageBuilder()).buildMessagePayload(context, action.getMessageType()), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+
+        Assert.assertEquals(action.getAttachments().get(0).getContent(), "This is an attachment");
+        Assert.assertEquals(action.getAttachments().get(0).getContentId(), testAttachment.getContentId());
+        Assert.assertEquals(action.getAttachments().get(0).getContentType(), testAttachment.getContentType());
+        Assert.assertEquals(action.getAttachments().get(0).getCharsetName(), testAttachment.getCharsetName());
+    }
+
+    @Test
+    public void testMultipleSoapAttachmentData() {
+        final SoapAttachment attachment1 = new SoapAttachment();
+        attachment1.setContentId("attachment01");
+        attachment1.setContent("This is an attachment");
+        attachment1.setContentType("text/plain");
+        attachment1.setCharsetName("UTF-8");
+
+        final SoapAttachment attachment2 = new SoapAttachment();
+        attachment2.setContentId("attachment02");
+        attachment2.setContent("This is an attachment");
+        attachment2.setContentType("text/plain");
+        attachment2.setCharsetName("UTF-8");
+
+        reset(server, messageConsumer, configuration);
+        when(server.createConsumer()).thenReturn(messageConsumer);
+        when(server.getEndpointConfiguration()).thenReturn(configuration);
+        when(configuration.getTimeout()).thenReturn(100L);
+        when(server.getActor()).thenReturn(null);
+        when(messageConsumer.receive(any(TestContext.class), anyLong())).thenReturn(new SoapMessage("<TestRequest><Message>Hello World!</Message></TestRequest>")
+                .setHeader("operation","foo")
+                .addAttachment(attachment1)
+                .addAttachment(attachment2));
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(soap().server(server)
+                        .receive()
+                        .message()
+                        .body("<TestRequest><Message>Hello World!</Message></TestRequest>")
+                        .attachment(attachment1.getContentId(), attachment1.getContentType(), attachment1.getContent())
+                        .attachment(attachment2.getContentId(), attachment2.getContentType(), attachment2.getContent()));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ReceiveSoapMessageAction.class);
+
+        ReceiveSoapMessageAction action = ((ReceiveSoapMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "receive");
+
+        Assert.assertEquals(action.getMessageType(), MessageType.XML.name());
+        Assert.assertEquals(action.getEndpoint(), server);
+        Assert.assertEquals(action.getValidationContexts().size(), 3);
+        Assert.assertEquals(action.getValidationContexts().get(0).getClass(), HeaderValidationContext.class);
+        Assert.assertEquals(action.getValidationContexts().get(1).getClass(), XmlMessageValidationContext.class);
+        Assert.assertEquals(action.getValidationContexts().get(2).getClass(), JsonMessageValidationContext.class);
+
+        Assert.assertTrue(action.getMessageBuilder() instanceof StaticMessageBuilder);
+        Assert.assertEquals(((StaticMessageBuilder)action.getMessageBuilder()).buildMessagePayload(context, action.getMessageType()), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+
+        Assert.assertEquals(action.getAttachments().size(), 2L);
+        Assert.assertNull(action.getAttachments().get(0).getContentResourcePath());
+        Assert.assertEquals(action.getAttachments().get(0).getContent(), attachment1.getContent());
+        Assert.assertEquals(action.getAttachments().get(0).getContentId(), attachment1.getContentId());
+        Assert.assertEquals(action.getAttachments().get(0).getContentType(), attachment1.getContentType());
+        Assert.assertEquals(action.getAttachments().get(0).getCharsetName(), attachment1.getCharsetName());
+
+        Assert.assertNull(action.getAttachments().get(1).getContentResourcePath());
+        Assert.assertEquals(action.getAttachments().get(1).getContent(), attachment2.getContent());
+        Assert.assertEquals(action.getAttachments().get(1).getContentId(), attachment2.getContentId());
+        Assert.assertEquals(action.getAttachments().get(1).getContentType(), attachment2.getContentType());
+        Assert.assertEquals(action.getAttachments().get(1).getCharsetName(), attachment2.getCharsetName());
+    }
+
+    @Test
+    public void testReceiveBuilderWithEndpointName() {
+        reset(referenceResolver);
+        reset(server, messageConsumer, configuration);
+        when(server.createConsumer()).thenReturn(messageConsumer);
+        when(server.getEndpointConfiguration()).thenReturn(configuration);
+        when(configuration.getTimeout()).thenReturn(100L);
+        when(server.getActor()).thenReturn(null);
+        when(messageConsumer.receive(any(TestContext.class), anyLong())).thenReturn(new SoapMessage("<TestRequest><Message>Hello World!</Message></TestRequest>")
+                .setHeader("operation","foo"));
+        when(referenceResolver.resolve(TestContext.class)).thenReturn(context);
+        when(referenceResolver.resolve("replyMessageEndpoint", Endpoint.class)).thenReturn(server);
+        when(referenceResolver.resolve("fooMessageEndpoint", Endpoint.class)).thenReturn(server);
+        when(referenceResolver.resolve(TestActionListeners.class)).thenReturn(new TestActionListeners());
+        when(referenceResolver.resolveAll(SequenceBeforeTest.class)).thenReturn(new HashMap<>());
+        when(referenceResolver.resolveAll(SequenceAfterTest.class)).thenReturn(new HashMap<>());
+
+        context.setReferenceResolver(referenceResolver);
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(soap().server("replyMessageEndpoint")
+                        .receive()
+                        .message()
+                        .body("<TestRequest><Message>Hello World!</Message></TestRequest>"));
+
+        builder.$(soap().server("fooMessageEndpoint")
+                        .receive()
+                        .message()
+                        .body("<TestRequest><Message>Hello World!</Message></TestRequest>"));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 2);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ReceiveSoapMessageAction.class);
+        Assert.assertEquals(test.getActions().get(1).getClass(), ReceiveSoapMessageAction.class);
+
+        ReceiveSoapMessageAction action = ((ReceiveSoapMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "receive");
+        Assert.assertEquals(action.getEndpointUri(), "replyMessageEndpoint");
+        Assert.assertEquals(action.getMessageType(), MessageType.XML.name());
+
+        action = ((ReceiveSoapMessageAction)test.getActions().get(1));
+        Assert.assertEquals(action.getName(), "receive");
+        Assert.assertEquals(action.getEndpointUri(), "fooMessageEndpoint");
+        Assert.assertEquals(action.getMessageType(), MessageType.XML.name());
+    }
+
+}

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/actions/dsl/SendSoapFaultTestActionBuilderTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/actions/dsl/SendSoapFaultTestActionBuilderTest.java
@@ -1,0 +1,311 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.ws.actions.dsl;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.HashMap;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.container.SequenceAfterTest;
+import org.citrusframework.container.SequenceBeforeTest;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.endpoint.Endpoint;
+import org.citrusframework.message.Message;
+import org.citrusframework.messaging.Producer;
+import org.citrusframework.report.TestActionListeners;
+import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.validation.builder.StaticMessageBuilder;
+import org.citrusframework.ws.UnitTestSupport;
+import org.citrusframework.ws.actions.SendSoapFaultAction;
+import org.citrusframework.ws.message.SoapFault;
+import org.citrusframework.ws.server.WebServiceServer;
+import org.mockito.Mockito;
+import org.springframework.core.io.Resource;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.ws.actions.SoapActionBuilder.soap;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class SendSoapFaultTestActionBuilderTest extends UnitTestSupport {
+
+    public static final String FAULT_STRING = "Something went wrong";
+    public static final String FAULT_CODE = "CITRUS-1000";
+    public static final String ERROR_DETAIL = "<ErrorDetail><message>Something went wrong</message></ErrorDetail>";
+
+    private final WebServiceServer soapServer = Mockito.mock(WebServiceServer.class);
+    private final Producer messageProducer = Mockito.mock(Producer.class);
+    private final ReferenceResolver referenceResolver = Mockito.mock(ReferenceResolver.class);
+    private final Resource resource = Mockito.mock(Resource.class);
+
+    @Test
+    public void testSendSoapFault() {
+        reset(soapServer, messageProducer);
+        when(soapServer.createProducer()).thenReturn(messageProducer);
+        when(soapServer.getActor()).thenReturn(null);
+        doAnswer(invocation -> {
+            SoapFault message = (SoapFault) invocation.getArguments()[0];
+            Assert.assertEquals(message.getFaultActor(), "faultActor");
+            Assert.assertEquals(message.getFaultCode(), FAULT_CODE);
+            Assert.assertEquals(message.getFaultString(), FAULT_STRING);
+            return null;
+        }).when(messageProducer).send(any(Message.class), any(TestContext.class));
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(soap().server(soapServer)
+                        .sendFault()
+                        .message()
+                        .faultActor("faultActor")
+                        .faultCode(FAULT_CODE)
+                        .faultString(FAULT_STRING));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), SendSoapFaultAction.class);
+
+        SendSoapFaultAction action = (SendSoapFaultAction)test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "send");
+
+        Assert.assertEquals(action.getEndpoint(), soapServer);
+        Assert.assertEquals(action.getMessageBuilder().getClass(), StaticMessageBuilder.class);
+
+        StaticMessageBuilder messageBuilder = (StaticMessageBuilder) action.getMessageBuilder();
+        Assert.assertEquals(messageBuilder.getMessage().getPayload(), "");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 0L);
+        Assert.assertEquals(action.getFaultActor(), "faultActor");
+        Assert.assertEquals(action.getFaultCode(), FAULT_CODE);
+        Assert.assertEquals(action.getFaultString(), FAULT_STRING);
+    }
+
+    @Test
+    public void testSendSoapFaultByEndpointName() {
+        reset(referenceResolver, soapServer, messageProducer);
+        when(soapServer.createProducer()).thenReturn(messageProducer);
+        when(soapServer.getActor()).thenReturn(null);
+        doAnswer(invocation -> {
+            SoapFault message = (SoapFault) invocation.getArguments()[0];
+            Assert.assertEquals(message.getFaultCode(), FAULT_CODE);
+            Assert.assertEquals(message.getFaultString(), FAULT_STRING);
+            return null;
+        }).when(messageProducer).send(any(Message.class), any(TestContext.class));
+
+        when(referenceResolver.resolve(TestContext.class)).thenReturn(context);
+        when(referenceResolver.resolve("soapServer", Endpoint.class)).thenReturn(soapServer);
+        when(referenceResolver.resolve(TestActionListeners.class)).thenReturn(new TestActionListeners());
+        when(referenceResolver.resolveAll(SequenceBeforeTest.class)).thenReturn(new HashMap<>());
+        when(referenceResolver.resolveAll(SequenceAfterTest.class)).thenReturn(new HashMap<>());
+
+        context.setReferenceResolver(referenceResolver);
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(soap().server("soapServer")
+                        .sendFault()
+                        .message()
+                        .faultCode(FAULT_CODE)
+                        .faultString(FAULT_STRING));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), SendSoapFaultAction.class);
+
+        SendSoapFaultAction action = (SendSoapFaultAction)test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "send");
+
+        Assert.assertEquals(action.getEndpointUri(), "soapServer");
+        Assert.assertEquals(action.getMessageBuilder().getClass(), StaticMessageBuilder.class);
+
+        StaticMessageBuilder messageBuilder = (StaticMessageBuilder) action.getMessageBuilder();
+        Assert.assertEquals(messageBuilder.getMessage().getPayload(), "");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 0L);
+        Assert.assertNull(action.getFaultActor());
+        Assert.assertEquals(action.getFaultCode(), FAULT_CODE);
+        Assert.assertEquals(action.getFaultString(), FAULT_STRING);
+    }
+
+    @Test
+    public void testSendSoapFaultWithDetailResource() throws IOException {
+        reset(resource, soapServer, messageProducer);
+        when(soapServer.createProducer()).thenReturn(messageProducer);
+        when(soapServer.getActor()).thenReturn(null);
+        doAnswer(invocation -> {
+            SoapFault message = (SoapFault) invocation.getArguments()[0];
+            Assert.assertEquals(message.getFaultCode(), FAULT_CODE);
+            Assert.assertEquals(message.getFaultString(), FAULT_STRING);
+            Assert.assertEquals(message.getFaultDetails().size(), 1L);
+            Assert.assertEquals(message.getFaultDetails().get(0), ERROR_DETAIL);
+            return null;
+        }).when(messageProducer).send(any(Message.class), any(TestContext.class));
+
+        when(resource.getInputStream()).thenReturn(new ByteArrayInputStream(ERROR_DETAIL.getBytes()));
+
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(soap().server(soapServer)
+                        .sendFault()
+                        .message()
+                        .faultCode(FAULT_CODE)
+                        .faultDetailResource(resource)
+                        .faultString(FAULT_STRING));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), SendSoapFaultAction.class);
+
+        SendSoapFaultAction action = (SendSoapFaultAction)test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "send");
+
+        Assert.assertEquals(action.getEndpoint(), soapServer);
+        Assert.assertEquals(action.getMessageBuilder().getClass(), StaticMessageBuilder.class);
+
+        StaticMessageBuilder messageBuilder = (StaticMessageBuilder) action.getMessageBuilder();
+        Assert.assertEquals(messageBuilder.getMessage().getPayload(), "");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 0L);
+        Assert.assertEquals(action.getFaultDetails().size(), 1L);
+        Assert.assertEquals(action.getFaultDetails().get(0), ERROR_DETAIL);
+        Assert.assertEquals(action.getFaultCode(), FAULT_CODE);
+        Assert.assertEquals(action.getFaultString(), FAULT_STRING);
+    }
+
+    @Test
+    public void testSendSoapFaultWithDetail() {
+        reset(soapServer, messageProducer);
+        when(soapServer.createProducer()).thenReturn(messageProducer);
+        when(soapServer.getActor()).thenReturn(null);
+        doAnswer(invocation -> {
+            SoapFault message = (SoapFault) invocation.getArguments()[0];
+            Assert.assertEquals(message.getFaultCode(), FAULT_CODE);
+            Assert.assertEquals(message.getFaultString(), FAULT_STRING);
+            Assert.assertEquals(message.getFaultDetails().size(), 1L);
+            Assert.assertEquals(message.getFaultDetails().get(0), "DETAIL");
+            return null;
+        }).when(messageProducer).send(any(Message.class), any(TestContext.class));
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(soap().server(soapServer)
+                        .sendFault()
+                        .message()
+                        .faultCode(FAULT_CODE)
+                        .faultDetail("DETAIL")
+                        .faultString(FAULT_STRING));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), SendSoapFaultAction.class);
+
+        SendSoapFaultAction action = (SendSoapFaultAction)test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "send");
+
+        Assert.assertEquals(action.getEndpoint(), soapServer);
+        Assert.assertEquals(action.getMessageBuilder().getClass(), StaticMessageBuilder.class);
+
+        StaticMessageBuilder messageBuilder = (StaticMessageBuilder) action.getMessageBuilder();
+        Assert.assertEquals(messageBuilder.getMessage().getPayload(), "");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 0L);
+        Assert.assertEquals(action.getFaultDetails().size(), 1L);
+        Assert.assertEquals(action.getFaultDetails().get(0), "DETAIL");
+        Assert.assertEquals(action.getFaultCode(), FAULT_CODE);
+        Assert.assertEquals(action.getFaultString(), FAULT_STRING);
+    }
+
+    @Test
+    public void testSendSoapFaultWithDetailResourcePath() {
+        reset(soapServer, messageProducer);
+        when(soapServer.createProducer()).thenReturn(messageProducer);
+        when(soapServer.getActor()).thenReturn(null);
+        doAnswer(invocation -> {
+            SoapFault message = (SoapFault) invocation.getArguments()[0];
+            Assert.assertEquals(message.getFaultCode(), FAULT_CODE);
+            Assert.assertEquals(message.getFaultString(), FAULT_STRING);
+            Assert.assertEquals(message.getFaultDetails().size(), 1L);
+            Assert.assertEquals(message.getFaultDetails().get(0).trim(), ERROR_DETAIL);
+            return null;
+        }).when(messageProducer).send(any(Message.class), any(TestContext.class));
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(soap().server(soapServer)
+                        .sendFault()
+                        .message()
+                        .faultCode(FAULT_CODE)
+                        .faultDetailResource("classpath:org/citrusframework/ws/actions/dsl/soap-fault-detail.xml")
+                        .faultString(FAULT_STRING));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), SendSoapFaultAction.class);
+
+        SendSoapFaultAction action = (SendSoapFaultAction)test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "send");
+
+        Assert.assertEquals(action.getEndpoint(), soapServer);
+        Assert.assertEquals(action.getMessageBuilder().getClass(), StaticMessageBuilder.class);
+
+        StaticMessageBuilder messageBuilder = (StaticMessageBuilder) action.getMessageBuilder();
+        Assert.assertEquals(messageBuilder.getMessage().getPayload(), "");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 0L);
+        Assert.assertEquals(action.getFaultDetails().size(), 0L);
+        Assert.assertEquals(action.getFaultDetailResourcePaths().size(), 1L);
+        Assert.assertEquals(action.getFaultDetailResourcePaths().get(0), "classpath:org/citrusframework/ws/actions/dsl/soap-fault-detail.xml");
+        Assert.assertEquals(action.getFaultCode(), FAULT_CODE);
+        Assert.assertEquals(action.getFaultString(), FAULT_STRING);
+    }
+
+    @Test
+    public void testSendSoapFaultWithMultipleDetail() {
+        reset(soapServer, messageProducer);
+        when(soapServer.createProducer()).thenReturn(messageProducer);
+        when(soapServer.getActor()).thenReturn(null);
+        doAnswer(invocation -> {
+            SoapFault message = (SoapFault) invocation.getArguments()[0];
+            Assert.assertEquals(message.getFaultCode(), FAULT_CODE);
+            Assert.assertEquals(message.getFaultString(), FAULT_STRING);
+            Assert.assertEquals(message.getFaultDetails().size(), 2L);
+            Assert.assertEquals(message.getFaultDetails().get(0), "DETAIL1");
+            Assert.assertEquals(message.getFaultDetails().get(1), "DETAIL2");
+            return null;
+        }).when(messageProducer).send(any(Message.class), any(TestContext.class));
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(soap().server(soapServer)
+                        .sendFault()
+                        .message()
+                        .faultCode(FAULT_CODE)
+                        .faultDetail("DETAIL1")
+                        .faultDetail("DETAIL2")
+                        .faultString(FAULT_STRING));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), SendSoapFaultAction.class);
+
+        SendSoapFaultAction action = (SendSoapFaultAction)test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "send");
+
+        Assert.assertEquals(action.getEndpoint(), soapServer);
+        Assert.assertEquals(action.getMessageBuilder().getClass(), StaticMessageBuilder.class);
+
+        StaticMessageBuilder messageBuilder = (StaticMessageBuilder) action.getMessageBuilder();
+        Assert.assertEquals(messageBuilder.getMessage().getPayload(), "");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 0L);
+        Assert.assertEquals(action.getFaultDetails().size(), 2L);
+        Assert.assertEquals(action.getFaultDetails().get(0), "DETAIL1");
+        Assert.assertEquals(action.getFaultDetails().get(1), "DETAIL2");
+        Assert.assertEquals(action.getFaultCode(), FAULT_CODE);
+        Assert.assertEquals(action.getFaultString(), FAULT_STRING);
+    }
+}

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/actions/dsl/SendSoapMessageTestActionBuilderTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/actions/dsl/SendSoapMessageTestActionBuilderTest.java
@@ -1,0 +1,438 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.ws.actions.dsl;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.HashMap;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.actions.SendMessageAction;
+import org.citrusframework.container.SequenceAfterTest;
+import org.citrusframework.container.SequenceBeforeTest;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.endpoint.Endpoint;
+import org.citrusframework.message.DefaultMessage;
+import org.citrusframework.message.Message;
+import org.citrusframework.message.MessageHeaders;
+import org.citrusframework.message.MessageType;
+import org.citrusframework.messaging.Producer;
+import org.citrusframework.report.TestActionListeners;
+import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.validation.builder.StaticMessageBuilder;
+import org.citrusframework.ws.UnitTestSupport;
+import org.citrusframework.ws.actions.SendSoapMessageAction;
+import org.citrusframework.ws.client.WebServiceClient;
+import org.citrusframework.ws.message.SoapAttachment;
+import org.citrusframework.ws.message.SoapMessage;
+import org.citrusframework.ws.message.SoapMessageHeaders;
+import org.mockito.Mockito;
+import org.springframework.core.io.Resource;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.ws.actions.SoapActionBuilder.soap;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class SendSoapMessageTestActionBuilderTest extends UnitTestSupport {
+
+    private final WebServiceClient soapClient = Mockito.mock(WebServiceClient.class);
+    private final Producer messageProducer = Mockito.mock(Producer.class);
+    private final ReferenceResolver referenceResolver = Mockito.mock(ReferenceResolver.class);
+    private final Resource resource = Mockito.mock(Resource.class);
+
+    private final SoapAttachment testAttachment = new SoapAttachment();
+
+    /**
+     * Setup test attachment.
+     */
+    @BeforeClass
+    public void setup() {
+        testAttachment.setContentId("attachment01");
+        testAttachment.setContent("This is an attachment");
+        testAttachment.setContentType("text/plain");
+        testAttachment.setCharsetName("UTF-8");
+    }
+
+    @Test
+    public void testFork() {
+        reset(soapClient, messageProducer);
+        when(soapClient.createProducer()).thenReturn(messageProducer);
+        when(soapClient.getActor()).thenReturn(null);
+        doAnswer(invocation -> {
+            Message message = (Message) invocation.getArguments()[0];
+            Assert.assertEquals(message.getPayload(String.class), "Foo");
+            return null;
+        }).when(messageProducer).send(any(Message.class), any(TestContext.class));
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(soap().client(soapClient)
+                        .send()
+                        .message(new DefaultMessage("Foo").setHeader("operation", "foo"))
+                            .header("additional", "additionalValue"));
+
+        builder.$(soap().client(soapClient)
+                .send()
+                .message(new DefaultMessage("Foo").setHeader("operation", "foo"))
+                .fork(true));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 2);
+        Assert.assertEquals(test.getActions().get(0).getClass(), SendSoapMessageAction.class);
+        Assert.assertEquals(test.getActions().get(1).getClass(), SendSoapMessageAction.class);
+
+        SendSoapMessageAction action = ((SendSoapMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "send");
+
+        Assert.assertEquals(action.getEndpoint(), soapClient);
+        Assert.assertEquals(action.getMessageBuilder().getClass(), StaticMessageBuilder.class);
+
+        StaticMessageBuilder messageBuilder = (StaticMessageBuilder) action.getMessageBuilder();
+        Assert.assertEquals(messageBuilder.getMessage().getPayload(String.class), "Foo");
+        Assert.assertEquals(messageBuilder.getMessage().getHeader("operation"), "foo");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 3L);
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get(MessageHeaders.MESSAGE_TYPE), MessageType.PLAINTEXT.name());
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get("additional"), "additionalValue");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get("operation"), "foo");
+
+        Assert.assertFalse(action.isForkMode());
+
+        action = ((SendSoapMessageAction)test.getActions().get(1));
+        Assert.assertEquals(action.getName(), "send");
+
+        Assert.assertEquals(action.getEndpoint(), soapClient);
+        Assert.assertEquals(action.getMessageBuilder().getClass(), StaticMessageBuilder.class);
+
+        Assert.assertTrue(action.isForkMode());
+    }
+
+    @Test
+    public void testSoapAction() {
+        reset(soapClient, messageProducer);
+        when(soapClient.createProducer()).thenReturn(messageProducer);
+        when(soapClient.getActor()).thenReturn(null);
+        doAnswer(invocation -> {
+            SoapMessage message = (SoapMessage) invocation.getArguments()[0];
+            Assert.assertEquals(message.getPayload(String.class), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+            Assert.assertEquals(message.getSoapAction(), "TestService/sayHello");
+            return null;
+        }).when(messageProducer).send(any(Message.class), any(TestContext.class));
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(soap().client(soapClient)
+                        .send()
+                        .message()
+                        .soapAction("TestService/sayHello")
+                        .body("<TestRequest><Message>Hello World!</Message></TestRequest>"));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), SendSoapMessageAction.class);
+
+        SendSoapMessageAction action = ((SendSoapMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "send");
+
+        Assert.assertEquals(action.getEndpoint(), soapClient);
+        Assert.assertEquals(action.getMessageBuilder().getClass(), StaticMessageBuilder.class);
+
+        StaticMessageBuilder messageBuilder = (StaticMessageBuilder) action.getMessageBuilder();
+        Assert.assertEquals(messageBuilder.buildMessagePayload(context, action.getMessageType()), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+        Assert.assertEquals(messageBuilder.getMessage().getHeaders().size(), 3L);
+        Assert.assertEquals(messageBuilder.getMessage().getHeaders().get(SoapMessageHeaders.SOAP_ACTION), "TestService/sayHello");
+    }
+
+    @Test
+    public void testSoapAttachment() {
+        reset(soapClient, messageProducer);
+        when(soapClient.createProducer()).thenReturn(messageProducer);
+        when(soapClient.getActor()).thenReturn(null);
+        doAnswer(invocation -> {
+            SoapMessage message = (SoapMessage) invocation.getArguments()[0];
+            Assert.assertEquals(message.getPayload(String.class), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+            Assert.assertEquals(message.getAttachments().size(), 1L);
+            Assert.assertEquals(message.getAttachments().get(0).getContent(), testAttachment.getContent());
+            return null;
+        }).when(messageProducer).send(any(Message.class), any(TestContext.class));
+
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(soap().client(soapClient)
+                        .send()
+                        .message()
+                        .body("<TestRequest><Message>Hello World!</Message></TestRequest>")
+                        .attachment(testAttachment));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), SendSoapMessageAction.class);
+
+        SendSoapMessageAction action = ((SendSoapMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "send");
+
+        Assert.assertEquals(action.getEndpoint(), soapClient);
+        Assert.assertEquals(action.getMessageBuilder().getClass(), StaticMessageBuilder.class);
+
+        StaticMessageBuilder messageBuilder = (StaticMessageBuilder) action.getMessageBuilder();
+        Assert.assertEquals(messageBuilder.buildMessagePayload(context, action.getMessageType()), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 0L);
+
+        Assert.assertEquals(action.getAttachments().size(), 1L);
+        Assert.assertNull(action.getAttachments().get(0).getContentResourcePath());
+        Assert.assertEquals(action.getAttachments().get(0).getContent(), testAttachment.getContent());
+        Assert.assertEquals(action.getAttachments().get(0).getContentId(), testAttachment.getContentId());
+        Assert.assertEquals(action.getAttachments().get(0).getContentType(), testAttachment.getContentType());
+        Assert.assertEquals(action.getAttachments().get(0).getCharsetName(), testAttachment.getCharsetName());
+    }
+
+    @Test
+    public void testSoapAttachmentData() {
+        reset(soapClient, messageProducer);
+        when(soapClient.createProducer()).thenReturn(messageProducer);
+        when(soapClient.getActor()).thenReturn(null);
+        doAnswer(invocation -> {
+            SoapMessage message = (SoapMessage) invocation.getArguments()[0];
+            Assert.assertEquals(message.getPayload(String.class), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+            Assert.assertEquals(message.getAttachments().size(), 1L);
+            Assert.assertEquals(message.getAttachments().get(0).getContent(), testAttachment.getContent());
+            return null;
+        }).when(messageProducer).send(any(Message.class), any(TestContext.class));
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(soap().client(soapClient)
+                        .send()
+                        .message()
+                        .body("<TestRequest><Message>Hello World!</Message></TestRequest>")
+                        .attachment(testAttachment.getContentId(), testAttachment.getContentType(), testAttachment.getContent()));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), SendSoapMessageAction.class);
+
+        SendSoapMessageAction action = ((SendSoapMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "send");
+
+        Assert.assertEquals(action.getEndpoint(), soapClient);
+        Assert.assertEquals(action.getMessageBuilder().getClass(), StaticMessageBuilder.class);
+
+        StaticMessageBuilder messageBuilder = (StaticMessageBuilder) action.getMessageBuilder();
+        Assert.assertEquals(messageBuilder.buildMessagePayload(context, action.getMessageType()), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 0L);
+
+        Assert.assertEquals(action.getAttachments().size(), 1L);
+        Assert.assertNull(action.getAttachments().get(0).getContentResourcePath());
+        Assert.assertEquals(action.getAttachments().get(0).getContent(), testAttachment.getContent());
+        Assert.assertEquals(action.getAttachments().get(0).getContentId(), testAttachment.getContentId());
+        Assert.assertEquals(action.getAttachments().get(0).getContentType(), testAttachment.getContentType());
+        Assert.assertEquals(action.getAttachments().get(0).getCharsetName(), testAttachment.getCharsetName());
+    }
+
+    @Test
+    public void testMtomSoapAttachmentData() {
+        reset(soapClient, messageProducer);
+        when(soapClient.createProducer()).thenReturn(messageProducer);
+        when(soapClient.getActor()).thenReturn(null);
+        doAnswer(invocation -> {
+            SoapMessage message = (SoapMessage) invocation.getArguments()[0];
+            Assert.assertEquals(message.getPayload(String.class), "<TestRequest><data><xop:Include xmlns:xop=\"http://www.w3.org/2004/08/xop/include\" href=\"cid:attachment01\"/></data></TestRequest>");
+            Assert.assertEquals(message.getAttachments().size(), 1L);
+            Assert.assertEquals(message.getAttachments().get(0).getContent(), testAttachment.getContent());
+            return null;
+        }).when(messageProducer).send(any(Message.class), any(TestContext.class));
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(soap().client(soapClient)
+                        .send()
+                        .message()
+                        .mtomEnabled(true)
+                        .body("<TestRequest><data>cid:attachment01</data></TestRequest>")
+                        .attachment(testAttachment.getContentId(), testAttachment.getContentType(), testAttachment.getContent()));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), SendSoapMessageAction.class);
+
+        SendSoapMessageAction action = ((SendSoapMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "send");
+
+        Assert.assertEquals(action.getEndpoint(), soapClient);
+        Assert.assertEquals(action.getMessageBuilder().getClass(), StaticMessageBuilder.class);
+
+        StaticMessageBuilder messageBuilder = (StaticMessageBuilder) action.getMessageBuilder();
+        Assert.assertEquals(messageBuilder.buildMessagePayload(context, action.getMessageType()), "<TestRequest><data>cid:attachment01</data></TestRequest>");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 0L);
+
+        Assert.assertTrue(action.getMtomEnabled());
+
+        Assert.assertEquals(action.getAttachments().size(), 1L);
+        Assert.assertNull(action.getAttachments().get(0).getContentResourcePath());
+        Assert.assertEquals(action.getAttachments().get(0).getContent(), testAttachment.getContent());
+        Assert.assertEquals(action.getAttachments().get(0).getContentId(), testAttachment.getContentId());
+        Assert.assertEquals(action.getAttachments().get(0).getContentType(), testAttachment.getContentType());
+        Assert.assertEquals(action.getAttachments().get(0).getCharsetName(), testAttachment.getCharsetName());
+    }
+
+    @Test
+    public void testMultipleSoapAttachmentData() {
+        reset(soapClient, messageProducer);
+        when(soapClient.getActor()).thenReturn(null);
+        doAnswer(invocation -> {
+            SoapMessage message = (SoapMessage) invocation.getArguments()[0];
+            Assert.assertEquals(message.getPayload(String.class), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+            Assert.assertEquals(message.getAttachments().size(), 2L);
+            Assert.assertEquals(message.getAttachments().get(0).getContent(), testAttachment.getContent() + 1);
+            Assert.assertEquals(message.getAttachments().get(1).getContent(), testAttachment.getContent() + 2);
+            return null;
+        }).when(messageProducer).send(any(Message.class), any(TestContext.class));
+        when(soapClient.createProducer()).thenReturn(messageProducer);
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(soap().client(soapClient)
+                        .send()
+                        .message()
+                        .body("<TestRequest><Message>Hello World!</Message></TestRequest>")
+                        .attachment(testAttachment.getContentId() + 1, testAttachment.getContentType(), testAttachment.getContent() + 1)
+                        .attachment(testAttachment.getContentId() + 2, testAttachment.getContentType(), testAttachment.getContent() + 2));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), SendSoapMessageAction.class);
+
+        SendSoapMessageAction action = ((SendSoapMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "send");
+
+        Assert.assertEquals(action.getEndpoint(), soapClient);
+        Assert.assertEquals(action.getMessageBuilder().getClass(), StaticMessageBuilder.class);
+
+        StaticMessageBuilder messageBuilder = (StaticMessageBuilder) action.getMessageBuilder();
+        Assert.assertEquals(messageBuilder.buildMessagePayload(context, action.getMessageType()), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 0L);
+
+        Assert.assertEquals(action.getAttachments().size(), 2L);
+        Assert.assertNull(action.getAttachments().get(0).getContentResourcePath());
+        Assert.assertEquals(action.getAttachments().get(0).getContent(), testAttachment.getContent() + 1);
+        Assert.assertEquals(action.getAttachments().get(0).getContentId(), testAttachment.getContentId() + 1);
+        Assert.assertEquals(action.getAttachments().get(0).getContentType(), testAttachment.getContentType());
+        Assert.assertEquals(action.getAttachments().get(0).getCharsetName(), testAttachment.getCharsetName());
+        Assert.assertNull(action.getAttachments().get(1).getContentResourcePath());
+        Assert.assertEquals(action.getAttachments().get(1).getContent(), testAttachment.getContent() + 2);
+        Assert.assertEquals(action.getAttachments().get(1).getContentId(), testAttachment.getContentId() + 2);
+        Assert.assertEquals(action.getAttachments().get(1).getContentType(), testAttachment.getContentType());
+        Assert.assertEquals(action.getAttachments().get(1).getCharsetName(), testAttachment.getCharsetName());
+    }
+
+    @Test
+    public void testSoapAttachmentResource() throws IOException {
+        reset(resource, soapClient, messageProducer);
+        when(soapClient.createProducer()).thenReturn(messageProducer);
+        when(soapClient.getActor()).thenReturn(null);
+        doAnswer(invocation -> {
+            SoapMessage message = (SoapMessage) invocation.getArguments()[0];
+            Assert.assertEquals(message.getPayload(String.class), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+            Assert.assertEquals(message.getAttachments().size(), 1L);
+            Assert.assertEquals(message.getAttachments().get(0).getContent(), "someAttachmentData");
+            return null;
+        }).when(messageProducer).send(any(Message.class), any(TestContext.class));
+
+        when(resource.getInputStream()).thenReturn(new ByteArrayInputStream("someAttachmentData".getBytes()));
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(soap().client(soapClient)
+                        .send()
+                        .message()
+                        .body("<TestRequest><Message>Hello World!</Message></TestRequest>")
+                        .attachment(testAttachment.getContentId(), testAttachment.getContentType(), resource));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), SendSoapMessageAction.class);
+
+        SendSoapMessageAction action = ((SendSoapMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "send");
+
+        Assert.assertEquals(action.getEndpoint(), soapClient);
+        Assert.assertEquals(action.getMessageBuilder().getClass(), StaticMessageBuilder.class);
+
+        StaticMessageBuilder messageBuilder = (StaticMessageBuilder) action.getMessageBuilder();
+        Assert.assertEquals(messageBuilder.buildMessagePayload(context, action.getMessageType()), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 0L);
+
+        Assert.assertEquals(action.getAttachments().get(0).getContent(), "someAttachmentData");
+        Assert.assertEquals(action.getAttachments().get(0).getContentId(), testAttachment.getContentId());
+        Assert.assertEquals(action.getAttachments().get(0).getContentType(), testAttachment.getContentType());
+        Assert.assertEquals(action.getAttachments().get(0).getCharsetName(), testAttachment.getCharsetName());
+    }
+
+    @Test
+    public void testSendBuilderWithEndpointName() {
+        reset(referenceResolver, soapClient, messageProducer);
+        when(soapClient.createProducer()).thenReturn(messageProducer);
+        when(soapClient.getActor()).thenReturn(null);
+        doAnswer(invocation -> {
+            SoapMessage message = (SoapMessage) invocation.getArguments()[0];
+            Assert.assertEquals(message.getPayload(String.class), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+            Assert.assertEquals(message.getAttachments().size(), 1L);
+            Assert.assertEquals(message.getAttachments().get(0).getContent(), testAttachment.getContent());
+            return null;
+        }).when(messageProducer).send(any(Message.class), any(TestContext.class));
+
+        doAnswer(invocation -> {
+            SoapMessage message = (SoapMessage) invocation.getArguments()[0];
+            Assert.assertEquals(message.getPayload(String.class), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+            return null;
+        }).when(messageProducer).send(any(Message.class), any(TestContext.class));
+
+        when(referenceResolver.resolve(TestContext.class)).thenReturn(context);
+        when(referenceResolver.resolve("soapClient", Endpoint.class)).thenReturn(soapClient);
+        when(referenceResolver.resolve("otherClient", Endpoint.class)).thenReturn(soapClient);
+        when(referenceResolver.resolve(TestActionListeners.class)).thenReturn(new TestActionListeners());
+        when(referenceResolver.resolveAll(SequenceBeforeTest.class)).thenReturn(new HashMap<>());
+        when(referenceResolver.resolveAll(SequenceAfterTest.class)).thenReturn(new HashMap<>());
+
+        context.setReferenceResolver(referenceResolver);
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(soap().client("soapClient")
+                        .send()
+                        .message()
+                        .body("<TestRequest><Message>Hello World!</Message></TestRequest>")
+                        .header("operation", "soapOperation")
+                        .attachment(testAttachment));
+
+        builder.$(soap().client("otherClient")
+                .send()
+                .message()
+                .body("<TestRequest><Message>Hello World!</Message></TestRequest>"));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 2);
+        Assert.assertEquals(test.getActions().get(0).getClass(), SendSoapMessageAction.class);
+        Assert.assertEquals(test.getActions().get(1).getClass(), SendSoapMessageAction.class);
+
+        SendMessageAction action = ((SendSoapMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "send");
+        Assert.assertEquals(action.getEndpointUri(), "soapClient");
+
+        StaticMessageBuilder messageBuilder = (StaticMessageBuilder) action.getMessageBuilder();
+        Assert.assertEquals(messageBuilder.buildMessagePayload(context, action.getMessageType()), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 1L);
+        Assert.assertTrue(messageBuilder.buildMessageHeaders(context).containsKey("operation"));
+
+        action = ((SendSoapMessageAction)test.getActions().get(1));
+        Assert.assertEquals(action.getName(), "send");
+        Assert.assertEquals(action.getEndpointUri(), "otherClient");
+    }
+}

--- a/endpoints/citrus-zookeeper/src/test/java/org/citrusframework/zookeeper/UnitTestSupport.java
+++ b/endpoints/citrus-zookeeper/src/test/java/org/citrusframework/zookeeper/UnitTestSupport.java
@@ -1,0 +1,32 @@
+package org.citrusframework.zookeeper;
+
+import org.citrusframework.context.TestContext;
+import org.citrusframework.context.TestContextFactory;
+import org.citrusframework.functions.DefaultFunctionLibrary;
+import org.citrusframework.validation.matcher.DefaultValidationMatcherLibrary;
+import org.testng.annotations.BeforeMethod;
+
+/**
+ * @author Christoph Deppisch
+ */
+public abstract class UnitTestSupport {
+
+    protected TestContextFactory testContextFactory;
+    protected TestContext context;
+
+    /**
+     * Setup test execution.
+     */
+    @BeforeMethod
+    public void prepareTest() {
+        testContextFactory = createTestContextFactory();
+        context = testContextFactory.getObject();
+    }
+
+    protected TestContextFactory createTestContextFactory() {
+        TestContextFactory factory = TestContextFactory.newInstance();
+        factory.getFunctionRegistry().addFunctionLibrary(new DefaultFunctionLibrary());
+        factory.getValidationMatcherRegistry().addValidationMatcherLibrary(new DefaultValidationMatcherLibrary());
+        return factory;
+    }
+}

--- a/endpoints/citrus-zookeeper/src/test/java/org/citrusframework/zookeeper/actions/dsl/ZooExecuteTestActionBuilderTest.java
+++ b/endpoints/citrus-zookeeper/src/test/java/org/citrusframework/zookeeper/actions/dsl/ZooExecuteTestActionBuilderTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2006-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.zookeeper.actions.dsl;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.zookeeper.AsyncCallback;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.data.Stat;
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.zookeeper.UnitTestSupport;
+import org.citrusframework.zookeeper.actions.ZooExecuteAction;
+import org.citrusframework.zookeeper.command.AbstractZooCommand;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.dsl.PathExpressionSupport.path;
+import static org.citrusframework.zookeeper.actions.ZooExecuteAction.Builder.zookeeper;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Martin Maher
+ * @since 2.5
+ */
+public class ZooExecuteTestActionBuilderTest extends UnitTestSupport {
+
+    private final ZooKeeper zookeeperClientMock = Mockito.mock(ZooKeeper.class);
+    private final Stat statMock = prepareStatMock();
+
+    @Test
+    public void testZookeeperBuilder() throws KeeperException, InterruptedException {
+        final String pwd = "SomePwd";
+        final String path = "my-node";
+        final String data = "my-data";
+        final List<String> children = Arrays.asList("child1", "child2");
+        final String newPath = "the-created-node";
+
+        reset(zookeeperClientMock);
+
+        //  prepare info
+        when(zookeeperClientMock.getState()).thenReturn(ZooKeeper.States.CONNECTED);
+        when(zookeeperClientMock.getSessionId()).thenReturn(100L);
+        when(zookeeperClientMock.getSessionPasswd()).thenReturn(pwd.getBytes());
+        when(zookeeperClientMock.getSessionTimeout()).thenReturn(200);
+
+        //  prepare create
+        when(zookeeperClientMock.create(path, data.getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL)).thenReturn(newPath);
+
+        //  prepare exists
+        when(zookeeperClientMock.exists(path, false)).thenReturn(statMock);
+
+        //  prepare get-children
+        when(zookeeperClientMock.getChildren(path, false)).thenReturn(children);
+
+        //  prepare get-data
+        when(zookeeperClientMock.getData(path, false, null)).thenReturn(data.getBytes());
+
+        //  prepare set-data
+        when(zookeeperClientMock.setData(path, data.getBytes(), 0)).thenReturn(statMock);
+
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(zookeeper().client(new org.citrusframework.zookeeper.client.ZooClient(zookeeperClientMock))
+                .validate("$.responseData.state", ZooKeeper.States.CONNECTED.name())
+                .extract(path().expression("$.responseData.state","state")
+                            .expression("$.responseData.sessionId","sessionId")
+                            .expression("$.responseData.sessionPwd","sessionPwd")
+                            .expression("$.responseData.sessionTimeout","sessionTimeout"))
+                .info()
+                .validateCommandResult((result, context) -> {
+                    Assert.assertNotNull(result);
+                    Assert.assertEquals(result.getResponseData().get("state"), ZooKeeper.States.CONNECTED.name());
+                    Assert.assertEquals(result.getResponseData().get("sessionId"), 100L);
+                    Assert.assertEquals(result.getResponseData().get("sessionPwd"), pwd.getBytes());
+                    Assert.assertEquals(result.getResponseData().get("sessionTimeout"), 200);
+                }));
+
+        builder.$(zookeeper().client(new org.citrusframework.zookeeper.client.ZooClient(zookeeperClientMock))
+                .create(path, data)
+                .validateCommandResult((result, context) -> {
+                    Assert.assertNotNull(result);
+                    Assert.assertEquals(result.getResponseData().get(AbstractZooCommand.PATH), newPath);
+                }));
+
+        builder.$(zookeeper().client(new org.citrusframework.zookeeper.client.ZooClient(zookeeperClientMock))
+                .delete(path)
+                .validateCommandResult((result, context) -> verify(zookeeperClientMock).delete(eq(path), eq(0), any(AsyncCallback.VoidCallback.class), isNull())));
+
+        builder.$(zookeeper().client(new org.citrusframework.zookeeper.client.ZooClient(zookeeperClientMock))
+                .exists(path)
+                .validateCommandResult((result, context) -> {
+                    Assert.assertNotNull(result);
+                    for (Object o : result.getResponseData().values()) {
+                        Assert.assertEquals(o.toString(), "1");
+                    }
+                }));
+
+        builder.$(zookeeper().client(new org.citrusframework.zookeeper.client.ZooClient(zookeeperClientMock))
+                .children(path)
+                .validateCommandResult((result, context) -> {
+                    Assert.assertNotNull(result);
+                    Assert.assertEquals(result.getResponseData().get(AbstractZooCommand.CHILDREN), children);
+                }));
+
+        builder.$(zookeeper().client(new org.citrusframework.zookeeper.client.ZooClient(zookeeperClientMock))
+                .get(path)
+                .validateCommandResult((result, context) -> {
+                    Assert.assertNotNull(result);
+                    Assert.assertEquals(result.getResponseData().get(AbstractZooCommand.DATA), data);
+                }));
+
+        builder.$(zookeeper().client(new org.citrusframework.zookeeper.client.ZooClient(zookeeperClientMock))
+                .set(path, data)
+                .validateCommandResult((result, context) -> {
+                    Assert.assertNotNull(result);
+                    for (Object o : result.getResponseData().values()) {
+                        Assert.assertEquals(o.toString(), "1");
+                    }
+                }));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 7);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ZooExecuteAction.class);
+        Assert.assertEquals(test.getActiveAction().getClass(), ZooExecuteAction.class);
+
+        String actionName = "zookeeper-execute";
+
+        ZooExecuteAction action = (ZooExecuteAction) test.getActions().get(0);
+        Assert.assertEquals(action.getName(), actionName);
+        Assert.assertEquals(action.getCommand().getClass(), org.citrusframework.zookeeper.command.Info.class);
+
+        action = (ZooExecuteAction) test.getActions().get(1);
+        Assert.assertEquals(action.getName(), actionName);
+        Assert.assertEquals(action.getCommand().getClass(), org.citrusframework.zookeeper.command.Create.class);
+
+        action = (ZooExecuteAction) test.getActions().get(2);
+        Assert.assertEquals(action.getName(), actionName);
+        Assert.assertEquals(action.getCommand().getClass(), org.citrusframework.zookeeper.command.Delete.class);
+
+        action = (ZooExecuteAction) test.getActions().get(3);
+        Assert.assertEquals(action.getName(), actionName);
+        Assert.assertEquals(action.getCommand().getClass(), org.citrusframework.zookeeper.command.Exists.class);
+
+        action = (ZooExecuteAction) test.getActions().get(4);
+        Assert.assertEquals(action.getName(), actionName);
+        Assert.assertEquals(action.getCommand().getClass(), org.citrusframework.zookeeper.command.GetChildren.class);
+
+        action = (ZooExecuteAction) test.getActions().get(5);
+        Assert.assertEquals(action.getName(), actionName);
+        Assert.assertEquals(action.getCommand().getClass(), org.citrusframework.zookeeper.command.GetData.class);
+
+        action = (ZooExecuteAction) test.getActions().get(6);
+        Assert.assertEquals(action.getName(), actionName);
+        Assert.assertEquals(action.getCommand().getClass(), org.citrusframework.zookeeper.command.SetData.class);
+    }
+
+
+    private Stat prepareStatMock() {
+        Stat stat = Mockito.mock(Stat.class);
+        when(stat.getAversion()).thenReturn(1);
+        when(stat.getCtime()).thenReturn(1L);
+        when(stat.getCversion()).thenReturn(1);
+        when(stat.getCzxid()).thenReturn(1L);
+        when(stat.getDataLength()).thenReturn(1);
+        when(stat.getEphemeralOwner()).thenReturn(1L);
+        when(stat.getMtime()).thenReturn(1L);
+        when(stat.getMzxid()).thenReturn(1L);
+        when(stat.getNumChildren()).thenReturn(1);
+        when(stat.getPzxid()).thenReturn(1L);
+        when(stat.getVersion()).thenReturn(1);
+        return stat;
+    }
+}

--- a/runtime/citrus-groovy/src/main/java/org/citrusframework/script/GroovyAction.java
+++ b/runtime/citrus-groovy/src/main/java/org/citrusframework/script/GroovyAction.java
@@ -193,6 +193,10 @@ public class GroovyAction extends AbstractTestAction {
         private String scriptTemplatePath = "classpath:org/citrusframework/script/script-template.groovy";
         private boolean useScriptTemplate = true;
 
+        public static Builder groovy() {
+            return new Builder();
+        }
+
         /**
          * Fluent API action building entry method used in Java DSL.
          * @param script

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/actions/dsl/GroovyTestActionBuilderTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/actions/dsl/GroovyTestActionBuilderTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.actions.dsl;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.script.GroovyAction;
+import org.mockito.Mockito;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.script.GroovyAction.Builder.groovy;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+public class GroovyTestActionBuilderTest extends UnitTestSupport {
+    private final Resource scriptResource = Mockito.mock(Resource.class);
+
+    @Test
+    public void testGroovyBuilderWithResource() throws IOException {
+        reset(scriptResource);
+        when(scriptResource.getInputStream()).thenReturn(new ByteArrayInputStream("println 'Wow groovy!'".getBytes()));
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(groovy().script(scriptResource)
+                        .skipTemplate());
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), GroovyAction.class);
+        Assert.assertEquals(test.getActions().get(0).getName(), "groovy");
+
+        GroovyAction action = (GroovyAction)test.getActions().get(0);
+        Assert.assertEquals(action.getScript(), "println 'Wow groovy!'");
+        Assert.assertFalse(action.isUseScriptTemplate());
+
+    }
+
+    @Test
+    public void testGroovyBuilderWithScript() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(groovy().script("println 'Groovy!'")
+                        .skipTemplate());
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), GroovyAction.class);
+
+        GroovyAction action = (GroovyAction)test.getActions().get(0);
+        Assert.assertEquals(action.getScript(), "println 'Groovy!'");
+        Assert.assertFalse(action.isUseScriptTemplate());
+    }
+
+    @Test
+    public void testGroovyBuilderWithTemplate() throws IOException {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(groovy().script("context.setVariable('message', 'Groovy!')")
+                        .template(new ClassPathResource("org/citrusframework/script/script-template.groovy")));
+
+        Assert.assertNotNull(context.getVariable("message"));
+        Assert.assertEquals(context.getVariable("message"), "Groovy!");
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), GroovyAction.class);
+
+        GroovyAction action = (GroovyAction)test.getActions().get(0);
+        Assert.assertNotNull(action.getScriptTemplate());
+        Assert.assertTrue(action.isUseScriptTemplate());
+    }
+
+    @Test
+    public void testGroovyBuilderWithTemplatePath() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(groovy().script("context.setVariable('message', 'Groovy!')")
+                        .template("classpath:org/citrusframework/script/script-template.groovy"));
+
+        Assert.assertNotNull(context.getVariable("message"));
+        Assert.assertEquals(context.getVariable("message"), "Groovy!");
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), GroovyAction.class);
+
+        GroovyAction action = (GroovyAction)test.getActions().get(0);
+        Assert.assertNotNull(action.getScriptTemplatePath());
+        Assert.assertTrue(action.isUseScriptTemplate());
+    }
+}

--- a/runtime/citrus-testng/pom.xml
+++ b/runtime/citrus-testng/pom.xml
@@ -45,6 +45,11 @@
       <artifactId>ant</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.thoughtworks.xstream</groupId>
+      <artifactId>xstream</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/TextEqualsMessageValidator.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/TextEqualsMessageValidator.java
@@ -1,4 +1,4 @@
-package org.citrusframework.integration;
+package org.citrusframework;
 
 import org.citrusframework.context.TestContext;
 import org.citrusframework.message.Message;
@@ -19,6 +19,11 @@ public class TextEqualsMessageValidator extends DefaultMessageValidator {
     @Override
     public void validateMessage(Message receivedMessage, Message controlMessage, TestContext context, ValidationContext validationContext) {
         Logger log = LoggerFactory.getLogger("TextEqualsMessageValidator");
+
+        if (controlMessage.getPayload(String.class).isBlank()) {
+            log.info("Skip text validation as no control message payload specified");
+            return;
+        }
 
         Assert.assertEquals(receivedMessage.getPayload(String.class), controlMessage.getPayload(String.class), "Validation failed - " +
                 "expected message contents not equal!");

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/UnitTestSupport.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/UnitTestSupport.java
@@ -1,0 +1,33 @@
+package org.citrusframework;
+
+import org.citrusframework.context.TestContext;
+import org.citrusframework.context.TestContextFactory;
+import org.citrusframework.functions.DefaultFunctionLibrary;
+import org.citrusframework.validation.matcher.DefaultValidationMatcherLibrary;
+import org.testng.annotations.BeforeMethod;
+
+/**
+ * @author Christoph Deppisch
+ */
+public abstract class UnitTestSupport {
+
+    protected TestContextFactory testContextFactory;
+    protected TestContext context;
+
+    /**
+     * Setup test execution.
+     */
+    @BeforeMethod
+    public void prepareTest() {
+        testContextFactory = createTestContextFactory();
+        context = testContextFactory.getObject();
+    }
+
+    protected TestContextFactory createTestContextFactory() {
+        TestContextFactory factory = TestContextFactory.newInstance();
+        factory.getFunctionRegistry().addFunctionLibrary(new DefaultFunctionLibrary());
+        factory.getValidationMatcherRegistry().addValidationMatcherLibrary(new DefaultValidationMatcherLibrary());
+        factory.getMessageValidatorRegistry().addMessageValidator("all", new TextEqualsMessageValidator());
+        return factory;
+    }
+}

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/AntRunTestActionBuilderTest.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/AntRunTestActionBuilderTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.actions.dsl;
+
+import org.apache.tools.ant.BuildEvent;
+import org.apache.tools.ant.BuildListener;
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.actions.AntRunAction;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.AntRunAction.Builder.antrun;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class AntRunTestActionBuilderTest extends UnitTestSupport {
+
+    @Test
+    public void testAntRunBuilder() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(antrun("org/citrusframework/actions/dsl/build.xml")
+                    .target("sayHello"));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), AntRunAction.class);
+        Assert.assertEquals(test.getActiveAction().getClass(), AntRunAction.class);
+
+        AntRunAction action = (AntRunAction)test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "antrun");
+        Assert.assertEquals(action.getBuildFilePath(), "org/citrusframework/actions/dsl/build.xml");
+        Assert.assertEquals(action.getTarget(), "sayHello");
+    }
+
+    @Test
+    public void testAntRunBuilderWithTargets() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(antrun("org/citrusframework/actions/dsl/build.xml")
+                        .targets("sayHello", "sayGoodbye"));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), AntRunAction.class);
+        Assert.assertEquals(test.getActiveAction().getClass(), AntRunAction.class);
+
+        AntRunAction action = (AntRunAction)test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "antrun");
+        Assert.assertEquals(action.getBuildFilePath(), "org/citrusframework/actions/dsl/build.xml");
+        Assert.assertNull(action.getTarget());
+        Assert.assertEquals(action.getTargets(), "sayHello,sayGoodbye");
+    }
+
+    @Test
+    public void testAntRunBuilderWithProperty() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(antrun("org/citrusframework/actions/dsl/build.xml")
+                        .target("sayHello")
+                        .property("welcomeText", "Hi everybody!")
+                        .property("goodbyeText", "Goodbye!"));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), AntRunAction.class);
+        Assert.assertEquals(test.getActiveAction().getClass(), AntRunAction.class);
+
+        AntRunAction action = (AntRunAction)test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "antrun");
+        Assert.assertEquals(action.getBuildFilePath(), "org/citrusframework/actions/dsl/build.xml");
+        Assert.assertEquals(action.getTarget(), "sayHello");
+        Assert.assertEquals(action.getProperties().size(), 2L);
+        Assert.assertEquals(action.getProperties().getProperty("welcomeText"), "Hi everybody!");
+        Assert.assertEquals(action.getProperties().getProperty("goodbyeText"), "Goodbye!");
+    }
+
+    @Test
+    public void testAntRunBuilderWithPropertyFile() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.variable("checked", true);
+
+        builder.$(antrun("org/citrusframework/actions/dsl/build.xml")
+                .target("checkMe")
+                .propertyFile("classpath:org/citrusframework/actions/dsl/build.properties"));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), AntRunAction.class);
+        Assert.assertEquals(test.getActiveAction().getClass(), AntRunAction.class);
+
+        AntRunAction action = (AntRunAction)test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "antrun");
+        Assert.assertEquals(action.getBuildFilePath(), "org/citrusframework/actions/dsl/build.xml");
+        Assert.assertEquals(action.getTarget(), "checkMe");
+        Assert.assertEquals(action.getProperties().size(), 0L);
+        Assert.assertEquals(action.getPropertyFilePath(), "classpath:org/citrusframework/actions/dsl/build.properties");
+    }
+
+    @Test
+    public void testAntRunBuilderWithBuildListener() {
+        final BuildListener buildListener = Mockito.mock(BuildListener.class);
+
+        reset(buildListener);
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(antrun("org/citrusframework/actions/dsl/build.xml")
+                        .target("sayHello")
+                        .listener(buildListener));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), AntRunAction.class);
+        Assert.assertEquals(test.getActiveAction().getClass(), AntRunAction.class);
+
+        AntRunAction action = (AntRunAction)test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "antrun");
+        Assert.assertEquals(action.getBuildListener(), buildListener);
+
+        verify(buildListener).taskStarted(any(BuildEvent.class));
+        verify(buildListener).targetStarted(any(BuildEvent.class));
+        verify(buildListener, times(3)).messageLogged(any(BuildEvent.class));
+        verify(buildListener).targetFinished(any(BuildEvent.class));
+        verify(buildListener).taskFinished(any(BuildEvent.class));
+    }
+}

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/ApplyTestBehaviorTest.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/ApplyTestBehaviorTest.java
@@ -1,0 +1,296 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.actions.dsl;
+
+import java.util.List;
+
+import org.citrusframework.DefaultTestCase;
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestAction;
+import org.citrusframework.TestActionRunner;
+import org.citrusframework.TestBehavior;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.actions.ApplyTestBehaviorAction;
+import org.citrusframework.actions.CreateVariablesAction;
+import org.citrusframework.actions.EchoAction;
+import org.citrusframework.container.Sequence;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.ApplyTestBehaviorAction.Builder.apply;
+import static org.citrusframework.actions.CreateVariablesAction.Builder.createVariables;
+import static org.citrusframework.actions.EchoAction.Builder.echo;
+import static org.citrusframework.container.FinallySequence.Builder.doFinally;
+import static org.citrusframework.container.Sequence.Builder.sequential;
+
+/**
+ * @author Christoph Deppisch
+ * @since 2.3
+ */
+public class ApplyTestBehaviorTest extends UnitTestSupport {
+
+    @Test
+    public void testBehaviorFrontPosition() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(apply().behavior(new FooBehavior()));
+        builder.$(echo("test"));
+
+        Assert.assertEquals(context.getVariable("foo"), "test");
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 4);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ApplyTestBehaviorAction.class);
+
+        Assert.assertEquals(test.getActions().get(1).getClass(), CreateVariablesAction.class);
+
+        Assert.assertEquals(test.getActions().get(2).getClass(), EchoAction.class);
+        Assert.assertEquals(((EchoAction)test.getActions().get(2)).getMessage(), "fooBehavior");
+
+        Assert.assertEquals(test.getActions().get(3).getClass(), EchoAction.class);
+        Assert.assertEquals(((EchoAction)test.getActions().get(3)).getMessage(), "test");
+    }
+
+    @Test
+    public void testBehaviorWithFinally() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(echo("test"));
+
+        builder.$(doFinally().actions(
+            echo("finally")
+        ));
+
+        builder.$(apply().behavior(runner -> {
+            runner.run(echo("behavior"));
+
+            runner.run(doFinally().actions(
+                echo("behaviorFinally")
+            ));
+        }));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 3);
+
+        Assert.assertEquals(test.getActions().get(0).getClass(), EchoAction.class);
+        Assert.assertEquals(((EchoAction)test.getActions().get(0)).getMessage(), "test");
+
+        Assert.assertEquals(test.getActions().get(1).getClass(), ApplyTestBehaviorAction.class);
+
+        Assert.assertEquals(test.getActions().get(2).getClass(), EchoAction.class);
+        Assert.assertEquals(((EchoAction)test.getActions().get(2)).getMessage(), "behavior");
+
+        Assert.assertTrue(test instanceof DefaultTestCase);
+        List<TestAction> finalActions = ((DefaultTestCase)test).getFinalActions();
+        Assert.assertEquals(finalActions.size(), 2);
+        Assert.assertEquals(finalActions.get(0).getClass(), EchoAction.class);
+        Assert.assertEquals(((EchoAction)finalActions.get(0)).getMessage(), "finally");
+
+        Assert.assertEquals(finalActions.get(1).getClass(), EchoAction.class);
+        Assert.assertEquals(((EchoAction)finalActions.get(1)).getMessage(), "behaviorFinally");
+    }
+
+    @Test
+    public void testBehaviorInContainer() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(sequential().actions(
+                    echo("before"),
+                    builder.applyBehavior(runner -> runner.run(echo("behavior"))),
+                    echo("after")
+                ));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 2);
+
+        Assert.assertEquals(test.getActions().get(0).getClass(), Sequence.class);
+        Sequence sequence = (Sequence) test.getActions().get(0);
+        Assert.assertEquals(sequence.getActionCount(), 3);
+
+
+        Assert.assertEquals(sequence.getActions().get(0).getClass(), EchoAction.class);
+        Assert.assertEquals(((EchoAction)sequence.getActions().get(0)).getMessage(), "before");
+
+        Assert.assertEquals(sequence.getActions().get(1).getClass(), ApplyTestBehaviorAction.class);
+
+        Assert.assertEquals(sequence.getActions().get(2).getClass(), EchoAction.class);
+        Assert.assertEquals(((EchoAction)sequence.getActions().get(2)).getMessage(), "after");
+
+        Assert.assertEquals(test.getActions().get(1).getClass(), EchoAction.class);
+        Assert.assertEquals(((EchoAction)test.getActions().get(1)).getMessage(), "behavior");
+    }
+
+    @Test
+    public void testBehaviorInContainerWithFinally() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(doFinally().actions(
+            echo("finally")
+        ));
+
+        builder.$(sequential().actions(
+            echo("test"),
+
+            builder.applyBehavior(runner -> {
+                runner.run(echo("behavior"));
+
+                runner.run(doFinally().actions(
+                    echo("behaviorFinally")
+                ));
+            })
+        ));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 2);
+
+        Assert.assertEquals(test.getActions().get(0).getClass(), Sequence.class);
+        Sequence sequence = (Sequence) test.getActions().get(0);
+        Assert.assertEquals(sequence.getActionCount(), 2);
+
+        Assert.assertEquals(sequence.getActions().get(0).getClass(), EchoAction.class);
+        Assert.assertEquals(((EchoAction)sequence.getActions().get(0)).getMessage(), "test");
+
+        Assert.assertEquals(sequence.getActions().get(1).getClass(), ApplyTestBehaviorAction.class);
+
+        Assert.assertEquals(test.getActions().get(1).getClass(), EchoAction.class);
+        Assert.assertEquals(((EchoAction)test.getActions().get(1)).getMessage(), "behavior");
+
+        Assert.assertTrue(test instanceof DefaultTestCase);
+        List<TestAction> finalActions = ((DefaultTestCase)test).getFinalActions();
+        Assert.assertEquals(finalActions.size(), 2);
+        Assert.assertEquals(finalActions.get(0).getClass(), EchoAction.class);
+        Assert.assertEquals(((EchoAction)finalActions.get(0)).getMessage(), "finally");
+
+        Assert.assertEquals(finalActions.get(1).getClass(), EchoAction.class);
+        Assert.assertEquals(((EchoAction)finalActions.get(1)).getMessage(), "behaviorFinally");
+    }
+
+    @Test
+    public void testApplyBehavior() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.variable("test", "test");
+
+        builder.$(apply().behavior(new FooBehavior()));
+
+        builder.$(echo("test"));
+
+        builder.$(apply().behavior(new BarBehavior()));
+
+        Assert.assertNotNull(context.getVariable("test"));
+        Assert.assertEquals(context.getVariable("test"), "test");
+        Assert.assertEquals(context.getVariable("foo"), "test");
+        Assert.assertEquals(context.getVariable("bar"), "test");
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 7);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ApplyTestBehaviorAction.class);
+
+        Assert.assertEquals(test.getActions().get(1).getClass(), CreateVariablesAction.class);
+
+        Assert.assertEquals(test.getActions().get(2).getClass(), EchoAction.class);
+        Assert.assertEquals(((EchoAction)test.getActions().get(2)).getMessage(), "fooBehavior");
+
+        Assert.assertEquals(test.getActions().get(3).getClass(), EchoAction.class);
+        Assert.assertEquals(((EchoAction)test.getActions().get(3)).getMessage(), "test");
+
+        Assert.assertEquals(test.getActions().get(4).getClass(), ApplyTestBehaviorAction.class);
+
+        Assert.assertEquals(test.getActions().get(5).getClass(), CreateVariablesAction.class);
+
+        Assert.assertEquals(test.getActions().get(6).getClass(), EchoAction.class);
+        Assert.assertEquals(((EchoAction)test.getActions().get(6)).getMessage(), "barBehavior");
+    }
+
+    @Test
+    public void testApplyBehaviorTwice() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        FooBehavior behavior = new FooBehavior();
+        builder.$(apply().behavior(behavior));
+
+        builder.$(echo("test"));
+
+        builder.$(apply().behavior(behavior));
+
+        Assert.assertEquals(context.getVariable("foo"), "test");
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 7);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ApplyTestBehaviorAction.class);
+
+        Assert.assertEquals(test.getActions().get(1).getClass(), CreateVariablesAction.class);
+        Assert.assertEquals(test.getActions().get(2).getClass(), EchoAction.class);
+        Assert.assertEquals(((EchoAction)test.getActions().get(2)).getMessage(), "fooBehavior");
+
+        Assert.assertEquals(test.getActions().get(3).getClass(), EchoAction.class);
+        Assert.assertEquals(((EchoAction)test.getActions().get(3)).getMessage(), "test");
+
+        Assert.assertEquals(test.getActions().get(4).getClass(), ApplyTestBehaviorAction.class);
+
+        Assert.assertEquals(test.getActions().get(5).getClass(), CreateVariablesAction.class);
+        Assert.assertEquals(test.getActions().get(6).getClass(), EchoAction.class);
+        Assert.assertEquals(((EchoAction)test.getActions().get(6)).getMessage(), "fooBehavior");
+    }
+
+    @Test
+    public void testApplyBehaviorInContainerTwice() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        FooBehavior behavior = new FooBehavior();
+
+        builder.$(sequential().actions(
+            builder.applyBehavior(behavior),
+            echo("test"),
+            builder.applyBehavior(behavior)
+        ));
+
+        Assert.assertEquals(context.getVariable("foo"), "test");
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 5);
+
+        Assert.assertEquals(test.getActions().get(0).getClass(), Sequence.class);
+        Sequence sequence = (Sequence) test.getActions().get(0);
+        Assert.assertEquals(sequence.getActionCount(), 3);
+
+        Assert.assertEquals(sequence.getActions().get(0).getClass(), ApplyTestBehaviorAction.class);
+
+        Assert.assertEquals(sequence.getActions().get(1).getClass(), EchoAction.class);
+        Assert.assertEquals(((EchoAction)sequence.getActions().get(1)).getMessage(), "test");
+
+        Assert.assertEquals(sequence.getActions().get(2).getClass(), ApplyTestBehaviorAction.class);
+
+        Assert.assertEquals(test.getActions().get(1).getClass(), CreateVariablesAction.class);
+        Assert.assertEquals(test.getActions().get(2).getClass(), EchoAction.class);
+        Assert.assertEquals(((EchoAction)test.getActions().get(2)).getMessage(), "fooBehavior");
+
+        Assert.assertEquals(test.getActions().get(3).getClass(), CreateVariablesAction.class);
+        Assert.assertEquals(test.getActions().get(4).getClass(), EchoAction.class);
+        Assert.assertEquals(((EchoAction)test.getActions().get(4)).getMessage(), "fooBehavior");
+    }
+
+    private static class FooBehavior implements TestBehavior {
+        public void apply(TestActionRunner runner) {
+            runner.run(createVariables().variable("foo", "test"));
+
+            runner.run(echo("fooBehavior"));
+        }
+    }
+
+    private static class BarBehavior implements TestBehavior {
+        public void apply(TestActionRunner runner) {
+            runner.run(createVariables().variable("bar", "test"));
+
+            runner.run(echo("barBehavior"));
+        }
+    }
+}

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/AssertExceptionTestActionBuilderTest.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/AssertExceptionTestActionBuilderTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.actions.dsl;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.actions.AbstractTestAction;
+import org.citrusframework.actions.EchoAction;
+import org.citrusframework.actions.FailAction;
+import org.citrusframework.container.Assert;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.EchoAction.Builder.echo;
+import static org.citrusframework.actions.FailAction.Builder.fail;
+import static org.citrusframework.container.Assert.Builder.assertException;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class AssertExceptionTestActionBuilderTest extends UnitTestSupport {
+
+    @Test
+    public void testAssertDefaultExceptionBuilder() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(assertException().when(fail("Error!")));
+
+        TestCase test = builder.getTestCase();
+        assertEquals(test.getActionCount(), 1);
+        assertEquals(test.getActions().get(0).getClass(), Assert.class);
+        assertEquals(test.getActions().get(0).getName(), "assert");
+
+        Assert container = (Assert)(test.getTestAction(0));
+
+        assertEquals(container.getActionCount(), 1);
+        assertEquals(container.getAction().getClass(), FailAction.class);
+        assertEquals(container.getException(), CitrusRuntimeException.class);
+    }
+
+    @Test
+    public void testAssertBuilder() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(assertException().exception(CitrusRuntimeException.class)
+                    .message("Unknown variable 'foo'")
+            .when(echo("${foo}")));
+
+        TestCase test = builder.getTestCase();
+        assertEquals(test.getActionCount(), 1);
+        assertEquals(test.getActions().get(0).getClass(), Assert.class);
+        assertEquals(test.getActions().get(0).getName(), "assert");
+
+        Assert container = (Assert)(test.getTestAction(0));
+
+        assertEquals(container.getActionCount(), 1);
+        assertEquals(container.getAction().getClass(), EchoAction.class);
+        assertEquals(container.getException(), CitrusRuntimeException.class);
+        assertEquals(container.getMessage(), "Unknown variable 'foo'");
+        assertEquals(((EchoAction)(container.getAction())).getMessage(), "${foo}");
+    }
+
+    @Test
+    public void testAssertBuilderWithAnonymousAction() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(assertException().exception(CitrusRuntimeException.class)
+                    .message("Unknown variable 'foo'")
+            .when(new AbstractTestAction() {
+                @Override
+                public void doExecute(TestContext context) {
+                    context.getVariable("foo");
+                }
+            }));
+
+        TestCase test = builder.getTestCase();
+        assertEquals(test.getActionCount(), 1);
+        assertEquals(test.getActions().get(0).getClass(), Assert.class);
+        assertEquals(test.getActions().get(0).getName(), "assert");
+
+        Assert container = (Assert)(test.getTestAction(0));
+
+        assertEquals(container.getActionCount(), 1);
+        assertTrue(container.getAction().getClass().isAnonymousClass());
+        assertEquals(container.getException(), CitrusRuntimeException.class);
+        assertEquals(container.getMessage(), "Unknown variable 'foo'");
+    }
+
+}

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/AsyncTestActionBuilderTest.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/AsyncTestActionBuilderTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2006-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.actions.dsl;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.actions.AbstractTestAction;
+import org.citrusframework.actions.EchoAction;
+import org.citrusframework.actions.SleepAction;
+import org.citrusframework.container.Async;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.exceptions.TestCaseFailedException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.EchoAction.Builder.echo;
+import static org.citrusframework.actions.FailAction.Builder.fail;
+import static org.citrusframework.actions.SleepAction.Builder.sleep;
+import static org.citrusframework.container.Async.Builder.async;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * @author Christoph Deppisch
+ * @since 2.7.4
+ */
+public class AsyncTestActionBuilderTest extends UnitTestSupport {
+
+    @Test
+    public void testAsyncBuilder() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.variable("var", "foo");
+
+        builder.$(async()
+            .actions(
+                echo("${var}"),
+                sleep().milliseconds(100L)
+            ));
+
+        TestCase test = builder.getTestCase();
+        assertEquals(test.getActionCount(), 1);
+        assertEquals(test.getActions().get(0).getClass(), Async.class);
+        assertEquals(test.getActions().get(0).getName(), "async");
+
+        Async container = (Async)test.getActions().get(0);
+        assertEquals(container.getActionCount(), 2);
+        assertEquals(container.getActions().get(0).getClass(), EchoAction.class);
+        assertEquals(container.getActions().get(1).getClass(), SleepAction.class);
+    }
+
+    @Test
+    public void testAsyncBuilderWithAnonymousAction() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.variable("var", "foo");
+
+        builder.$(async()
+            .actions(
+                echo("${var}"),
+                () -> new AbstractTestAction() {
+                    @Override
+                    public void doExecute(TestContext context) {
+                        context.setVariable("anonymous", "anonymous");
+                    }
+                },
+                sleep().milliseconds(100L),
+                () -> new AbstractTestAction() {
+                    @Override
+                    public void doExecute(TestContext context) {
+                        context.getVariable("anonymous");
+                    }
+                }
+            ));
+
+        TestCase test = builder.getTestCase();
+        assertEquals(test.getActionCount(), 1);
+        assertEquals(test.getActions().get(0).getClass(), Async.class);
+        assertEquals(test.getActions().get(0).getName(), "async");
+
+        Async container = (Async)test.getActions().get(0);
+        assertEquals(container.getActionCount(), 4);
+        assertEquals(container.getActions().get(0).getClass(), EchoAction.class);
+        assertTrue(container.getActions().get(1).getClass().isAnonymousClass());
+        assertEquals(container.getActions().get(2).getClass(), SleepAction.class);
+        assertTrue(container.getActions().get(3).getClass().isAnonymousClass());
+    }
+
+    @Test(expectedExceptions = TestCaseFailedException.class)
+    public void testAsyncError() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.variable("var", "foo");
+
+        builder.$(async()
+            .actions(
+                fail("Something went wrong!")
+            ));
+
+        builder.stop();
+    }
+
+    @Test(expectedExceptions = TestCaseFailedException.class)
+    public void testAsyncErrorActions() throws Exception {
+        CompletableFuture<Boolean> successActionPerformed = new CompletableFuture<>();
+        CompletableFuture<Boolean> errorActionPerformed = new CompletableFuture<>();
+
+        try {
+            DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+            builder.variable("var", "foo");
+
+            builder.$(async()
+                .actions(
+                    sleep().milliseconds(100L),
+                    fail("Something went wrong!")
+                ).successAction(new AbstractTestAction() {
+                    @Override
+                    public void doExecute(TestContext context) {
+                        successActionPerformed.complete(true);
+                    }
+                }).errorAction(new AbstractTestAction() {
+                    @Override
+                    public void doExecute(TestContext context) {
+                        errorActionPerformed.complete(true);
+                    }
+                }));
+
+            builder.stop();
+        } finally {
+            assertFalse(successActionPerformed.isDone());
+            errorActionPerformed.get(1000L, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    @Test
+    public void testAsyncSuccessActions() throws Exception {
+        CompletableFuture<Boolean> successActionPerformed = new CompletableFuture<>();
+        CompletableFuture<Boolean> errorActionPerformed = new CompletableFuture<>();
+
+        try {
+            DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+            builder.variable("var", "foo");
+
+            builder.$(async()
+                .actions(
+                    sleep().milliseconds(100L),
+                    echo("Do something!")
+                ).successAction(new AbstractTestAction() {
+                    @Override
+                    public void doExecute(TestContext context) {
+                        successActionPerformed.complete(true);
+                    }
+                }).errorAction(new AbstractTestAction() {
+                    @Override
+                    public void doExecute(TestContext context) {
+                        errorActionPerformed.complete(true);
+                    }
+                }));
+        } finally {
+            assertFalse(errorActionPerformed.isDone());
+            successActionPerformed.get(1000L, TimeUnit.MILLISECONDS);
+            Assert.assertEquals(context.getExceptions().size(), 0L);
+        }
+
+    }
+}

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/CatchExceptionTestActionBuilderTest.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/CatchExceptionTestActionBuilderTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.actions.dsl;
+
+import java.util.concurrent.TimeUnit;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.actions.EchoAction;
+import org.citrusframework.actions.SleepAction;
+import org.citrusframework.container.Catch;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.EchoAction.Builder.echo;
+import static org.citrusframework.actions.FailAction.Builder.fail;
+import static org.citrusframework.actions.SleepAction.Builder.sleep;
+import static org.citrusframework.container.Catch.Builder.catchException;
+import static org.testng.Assert.assertEquals;
+
+public class CatchExceptionTestActionBuilderTest extends UnitTestSupport {
+    @Test
+    public void testCatchDefaultExceptionBuilder() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(catchException().when(fail("Error")));
+
+        TestCase test = builder.getTestCase();
+        assertEquals(test.getActionCount(), 1);
+        assertEquals(test.getActions().get(0).getClass(), Catch.class);
+        assertEquals(test.getActions().get(0).getName(), "catch");
+
+        Catch container = (Catch)test.getActions().get(0);
+        assertEquals(container.getActionCount(), 1);
+        assertEquals(container.getException(), CitrusRuntimeException.class.getName());
+    }
+
+    @Test
+    public void testCatchBuilder() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(catchException().exception(CitrusRuntimeException.class.getName())
+                .when(echo("${var}")));
+
+
+        builder.$(catchException().exception(CitrusRuntimeException.class)
+                .when(echo("${var}"), sleep().milliseconds(100L)));
+
+        TestCase test = builder.getTestCase();
+        assertEquals(test.getActionCount(), 2);
+        assertEquals(test.getActions().get(0).getClass(), Catch.class);
+        assertEquals(test.getActions().get(0).getName(), "catch");
+        assertEquals(test.getActions().get(1).getClass(), Catch.class);
+        assertEquals(test.getActions().get(1).getName(), "catch");
+
+        Catch container = (Catch)test.getActions().get(0);
+        assertEquals(container.getActionCount(), 1);
+        assertEquals(container.getException(), CitrusRuntimeException.class.getName());
+        assertEquals(((EchoAction)(container.getActions().get(0))).getMessage(), "${var}");
+
+        container = (Catch)test.getActions().get(1);
+        assertEquals(container.getActionCount(), 2);
+        assertEquals(container.getException(), CitrusRuntimeException.class.getName());
+        assertEquals(((EchoAction)(container.getActions().get(0))).getMessage(), "${var}");
+        assertEquals(((SleepAction)(container.getActions().get(1))).getTime(), "100");
+        assertEquals(((SleepAction)(container.getActions().get(1))).getTimeUnit(), TimeUnit.MILLISECONDS);
+    }
+}

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/ConditionalTestActionBuilderTest.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/ConditionalTestActionBuilderTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.actions.dsl;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.container.Conditional;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.CreateVariablesAction.Builder.createVariable;
+import static org.citrusframework.actions.EchoAction.Builder.echo;
+import static org.citrusframework.container.Conditional.Builder.conditional;
+
+public class ConditionalTestActionBuilderTest extends UnitTestSupport {
+    @Test
+    public void testConditionalBuilder() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.variable("var", 5);
+
+        builder.$(conditional().when("${var} = 5")
+                .actions(echo("${var}"), createVariable("execution", "true")));
+
+        Assert.assertNotNull(context.getVariable("execution"));
+        Assert.assertEquals(context.getVariable("execution"), "true");
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), Conditional.class);
+        Assert.assertEquals(test.getActions().get(0).getName(), "conditional");
+
+        Conditional container = (Conditional)test.getActions().get(0);
+        Assert.assertEquals(container.getActionCount(), 2);
+        Assert.assertEquals(container.getCondition(), "${var} = 5");
+    }
+
+    @Test
+    public void testConditionalBuilderSkip() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.variable("var", 0);
+
+        builder.$(conditional().when("${var} = 5")
+                .actions(echo("${var}"), createVariable("execution", "true")));
+
+        Assert.assertNull(context.getVariables().get("execution"));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), Conditional.class);
+        Assert.assertEquals(test.getActions().get(0).getName(), "conditional");
+
+        Conditional container = (Conditional)test.getActions().get(0);
+        Assert.assertEquals(container.getActionCount(), 2);
+        Assert.assertEquals(container.getCondition(), "${var} = 5");
+    }
+
+    @Test
+    public void testConditionalBuilderConditionExpression() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.variable("var", 5);
+
+        builder.$(conditional().when(context -> context.getVariable("var").equals("5"))
+                .actions(echo("${var}"), createVariable("execution", "true")));
+
+        Assert.assertNotNull(context.getVariable("execution"));
+        Assert.assertEquals(context.getVariable("execution"), "true");
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), Conditional.class);
+        Assert.assertEquals(test.getActions().get(0).getName(), "conditional");
+
+        Conditional container = (Conditional)test.getActions().get(0);
+        Assert.assertEquals(container.getActionCount(), 2);
+        Assert.assertNotNull(container.getConditionExpression());
+    }
+}

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/CreateVariablesTestActionBuilderTest.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/CreateVariablesTestActionBuilderTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.actions.dsl;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.actions.CreateVariablesAction;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.CreateVariablesAction.Builder.createVariable;
+
+public class CreateVariablesTestActionBuilderTest extends UnitTestSupport {
+
+    @Test
+    public void testCreateVariablesBuilder() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(createVariable("foo", "bar"));
+        builder.$(createVariable("text", "Hello Citrus!"));
+        builder.$(createVariable("foobar", "bars"));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 3);
+        Assert.assertEquals(test.getActions().get(0).getClass(), CreateVariablesAction.class);
+        Assert.assertEquals(test.getActions().get(1).getClass(), CreateVariablesAction.class);
+        Assert.assertEquals(test.getActions().get(2).getClass(), CreateVariablesAction.class);
+
+        CreateVariablesAction action = (CreateVariablesAction)test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "create-variables");
+        Assert.assertEquals(action.getVariables().toString(), "{foo=bar}");
+
+        action = (CreateVariablesAction)test.getActions().get(1);
+        Assert.assertEquals(action.getName(), "create-variables");
+        Assert.assertEquals(action.getVariables().toString(), "{text=Hello Citrus!}");
+
+        action = (CreateVariablesAction)test.getActions().get(2);
+        Assert.assertEquals(action.getName(), "create-variables");
+        Assert.assertEquals(action.getVariables().toString(), "{foobar=bars}");
+    }
+}

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/CustomContainerTestActionBuilderTest.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/CustomContainerTestActionBuilderTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2006-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.actions.dsl;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestActionBuilder;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.actions.EchoAction;
+import org.citrusframework.container.AbstractActionContainer;
+import org.citrusframework.context.TestContext;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.AbstractTestContainerBuilder.container;
+import static org.citrusframework.actions.EchoAction.Builder.echo;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * @author Christoph Deppisch
+ * @since 2.6
+ */
+public class CustomContainerTestActionBuilderTest extends UnitTestSupport {
+
+    @Test
+    public void testCustomContainer() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(container(new CustomActionContainer()).actions(
+                echo("Hello"),
+                echo("${index}")
+        ));
+
+        TestCase test = builder.getTestCase();
+        assertEquals(test.getActionCount(), 1);
+        assertEquals(test.getActions().get(0).getClass(), CustomActionContainer.class);
+        assertEquals(test.getActions().get(0).getName(), "custom");
+
+        CustomActionContainer container = (CustomActionContainer) test.getActions().get(0);
+        assertEquals(container.getActionCount(), 2);
+        assertEquals(container.getActions().get(0).getClass(), EchoAction.class);
+        assertEquals(((EchoAction)container.getActions().get(0)).getMessage(), "Hello");
+        assertEquals(container.getActions().get(1).getClass(), EchoAction.class);
+        assertEquals(((EchoAction)container.getActions().get(1)).getMessage(), "${index}");
+
+        assertEquals(context.getVariable("index"), "10");
+    }
+
+    @Test
+    public void testCustomContainerWithPredefinedActions() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        CustomActionContainer container = new CustomActionContainer();
+        container.addTestAction(new EchoAction.Builder().message("This is a custom container action").build());
+        builder.$(container(container));
+
+        TestCase test = builder.getTestCase();
+        assertEquals(test.getActionCount(), 1);
+        assertEquals(test.getActions().get(0).getClass(), CustomActionContainer.class);
+        assertEquals(test.getActions().get(0).getName(), "custom");
+
+        container = (CustomActionContainer) test.getActions().get(0);
+        assertEquals(container.getActionCount(), 1);
+        assertEquals(container.getActions().get(0).getClass(), EchoAction.class);
+        assertEquals(((EchoAction)container.getActions().get(0)).getMessage(), "This is a custom container action");
+
+        assertEquals(context.getVariable("index"), "10");
+    }
+
+    private static class CustomActionContainer extends AbstractActionContainer {
+
+        public CustomActionContainer() {
+            setName("custom");
+        }
+
+        @Override
+        public void doExecute(TestContext context) {
+            for (int i = 1; i <= 10; i++) {
+                context.setVariable("index", i);
+
+                for (TestActionBuilder<?> actionBuilder : actions) {
+                    executeAction(actionBuilder.build(), context);
+                }
+            }
+        }
+    }
+}

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/EchoTestActionBuilderTest.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/EchoTestActionBuilderTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.actions.dsl;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.actions.EchoAction;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.EchoAction.Builder.echo;
+
+/**
+ * @author Christoph Deppisch
+ * @since 2.3
+ */
+public class EchoTestActionBuilderTest extends UnitTestSupport {
+
+    @Test
+    public void testEchoBuilder() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(echo("Hello Citrus!"));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), EchoAction.class);
+        Assert.assertEquals(test.getActiveAction().getClass(), EchoAction.class);
+
+        EchoAction action = (EchoAction)test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "echo");
+        Assert.assertEquals(action.getMessage(), "Hello Citrus!");
+    }
+}

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/ExpectTimeoutTestActionBuilderTest.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/ExpectTimeoutTestActionBuilderTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.actions.dsl;
+
+import java.util.HashMap;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.actions.ReceiveTimeoutAction;
+import org.citrusframework.container.SequenceAfterTest;
+import org.citrusframework.container.SequenceBeforeTest;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.endpoint.Endpoint;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.message.DefaultMessage;
+import org.citrusframework.messaging.Consumer;
+import org.citrusframework.report.TestActionListeners;
+import org.citrusframework.spi.ReferenceResolver;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.ReceiveTimeoutAction.Builder.expectTimeout;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Christoph Deppisch
+ * @since 2.3
+ */
+public class ExpectTimeoutTestActionBuilderTest extends UnitTestSupport {
+
+    private final Endpoint messageEndpoint = Mockito.mock(Endpoint.class);
+    private final Consumer messageConsumer = Mockito.mock(Consumer.class);
+    private final ReferenceResolver referenceResolver = Mockito.mock(ReferenceResolver.class);
+
+    @Test
+    public void testReceiveTimeoutBuilder() {
+        reset(messageEndpoint, messageConsumer);
+        when(messageEndpoint.createConsumer()).thenReturn(messageConsumer);
+        doAnswer(invocation -> {
+            Thread.sleep(500L);
+            return null;
+        }).when(messageConsumer).receive(any(TestContext.class), eq(250L));
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(expectTimeout().endpoint(messageEndpoint)
+                        .timeout(250)
+                        .selector("TestMessageSelector"));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ReceiveTimeoutAction.class);
+        Assert.assertEquals(test.getActiveAction().getClass(), ReceiveTimeoutAction.class);
+
+        ReceiveTimeoutAction action = (ReceiveTimeoutAction)test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "receive-timeout");
+        Assert.assertEquals(action.getEndpoint(), messageEndpoint);
+        Assert.assertEquals(action.getMessageSelector(),"TestMessageSelector");
+        Assert.assertEquals(action.getTimeout(), 250);
+
+    }
+
+    @Test
+    public void testReceiveTimeoutBuilderWithEndpointName() {
+        reset(referenceResolver, messageEndpoint, messageConsumer);
+        when(messageEndpoint.createConsumer()).thenReturn(messageConsumer);
+        doAnswer(invocation -> {
+            Thread.sleep(600L);
+            return null;
+        }).when(messageConsumer).receive(any(TestContext.class), eq(500L));
+
+        when(referenceResolver.resolve(TestContext.class)).thenReturn(context);
+        when(referenceResolver.resolve("fooMessageEndpoint", Endpoint.class)).thenReturn(messageEndpoint);
+        when(referenceResolver.resolve(TestActionListeners.class)).thenReturn(new TestActionListeners());
+        when(referenceResolver.resolveAll(SequenceBeforeTest.class)).thenReturn(new HashMap<>());
+        when(referenceResolver.resolveAll(SequenceAfterTest.class)).thenReturn(new HashMap<>());
+
+        context.setReferenceResolver(referenceResolver);
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(expectTimeout().endpoint("fooMessageEndpoint")
+                        .timeout(500));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ReceiveTimeoutAction.class);
+        Assert.assertEquals(test.getActiveAction().getClass(), ReceiveTimeoutAction.class);
+
+        ReceiveTimeoutAction action = (ReceiveTimeoutAction)test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "receive-timeout");
+        Assert.assertEquals(action.getEndpointUri(), "fooMessageEndpoint");
+        Assert.assertEquals(action.getTimeout(), 500);
+
+    }
+
+    @Test
+    public void testReceiveTimeoutBuilderFailure() {
+        reset(messageEndpoint, messageConsumer);
+        when(messageEndpoint.createConsumer()).thenReturn(messageConsumer);
+        doAnswer(invocation -> {
+            Thread.sleep(100L);
+            return new DefaultMessage("Hello Citrus!");
+        }).when(messageConsumer).receive(any(TestContext.class), eq(250L));
+        try {
+            DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+            builder.$(expectTimeout().endpoint(messageEndpoint)
+                            .timeout(250)
+                            .selector("TestMessageSelector"));
+
+            Assert.fail("Missing validation exception due to message received during timeout");
+        } catch (CitrusRuntimeException e) {
+            Assert.assertTrue(e.getCause().getMessage().contains("Message timeout validation failed"));
+        }
+    }
+}

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/FailTestActionBuilderTest.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/FailTestActionBuilderTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.actions.dsl;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.actions.FailAction;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.FailAction.Builder.fail;
+
+/**
+ * @author Christoph Deppisch
+ * @since 2.3
+ */
+public class FailTestActionBuilderTest extends UnitTestSupport {
+
+    @Test
+    public void testFailBuilder() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+
+        try {
+            builder.$(fail("This test will fail."));
+            Assert.fail("Missing test failure exception");
+        } catch (CitrusRuntimeException e) {
+            TestCase test = builder.getTestCase();
+            Assert.assertEquals(test.getActionCount(), 1);
+            Assert.assertEquals(test.getActions().get(0).getClass(), FailAction.class);
+            Assert.assertEquals(test.getActiveAction().getClass(), FailAction.class);
+
+            FailAction action = (FailAction) test.getActions().get(0);
+            Assert.assertEquals(action.getName(), "fail");
+            Assert.assertEquals(action.getMessage(), "This test will fail.");
+        }
+    }
+}

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/InputTestActionBuilderTest.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/InputTestActionBuilderTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.actions.dsl;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.actions.InputAction;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.InputAction.Builder.input;
+
+public class InputTestActionBuilderTest extends UnitTestSupport {
+
+    @Test
+    public void TestInputBuilder() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.variable("answer", "yes");
+
+        builder.$(input().message("Want to test me?")
+                .result("answer")
+                .answers("yes", "no", "maybe"));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), InputAction.class);
+
+        InputAction action = (InputAction)test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "input");
+        Assert.assertEquals(action.getMessage(), "Want to test me?");
+        Assert.assertEquals(action.getValidAnswers(), "yes/no/maybe");
+        Assert.assertEquals(action.getVariable(), "answer");
+    }
+}

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/IterateTestActionBuilderTest.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/IterateTestActionBuilderTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.actions.dsl;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.actions.AbstractTestAction;
+import org.citrusframework.container.Iterate;
+import org.citrusframework.context.TestContext;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.CreateVariablesAction.Builder.createVariable;
+import static org.citrusframework.container.Iterate.Builder.iterate;
+import static org.testng.Assert.assertEquals;
+
+public class IterateTestActionBuilderTest extends UnitTestSupport {
+    @Test
+    public void testIterateBuilder() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(iterate().index("i")
+                    .startsWith(0)
+                    .step(1)
+                    .condition("i lt 5")
+            .actions(createVariable("index", "${i}")));
+
+        Assert.assertNotNull(context.getVariable("i"));
+        Assert.assertEquals(context.getVariable("i"), "4");
+
+        TestCase test = builder.getTestCase();
+        assertEquals(test.getActionCount(), 1);
+        assertEquals(test.getActions().get(0).getClass(), Iterate.class);
+        assertEquals(test.getActions().get(0).getName(), "iterate");
+
+        Iterate container = (Iterate)test.getActions().get(0);
+        assertEquals(container.getActionCount(), 1);
+        assertEquals(container.getIndexName(), "i");
+        assertEquals(container.getCondition(), "i lt 5");
+        assertEquals(container.getStep(), 1);
+        assertEquals(container.getStart(), 0);
+    }
+
+    @Test
+    public void testIterateBuilderWithAnonymousAction() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(iterate().index("i")
+                    .startsWith(1)
+                    .step(1)
+                    .condition("i lt= 3")
+            .actions(createVariable("index", "${i}"),
+                () -> new AbstractTestAction() {
+                @Override
+                public void doExecute(TestContext context) {
+                    Assert.assertTrue(Integer.valueOf(context.getVariable("index")) > 0);
+                }
+            }));
+
+        Assert.assertNotNull(context.getVariable("i"));
+        Assert.assertEquals(context.getVariable("i"), "3");
+
+        TestCase test = builder.getTestCase();
+        assertEquals(test.getActionCount(), 1);
+        assertEquals(test.getActions().get(0).getClass(), Iterate.class);
+        assertEquals(test.getActions().get(0).getName(), "iterate");
+
+        Iterate container = (Iterate)test.getActions().get(0);
+        assertEquals(container.getActionCount(), 2);
+        assertEquals(container.getIndexName(), "i");
+        assertEquals(container.getCondition(), "i lt= 3");
+        assertEquals(container.getStep(), 1);
+        assertEquals(container.getStart(), 1);
+    }
+
+    @Test
+    public void testIterateBuilderWithConditionExpression() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(iterate().startsWith(0)
+                    .step(1)
+                    .condition((index, context) -> index < 5)
+            .actions(createVariable("index", "${i}")));
+
+        Assert.assertNotNull(context.getVariable("i"));
+        Assert.assertEquals(context.getVariable("i"), "4");
+
+        TestCase test = builder.getTestCase();
+        assertEquals(test.getActionCount(), 1);
+        assertEquals(test.getActions().get(0).getClass(), Iterate.class);
+        assertEquals(test.getActions().get(0).getName(), "iterate");
+
+        Iterate container = (Iterate)test.getActions().get(0);
+        assertEquals(container.getActionCount(), 1);
+        assertEquals(container.getIndexName(), "i");
+        assertEquals(container.getStep(), 1);
+        assertEquals(container.getStart(), 0);
+    }
+
+}

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/LoadPropertiesTestActionBuilderTest.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/LoadPropertiesTestActionBuilderTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.actions.dsl;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.actions.LoadPropertiesAction;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.LoadPropertiesAction.Builder.load;
+
+/**
+ * @author Christoph Deppisch
+ * @since 2.3
+ */
+public class LoadPropertiesTestActionBuilderTest extends UnitTestSupport {
+    @Test
+    public void testLoadBuilder() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.variable("checked", true);
+        builder.$(load("classpath:org/citrusframework/actions/dsl/build.properties"));
+
+        Assert.assertNotNull(context.getVariable("welcomeText"));
+        Assert.assertEquals(context.getVariable("welcomeText"), "Welcome with property file!");
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), LoadPropertiesAction.class);
+        Assert.assertEquals(test.getActiveAction().getClass(), LoadPropertiesAction.class);
+
+        LoadPropertiesAction action = (LoadPropertiesAction)test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "load");
+        Assert.assertEquals(action.getFilePath(), "classpath:org/citrusframework/actions/dsl/build.properties");
+    }
+}

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/ParallelTestActionBuilderTest.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/ParallelTestActionBuilderTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.actions.dsl;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.actions.EchoAction;
+import org.citrusframework.container.Parallel;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.EchoAction.Builder.echo;
+import static org.citrusframework.actions.SleepAction.Builder.sleep;
+import static org.citrusframework.container.Parallel.Builder.parallel;
+import static org.citrusframework.container.Sequence.Builder.sequential;
+import static org.testng.Assert.assertEquals;
+
+public class ParallelTestActionBuilderTest extends UnitTestSupport {
+    @Test
+    public void testParallelBuilder() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.variable("var", "foo");
+
+        builder.$(parallel()
+            .actions(
+                    echo("${var}"),
+                    sleep().milliseconds(200L),
+                    echo("Hello World!")
+            ));
+
+        TestCase test = builder.getTestCase();
+        assertEquals(test.getActionCount(), 1);
+        assertEquals(test.getActions().get(0).getClass(), Parallel.class);
+        assertEquals(test.getActions().get(0).getName(), "parallel");
+
+        Parallel container = (Parallel)test.getActions().get(0);
+        assertEquals(container.getActionCount(), 3);
+        assertEquals(container.getTestAction(0).getClass(), EchoAction.class);
+    }
+
+    @Test
+    public void testParallelBuilderNestedContainer() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.variable("var", "foo");
+
+        builder.$(parallel()
+            .actions(
+                echo("${var}"),
+                sequential()
+                    .actions(
+                        echo("1st in sequential"),
+                        echo("2nd in sequential")
+                    ),
+                sleep().milliseconds(200),
+                echo("Hello World!")
+            ));
+
+        TestCase test = builder.getTestCase();
+        assertEquals(test.getActionCount(), 1);
+        assertEquals(test.getActions().get(0).getClass(), Parallel.class);
+        assertEquals(test.getActions().get(0).getName(), "parallel");
+
+        Parallel container = (Parallel)test.getActions().get(0);
+        assertEquals(container.getActionCount(), 4);
+        assertEquals(container.getTestAction(0).getClass(), EchoAction.class);
+    }
+}

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/PurgeEndpointTestActionBuilderTest.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/PurgeEndpointTestActionBuilderTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.actions.dsl;
+
+import java.util.HashMap;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.actions.PurgeEndpointAction;
+import org.citrusframework.container.SequenceAfterTest;
+import org.citrusframework.container.SequenceBeforeTest;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.endpoint.Endpoint;
+import org.citrusframework.exceptions.ActionTimeoutException;
+import org.citrusframework.messaging.Consumer;
+import org.citrusframework.messaging.SelectiveConsumer;
+import org.citrusframework.report.TestActionListeners;
+import org.citrusframework.spi.ReferenceResolver;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.PurgeEndpointAction.Builder.purgeEndpoints;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Christoph Deppisch
+ * @since 2.3
+ */
+public class PurgeEndpointTestActionBuilderTest extends UnitTestSupport {
+
+    private final Endpoint endpoint1 = Mockito.mock(Endpoint.class);
+    private final Endpoint endpoint2 = Mockito.mock(Endpoint.class);
+    private final Endpoint endpoint3 = Mockito.mock(Endpoint.class);
+    private final Endpoint endpoint4 = Mockito.mock(Endpoint.class);
+
+    private final Consumer consumer = Mockito.mock(Consumer.class);
+    private final SelectiveConsumer selectiveConsumer = Mockito.mock(SelectiveConsumer.class);
+
+    private final ReferenceResolver referenceResolver = Mockito.mock(ReferenceResolver.class);
+
+    @Test
+    public void testPurgeEndpointsBuilderWithEndpoints() {
+        reset(endpoint1, endpoint2, endpoint3, endpoint4, consumer, selectiveConsumer);
+
+        when(endpoint1.getName()).thenReturn("e1");
+        when(endpoint2.getName()).thenReturn("e2");
+        when(endpoint3.getName()).thenReturn("e3");
+
+        when(endpoint1.createConsumer()).thenReturn(consumer);
+        when(endpoint2.createConsumer()).thenReturn(consumer);
+        when(endpoint3.createConsumer()).thenReturn(consumer);
+
+        doThrow(new ActionTimeoutException()).when(consumer).receive(any(TestContext.class), eq(100L));
+
+        context.setReferenceResolver(referenceResolver);
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(purgeEndpoints().endpoints(endpoint1, endpoint2)
+                        .endpoint(endpoint3));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), PurgeEndpointAction.class);
+        Assert.assertEquals(test.getActions().get(0).getName(), "purge-endpoint");
+
+        PurgeEndpointAction action = (PurgeEndpointAction) test.getActions().get(0);
+        Assert.assertEquals(action.getEndpoints().size(), 3);
+        Assert.assertEquals(action.getEndpoints().toString(), "[" + endpoint1.toString() + ", " + endpoint2.toString() + ", " + endpoint3.toString() + "]");
+        Assert.assertEquals(action.getMessageSelectorMap().size(), 0);
+        Assert.assertNull(action.getMessageSelector());
+    }
+
+    @Test
+    public void testPurgeEndpointBuilderWithNames() {
+        reset(referenceResolver, endpoint1, endpoint2, endpoint3, endpoint4, consumer, selectiveConsumer);
+
+        when(referenceResolver.resolve(TestContext.class)).thenReturn(context);
+        when(referenceResolver.resolve(TestActionListeners.class)).thenReturn(new TestActionListeners());
+        when(referenceResolver.resolveAll(SequenceBeforeTest.class)).thenReturn(new HashMap<>());
+        when(referenceResolver.resolveAll(SequenceAfterTest.class)).thenReturn(new HashMap<>());
+
+        when(endpoint1.getName()).thenReturn("e1");
+        when(endpoint2.getName()).thenReturn("e2");
+        when(endpoint3.getName()).thenReturn("e3");
+        when(endpoint4.getName()).thenReturn("e4");
+
+        when(endpoint1.createConsumer()).thenReturn(selectiveConsumer);
+        when(endpoint2.createConsumer()).thenReturn(consumer);
+        when(endpoint3.createConsumer()).thenReturn(selectiveConsumer);
+        when(endpoint4.createConsumer()).thenReturn(consumer);
+
+        when(referenceResolver.resolve("e1", Endpoint.class)).thenReturn(endpoint1);
+        when(referenceResolver.resolve("e2", Endpoint.class)).thenReturn(endpoint2);
+        when(referenceResolver.resolve("e3", Endpoint.class)).thenReturn(endpoint3);
+        when(referenceResolver.resolve("e4", Endpoint.class)).thenReturn(endpoint4);
+
+        doThrow(new ActionTimeoutException()).when(consumer).receive(any(TestContext.class), eq(100L));
+        doThrow(new ActionTimeoutException()).when(selectiveConsumer).receive(eq("operation = 'sayHello'"), any(TestContext.class), eq(100L));
+
+        context.setReferenceResolver(referenceResolver);
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(purgeEndpoints().endpointNames("e1", "e2", "e3")
+                        .endpoint("e4")
+                        .selector("operation = 'sayHello'"));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), PurgeEndpointAction.class);
+
+        PurgeEndpointAction action = (PurgeEndpointAction) test.getActions().get(0);
+        Assert.assertEquals(action.getEndpointNames().size(), 4);
+        Assert.assertEquals(action.getEndpointNames().toString(), "[e1, e2, e3, e4]");
+        Assert.assertNotNull(action.getReferenceResolver());
+        Assert.assertEquals(action.getMessageSelectorMap().size(), 0);
+        Assert.assertEquals(action.getMessageSelector(), "operation = 'sayHello'");
+
+    }
+
+    @Test
+    public void testCustomEndpointResolver() {
+        reset(referenceResolver, endpoint1, consumer, selectiveConsumer);
+
+        when(referenceResolver.resolve(TestContext.class)).thenReturn(context);
+        when(referenceResolver.resolve(TestActionListeners.class)).thenReturn(new TestActionListeners());
+        when(referenceResolver.resolveAll(SequenceBeforeTest.class)).thenReturn(new HashMap<>());
+        when(referenceResolver.resolveAll(SequenceAfterTest.class)).thenReturn(new HashMap<>());
+
+        when(endpoint1.getName()).thenReturn("e1");
+        when(endpoint1.createConsumer()).thenReturn(consumer);
+
+        when(referenceResolver.resolve("e1", Endpoint.class)).thenReturn(endpoint1);
+        doThrow(new ActionTimeoutException()).when(consumer).receive(any(TestContext.class), eq(100L));
+
+        context.setReferenceResolver(referenceResolver);
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(purgeEndpoints().endpoint("e1")
+                        .withReferenceResolver(referenceResolver));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), PurgeEndpointAction.class);
+
+        PurgeEndpointAction action = (PurgeEndpointAction) test.getActions().get(0);
+        Assert.assertEquals(action.getEndpointNames().size(), 1);
+        Assert.assertEquals(action.getEndpointNames().toString(), "[e1]");
+        Assert.assertNotNull(action.getReferenceResolver());
+        Assert.assertEquals(action.getReferenceResolver(), referenceResolver);
+    }
+}

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/ReceiveMessageTestActionBuilderTest.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/ReceiveMessageTestActionBuilderTest.java
@@ -1,0 +1,765 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.actions.dsl;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.TextEqualsMessageValidator;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.actions.ReceiveMessageAction;
+import org.citrusframework.container.SequenceAfterTest;
+import org.citrusframework.container.SequenceBeforeTest;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.endpoint.Endpoint;
+import org.citrusframework.endpoint.EndpointConfiguration;
+import org.citrusframework.message.DefaultMessage;
+import org.citrusframework.message.Message;
+import org.citrusframework.message.MessageType;
+import org.citrusframework.messaging.Consumer;
+import org.citrusframework.messaging.SelectiveConsumer;
+import org.citrusframework.report.TestActionListeners;
+import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.validation.AbstractValidationProcessor;
+import org.citrusframework.validation.builder.DefaultMessageBuilder;
+import org.citrusframework.validation.builder.StaticMessageBuilder;
+import org.citrusframework.validation.context.HeaderValidationContext;
+import org.citrusframework.validation.json.JsonMessageValidationContext;
+import org.citrusframework.validation.xml.XmlMessageValidationContext;
+import org.citrusframework.variable.MessageHeaderVariableExtractor;
+import org.mockito.Mockito;
+import org.springframework.core.io.Resource;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.ReceiveMessageAction.Builder.receive;
+import static org.citrusframework.dsl.MessageSupport.message;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class ReceiveMessageTestActionBuilderTest extends UnitTestSupport {
+
+    private final Endpoint messageEndpoint = Mockito.mock(Endpoint.class);
+    private final Consumer messageConsumer = Mockito.mock(Consumer.class);
+    private final EndpointConfiguration configuration = Mockito.mock(EndpointConfiguration.class);
+    private final Resource resource = Mockito.mock(Resource.class);
+    private final ReferenceResolver referenceResolver = Mockito.mock(ReferenceResolver.class);
+
+    @Test
+    public void testReceiveEmpty() {
+        reset(messageEndpoint, messageConsumer, configuration);
+        when(messageEndpoint.createConsumer()).thenReturn(messageConsumer);
+        when(messageEndpoint.getEndpointConfiguration()).thenReturn(configuration);
+        when(configuration.getTimeout()).thenReturn(100L);
+        when(messageEndpoint.getActor()).thenReturn(null);
+        when(messageConsumer.receive(any(TestContext.class), anyLong())).thenReturn(new DefaultMessage("<Message>Hello</Message>"));
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(receive().endpoint(messageEndpoint));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ReceiveMessageAction.class);
+
+        ReceiveMessageAction action = ((ReceiveMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "receive");
+
+        Assert.assertEquals(action.getMessageType(), MessageType.XML.name());
+        Assert.assertEquals(action.getEndpoint(), messageEndpoint);
+        Assert.assertEquals(action.getValidationContexts().size(), 3);
+        Assert.assertTrue(action.getValidationContexts().stream().anyMatch(HeaderValidationContext.class::isInstance));
+        Assert.assertTrue(action.getValidationContexts().stream().anyMatch(XmlMessageValidationContext.class::isInstance));
+        Assert.assertTrue(action.getValidationContexts().stream().anyMatch(JsonMessageValidationContext.class::isInstance));
+    }
+
+    @Test
+    public void testReceiveBuilder() {
+        reset(messageEndpoint, messageConsumer, configuration);
+        when(messageEndpoint.createConsumer()).thenReturn(messageConsumer);
+        when(messageEndpoint.getEndpointConfiguration()).thenReturn(configuration);
+        when(configuration.getTimeout()).thenReturn(100L);
+        when(messageEndpoint.getActor()).thenReturn(null);
+        when(messageConsumer.receive(any(TestContext.class), anyLong())).thenReturn(new DefaultMessage("Foo").setHeader("operation", "foo"));
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(receive().endpoint(messageEndpoint)
+                        .message(new DefaultMessage("Foo").setHeader("operation", "foo")));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ReceiveMessageAction.class);
+
+        ReceiveMessageAction action = ((ReceiveMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "receive");
+
+        Assert.assertEquals(action.getMessageType(), MessageType.PLAINTEXT.name());
+        Assert.assertEquals(action.getEndpoint(), messageEndpoint);
+        Assert.assertEquals(action.getValidationContexts().size(), 3);
+        Assert.assertTrue(action.getValidationContexts().stream().anyMatch(HeaderValidationContext.class::isInstance));
+        Assert.assertTrue(action.getValidationContexts().stream().anyMatch(XmlMessageValidationContext.class::isInstance));
+        Assert.assertTrue(action.getValidationContexts().stream().anyMatch(JsonMessageValidationContext.class::isInstance));
+
+        Assert.assertTrue(action.getMessageBuilder() instanceof StaticMessageBuilder);
+        Assert.assertEquals(((StaticMessageBuilder)action.getMessageBuilder()).getMessage().getPayload(), "Foo");
+        Assert.assertNotNull(((StaticMessageBuilder)action.getMessageBuilder()).getMessage().getHeader("operation"));
+    }
+
+    @Test
+    public void testReceiveBuilderWithPayloadString() {
+        reset(messageEndpoint, messageConsumer, configuration);
+        when(messageEndpoint.createConsumer()).thenReturn(messageConsumer);
+        when(messageEndpoint.getEndpointConfiguration()).thenReturn(configuration);
+        when(configuration.getTimeout()).thenReturn(100L);
+        when(messageEndpoint.getActor()).thenReturn(null);
+        when(messageConsumer.receive(any(TestContext.class), anyLong())).thenReturn(
+                new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>")
+                        .setHeader("operation", "foo"));
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(receive().endpoint(messageEndpoint)
+                        .message()
+                        .body("<TestRequest><Message>Hello World!</Message></TestRequest>"));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ReceiveMessageAction.class);
+
+        ReceiveMessageAction action = ((ReceiveMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "receive");
+
+        Assert.assertEquals(action.getMessageType(), MessageType.XML.name());
+        Assert.assertEquals(action.getEndpoint(), messageEndpoint);
+        Assert.assertEquals(action.getValidationContexts().size(), 3);
+        Assert.assertTrue(action.getValidationContexts().stream().anyMatch(HeaderValidationContext.class::isInstance));
+        Assert.assertTrue(action.getValidationContexts().stream().anyMatch(XmlMessageValidationContext.class::isInstance));
+        Assert.assertTrue(action.getValidationContexts().stream().anyMatch(JsonMessageValidationContext.class::isInstance));
+
+        Assert.assertTrue(action.getMessageBuilder() instanceof DefaultMessageBuilder);
+        Assert.assertEquals(((DefaultMessageBuilder)action.getMessageBuilder()).buildMessagePayload(context, action.getMessageType()), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+
+    }
+
+    @Test
+    public void testReceiveBuilderWithPayloadResource() throws IOException {
+        reset(resource, messageEndpoint, messageConsumer, configuration);
+        when(messageEndpoint.createConsumer()).thenReturn(messageConsumer);
+        when(messageEndpoint.getEndpointConfiguration()).thenReturn(configuration);
+        when(configuration.getTimeout()).thenReturn(100L);
+        when(messageEndpoint.getActor()).thenReturn(null);
+        when(messageConsumer.receive(any(TestContext.class), anyLong())).thenReturn(
+                new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>")
+                        .setHeader("operation", "foo"));
+
+        when(resource.getInputStream()).thenReturn(new ByteArrayInputStream("<TestRequest><Message>Hello World!</Message></TestRequest>".getBytes()));
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(receive().endpoint(messageEndpoint)
+                        .message()
+                        .body(resource));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ReceiveMessageAction.class);
+
+        ReceiveMessageAction action = ((ReceiveMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "receive");
+
+        Assert.assertEquals(action.getMessageType(), MessageType.XML.name());
+        Assert.assertEquals(action.getEndpoint(), messageEndpoint);
+        Assert.assertEquals(action.getValidationContexts().size(), 3);
+        Assert.assertTrue(action.getValidationContexts().stream().anyMatch(HeaderValidationContext.class::isInstance));
+        Assert.assertTrue(action.getValidationContexts().stream().anyMatch(XmlMessageValidationContext.class::isInstance));
+        Assert.assertTrue(action.getValidationContexts().stream().anyMatch(JsonMessageValidationContext.class::isInstance));
+
+        Assert.assertTrue(action.getMessageBuilder() instanceof DefaultMessageBuilder);
+        Assert.assertEquals(((DefaultMessageBuilder)action.getMessageBuilder()).buildMessagePayload(context, action.getMessageType()), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+
+    }
+
+    @Test
+    public void testReceiveBuilderWithEndpointName() {
+        reset(referenceResolver, messageEndpoint, messageConsumer, configuration);
+        when(messageEndpoint.createConsumer()).thenReturn(messageConsumer);
+        when(messageEndpoint.getEndpointConfiguration()).thenReturn(configuration);
+        when(configuration.getTimeout()).thenReturn(100L);
+        when(messageEndpoint.getActor()).thenReturn(null);
+        when(messageConsumer.receive(any(TestContext.class), anyLong())).thenReturn(
+                new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>")
+                        .setHeader("operation", "foo"));
+
+        when(referenceResolver.resolve(TestContext.class)).thenReturn(context);
+        when(referenceResolver.resolve("fooMessageEndpoint", Endpoint.class)).thenReturn(messageEndpoint);
+        when(referenceResolver.resolve(TestActionListeners.class)).thenReturn(new TestActionListeners());
+        when(referenceResolver.resolveAll(SequenceBeforeTest.class)).thenReturn(new HashMap<>());
+        when(referenceResolver.resolveAll(SequenceAfterTest.class)).thenReturn(new HashMap<>());
+
+        context.setReferenceResolver(referenceResolver);
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(receive().endpoint("fooMessageEndpoint")
+                        .message()
+                        .body("<TestRequest><Message>Hello World!</Message></TestRequest>"));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ReceiveMessageAction.class);
+
+        ReceiveMessageAction action = ((ReceiveMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "receive");
+        Assert.assertEquals(action.getEndpointUri(), "fooMessageEndpoint");
+        Assert.assertEquals(action.getMessageType(), MessageType.XML.name());
+    }
+
+    @Test
+    public void testReceiveBuilderWithTimeout() {
+        reset(messageEndpoint, messageConsumer, configuration);
+        when(messageEndpoint.createConsumer()).thenReturn(messageConsumer);
+        when(messageEndpoint.getActor()).thenReturn(null);
+        when(messageConsumer.receive(any(TestContext.class), anyLong())).thenReturn(
+                new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>")
+                        .setHeader("operation", "foo"));
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(receive().endpoint(messageEndpoint)
+                        .message()
+                        .body("<TestRequest><Message>Hello World!</Message></TestRequest>")
+                        .timeout(1000L));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ReceiveMessageAction.class);
+
+        ReceiveMessageAction action = ((ReceiveMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "receive");
+
+        Assert.assertEquals(action.getEndpoint(), messageEndpoint);
+        Assert.assertEquals(action.getReceiveTimeout(), 1000L);
+
+    }
+
+    @Test
+    public void testReceiveBuilderWithHeaders() {
+        reset(messageEndpoint, messageConsumer, configuration);
+        when(messageEndpoint.createConsumer()).thenReturn(messageConsumer);
+        when(messageEndpoint.getEndpointConfiguration()).thenReturn(configuration);
+        when(configuration.getTimeout()).thenReturn(100L);
+        when(messageEndpoint.getActor()).thenReturn(null);
+        when(messageConsumer.receive(any(TestContext.class), anyLong())).thenReturn(
+                new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>")
+                        .setHeader("some", "value")
+                        .setHeader("operation", "sayHello")
+                        .setHeader("foo", "bar"));
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(receive().endpoint(messageEndpoint)
+                        .message()
+                        .body("<TestRequest><Message>Hello World!</Message></TestRequest>")
+                        .headers(Collections.singletonMap("some", "value"))
+                        .header("operation", "sayHello")
+                        .header("foo", "bar"));
+
+        builder.$(receive().endpoint(messageEndpoint)
+                .message()
+                .header("operation", "sayHello")
+                .header("foo", "bar")
+                .headers(Collections.singletonMap("some", "value"))
+                .body("<TestRequest><Message>Hello World!</Message></TestRequest>"));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 2);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ReceiveMessageAction.class);
+        Assert.assertEquals(test.getActions().get(1).getClass(), ReceiveMessageAction.class);
+
+        ReceiveMessageAction action = ((ReceiveMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "receive");
+
+        Assert.assertEquals(action.getEndpoint(), messageEndpoint);
+        Assert.assertEquals(action.getMessageType(), MessageType.XML.name());
+
+        Assert.assertTrue(action.getMessageBuilder() instanceof DefaultMessageBuilder);
+        Assert.assertEquals(((DefaultMessageBuilder)action.getMessageBuilder()).buildMessagePayload(context, action.getMessageType()), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+        Assert.assertTrue(((DefaultMessageBuilder)action.getMessageBuilder()).buildMessageHeaders(context).containsKey("some"));
+        Assert.assertTrue(((DefaultMessageBuilder)action.getMessageBuilder()).buildMessageHeaders(context).containsKey("operation"));
+        Assert.assertTrue(((DefaultMessageBuilder)action.getMessageBuilder()).buildMessageHeaders(context).containsKey("foo"));
+
+        action = ((ReceiveMessageAction)test.getActions().get(1));
+        Assert.assertEquals(action.getName(), "receive");
+
+        Assert.assertEquals(action.getEndpoint(), messageEndpoint);
+        Assert.assertEquals(action.getMessageType(), MessageType.XML.name());
+
+        Assert.assertTrue(action.getMessageBuilder() instanceof DefaultMessageBuilder);
+        Assert.assertEquals(((DefaultMessageBuilder)action.getMessageBuilder()).buildMessagePayload(context, action.getMessageType()), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+        Assert.assertTrue(((DefaultMessageBuilder)action.getMessageBuilder()).buildMessageHeaders(context).containsKey("some"));
+        Assert.assertTrue(((DefaultMessageBuilder)action.getMessageBuilder()).buildMessageHeaders(context).containsKey("operation"));
+        Assert.assertTrue(((DefaultMessageBuilder)action.getMessageBuilder()).buildMessageHeaders(context).containsKey("foo"));
+
+    }
+
+    @Test
+    public void testReceiveBuilderWithHeaderData() {
+        reset(messageEndpoint, messageConsumer, configuration);
+        when(messageEndpoint.createConsumer()).thenReturn(messageConsumer);
+        when(messageEndpoint.getEndpointConfiguration()).thenReturn(configuration);
+        when(configuration.getTimeout()).thenReturn(100L);
+        when(messageEndpoint.getActor()).thenReturn(null);
+        when(messageConsumer.receive(any(TestContext.class), anyLong())).thenReturn(
+                new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>")
+                        .setHeader("operation", "foo")
+                        .addHeaderData("<Header><Name>operation</Name><Value>foo</Value></Header>"));
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(receive().endpoint(messageEndpoint)
+                        .message()
+                        .body("<TestRequest><Message>Hello World!</Message></TestRequest>")
+                        .header("<Header><Name>operation</Name><Value>foo</Value></Header>"));
+
+        builder.$(receive().endpoint(messageEndpoint)
+                .message(new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>"))
+                .header("<Header><Name>operation</Name><Value>foo</Value></Header>"));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 2);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ReceiveMessageAction.class);
+        Assert.assertEquals(test.getActions().get(1).getClass(), ReceiveMessageAction.class);
+
+        ReceiveMessageAction action = ((ReceiveMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "receive");
+
+        Assert.assertEquals(action.getEndpoint(), messageEndpoint);
+        Assert.assertEquals(action.getMessageType(), MessageType.XML.name());
+
+        Assert.assertTrue(action.getMessageBuilder() instanceof DefaultMessageBuilder);
+        Assert.assertEquals(((DefaultMessageBuilder)action.getMessageBuilder()).buildMessagePayload(context, action.getMessageType()), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+        Assert.assertEquals(((DefaultMessageBuilder)action.getMessageBuilder()).buildMessageHeaderData(context).size(), 1L);
+        Assert.assertEquals(((DefaultMessageBuilder)action.getMessageBuilder()).buildMessageHeaderData(context).get(0), "<Header><Name>operation</Name><Value>foo</Value></Header>");
+
+        action = ((ReceiveMessageAction) test.getActions().get(1));
+        Assert.assertEquals(action.getName(), "receive");
+
+        Assert.assertEquals(action.getEndpoint(), messageEndpoint);
+        Assert.assertEquals(action.getMessageType(), MessageType.XML.name());
+
+        Assert.assertTrue(action.getMessageBuilder() instanceof StaticMessageBuilder);
+        Assert.assertEquals(((StaticMessageBuilder)action.getMessageBuilder()).getMessage().getPayload(), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+        Assert.assertEquals(((StaticMessageBuilder)action.getMessageBuilder()).buildMessageHeaderData(context).size(), 1L);
+        Assert.assertEquals(((StaticMessageBuilder)action.getMessageBuilder()).buildMessageHeaderData(context).get(0), "<Header><Name>operation</Name><Value>foo</Value></Header>");
+
+    }
+
+    @Test
+    public void testReceiveBuilderWithMultipleHeaderData() {
+        reset(messageEndpoint, messageConsumer, configuration);
+        when(messageEndpoint.createConsumer()).thenReturn(messageConsumer);
+        when(messageEndpoint.getEndpointConfiguration()).thenReturn(configuration);
+        when(configuration.getTimeout()).thenReturn(100L);
+        when(messageEndpoint.getActor()).thenReturn(null);
+        when(messageConsumer.receive(any(TestContext.class), anyLong())).thenReturn(
+                new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>")
+                        .setHeader("operation", "foo")
+                        .addHeaderData("<Header><Name>operation</Name><Value>foo1</Value></Header>")
+                        .addHeaderData("<Header><Name>operation</Name><Value>foo2</Value></Header>"));
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(receive().endpoint(messageEndpoint)
+                .message()
+                .body("<TestRequest><Message>Hello World!</Message></TestRequest>")
+                .header("<Header><Name>operation</Name><Value>foo1</Value></Header>")
+                .header("<Header><Name>operation</Name><Value>foo2</Value></Header>"));
+
+        builder.$(receive().endpoint(messageEndpoint)
+                .message(new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>"))
+                .header("<Header><Name>operation</Name><Value>foo1</Value></Header>")
+                .header("<Header><Name>operation</Name><Value>foo2</Value></Header>"));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 2);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ReceiveMessageAction.class);
+        Assert.assertEquals(test.getActions().get(1).getClass(), ReceiveMessageAction.class);
+
+        ReceiveMessageAction action = ((ReceiveMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "receive");
+
+        Assert.assertEquals(action.getEndpoint(), messageEndpoint);
+        Assert.assertEquals(action.getMessageType(), MessageType.XML.name());
+
+        Assert.assertTrue(action.getMessageBuilder() instanceof DefaultMessageBuilder);
+        Assert.assertEquals(((DefaultMessageBuilder)action.getMessageBuilder()).buildMessagePayload(context, action.getMessageType()), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+        Assert.assertEquals(((DefaultMessageBuilder)action.getMessageBuilder()).buildMessageHeaderData(context).size(), 2L);
+        Assert.assertEquals(((DefaultMessageBuilder)action.getMessageBuilder()).buildMessageHeaderData(context).get(0), "<Header><Name>operation</Name><Value>foo1</Value></Header>");
+        Assert.assertEquals(((DefaultMessageBuilder)action.getMessageBuilder()).buildMessageHeaderData(context).get(1), "<Header><Name>operation</Name><Value>foo2</Value></Header>");
+
+        action = ((ReceiveMessageAction)test.getActions().get(1));
+        Assert.assertEquals(action.getName(), "receive");
+
+        Assert.assertEquals(action.getEndpoint(), messageEndpoint);
+        Assert.assertEquals(action.getMessageType(), MessageType.XML.name());
+
+        Assert.assertTrue(action.getMessageBuilder() instanceof StaticMessageBuilder);
+        Assert.assertEquals(((StaticMessageBuilder)action.getMessageBuilder()).getMessage().getPayload(), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+        Assert.assertEquals(((StaticMessageBuilder)action.getMessageBuilder()).buildMessageHeaderData(context).size(), 2L);
+        Assert.assertEquals(((StaticMessageBuilder)action.getMessageBuilder()).buildMessageHeaderData(context).get(0), "<Header><Name>operation</Name><Value>foo1</Value></Header>");
+        Assert.assertEquals(((StaticMessageBuilder)action.getMessageBuilder()).buildMessageHeaderData(context).get(1), "<Header><Name>operation</Name><Value>foo2</Value></Header>");
+
+    }
+
+    @Test
+    public void testReceiveBuilderWithHeaderResource() throws IOException {
+        reset(resource, messageEndpoint, messageConsumer, configuration);
+        when(messageEndpoint.createConsumer()).thenReturn(messageConsumer);
+        when(messageEndpoint.getEndpointConfiguration()).thenReturn(configuration);
+        when(configuration.getTimeout()).thenReturn(100L);
+        when(messageEndpoint.getActor()).thenReturn(null);
+        when(messageConsumer.receive(any(TestContext.class), anyLong()))
+                .thenReturn(new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>")
+                        .setHeader("operation", "foo")
+                        .addHeaderData("<Header><Name>operation</Name><Value>foo</Value></Header>"))
+                .thenReturn(new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>")
+                        .setHeader("operation", "bar")
+                        .addHeaderData("<Header><Name>operation</Name><Value>bar</Value></Header>"));
+
+        when(resource.getInputStream()).thenReturn(new ByteArrayInputStream("<Header><Name>operation</Name><Value>foo</Value></Header>".getBytes()))
+                                       .thenReturn(new ByteArrayInputStream("<Header><Name>operation</Name><Value>bar</Value></Header>".getBytes()));
+
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(receive().endpoint(messageEndpoint)
+                        .message()
+                        .body("<TestRequest><Message>Hello World!</Message></TestRequest>")
+                        .header(resource));
+
+        builder.$(receive().endpoint(messageEndpoint)
+                        .message(new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>"))
+                        .header(resource));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 2);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ReceiveMessageAction.class);
+        Assert.assertEquals(test.getActions().get(1).getClass(), ReceiveMessageAction.class);
+
+        ReceiveMessageAction action = ((ReceiveMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "receive");
+
+        Assert.assertEquals(action.getEndpoint(), messageEndpoint);
+        Assert.assertEquals(action.getMessageType(), MessageType.XML.name());
+
+        Assert.assertTrue(action.getMessageBuilder() instanceof DefaultMessageBuilder);
+        Assert.assertEquals(((DefaultMessageBuilder)action.getMessageBuilder()).buildMessagePayload(context, action.getMessageType()), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+        Assert.assertEquals(((DefaultMessageBuilder)action.getMessageBuilder()).buildMessageHeaderData(context).size(), 1L);
+        Assert.assertEquals(((DefaultMessageBuilder)action.getMessageBuilder()).buildMessageHeaderData(context).get(0), "<Header><Name>operation</Name><Value>foo</Value></Header>");
+
+        action = ((ReceiveMessageAction)test.getActions().get(1));
+        Assert.assertEquals(action.getName(), "receive");
+
+        Assert.assertEquals(action.getEndpoint(), messageEndpoint);
+        Assert.assertEquals(action.getMessageType(), MessageType.XML.name());
+
+        Assert.assertTrue(action.getMessageBuilder() instanceof StaticMessageBuilder);
+        Assert.assertEquals(((StaticMessageBuilder)action.getMessageBuilder()).getMessage().getPayload(), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+        Assert.assertEquals(((StaticMessageBuilder)action.getMessageBuilder()).buildMessageHeaderData(context).size(), 1L);
+        Assert.assertEquals(((StaticMessageBuilder)action.getMessageBuilder()).buildMessageHeaderData(context).get(0), "<Header><Name>operation</Name><Value>bar</Value></Header>");
+
+    }
+
+    @Test
+    public void testReceiveBuilderWithMultipleHeaderResource() throws IOException {
+        reset(resource, messageEndpoint, messageConsumer, configuration);
+        when(messageEndpoint.createConsumer()).thenReturn(messageConsumer);
+        when(messageEndpoint.getEndpointConfiguration()).thenReturn(configuration);
+        when(configuration.getTimeout()).thenReturn(100L);
+        when(messageEndpoint.getActor()).thenReturn(null);
+        when(messageConsumer.receive(any(TestContext.class), anyLong())).thenReturn(
+                new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>")
+                        .setHeader("operation", "foo")
+                        .addHeaderData("<Header><Name>operation</Name><Value>sayHello</Value></Header>")
+                        .addHeaderData("<Header><Name>operation</Name><Value>foo</Value></Header>")
+                        .addHeaderData("<Header><Name>operation</Name><Value>bar</Value></Header>"));
+
+        when(resource.getInputStream()).thenReturn(new ByteArrayInputStream("<Header><Name>operation</Name><Value>foo</Value></Header>".getBytes()))
+                                       .thenReturn(new ByteArrayInputStream("<Header><Name>operation</Name><Value>bar</Value></Header>".getBytes()))
+                                       .thenReturn(new ByteArrayInputStream("<Header><Name>operation</Name><Value>foo</Value></Header>".getBytes()))
+                                       .thenReturn(new ByteArrayInputStream("<Header><Name>operation</Name><Value>bar</Value></Header>".getBytes()));
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(receive().endpoint(messageEndpoint)
+                        .message()
+                        .body("<TestRequest><Message>Hello World!</Message></TestRequest>")
+                        .header("<Header><Name>operation</Name><Value>sayHello</Value></Header>")
+                        .header(resource)
+                        .header(resource));
+
+        builder.$(receive().endpoint(messageEndpoint)
+                        .message(new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>"))
+                        .header("<Header><Name>operation</Name><Value>sayHello</Value></Header>")
+                        .header(resource)
+                        .header(resource));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 2);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ReceiveMessageAction.class);
+        Assert.assertEquals(test.getActions().get(1).getClass(), ReceiveMessageAction.class);
+
+        ReceiveMessageAction action = ((ReceiveMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "receive");
+
+        Assert.assertEquals(action.getEndpoint(), messageEndpoint);
+        Assert.assertEquals(action.getMessageType(), MessageType.XML.name());
+
+        Assert.assertTrue(action.getMessageBuilder() instanceof DefaultMessageBuilder);
+        Assert.assertEquals(((DefaultMessageBuilder) action.getMessageBuilder()).buildMessagePayload(context, action.getMessageType()), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+        Assert.assertEquals(((DefaultMessageBuilder) action.getMessageBuilder()).buildMessageHeaderData(context).size(), 3L);
+        Assert.assertEquals(((DefaultMessageBuilder) action.getMessageBuilder()).buildMessageHeaderData(context).get(0), "<Header><Name>operation</Name><Value>sayHello</Value></Header>");
+        Assert.assertEquals(((DefaultMessageBuilder)action.getMessageBuilder()).buildMessageHeaderData(context).get(1), "<Header><Name>operation</Name><Value>foo</Value></Header>");
+        Assert.assertEquals(((DefaultMessageBuilder)action.getMessageBuilder()).buildMessageHeaderData(context).get(2), "<Header><Name>operation</Name><Value>bar</Value></Header>");
+
+        action = ((ReceiveMessageAction)test.getActions().get(1));
+        Assert.assertEquals(action.getName(), "receive");
+
+        Assert.assertEquals(action.getEndpoint(), messageEndpoint);
+        Assert.assertEquals(action.getMessageType(), MessageType.XML.name());
+
+        Assert.assertTrue(action.getMessageBuilder() instanceof StaticMessageBuilder);
+        Assert.assertEquals(((StaticMessageBuilder) action.getMessageBuilder()).getMessage().getPayload(), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+        Assert.assertEquals(((StaticMessageBuilder) action.getMessageBuilder()).buildMessageHeaderData(context).size(), 3L);
+        Assert.assertEquals(((StaticMessageBuilder)action.getMessageBuilder()).buildMessageHeaderData(context).get(0), "<Header><Name>operation</Name><Value>sayHello</Value></Header>");
+        Assert.assertEquals(((StaticMessageBuilder)action.getMessageBuilder()).buildMessageHeaderData(context).get(1), "<Header><Name>operation</Name><Value>foo</Value></Header>");
+        Assert.assertEquals(((StaticMessageBuilder)action.getMessageBuilder()).buildMessageHeaderData(context).get(2), "<Header><Name>operation</Name><Value>bar</Value></Header>");
+
+    }
+
+    @Test
+    public void testReceiveBuilderWithValidator() {
+        reset(messageEndpoint, messageConsumer, configuration);
+        when(messageEndpoint.createConsumer()).thenReturn(messageConsumer);
+        when(messageEndpoint.getEndpointConfiguration()).thenReturn(configuration);
+        when(configuration.getTimeout()).thenReturn(100L);
+        when(messageEndpoint.getActor()).thenReturn(null);
+        when(messageConsumer.receive(any(TestContext.class), anyLong())).thenReturn(new DefaultMessage("TestMessage").setHeader("operation", "sayHello"));
+        final TextEqualsMessageValidator validator = new TextEqualsMessageValidator();
+
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(receive().endpoint(messageEndpoint)
+                        .message()
+                        .type(MessageType.PLAINTEXT)
+                        .body("TestMessage")
+                        .header("operation", "sayHello")
+                        .validator(validator));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ReceiveMessageAction.class);
+
+        ReceiveMessageAction action = ((ReceiveMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "receive");
+
+        Assert.assertEquals(action.getEndpoint(), messageEndpoint);
+        Assert.assertEquals(action.getMessageType(), MessageType.PLAINTEXT.name());
+        Assert.assertEquals(action.getValidators().size(), 1L);
+        Assert.assertEquals(action.getValidators().get(0), validator);
+
+        Assert.assertTrue(action.getMessageBuilder() instanceof DefaultMessageBuilder);
+        Assert.assertEquals(((DefaultMessageBuilder) action.getMessageBuilder()).buildMessagePayload(context, action.getMessageType()), "TestMessage");
+        Assert.assertTrue(((DefaultMessageBuilder) action.getMessageBuilder()).buildMessageHeaders(context).containsKey("operation"));
+
+    }
+
+    @Test
+    public void testReceiveBuilderWithValidatorName() {
+        final TextEqualsMessageValidator validator = new TextEqualsMessageValidator();
+
+        reset(referenceResolver, messageEndpoint, messageConsumer, configuration);
+        when(messageEndpoint.createConsumer()).thenReturn(messageConsumer);
+        when(messageEndpoint.getEndpointConfiguration()).thenReturn(configuration);
+        when(configuration.getTimeout()).thenReturn(100L);
+        when(messageEndpoint.getActor()).thenReturn(null);
+        when(messageConsumer.receive(any(TestContext.class), anyLong())).thenReturn(new DefaultMessage("TestMessage").setHeader("operation", "sayHello"));
+
+        when(referenceResolver.resolve(TestContext.class)).thenReturn(context);
+        when(referenceResolver.resolve("plainTextValidator")).thenReturn(validator);
+        when(referenceResolver.resolve(TestActionListeners.class)).thenReturn(new TestActionListeners());
+        when(referenceResolver.resolveAll(SequenceBeforeTest.class)).thenReturn(new HashMap<>());
+        when(referenceResolver.resolveAll(SequenceAfterTest.class)).thenReturn(new HashMap<>());
+
+        context.setReferenceResolver(referenceResolver);
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(receive().endpoint(messageEndpoint)
+                        .message()
+                        .type(MessageType.PLAINTEXT)
+                        .body("TestMessage")
+                        .header("operation", "sayHello")
+                        .validator("plainTextValidator"));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ReceiveMessageAction.class);
+
+        ReceiveMessageAction action = ((ReceiveMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "receive");
+
+        Assert.assertEquals(action.getEndpoint(), messageEndpoint);
+        Assert.assertEquals(action.getMessageType(), MessageType.PLAINTEXT.name());
+        Assert.assertEquals(action.getValidators().size(), 1L);
+        Assert.assertEquals(action.getValidators().get(0), validator);
+
+        Assert.assertTrue(action.getMessageBuilder() instanceof DefaultMessageBuilder);
+        Assert.assertEquals(((DefaultMessageBuilder)action.getMessageBuilder()).buildMessagePayload(context, action.getMessageType()), "TestMessage");
+        Assert.assertTrue(((DefaultMessageBuilder)action.getMessageBuilder()).buildMessageHeaders(context).containsKey("operation"));
+    }
+
+    @Test
+    public void testReceiveBuilderWithSelector() {
+        SelectiveConsumer selectiveConsumer = Mockito.mock(SelectiveConsumer.class);
+
+        reset(messageEndpoint, selectiveConsumer, configuration);
+        when(messageEndpoint.createConsumer()).thenReturn(selectiveConsumer);
+        when(messageEndpoint.getEndpointConfiguration()).thenReturn(configuration);
+        when(configuration.getTimeout()).thenReturn(100L);
+        when(messageEndpoint.getActor()).thenReturn(null);
+        when(selectiveConsumer.receive(eq("operation = 'sayHello'"), any(TestContext.class), anyLong())).thenReturn(
+                new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>")
+                        .setHeader("operation", "sayHello"));
+        final Map<String, String> messageSelector = new HashMap<>();
+        messageSelector.put("operation", "sayHello");
+
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(receive().endpoint(messageEndpoint)
+                        .message()
+                        .body("<TestRequest><Message>Hello World!</Message></TestRequest>")
+                        .selector(messageSelector));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ReceiveMessageAction.class);
+
+        ReceiveMessageAction action = ((ReceiveMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "receive");
+
+        Assert.assertEquals(action.getMessageType(), MessageType.XML.name());
+        Assert.assertEquals(action.getEndpoint(), messageEndpoint);
+
+        Assert.assertEquals(action.getMessageSelectorMap(), messageSelector);
+
+    }
+
+    @Test
+    public void testReceiveBuilderWithSelectorExpression() {
+        SelectiveConsumer selectiveConsumer = Mockito.mock(SelectiveConsumer.class);
+
+        reset(messageEndpoint, selectiveConsumer, configuration);
+        when(messageEndpoint.createConsumer()).thenReturn(selectiveConsumer);
+        when(messageEndpoint.getEndpointConfiguration()).thenReturn(configuration);
+        when(configuration.getTimeout()).thenReturn(100L);
+        when(messageEndpoint.getActor()).thenReturn(null);
+        when(selectiveConsumer.receive(eq("operation = 'sayHello'"), any(TestContext.class), anyLong())).thenReturn(
+                new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>")
+                        .setHeader("operation", "sayHello"));
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(receive().endpoint(messageEndpoint)
+                        .message()
+                        .body("<TestRequest><Message>Hello World!</Message></TestRequest>")
+                        .selector("operation = 'sayHello'"));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ReceiveMessageAction.class);
+
+        ReceiveMessageAction action = ((ReceiveMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "receive");
+
+        Assert.assertEquals(action.getMessageType(), MessageType.XML.name());
+        Assert.assertEquals(action.getEndpoint(), messageEndpoint);
+
+        Assert.assertTrue(action.getMessageSelectorMap().isEmpty());
+        Assert.assertEquals(action.getMessageSelector(), "operation = 'sayHello'");
+
+    }
+
+    @Test
+    public void testReceiveBuilderWithValidationProcessor() {
+        final AbstractValidationProcessor processor = Mockito.mock(AbstractValidationProcessor.class);
+
+        reset(processor, messageEndpoint, messageConsumer, configuration);
+        when(messageEndpoint.createConsumer()).thenReturn(messageConsumer);
+        when(messageEndpoint.getEndpointConfiguration()).thenReturn(configuration);
+        when(configuration.getTimeout()).thenReturn(100L);
+        when(messageEndpoint.getActor()).thenReturn(null);
+        when(messageConsumer.receive(any(TestContext.class), anyLong())).thenReturn(new DefaultMessage("TestMessage").setHeader("operation", "sayHello"));
+
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(receive().endpoint(messageEndpoint)
+                .message()
+                .type(MessageType.PLAINTEXT)
+                .body("TestMessage")
+                .header("operation", "sayHello")
+                .validate(processor));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ReceiveMessageAction.class);
+
+        ReceiveMessageAction action = ((ReceiveMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "receive");
+
+        Assert.assertEquals(action.getEndpoint(), messageEndpoint);
+        Assert.assertEquals(action.getMessageType(), MessageType.PLAINTEXT.name());
+        Assert.assertEquals(action.getValidationProcessor(), processor);
+
+        Assert.assertTrue(action.getMessageBuilder() instanceof DefaultMessageBuilder);
+        Assert.assertEquals(((DefaultMessageBuilder) action.getMessageBuilder()).buildMessagePayload(context, action.getMessageType()), "TestMessage");
+        Assert.assertTrue(((DefaultMessageBuilder) action.getMessageBuilder()).buildMessageHeaders(context).containsKey("operation"));
+
+        verify(processor, atLeastOnce()).setReferenceResolver(context.getReferenceResolver());
+        verify(processor).validate(any(Message.class), any(TestContext.class));
+    }
+
+    @Test
+    public void testReceiveBuilderExtractFromHeader() {
+        reset(messageEndpoint, messageConsumer, configuration);
+        when(messageEndpoint.createConsumer()).thenReturn(messageConsumer);
+        when(messageEndpoint.getEndpointConfiguration()).thenReturn(configuration);
+        when(configuration.getTimeout()).thenReturn(100L);
+        when(messageEndpoint.getActor()).thenReturn(null);
+        when(messageConsumer.receive(any(TestContext.class), anyLong())).thenReturn(
+                new DefaultMessage("<TestRequest><Message lang=\"ENG\">Hello World!</Message></TestRequest>")
+                        .setHeader("operation", "sayHello")
+                        .setHeader("requestId", "123456"));
+
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(receive().endpoint(messageEndpoint)
+                        .message()
+                        .body("<TestRequest><Message lang=\"ENG\">Hello World!</Message></TestRequest>")
+                        .extract(message().headers()
+                                .expression("operation", "operationHeader")
+                                .expression("requestId", "id")));
+
+        Assert.assertNotNull(context.getVariable("operationHeader"));
+        Assert.assertNotNull(context.getVariable("id"));
+        Assert.assertEquals(context.getVariable("operationHeader"), "sayHello");
+        Assert.assertEquals(context.getVariable("id"), "123456");
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ReceiveMessageAction.class);
+
+        ReceiveMessageAction action = ((ReceiveMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "receive");
+
+        Assert.assertEquals(action.getMessageType(), MessageType.XML.name());
+        Assert.assertEquals(action.getEndpoint(), messageEndpoint);
+
+        Assert.assertEquals(action.getVariableExtractors().size(), 1);
+        Assert.assertTrue(action.getVariableExtractors().get(0) instanceof MessageHeaderVariableExtractor);
+        Assert.assertTrue(((MessageHeaderVariableExtractor) action.getVariableExtractors().get(0)).getHeaderMappings().containsKey("operation"));
+        Assert.assertTrue(((MessageHeaderVariableExtractor) action.getVariableExtractors().get(0)).getHeaderMappings().containsKey("requestId"));
+    }
+}

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/RepeatOnErrorTestActionBuilderTest.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/RepeatOnErrorTestActionBuilderTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.actions.dsl;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.actions.EchoAction;
+import org.citrusframework.container.RepeatOnErrorUntilTrue;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.EchoAction.Builder.echo;
+import static org.citrusframework.actions.SleepAction.Builder.sleep;
+import static org.citrusframework.container.RepeatOnErrorUntilTrue.Builder.repeatOnError;
+import static org.testng.Assert.assertEquals;
+
+public class RepeatOnErrorTestActionBuilderTest extends UnitTestSupport {
+    @Test
+    public void testRepeatOnErrorBuilder() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.variable("var", "foo");
+
+        builder.$(repeatOnError().autoSleep(250)
+                        .until("i gt 5")
+                .actions(echo("${var}"), sleep().milliseconds(50), echo("${var}")));
+
+        builder.$(repeatOnError().autoSleep(200)
+                        .index("k")
+                        .startsWith(2)
+                        .until("k gt= 5")
+                .actions(echo("${var}")));
+
+        Assert.assertNotNull(context.getVariable("i"));
+        Assert.assertEquals(context.getVariable("i"), "1");
+        Assert.assertNotNull(context.getVariable("k"));
+        Assert.assertEquals(context.getVariable("k"), "2");
+
+        TestCase test = builder.getTestCase();
+        assertEquals(test.getActionCount(), 2);
+        assertEquals(test.getActions().get(0).getClass(), RepeatOnErrorUntilTrue.class);
+        assertEquals(test.getActions().get(0).getName(), "repeat-on-error");
+
+        RepeatOnErrorUntilTrue container = (RepeatOnErrorUntilTrue)test.getActions().get(0);
+        assertEquals(container.getActionCount(), 3);
+        assertEquals(container.getAutoSleep(), Long.valueOf(250L));
+        assertEquals(container.getCondition(), "i gt 5");
+        assertEquals(container.getStart(), 1);
+        assertEquals(container.getIndexName(), "i");
+        assertEquals(container.getTestAction(0).getClass(), EchoAction.class);
+
+        container = (RepeatOnErrorUntilTrue)test.getActions().get(1);
+        assertEquals(container.getActionCount(), 1);
+        assertEquals(container.getAutoSleep(), Long.valueOf(200L));
+        assertEquals(container.getCondition(), "k gt= 5");
+        assertEquals(container.getStart(), 2);
+        assertEquals(container.getIndexName(), "k");
+        assertEquals(container.getTestAction(0).getClass(), EchoAction.class);
+    }
+
+    @Test
+    public void testRepeatOnErrorBuilderWithConditionExpression() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.variable("var", "foo");
+
+        builder.$(repeatOnError().autoSleep(250)
+                        .until("i gt 5")
+                .actions(echo("${var}"), sleep().milliseconds(50), echo("${var}")));
+
+        builder.$(repeatOnError().autoSleep(200)
+                        .index("k")
+                        .startsWith(2)
+                        .until((index, context) -> index >= 5)
+                .actions(echo("${var}")));
+
+        Assert.assertNotNull(context.getVariable("i"));
+        Assert.assertEquals(context.getVariable("i"), "1");
+        Assert.assertNotNull(context.getVariable("k"));
+        Assert.assertEquals(context.getVariable("k"), "2");
+
+        TestCase test = builder.getTestCase();
+        assertEquals(test.getActionCount(), 2);
+        assertEquals(test.getActions().get(0).getClass(), RepeatOnErrorUntilTrue.class);
+        assertEquals(test.getActions().get(0).getName(), "repeat-on-error");
+
+        RepeatOnErrorUntilTrue container = (RepeatOnErrorUntilTrue)test.getActions().get(0);
+        assertEquals(container.getActionCount(), 3);
+        assertEquals(container.getAutoSleep(), Long.valueOf(250L));
+        assertEquals(container.getCondition(), "i gt 5");
+        assertEquals(container.getStart(), 1);
+        assertEquals(container.getIndexName(), "i");
+        assertEquals(container.getTestAction(0).getClass(), EchoAction.class);
+
+        container = (RepeatOnErrorUntilTrue)test.getActions().get(1);
+        assertEquals(container.getActionCount(), 1);
+        assertEquals(container.getAutoSleep(), Long.valueOf(200L));
+        assertEquals(container.getStart(), 2);
+        assertEquals(container.getIndexName(), "k");
+        assertEquals(container.getTestAction(0).getClass(), EchoAction.class);
+    }
+}

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/RepeatTestRunnerTest.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/RepeatTestRunnerTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.actions.dsl;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.actions.EchoAction;
+import org.citrusframework.container.RepeatUntilTrue;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.EchoAction.Builder.echo;
+import static org.citrusframework.actions.SleepAction.Builder.sleep;
+import static org.citrusframework.container.RepeatUntilTrue.Builder.repeat;
+import static org.testng.Assert.assertEquals;
+
+public class RepeatTestRunnerTest extends UnitTestSupport {
+    @Test
+    public void testRepeatBuilder() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.variable("var", "foo");
+
+        builder.$(repeat().index("i")
+                    .startsWith(2)
+                    .until("i lt 5")
+                .actions(echo("${var}"), sleep().milliseconds(100), echo("${var}")));
+
+        Assert.assertNotNull(context.getVariable("i"));
+        Assert.assertEquals(context.getVariable("i"), "2");
+
+        TestCase test = builder.getTestCase();
+        assertEquals(test.getActionCount(), 1);
+        assertEquals(test.getActions().get(0).getClass(), RepeatUntilTrue.class);
+        assertEquals(test.getActions().get(0).getName(), "repeat");
+
+        RepeatUntilTrue container = (RepeatUntilTrue)test.getActions().get(0);
+        assertEquals(container.getActionCount(), 3);
+        assertEquals(container.getCondition(), "i lt 5");
+        assertEquals(container.getStart(), 2);
+        assertEquals(container.getIndexName(), "i");
+        assertEquals(container.getTestAction(0).getClass(), EchoAction.class);
+    }
+
+    @Test
+    public void testRepeatBuilderWithConditionExpression() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.variable("var", "foo");
+
+        builder.$(repeat().index("i")
+                    .startsWith(2)
+                    .until((index, context) -> index > 5)
+                .actions(echo("${var}"), sleep().milliseconds(100), echo("${var}")));
+
+        Assert.assertNotNull(context.getVariable("i"));
+        Assert.assertEquals(context.getVariable("i"), "5");
+
+        TestCase test = builder.getTestCase();
+        assertEquals(test.getActionCount(), 1);
+        assertEquals(test.getActions().get(0).getClass(), RepeatUntilTrue.class);
+        assertEquals(test.getActions().get(0).getName(), "repeat");
+
+        RepeatUntilTrue container = (RepeatUntilTrue)test.getActions().get(0);
+        assertEquals(container.getActionCount(), 3);
+        assertEquals(container.getStart(), 2);
+        assertEquals(container.getIndexName(), "i");
+        assertEquals(container.getTestAction(0).getClass(), EchoAction.class);
+    }
+}

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/SendMessageTestActionBuilderTest.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/SendMessageTestActionBuilderTest.java
@@ -1,0 +1,538 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.actions.dsl;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.actions.SendMessageAction;
+import org.citrusframework.container.SequenceAfterTest;
+import org.citrusframework.container.SequenceBeforeTest;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.endpoint.Endpoint;
+import org.citrusframework.message.DefaultMessage;
+import org.citrusframework.message.Message;
+import org.citrusframework.message.MessageHeaders;
+import org.citrusframework.message.MessageType;
+import org.citrusframework.messaging.Producer;
+import org.citrusframework.report.TestActionListeners;
+import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.validation.builder.DefaultMessageBuilder;
+import org.citrusframework.validation.builder.StaticMessageBuilder;
+import org.citrusframework.variable.MessageHeaderVariableExtractor;
+import org.citrusframework.xml.Marshaller;
+import org.mockito.Mockito;
+import org.springframework.core.io.Resource;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.SendMessageAction.Builder.send;
+import static org.citrusframework.dsl.MessageSupport.MessageHeaderSupport.fromHeaders;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ * @since 2.3
+ */
+public class SendMessageTestActionBuilderTest extends UnitTestSupport {
+
+    private final ReferenceResolver referenceResolver = Mockito.mock(ReferenceResolver.class);
+    private final Endpoint messageEndpoint = Mockito.mock(Endpoint.class);
+    private final Producer messageProducer = Mockito.mock(Producer.class);
+    private final Resource resource = Mockito.mock(Resource.class);
+
+    private final Marshaller marshaller = Mockito.mock(Marshaller.class);
+
+    @Test
+    public void testSendBuilderWithMessageInstance() {
+        reset(messageEndpoint, messageProducer);
+        when(messageEndpoint.createProducer()).thenReturn(messageProducer);
+        when(messageEndpoint.getActor()).thenReturn(null);
+        doAnswer(invocation -> {
+            Message message = (Message) invocation.getArguments()[0];
+            Assert.assertEquals(message.getPayload(String.class), "Foo");
+            Assert.assertNotNull(message.getHeader("operation"));
+            Assert.assertEquals(message.getHeader("operation"), "foo");
+            return null;
+        }).when(messageProducer).send(any(Message.class), any(TestContext.class));
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(send().endpoint(messageEndpoint)
+                        .message(new DefaultMessage("Foo").setHeader("operation", "foo"))
+                        .header("additional", "additionalValue"));
+
+        final TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), SendMessageAction.class);
+
+        final SendMessageAction action = ((SendMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "send");
+
+        Assert.assertEquals(action.getEndpoint(), messageEndpoint);
+        Assert.assertEquals(action.getMessageBuilder().getClass(), StaticMessageBuilder.class);
+
+        final StaticMessageBuilder messageBuilder = (StaticMessageBuilder) action.getMessageBuilder();
+        Assert.assertEquals(messageBuilder.getMessage().getPayload(String.class), "Foo");
+        Assert.assertEquals(messageBuilder.getMessage().getHeader("operation"), "foo");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get("additional"), "additionalValue");
+    }
+
+    @Test
+    public void testSendBuilderWithObjectMessageInstance() {
+        reset(messageEndpoint, messageProducer);
+        when(messageEndpoint.createProducer()).thenReturn(messageProducer);
+        when(messageEndpoint.getActor()).thenReturn(null);
+        doAnswer(invocation -> {
+            Message message = (Message) invocation.getArguments()[0];
+            Assert.assertEquals(message.getPayload(Integer.class), Integer.valueOf(10));
+            Assert.assertNotNull(message.getHeader("operation"));
+            Assert.assertEquals(message.getHeader("operation"), "foo");
+            return null;
+        }).when(messageProducer).send(any(Message.class), any(TestContext.class));
+        final Message message = new DefaultMessage(10).setHeader("operation", "foo");
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(send().endpoint(messageEndpoint)
+                        .message(message));
+
+        final TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), SendMessageAction.class);
+
+        final SendMessageAction action = ((SendMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "send");
+
+        Assert.assertEquals(action.getEndpoint(), messageEndpoint);
+        Assert.assertEquals(action.getMessageBuilder().getClass(), StaticMessageBuilder.class);
+
+        final StaticMessageBuilder messageBuilder = (StaticMessageBuilder) action.getMessageBuilder();
+        Assert.assertEquals(messageBuilder.getMessage().getPayload(), 10);
+        Assert.assertEquals(messageBuilder.getMessage().getHeaders().size(), message.getHeaders().size());
+        Assert.assertEquals(messageBuilder.getMessage().getHeader(MessageHeaders.ID), message.getHeader(MessageHeaders.ID));
+        Assert.assertEquals(messageBuilder.getMessage().getHeader("operation"), "foo");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 1L);
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get("operation"), "foo");
+
+        final Message constructed = messageBuilder.build(new TestContext(), MessageType.PLAINTEXT.name());
+        Assert.assertEquals(constructed.getHeaders().size(), message.getHeaders().size() + 1);
+        Assert.assertEquals(constructed.getHeader("operation"), "foo");
+        Assert.assertNotEquals(constructed.getHeader(MessageHeaders.ID), message.getHeader(MessageHeaders.ID));
+    }
+
+    @Test
+    public void testSendBuilderWithObjectMessageInstanceAdditionalHeader() {
+        reset(messageEndpoint, messageProducer);
+        when(messageEndpoint.createProducer()).thenReturn(messageProducer);
+        when(messageEndpoint.getActor()).thenReturn(null);
+        doAnswer(invocation -> {
+            Message message = (Message) invocation.getArguments()[0];
+            Assert.assertEquals(message.getPayload(Integer.class), Integer.valueOf(10));
+            Assert.assertNotNull(message.getHeader("operation"));
+            Assert.assertEquals(message.getHeader("operation"), "foo");
+            Assert.assertNotNull(message.getHeader("additional"));
+            Assert.assertEquals(message.getHeader("additional"), "new");
+            return null;
+        }).when(messageProducer).send(any(Message.class), any(TestContext.class));
+        final Message message = new DefaultMessage(10).setHeader("operation", "foo");
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(send().endpoint(messageEndpoint)
+                        .message(message)
+                        .header("additional", "new"));
+
+        final TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), SendMessageAction.class);
+
+        final SendMessageAction action = ((SendMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "send");
+
+        Assert.assertEquals(action.getEndpoint(), messageEndpoint);
+        Assert.assertEquals(action.getMessageBuilder().getClass(), StaticMessageBuilder.class);
+
+        final StaticMessageBuilder messageBuilder = (StaticMessageBuilder) action.getMessageBuilder();
+        Assert.assertEquals(messageBuilder.getMessage().getPayload(), 10);
+        Assert.assertEquals(messageBuilder.getMessage().getHeaders().size(), message.getHeaders().size());
+        Assert.assertEquals(messageBuilder.getMessage().getHeader(MessageHeaders.ID), message.getHeader(MessageHeaders.ID));
+        Assert.assertEquals(messageBuilder.getMessage().getHeader("operation"), "foo");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 2L);
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get("additional"), "new");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get("operation"), "foo");
+
+        final Message constructed = messageBuilder.build(new TestContext(), MessageType.PLAINTEXT.name());
+        Assert.assertEquals(constructed.getHeaders().size(), message.getHeaders().size() + 2);
+        Assert.assertEquals(constructed.getHeader("operation"), "foo");
+        Assert.assertEquals(constructed.getHeader("additional"), "new");
+    }
+
+    @Test
+    public void testSendBuilderWithPayloadData() {
+        reset(messageEndpoint, messageProducer);
+        when(messageEndpoint.createProducer()).thenReturn(messageProducer);
+        when(messageEndpoint.getActor()).thenReturn(null);
+        doAnswer(invocation -> {
+            Message message = (Message) invocation.getArguments()[0];
+            Assert.assertEquals(message.getPayload(String.class), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+            return null;
+        }).when(messageProducer).send(any(Message.class), any(TestContext.class));
+
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(send().endpoint(messageEndpoint)
+                .message()
+                .body("<TestRequest><Message>Hello World!</Message></TestRequest>"));
+
+        final TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), SendMessageAction.class);
+
+        final SendMessageAction action = ((SendMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "send");
+
+        Assert.assertEquals(action.getEndpoint(), messageEndpoint);
+        Assert.assertEquals(action.getMessageBuilder().getClass(), DefaultMessageBuilder.class);
+
+        final DefaultMessageBuilder messageBuilder = (DefaultMessageBuilder) action.getMessageBuilder();
+        Assert.assertEquals(messageBuilder.buildMessagePayload(context, action.getMessageType()), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 0L);
+    }
+
+    @Test
+    public void testSendBuilderWithPayloadResource() throws IOException {
+        reset(resource, messageEndpoint, messageProducer);
+        when(messageEndpoint.createProducer()).thenReturn(messageProducer);
+        when(messageEndpoint.getActor()).thenReturn(null);
+        doAnswer(invocation -> {
+            Message message = (Message) invocation.getArguments()[0];
+            Assert.assertEquals(message.getPayload(String.class), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+            return null;
+        }).when(messageProducer).send(any(Message.class), any(TestContext.class));
+
+        when(resource.getInputStream()).thenReturn(new ByteArrayInputStream("<TestRequest><Message>Hello World!</Message></TestRequest>".getBytes()));
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(send().endpoint(messageEndpoint)
+                .message()
+                .body(resource));
+
+        final TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), SendMessageAction.class);
+
+        final SendMessageAction action = ((SendMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "send");
+
+        Assert.assertEquals(action.getEndpoint(), messageEndpoint);
+        Assert.assertEquals(action.getMessageBuilder().getClass(), DefaultMessageBuilder.class);
+
+        final DefaultMessageBuilder messageBuilder = (DefaultMessageBuilder) action.getMessageBuilder();
+        Assert.assertEquals(messageBuilder.buildMessagePayload(context, action.getMessageType()), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 0L);
+    }
+
+    @Test
+    public void testSendBuilderWithEndpointName() {
+        reset(referenceResolver, messageEndpoint, messageProducer);
+        when(messageEndpoint.createProducer()).thenReturn(messageProducer);
+        when(messageEndpoint.getActor()).thenReturn(null);
+        doAnswer(invocation -> {
+            Message message = (Message) invocation.getArguments()[0];
+            Assert.assertEquals(message.getPayload(String.class), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+            return null;
+        }).when(messageProducer).send(any(Message.class), any(TestContext.class));
+
+        when(referenceResolver.resolve(TestContext.class)).thenReturn(context);
+        when(referenceResolver.resolve("fooMessageEndpoint", Endpoint.class)).thenReturn(messageEndpoint);
+        when(referenceResolver.resolve(TestActionListeners.class)).thenReturn(new TestActionListeners());
+        when(referenceResolver.resolveAll(SequenceBeforeTest.class)).thenReturn(new HashMap<>());
+        when(referenceResolver.resolveAll(SequenceAfterTest.class)).thenReturn(new HashMap<>());
+
+        context.setReferenceResolver(referenceResolver);
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(send().endpoint("fooMessageEndpoint")
+                .message()
+                .body("<TestRequest><Message>Hello World!</Message></TestRequest>"));
+
+        final TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), SendMessageAction.class);
+
+        final SendMessageAction action = ((SendMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "send");
+        Assert.assertEquals(action.getEndpointUri(), "fooMessageEndpoint");
+    }
+
+    @Test
+    public void testSendBuilderWithHeaders() {
+        reset(messageEndpoint, messageProducer);
+        when(messageEndpoint.createProducer()).thenReturn(messageProducer);
+        when(messageEndpoint.getActor()).thenReturn(null);
+        doAnswer(invocation -> {
+            Message message = (Message) invocation.getArguments()[0];
+            Assert.assertEquals(message.getPayload(String.class), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+            Assert.assertNotNull(message.getHeader("operation"));
+            Assert.assertEquals(message.getHeader("operation"), "foo");
+            Assert.assertNotNull(message.getHeader("language"));
+            Assert.assertEquals(message.getHeader("language"), "eng");
+            return null;
+        }).when(messageProducer).send(any(Message.class), any(TestContext.class));
+
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(send().endpoint(messageEndpoint)
+                .message()
+                .body("<TestRequest><Message>Hello World!</Message></TestRequest>")
+                .headers(Collections.singletonMap("some", "value"))
+                .header("operation", "foo")
+                .header("language", "eng"));
+
+        final TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), SendMessageAction.class);
+
+        final SendMessageAction action = ((SendMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "send");
+
+        Assert.assertEquals(action.getEndpoint(), messageEndpoint);
+        Assert.assertEquals(action.getMessageBuilder().getClass(), DefaultMessageBuilder.class);
+
+        final DefaultMessageBuilder messageBuilder = (DefaultMessageBuilder) action.getMessageBuilder();
+        Assert.assertEquals(messageBuilder.buildMessagePayload(context, action.getMessageType()), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 3L);
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get("some"), "value");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get("operation"), "foo");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get("language"), "eng");
+    }
+
+    @Test
+    public void testSendBuilderWithHeaderData() {
+        reset(messageEndpoint, messageProducer);
+        when(messageEndpoint.createProducer()).thenReturn(messageProducer);
+        when(messageEndpoint.getActor()).thenReturn(null);
+        doAnswer(invocation -> {
+            Message message = (Message) invocation.getArguments()[0];
+            Assert.assertEquals(message.getPayload(String.class), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+            Assert.assertNotNull(message.getHeaderData());
+            Assert.assertEquals(message.getHeaderData().size(), 1L);
+            Assert.assertEquals(message.getHeaderData().get(0), "<Header><Name>operation</Name><Value>foo</Value></Header>");
+            return null;
+        }).when(messageProducer).send(any(Message.class), any(TestContext.class));
+
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(send().endpoint(messageEndpoint)
+                .message()
+                .body("<TestRequest><Message>Hello World!</Message></TestRequest>")
+                .header("<Header><Name>operation</Name><Value>foo</Value></Header>"));
+
+        builder.$(send().endpoint(messageEndpoint)
+            .message(new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>"))
+            .header("<Header><Name>operation</Name><Value>foo</Value></Header>"));
+
+        final TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 2);
+        Assert.assertEquals(test.getActions().get(0).getClass(), SendMessageAction.class);
+        Assert.assertEquals(test.getActions().get(1).getClass(), SendMessageAction.class);
+
+        SendMessageAction action = ((SendMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "send");
+
+        Assert.assertEquals(action.getEndpoint(), messageEndpoint);
+        Assert.assertEquals(action.getMessageBuilder().getClass(), DefaultMessageBuilder.class);
+
+        final DefaultMessageBuilder messageBuilder = (DefaultMessageBuilder) action.getMessageBuilder();
+        Assert.assertEquals(messageBuilder.buildMessagePayload(context, action.getMessageType()), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 0L);
+        Assert.assertEquals(messageBuilder.buildMessageHeaderData(context).size(), 1L);
+        Assert.assertEquals(messageBuilder.buildMessageHeaderData(context).get(0), "<Header><Name>operation</Name><Value>foo</Value></Header>");
+
+        action = ((SendMessageAction)test.getActions().get(1));
+        Assert.assertEquals(action.getName(), "send");
+
+        Assert.assertEquals(action.getEndpoint(), messageEndpoint);
+        Assert.assertEquals(action.getMessageBuilder().getClass(), StaticMessageBuilder.class);
+
+        final StaticMessageBuilder staticMessageBuilder = (StaticMessageBuilder) action.getMessageBuilder();
+        Assert.assertEquals(staticMessageBuilder.getMessage().getPayload(String.class), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+        Assert.assertEquals(staticMessageBuilder.buildMessageHeaders(context).size(), 0L);
+        Assert.assertEquals(staticMessageBuilder.buildMessageHeaderData(context).size(), 1L);
+        Assert.assertEquals(staticMessageBuilder.buildMessageHeaderData(context).get(0), "<Header><Name>operation</Name><Value>foo</Value></Header>");
+    }
+
+    @Test
+    public void testSendBuilderWithMultipleHeaderData() {
+        reset(messageEndpoint, messageProducer);
+        when(messageEndpoint.createProducer()).thenReturn(messageProducer);
+        when(messageEndpoint.getActor()).thenReturn(null);
+        doAnswer(invocation -> {
+            Message message = (Message) invocation.getArguments()[0];
+            Assert.assertEquals(message.getPayload(String.class), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+            Assert.assertNotNull(message.getHeaderData());
+            Assert.assertEquals(message.getHeaderData().size(), 2L);
+            Assert.assertEquals(message.getHeaderData().get(0), "<Header><Name>operation</Name><Value>foo1</Value></Header>");
+            Assert.assertEquals(message.getHeaderData().get(1), "<Header><Name>operation</Name><Value>foo2</Value></Header>");
+            return null;
+        }).when(messageProducer).send(any(Message.class), any(TestContext.class));
+
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(send().endpoint(messageEndpoint)
+                .message()
+                .body("<TestRequest><Message>Hello World!</Message></TestRequest>")
+                .header("<Header><Name>operation</Name><Value>foo1</Value></Header>")
+                .header("<Header><Name>operation</Name><Value>foo2</Value></Header>"));
+
+        builder.$(send().endpoint(messageEndpoint)
+            .message(new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>"))
+            .header("<Header><Name>operation</Name><Value>foo1</Value></Header>")
+            .header("<Header><Name>operation</Name><Value>foo2</Value></Header>"));
+
+        final TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 2);
+        Assert.assertEquals(test.getActions().get(0).getClass(), SendMessageAction.class);
+        Assert.assertEquals(test.getActions().get(1).getClass(), SendMessageAction.class);
+
+        SendMessageAction action = ((SendMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "send");
+
+        Assert.assertEquals(action.getEndpoint(), messageEndpoint);
+        Assert.assertEquals(action.getMessageBuilder().getClass(), DefaultMessageBuilder.class);
+
+        final DefaultMessageBuilder messageBuilder = (DefaultMessageBuilder) action.getMessageBuilder();
+        Assert.assertEquals(messageBuilder.buildMessagePayload(context, action.getMessageType()), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 0L);
+        Assert.assertEquals(messageBuilder.buildMessageHeaderData(context).size(), 2L);
+        Assert.assertEquals(messageBuilder.buildMessageHeaderData(context).get(0), "<Header><Name>operation</Name><Value>foo1</Value></Header>");
+        Assert.assertEquals(messageBuilder.buildMessageHeaderData(context).get(1), "<Header><Name>operation</Name><Value>foo2</Value></Header>");
+
+        action = ((SendMessageAction)test.getActions().get(1));
+        Assert.assertEquals(action.getName(), "send");
+
+        Assert.assertEquals(action.getEndpoint(), messageEndpoint);
+        Assert.assertEquals(action.getMessageBuilder().getClass(), StaticMessageBuilder.class);
+
+        final StaticMessageBuilder staticMessageBuilder = (StaticMessageBuilder) action.getMessageBuilder();
+        Assert.assertEquals(staticMessageBuilder.getMessage().getPayload(String.class), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+        Assert.assertEquals(staticMessageBuilder.buildMessageHeaders(context).size(), 0L);
+        Assert.assertEquals(staticMessageBuilder.buildMessageHeaderData(context).size(), 2L);
+        Assert.assertEquals(staticMessageBuilder.buildMessageHeaderData(context).get(0), "<Header><Name>operation</Name><Value>foo1</Value></Header>");
+        Assert.assertEquals(staticMessageBuilder.buildMessageHeaderData(context).get(1), "<Header><Name>operation</Name><Value>foo2</Value></Header>");
+    }
+
+    @Test
+    public void testSendBuilderWithHeaderDataResource() throws IOException {
+        reset(resource, messageEndpoint, messageProducer);
+        when(messageEndpoint.createProducer()).thenReturn(messageProducer);
+        when(messageEndpoint.getActor()).thenReturn(null);
+        doAnswer(invocation -> {
+            Message message = (Message) invocation.getArguments()[0];
+            Assert.assertEquals(message.getPayload(String.class), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+            Assert.assertNotNull(message.getHeaderData());
+            Assert.assertEquals(message.getHeaderData().size(), 1L);
+            Assert.assertEquals(message.getHeaderData().get(0), "<Header><Name>operation</Name><Value>foo1</Value></Header>");
+            return null;
+        }).doAnswer(invocation -> {
+            Message message = (Message) invocation.getArguments()[0];
+            Assert.assertEquals(message.getPayload(String.class), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+            Assert.assertNotNull(message.getHeaderData());
+            Assert.assertEquals(message.getHeaderData().size(), 1L);
+            Assert.assertEquals(message.getHeaderData().get(0), "<Header><Name>operation</Name><Value>foo2</Value></Header>");
+            return null;
+        }).when(messageProducer).send(any(Message.class), any(TestContext.class));
+
+        when(resource.getInputStream()).thenReturn(new ByteArrayInputStream("<Header><Name>operation</Name><Value>foo1</Value></Header>".getBytes()))
+                                       .thenReturn(new ByteArrayInputStream("<Header><Name>operation</Name><Value>foo2</Value></Header>".getBytes()));
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(send().endpoint(messageEndpoint)
+                .message()
+                .body("<TestRequest><Message>Hello World!</Message></TestRequest>")
+                .header(resource));
+
+        builder.$(send().endpoint(messageEndpoint)
+                .message(new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>"))
+                .header(resource));
+
+        final TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 2);
+        Assert.assertEquals(test.getActions().get(0).getClass(), SendMessageAction.class);
+        Assert.assertEquals(test.getActions().get(1).getClass(), SendMessageAction.class);
+
+        SendMessageAction action = ((SendMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "send");
+
+        Assert.assertEquals(action.getEndpoint(), messageEndpoint);
+        Assert.assertEquals(action.getMessageBuilder().getClass(), DefaultMessageBuilder.class);
+
+        final DefaultMessageBuilder messageBuilder = (DefaultMessageBuilder) action.getMessageBuilder();
+        Assert.assertEquals(messageBuilder.buildMessagePayload(context, action.getMessageType()), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 0L);
+        Assert.assertEquals(messageBuilder.buildMessageHeaderData(context).size(), 1L);
+        Assert.assertEquals(messageBuilder.buildMessageHeaderData(context).get(0), "<Header><Name>operation</Name><Value>foo1</Value></Header>");
+
+        action = ((SendMessageAction)test.getActions().get(1));
+        Assert.assertEquals(action.getName(), "send");
+
+        Assert.assertEquals(action.getEndpoint(), messageEndpoint);
+        Assert.assertEquals(action.getMessageBuilder().getClass(), StaticMessageBuilder.class);
+
+        final StaticMessageBuilder staticMessageBuilder = (StaticMessageBuilder) action.getMessageBuilder();
+        Assert.assertEquals(staticMessageBuilder.getMessage().getPayload(String.class), "<TestRequest><Message>Hello World!</Message></TestRequest>");
+        Assert.assertEquals(staticMessageBuilder.buildMessageHeaders(context).size(), 0L);
+        Assert.assertEquals(staticMessageBuilder.buildMessageHeaderData(context).size(), 1L);
+        Assert.assertEquals(staticMessageBuilder.buildMessageHeaderData(context).get(0), "<Header><Name>operation</Name><Value>foo2</Value></Header>");
+    }
+
+    @Test
+    public void testSendBuilderExtractFromHeader() {
+        reset(messageEndpoint, messageProducer);
+        when(messageEndpoint.createProducer()).thenReturn(messageProducer);
+        when(messageEndpoint.getActor()).thenReturn(null);
+        doAnswer(invocation -> {
+            Message message = (Message) invocation.getArguments()[0];
+            Assert.assertEquals(message.getPayload(String.class), "<TestRequest><Message lang=\"ENG\">Hello World!</Message></TestRequest>");
+            return null;
+        }).when(messageProducer).send(any(Message.class), any(TestContext.class));
+
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(send().endpoint(messageEndpoint)
+                .message()
+                .body("<TestRequest><Message lang=\"ENG\">Hello World!</Message></TestRequest>")
+                .header("operation", "sayHello")
+                .header("requestId", "123456")
+                .extract(fromHeaders().header("operation", "operationHeader")
+                                    .header("requestId", "id")));
+
+        Assert.assertNotNull(context.getVariable("operationHeader"));
+        Assert.assertNotNull(context.getVariable("id"));
+        Assert.assertEquals(context.getVariable("operationHeader"), "sayHello");
+        Assert.assertEquals(context.getVariable("id"), "123456");
+
+        final TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), SendMessageAction.class);
+
+        final SendMessageAction action = ((SendMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "send");
+
+        Assert.assertEquals(action.getEndpoint(), messageEndpoint);
+
+        Assert.assertEquals(action.getVariableExtractors().size(), 1);
+        Assert.assertTrue(action.getVariableExtractors().get(0) instanceof MessageHeaderVariableExtractor);
+        Assert.assertTrue(((MessageHeaderVariableExtractor) action.getVariableExtractors().get(0)).getHeaderMappings().containsKey("operation"));
+        Assert.assertTrue(((MessageHeaderVariableExtractor) action.getVariableExtractors().get(0)).getHeaderMappings().containsKey("requestId"));
+    }
+}

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/SequentialTestActionBuilderTest.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/SequentialTestActionBuilderTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.actions.dsl;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.actions.AbstractTestAction;
+import org.citrusframework.actions.EchoAction;
+import org.citrusframework.actions.SleepAction;
+import org.citrusframework.container.Sequence;
+import org.citrusframework.context.TestContext;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.EchoAction.Builder.echo;
+import static org.citrusframework.actions.SleepAction.Builder.sleep;
+import static org.citrusframework.container.Sequence.Builder.sequential;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * @author Christoph Deppisch
+ * @since 2.3
+ */
+public class SequentialTestActionBuilderTest extends UnitTestSupport {
+    @Test
+    public void testSequenceBuilder() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.variable("var", "foo");
+
+        builder.$(sequential()
+            .actions(
+                echo("${var}"),
+                sleep().milliseconds(100L)
+            ));
+
+        TestCase test = builder.getTestCase();
+        assertEquals(test.getActionCount(), 1);
+        assertEquals(test.getActions().get(0).getClass(), Sequence.class);
+        assertEquals(test.getActions().get(0).getName(), "sequential");
+
+        Sequence container = (Sequence)test.getActions().get(0);
+        assertEquals(container.getActionCount(), 2);
+        assertEquals(container.getActions().get(0).getClass(), EchoAction.class);
+    }
+
+    @Test
+    public void testSequenceBuilderWithAnonymousAction() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.variable("var", "foo");
+
+        builder.$(sequential()
+            .actions(
+                echo("${var}"),
+                () -> new AbstractTestAction() {
+                    @Override
+                    public void doExecute(TestContext context) {
+                        context.setVariable("anonymous", "anonymous");
+                    }
+                },
+                sleep().milliseconds(100L),
+                () -> new AbstractTestAction() {
+                    @Override
+                    public void doExecute(TestContext context) {
+                        context.getVariable("anonymous");
+                    }
+                }
+            ));
+
+        TestCase test = builder.getTestCase();
+        assertEquals(test.getActionCount(), 1);
+        assertEquals(test.getActions().get(0).getClass(), Sequence.class);
+        assertEquals(test.getActions().get(0).getName(), "sequential");
+
+        Sequence container = (Sequence)test.getActions().get(0);
+        assertEquals(container.getActionCount(), 4);
+        assertEquals(container.getActions().get(0).getClass(), EchoAction.class);
+        assertTrue(container.getActions().get(1).getClass().isAnonymousClass());
+        assertEquals(container.getActions().get(2).getClass(), SleepAction.class);
+        assertTrue(container.getActions().get(3).getClass().isAnonymousClass());
+    }
+}

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/SleepTestActionBuilderTest.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/SleepTestActionBuilderTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.actions.dsl;
+
+import java.util.concurrent.TimeUnit;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.actions.SleepAction;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.SleepAction.Builder.sleep;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class SleepTestActionBuilderTest extends UnitTestSupport {
+
+    @Test
+    public void testSleepBuilder() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(sleep().milliseconds(200));
+        builder.$(sleep().milliseconds(150));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 2);
+        Assert.assertEquals(test.getActions().get(0).getClass(), SleepAction.class);
+        Assert.assertEquals(test.getActions().get(1).getClass(), SleepAction.class);
+
+        SleepAction action = (SleepAction)test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "sleep");
+        Assert.assertEquals(action.getTime(), "200");
+        Assert.assertEquals(action.getTimeUnit(), TimeUnit.MILLISECONDS);
+
+        action = (SleepAction)test.getActions().get(1);
+        Assert.assertEquals(action.getName(), "sleep");
+        Assert.assertEquals(action.getTime(), "150");
+        Assert.assertEquals(action.getTimeUnit(), TimeUnit.MILLISECONDS);
+    }
+}

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/StartServerTestActionBuilderTest.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/StartServerTestActionBuilderTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.actions.dsl;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.actions.StartServerAction;
+import org.citrusframework.server.Server;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.StartServerAction.Builder.start;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ * @since 2.3
+ */
+public class StartServerTestActionBuilderTest extends UnitTestSupport {
+    private final Server testServer = Mockito.mock(Server.class);
+
+    private final Server server1 = Mockito.mock(Server.class);
+    private final Server server2 = Mockito.mock(Server.class);
+    private final Server server3 = Mockito.mock(Server.class);
+
+    @Test
+    public void testStartServerBuilder() {
+        reset(testServer, server1, server2, server3);
+        when(testServer.getName()).thenReturn("testServer");
+        when(server1.getName()).thenReturn("server1");
+        when(server2.getName()).thenReturn("server1");
+        when(server3.getName()).thenReturn("server1");
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(start(testServer));
+        builder.$(start(server1, server2, server3));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 2);
+        Assert.assertEquals(test.getActions().get(0).getClass(), StartServerAction.class);
+        Assert.assertEquals(test.getActions().get(1).getClass(), StartServerAction.class);
+
+        StartServerAction action = (StartServerAction)test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "start-server");
+        Assert.assertEquals(action.getServers().size(), 1);
+        Assert.assertEquals(action.getServers().get(0), testServer);
+
+        action = (StartServerAction)test.getActions().get(1);
+        Assert.assertEquals(action.getName(), "start-server");
+        Assert.assertEquals(action.getServers().size(), 3);
+        Assert.assertEquals(action.getServers().toString(), "[" + server1.toString() + ", " + server2.toString() + ", " + server3.toString() + "]");
+
+        verify(testServer).start();
+        verify(server1).start();
+        verify(server2).start();
+        verify(server3).start();
+    }
+}

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/StopServerTestActionBuilderTest.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/StopServerTestActionBuilderTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.actions.dsl;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.actions.StopServerAction;
+import org.citrusframework.server.Server;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.StopServerAction.Builder.stop;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ * @since 2.3
+ */
+public class StopServerTestActionBuilderTest extends UnitTestSupport {
+	private final Server testServer = Mockito.mock(Server.class);
+
+	private final Server server1 = Mockito.mock(Server.class);
+	private final Server server2 = Mockito.mock(Server.class);
+	private final Server server3 = Mockito.mock(Server.class);
+
+	@Test
+	public void testStopServerBuilder() {
+		reset(testServer, server1, server2, server3);
+		when(testServer.getName()).thenReturn("testServer");
+		when(server1.getName()).thenReturn("server1");
+		when(server2.getName()).thenReturn("server1");
+		when(server3.getName()).thenReturn("server1");
+		DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+		builder.$(stop(testServer));
+		builder.$(stop(server1, server2, server3));
+
+		TestCase test = builder.getTestCase();
+		Assert.assertEquals(test.getActionCount(), 2);
+		Assert.assertEquals(test.getActions().get(0).getClass(), StopServerAction.class);
+		Assert.assertEquals(test.getActions().get(1).getClass(), StopServerAction.class);
+
+		StopServerAction action = (StopServerAction)test.getActions().get(0);
+		Assert.assertEquals(action.getName(), "stop-server");
+		Assert.assertEquals(action.getServers().size(), 1);
+		Assert.assertEquals(action.getServers().get(0), testServer);
+
+		action = (StopServerAction)test.getActions().get(1);
+        Assert.assertEquals(action.getName(), "stop-server");
+		Assert.assertEquals(action.getServers().size(), 3);
+		Assert.assertEquals(action.getServers().toString(), "[" + server1.toString() + ", " + server2.toString() + ", " + server3.toString() + "]");
+
+		verify(testServer).stop();
+		verify(server1).stop();
+		verify(server2).stop();
+		verify(server3).stop();
+	}
+}

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/StopTimeTestActionBuilderTest.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/StopTimeTestActionBuilderTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.actions.dsl;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.actions.StopTimeAction;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.SleepAction.Builder.sleep;
+import static org.citrusframework.actions.StopTimeAction.Builder.stopTime;
+
+public class StopTimeTestActionBuilderTest extends UnitTestSupport {
+
+    @Test
+    public void testStopTimeBuilder() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(stopTime());
+        builder.$(stopTime("timerId"));
+
+        builder.$(sleep().milliseconds(200));
+
+        builder.$(stopTime());
+        builder.$(stopTime("timerId"));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 5);
+        Assert.assertEquals(test.getActions().get(0).getClass(), StopTimeAction.class);
+
+        StopTimeAction action = (StopTimeAction)test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "stop-time");
+        Assert.assertEquals(action.getId(), "CITRUS_TIMELINE");
+
+        action = (StopTimeAction)test.getActions().get(1);
+        Assert.assertEquals(action.getName(), "stop-time");
+        Assert.assertEquals(action.getId(), "timerId");
+    }
+}

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/StopTimerTestActionBuilderTest.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/StopTimerTestActionBuilderTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.actions.dsl;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.actions.StopTimerAction;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.StopTimerAction.Builder.stopTimer;
+import static org.citrusframework.actions.StopTimerAction.Builder.stopTimers;
+
+/**
+ * @author Martin Maher
+ * @since 2.5
+ */
+public class StopTimerTestActionBuilderTest extends UnitTestSupport {
+
+    @Test
+    public void testStopTimerBuilder() {
+        final String timerId = "timerId1";
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(stopTimer(timerId));
+        builder.$(stopTimers());
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 2);
+        Assert.assertEquals(test.getActions().get(0).getClass(), StopTimerAction.class);
+
+        StopTimerAction action = (StopTimerAction) test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "stop-timer");
+        Assert.assertEquals(action.getTimerId(), timerId);
+
+        action = (StopTimerAction) test.getActions().get(1);
+        Assert.assertEquals(action.getName(), "stop-timer");
+        Assert.assertNull(action.getTimerId());
+    }
+}

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/TemplateTestActionBuilderTest.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/TemplateTestActionBuilderTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.actions.dsl;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestAction;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.actions.EchoAction;
+import org.citrusframework.actions.TraceVariablesAction;
+import org.citrusframework.container.SequenceAfterTest;
+import org.citrusframework.container.SequenceBeforeTest;
+import org.citrusframework.container.Template;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.report.TestActionListeners;
+import org.citrusframework.spi.ReferenceResolver;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.container.Template.Builder.applyTemplate;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+public class TemplateTestActionBuilderTest extends UnitTestSupport {
+
+    private final ReferenceResolver referenceResolver = Mockito.mock(ReferenceResolver.class);
+
+    @Test
+    public void testTemplateBuilder() {
+        List<TestAction> actions = new ArrayList<>();
+        actions.add(new EchoAction.Builder().build());
+        actions.add(new TraceVariablesAction.Builder().build());
+        Template rootTemplate = new Template.Builder()
+                .templateName("fooTemplate")
+                .actions(actions)
+                .build();
+
+        reset(referenceResolver);
+
+        when(referenceResolver.resolve(TestContext.class)).thenReturn(context);
+        when(referenceResolver.resolve("fooTemplate", Template.class)).thenReturn(rootTemplate);
+        when(referenceResolver.resolve(TestActionListeners.class)).thenReturn(new TestActionListeners());
+        when(referenceResolver.resolveAll(SequenceBeforeTest.class)).thenReturn(new HashMap<>());
+        when(referenceResolver.resolveAll(SequenceAfterTest.class)).thenReturn(new HashMap<>());
+
+        context.setReferenceResolver(referenceResolver);
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(applyTemplate("fooTemplate")
+                        .parameter("param", "foo")
+                        .parameter("text", "Citrus rocks!"));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActions().size(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), Template.class);
+        Assert.assertEquals(test.getActions().get(0).getName(), "template:fooTemplate");
+
+        Template container = (Template)test.getActions().get(0);
+        Assert.assertTrue(container.isGlobalContext());
+        Assert.assertEquals(container.getParameter().toString(), "{param=foo, text=Citrus rocks!}");
+        Assert.assertEquals(container.getActions().size(), 2);
+        Assert.assertEquals(container.getActions().get(0).getClass(), EchoAction.class);
+        Assert.assertEquals(container.getActions().get(1).getClass(), TraceVariablesAction.class);
+    }
+
+    @Test
+    public void testTemplateBuilderGlobalContext() {
+        Template rootTemplate = new Template.Builder()
+                .templateName("fooTemplate")
+                .actions(new EchoAction.Builder().build())
+                .build();
+
+        reset(referenceResolver);
+
+        when(referenceResolver.resolve(TestContext.class)).thenReturn(context);
+        when(referenceResolver.resolve("fooTemplate", Template.class)).thenReturn(rootTemplate);
+        when(referenceResolver.resolve(TestActionListeners.class)).thenReturn(new TestActionListeners());
+        when(referenceResolver.resolveAll(SequenceBeforeTest.class)).thenReturn(new HashMap<>());
+        when(referenceResolver.resolveAll(SequenceAfterTest.class)).thenReturn(new HashMap<>());
+
+        context.setReferenceResolver(referenceResolver);
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(applyTemplate("fooTemplate")
+                        .globalContext(false));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActions().size(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), Template.class);
+        Assert.assertEquals(test.getActions().get(0).getName(), "template:fooTemplate");
+
+        Template container = (Template)test.getActions().get(0);
+        Assert.assertFalse(container.isGlobalContext());
+        Assert.assertEquals(container.getParameter().size(), 0L);
+        Assert.assertEquals(container.getActions().size(), 1);
+        Assert.assertEquals(container.getActions().get(0).getClass(), EchoAction.class);
+    }
+}

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/TimerTestActionBuilderTest.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/TimerTestActionBuilderTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.actions.dsl;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.container.Timer;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.EchoAction.Builder.echo;
+import static org.citrusframework.container.Timer.Builder.timer;
+
+/**
+ * @author Martin Maher
+ * @since 2.5
+ */
+public class TimerTestActionBuilderTest extends UnitTestSupport {
+
+    @Test
+    public void testTimerBuilder() {
+        final String timerId = "testTimer1";
+        final int delay = 100;
+        final int interval = 200;
+        final int repeatCount = 1;
+        final boolean fork = false;
+
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(timer()
+                    .timerId(timerId)
+                    .delay(delay)
+                    .interval(interval)
+                    .repeatCount(repeatCount)
+                    .fork(fork)
+                    .actions(echo("hello")));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), Timer.class);
+
+        Timer action = (Timer) test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "timer");
+        Assert.assertEquals(action.getDelay(), delay);
+        Assert.assertEquals(action.getInterval(), interval);
+        Assert.assertEquals(action.getRepeatCount(), repeatCount);
+        Assert.assertEquals(action.isFork(), fork);
+        Assert.assertEquals(action.getActionCount(), 1);
+    }
+}

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/TraceVariablesTestActionBuilderTest.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/TraceVariablesTestActionBuilderTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.actions.dsl;
+
+import java.util.Collections;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.actions.TraceVariablesAction;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.TraceVariablesAction.Builder.traceVariables;
+
+public class TraceVariablesTestActionBuilderTest extends UnitTestSupport {
+
+    @Test
+    public void testTraceVariablesBuilder() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.variable("variable1", "foo");
+        builder.variable("variable2", "bar");
+
+        builder.variable("ONE", "1");
+        builder.variable("TWO", "2");
+
+        builder.variable("TWELFE", "${ONE}${TWO}");
+
+        builder.$(traceVariables());
+        builder.$(traceVariables("variable1", "variable2"));
+        builder.$(traceVariables("ONE", "TWO", "TWELFE"));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 3);
+        Assert.assertEquals(test.getActions().get(0).getClass(), TraceVariablesAction.class);
+        Assert.assertEquals(test.getActions().get(1).getClass(), TraceVariablesAction.class);
+        Assert.assertEquals(test.getActions().get(2).getClass(), TraceVariablesAction.class);
+
+        TraceVariablesAction action = (TraceVariablesAction)test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "trace");
+        Assert.assertEquals(action.getVariableNames(), Collections.emptyList());
+
+        action = (TraceVariablesAction)test.getActions().get(1);
+        Assert.assertEquals(action.getName(), "trace");
+        Assert.assertNotNull(action.getVariableNames());
+        Assert.assertEquals(action.getVariableNames().toString(), "[variable1, variable2]");
+    }
+}

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/TransformTestActionBuilderTest.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/TransformTestActionBuilderTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.actions.dsl;
+
+import java.io.IOException;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.actions.TransformAction;
+import org.springframework.core.io.ClassPathResource;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.TransformAction.Builder.transform;
+
+public class TransformTestActionBuilderTest extends UnitTestSupport {
+    @Test
+    public void testTransformBuilderWithData() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(transform().source("<TestRequest>" +
+                            "<Message>Hello World!</Message>" +
+                        "</TestRequest>")
+                .xslt(String.format("<xsl:stylesheet version=\"1.0\" xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\">%n" +
+                        "<xsl:template match=\"/\">%n" +
+                        "<html>%n" +
+                        "<body>%n" +
+                        "<h2>Test Request</h2>%n" +
+                        "<p>Message: <xsl:value-of select=\"TestRequest/Message\"/></p>%n" +
+                        "</body>%n" +
+                        "</html>%n" +
+                        "</xsl:template>%n" +
+                        "</xsl:stylesheet>"))
+                .result("result"));
+
+        Assert.assertNotNull(context.getVariable("result"));
+        Assert.assertEquals(context.getVariable("result"), String.format("<html>%n" +
+					"    <body>%n" +
+						"        <h2>Test Request</h2>%n" +
+						"        <p>Message: Hello World!</p>%n" +
+					"    </body>%n" +
+				"</html>%n"));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), TransformAction.class);
+
+        TransformAction action = (TransformAction)test.getActions().get(0);
+
+        Assert.assertEquals(action.getName(), "transform");
+        Assert.assertTrue(action.getXmlData().startsWith("<TestRequest>"));
+        Assert.assertTrue(action.getXsltData().contains("<h2>Test Request</h2>"));
+        Assert.assertEquals(action.getTargetVariable(), "result");
+    }
+
+    @Test
+    public void testTransformBuilderWithResource() throws IOException {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(transform().source(new ClassPathResource("org/citrusframework/actions/dsl/transform-source.xml"))
+                .xslt(new ClassPathResource("org/citrusframework/actions/dsl/transform.xslt"))
+                .result("result"));
+
+		Assert.assertNotNull(context.getVariable("result"));
+		Assert.assertEquals(context.getVariable("result"), String.format("<html>%n" +
+					"    <body>%n" +
+						"        <h2>Test Request</h2>%n" +
+						"        <p>Message: Hello World!</p>%n" +
+					"    </body>%n" +
+				"</html>%n"));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), TransformAction.class);
+
+        TransformAction action = (TransformAction)test.getActions().get(0);
+
+		Assert.assertEquals(action.getName(), "transform");
+		Assert.assertTrue(action.getXmlData().contains("<TestRequest>"));
+		Assert.assertTrue(action.getXsltData().contains("<h2>Test Request</h2>"));
+		Assert.assertEquals(action.getTargetVariable(), "result");
+    }
+}

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/WaitTestActionBuilderTest.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/WaitTestActionBuilderTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.actions.dsl;
+
+import java.io.File;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.condition.ActionCondition;
+import org.citrusframework.condition.Condition;
+import org.citrusframework.condition.FileCondition;
+import org.citrusframework.container.Wait;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.exceptions.TestCaseFailedException;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.FailAction.Builder.fail;
+import static org.citrusframework.actions.SleepAction.Builder.sleep;
+import static org.citrusframework.container.Wait.Builder.waitFor;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Martin Maher
+ * @since 2.4
+ */
+public class WaitTestActionBuilderTest extends UnitTestSupport {
+
+    private final Condition condition = Mockito.mock(Condition.class);
+    private final File file = Mockito.mock(File.class);
+
+    @Test
+    public void testWaitBuilder() {
+        reset(condition);
+        when(condition.getName()).thenReturn("check");
+        when(condition.isSatisfied(any(TestContext.class))).thenReturn(Boolean.FALSE);
+        when(condition.isSatisfied(any(TestContext.class))).thenReturn(Boolean.TRUE);
+        when(condition.getSuccessMessage(any(TestContext.class))).thenReturn("Condition success!");
+        final double seconds = 3.0;
+        final String interval = "500";
+
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(waitFor()
+                    .seconds(seconds)
+                    .interval(interval)
+                    .condition(condition));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), Wait.class);
+
+        Wait action = (Wait)test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "wait");
+        Assert.assertEquals(action.getTime(), "3000");
+        Assert.assertEquals(action.getInterval(), interval);
+        Assert.assertEquals(action.getCondition(), condition);
+    }
+
+    @Test
+    public void testWaitFileBuilderSuccess() {
+        reset(file);
+
+        when(file.getPath()).thenReturn("path/to/some/file.txt");
+        when(file.exists()).thenReturn(false);
+        when(file.exists()).thenReturn(true);
+        when(file.isFile()).thenReturn(true);
+
+        final String time = "3000";
+        final String interval = "500";
+
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(waitFor().file()
+                     .milliseconds(time)
+                     .interval(interval)
+                     .resource(file));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), Wait.class);
+
+        Wait action = (Wait)test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "wait");
+        Assert.assertEquals(action.getTime(), time);
+        Assert.assertEquals(action.getInterval(), interval);
+        Assert.assertEquals(action.getCondition().getClass(), FileCondition.class);
+    }
+
+    @Test
+    public void testWaitActionBuilderSuccess() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(waitFor().execution()
+                    .seconds(1L)
+                    .interval(300L)
+                    .action(sleep().milliseconds(200L)));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), Wait.class);
+
+        Wait action = (Wait)test.getActions().get(0);
+        Assert.assertEquals(action.getName(), "wait");
+        Assert.assertEquals(action.getTime(), "1000");
+        Assert.assertEquals(action.getInterval(), "300");
+        Assert.assertEquals(action.getCondition().getClass(), ActionCondition.class);
+    }
+
+    @Test(expectedExceptions = TestCaseFailedException.class)
+    public void testWaitFileBuilderFailed() {
+        reset(file);
+
+        when(file.getPath()).thenReturn("path/to/some/file.txt");
+        when(file.exists()).thenReturn(false);
+
+        final long seconds = 1L;
+        final String interval = "500";
+
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(waitFor().file()
+                    .seconds(seconds)
+                    .interval(interval)
+                    .resource(file));
+    }
+
+    @Test(expectedExceptions = TestCaseFailedException.class)
+    public void testWaitActionBuilderFailed() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(waitFor().execution()
+                    .milliseconds(500L)
+                    .interval(100L)
+                    .action(fail("I am failing!")));
+    }
+}

--- a/runtime/citrus-testng/src/test/resources/citrus-context.xml
+++ b/runtime/citrus-testng/src/test/resources/citrus-context.xml
@@ -22,7 +22,7 @@
   <bean class="org.citrusframework.report.MessageTracingTestListener"/>
 
   <!-- Text equals message validator -->
-  <bean id="textEqualsMessageValidator" class="org.citrusframework.integration.TextEqualsMessageValidator"/>
+  <bean id="textEqualsMessageValidator" class="org.citrusframework.TextEqualsMessageValidator"/>
 
   <citrus:direct-endpoint id="helloEndpoint"
                           queue="helloQueue"/>

--- a/runtime/citrus-testng/src/test/resources/org/citrusframework/actions/dsl/build.properties
+++ b/runtime/citrus-testng/src/test/resources/org/citrusframework/actions/dsl/build.properties
@@ -1,0 +1,2 @@
+welcomeText=Welcome with property file!
+checked=${checked}

--- a/runtime/citrus-testng/src/test/resources/org/citrusframework/actions/dsl/build.xml
+++ b/runtime/citrus-testng/src/test/resources/org/citrusframework/actions/dsl/build.xml
@@ -1,0 +1,15 @@
+<project name="citrus-build" default="sayHello">
+	<property name="welcomeText" value="Welcome to Citrus!"></property>
+	
+    <target name="sayHello">
+    	<echo message="${welcomeText}"></echo>
+    </target>
+	
+	<target name="sayGoodbye">
+        <echo message="Goodbye!"></echo>
+    </target>
+	
+	<target name="checkMe">
+		<fail unless="${checked}" message="Failed with missing property"/>
+	</target>
+</project>

--- a/runtime/citrus-testng/src/test/resources/org/citrusframework/actions/dsl/helloRequest.xml
+++ b/runtime/citrus-testng/src/test/resources/org/citrusframework/actions/dsl/helloRequest.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<HelloRequest xmlns="http://citrusframework.org/schemas/samples/sayHello.xsd">
+     <MessageId>${messageId}</MessageId>
+     <CorrelationId>${correlationId}</CorrelationId>
+     <User>${user}</User>
+     <Text>Hello TestFramework</Text>
+</HelloRequest>

--- a/runtime/citrus-testng/src/test/resources/org/citrusframework/actions/dsl/helloResponse.xml
+++ b/runtime/citrus-testng/src/test/resources/org/citrusframework/actions/dsl/helloResponse.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<HelloResponse xmlns="http://citrusframework.org/schemas/samples/sayHello.xsd">
+    <MessageId>${messageId}</MessageId>
+    <CorrelationId>${correlationId}</CorrelationId>
+    <User>HelloService</User>
+    <Text>Hello ${user}</Text>
+</HelloResponse>

--- a/runtime/citrus-testng/src/test/resources/org/citrusframework/actions/dsl/load.properties
+++ b/runtime/citrus-testng/src/test/resources/org/citrusframework/actions/dsl/load.properties
@@ -1,0 +1,3 @@
+user=Mr. X
+welcomeText=Hello ${user}
+todayDate=citrus:currentDate('yyyy-MM-dd')

--- a/runtime/citrus-testng/src/test/resources/org/citrusframework/actions/dsl/script.sql
+++ b/runtime/citrus-testng/src/test/resources/org/citrusframework/actions/dsl/script.sql
@@ -1,0 +1,12 @@
+-- clean up database
+DELETE FROM CUSTOMERS;
+DELETE FROM ORDERS;
+
+-- insert data
+INSERT INTO 
+CUSTOMERS 
+VALUES (1, 'Christoph', 'VIP Customer');
+
+INSERT INTO ORDERS VALUES(1, 'requestTag', 'conversationId', 'creation_date', 'Migrate');
+INSERT INTO ORDERS VALUES(2, 'requestTag', 'conversationId', 'creation_date', NULL);
+COMMIT;

--- a/runtime/citrus-testng/src/test/resources/org/citrusframework/actions/dsl/transform-source.xml
+++ b/runtime/citrus-testng/src/test/resources/org/citrusframework/actions/dsl/transform-source.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TestRequest>
+	<Message>Hello World!</Message>
+</TestRequest>

--- a/runtime/citrus-testng/src/test/resources/org/citrusframework/actions/dsl/transform.xslt
+++ b/runtime/citrus-testng/src/test/resources/org/citrusframework/actions/dsl/transform.xslt
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:template match="/">
+	<html>
+		<body>
+			<h2>Test Request</h2>
+			<p>Message: <xsl:value-of select="TestRequest/Message"/></p>
+		</body>  
+	</html>
+</xsl:template>
+</xsl:stylesheet>

--- a/validation/citrus-validation-groovy/src/main/java/org/citrusframework/validation/script/GroovyScriptMessageValidator.java
+++ b/validation/citrus-validation-groovy/src/main/java/org/citrusframework/validation/script/GroovyScriptMessageValidator.java
@@ -52,7 +52,7 @@ public class GroovyScriptMessageValidator extends AbstractMessageValidator<Scrip
     private static Logger log = LoggerFactory.getLogger(GroovyScriptMessageValidator.class);
 
     /** Static code snippet for groovy script validation */
-    private Resource scriptTemplateResource;
+    private final Resource scriptTemplateResource;
 
     /**
      * Default constructor using default script template.

--- a/validation/citrus-validation-groovy/src/test/java/org/citrusframework/UnitTestSupport.java
+++ b/validation/citrus-validation-groovy/src/test/java/org/citrusframework/UnitTestSupport.java
@@ -1,0 +1,32 @@
+package org.citrusframework;
+
+import org.citrusframework.context.TestContext;
+import org.citrusframework.context.TestContextFactory;
+import org.citrusframework.functions.DefaultFunctionLibrary;
+import org.citrusframework.validation.matcher.DefaultValidationMatcherLibrary;
+import org.testng.annotations.BeforeMethod;
+
+/**
+ * @author Christoph Deppisch
+ */
+public abstract class UnitTestSupport {
+
+    protected TestContextFactory testContextFactory;
+    protected TestContext context;
+
+    /**
+     * Setup test execution.
+     */
+    @BeforeMethod
+    public void prepareTest() {
+        testContextFactory = createTestContextFactory();
+        context = testContextFactory.getObject();
+    }
+
+    protected TestContextFactory createTestContextFactory() {
+        TestContextFactory factory = TestContextFactory.newInstance();
+        factory.getFunctionRegistry().addFunctionLibrary(new DefaultFunctionLibrary());
+        factory.getValidationMatcherRegistry().addValidationMatcherLibrary(new DefaultValidationMatcherLibrary());
+        return factory;
+    }
+}

--- a/validation/citrus-validation-groovy/src/test/java/org/citrusframework/actions/dsl/ExecuteSQLQueryTestActionBuilderTest.java
+++ b/validation/citrus-validation-groovy/src/test/java/org/citrusframework/actions/dsl/ExecuteSQLQueryTestActionBuilderTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.actions.dsl;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.actions.ExecuteSQLQueryAction;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.script.ScriptTypes;
+import org.citrusframework.validation.script.ScriptValidationContext;
+import org.citrusframework.validation.script.sql.SqlResultSetScriptValidator;
+import org.mockito.Mockito;
+import org.springframework.core.io.Resource;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.ExecuteSQLQueryAction.Builder.query;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ * @since 2.3
+ */
+public class ExecuteSQLQueryTestActionBuilderTest extends UnitTestSupport {
+
+    private final JdbcTemplate jdbcTemplate = Mockito.mock(JdbcTemplate.class);
+    private final Resource resource = Mockito.mock(Resource.class);
+
+    private final SqlResultSetScriptValidator validator = Mockito.mock(SqlResultSetScriptValidator.class);
+
+    @Test
+    public void testValidationScript() {
+        List<Map<String, Object>> results = new ArrayList<>();
+        results.add(Collections.<String, Object>singletonMap("NAME", "Penny"));
+        results.add(Collections.<String, Object>singletonMap("NAME", "Sheldon"));
+
+        reset(jdbcTemplate);
+        when(jdbcTemplate.queryForList("SELECT NAME FROM ACTORS")).thenReturn(results);
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(query().jdbcTemplate(jdbcTemplate)
+            .statement("SELECT NAME FROM ACTORS")
+            .validateScript("assert rows[0].NAME == 'Penny'\n" +
+                    "assert rows[1].NAME == 'Sheldon'", ScriptTypes.GROOVY));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ExecuteSQLQueryAction.class);
+
+        ExecuteSQLQueryAction action = (ExecuteSQLQueryAction)test.getActions().get(0);
+
+        Assert.assertEquals(action.getName(), "sql-query");
+        Assert.assertEquals(action.getControlResultSet().size(), 0);
+        Assert.assertEquals(action.getExtractVariables().size(), 0);
+        Assert.assertNotNull(action.getScriptValidationContext());
+        Assert.assertTrue(action.getScriptValidationContext().getValidationScript().startsWith("assert rows[0].NAME == 'Penny'"));
+        Assert.assertNull(action.getScriptValidationContext().getValidationScriptResourcePath());
+        Assert.assertEquals(action.getStatements().size(), 1);
+        Assert.assertEquals(action.getStatements().toString(), "[SELECT NAME FROM ACTORS]");
+        Assert.assertEquals(action.getJdbcTemplate(), jdbcTemplate);
+
+    }
+
+    @Test
+    public void testValidationScriptResource() throws IOException {
+        List<Map<String, Object>> results = new ArrayList<>();
+        results.add(Collections.<String, Object>singletonMap("NAME", "Radj"));
+
+        reset(jdbcTemplate, resource);
+        when(resource.getInputStream()).thenReturn(new ByteArrayInputStream("assert rows[0].NAME == 'Radj'".getBytes()));
+        when(jdbcTemplate.queryForList("SELECT NAME FROM ACTORS")).thenReturn(results);
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(query().jdbcTemplate(jdbcTemplate)
+            .statement("SELECT NAME FROM ACTORS")
+            .validateScript(resource, ScriptTypes.GROOVY));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ExecuteSQLQueryAction.class);
+
+        ExecuteSQLQueryAction action = (ExecuteSQLQueryAction)test.getActions().get(0);
+
+        Assert.assertEquals(action.getName(), "sql-query");
+        Assert.assertEquals(action.getControlResultSet().size(), 0);
+        Assert.assertEquals(action.getExtractVariables().size(), 0);
+        Assert.assertNotNull(action.getScriptValidationContext());
+        Assert.assertEquals(action.getScriptValidationContext().getValidationScript(), "assert rows[0].NAME == 'Radj'");
+        Assert.assertNull(action.getScriptValidationContext().getValidationScriptResourcePath());
+        Assert.assertEquals(action.getStatements().size(), 1);
+        Assert.assertEquals(action.getStatements().toString(), "[SELECT NAME FROM ACTORS]");
+        Assert.assertEquals(action.getJdbcTemplate(), jdbcTemplate);
+
+    }
+
+    @Test
+    public void testGroovyValidationScript() {
+        List<Map<String, Object>> results = new ArrayList<>();
+        results.add(Collections.<String, Object>singletonMap("NAME", "Howard"));
+        results.add(Collections.<String, Object>singletonMap("NAME", "Sheldon"));
+
+        reset(jdbcTemplate);
+        when(jdbcTemplate.queryForList("SELECT NAME FROM ACTORS")).thenReturn(results);
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(query().jdbcTemplate(jdbcTemplate)
+            .statement("SELECT NAME FROM ACTORS")
+            .groovy("assert rows[0].NAME == 'Howard'"));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ExecuteSQLQueryAction.class);
+
+        ExecuteSQLQueryAction action = (ExecuteSQLQueryAction)test.getActions().get(0);
+
+        Assert.assertEquals(action.getName(), "sql-query");
+        Assert.assertEquals(action.getControlResultSet().size(), 0);
+        Assert.assertEquals(action.getExtractVariables().size(), 0);
+        Assert.assertNotNull(action.getScriptValidationContext());
+        Assert.assertEquals(action.getScriptValidationContext().getValidationScript(), "assert rows[0].NAME == 'Howard'");
+        Assert.assertNull(action.getScriptValidationContext().getValidationScriptResourcePath());
+        Assert.assertEquals(action.getStatements().size(), 1);
+        Assert.assertEquals(action.getStatements().toString(), "[SELECT NAME FROM ACTORS]");
+        Assert.assertEquals(action.getJdbcTemplate(), jdbcTemplate);
+    }
+
+    @Test
+    public void testGroovyValidationScriptResource() throws IOException {
+        List<Map<String, Object>> results = new ArrayList<>();
+        results.add(Collections.<String, Object>singletonMap("NAME", "Penny"));
+        results.add(Collections.<String, Object>singletonMap("NAME", "Howard"));
+        results.add(Collections.<String, Object>singletonMap("NAME", "Sheldon"));
+
+        reset(jdbcTemplate, resource);
+        when(resource.getInputStream()).thenReturn(new ByteArrayInputStream("assert rows[1].NAME == 'Howard'".getBytes()));
+        when(jdbcTemplate.queryForList("SELECT NAME FROM ACTORS")).thenReturn(results);
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(query().jdbcTemplate(jdbcTemplate)
+            .statement("SELECT NAME FROM ACTORS")
+            .groovy(resource));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ExecuteSQLQueryAction.class);
+
+        ExecuteSQLQueryAction action = (ExecuteSQLQueryAction)test.getActions().get(0);
+
+        Assert.assertEquals(action.getName(), "sql-query");
+        Assert.assertEquals(action.getControlResultSet().size(), 0);
+        Assert.assertEquals(action.getExtractVariables().size(), 0);
+        Assert.assertNotNull(action.getScriptValidationContext());
+        Assert.assertEquals(action.getScriptValidationContext().getValidationScript(), "assert rows[1].NAME == 'Howard'");
+        Assert.assertNull(action.getScriptValidationContext().getValidationScriptResourcePath());
+        Assert.assertEquals(action.getStatements().size(), 1);
+        Assert.assertEquals(action.getStatements().toString(), "[SELECT NAME FROM ACTORS]");
+        Assert.assertEquals(action.getJdbcTemplate(), jdbcTemplate);
+
+    }
+
+    @Test
+    public void testCustomScriptValidator() {
+        List<Map<String, Object>> results = new ArrayList<>();
+        results.add(Collections.<String, Object>singletonMap("NAME", "Howard"));
+        results.add(Collections.<String, Object>singletonMap("NAME", "Penny"));
+        results.add(Collections.<String, Object>singletonMap("NAME", "Sheldon"));
+
+        reset(jdbcTemplate, validator);
+        when(jdbcTemplate.queryForList("SELECT NAME FROM ACTORS")).thenReturn(results);
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(query().jdbcTemplate(jdbcTemplate)
+            .statement("SELECT NAME FROM ACTORS")
+            .groovy("assert rows[0].NAME == 'Howard'")
+            .validator(validator));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ExecuteSQLQueryAction.class);
+
+        ExecuteSQLQueryAction action = (ExecuteSQLQueryAction)test.getActions().get(0);
+
+        Assert.assertEquals(action.getName(), "sql-query");
+        Assert.assertEquals(action.getControlResultSet().size(), 0);
+        Assert.assertEquals(action.getExtractVariables().size(), 0);
+        Assert.assertNotNull(action.getScriptValidationContext());
+        Assert.assertEquals(action.getScriptValidationContext().getValidationScript(), "assert rows[0].NAME == 'Howard'");
+        Assert.assertNull(action.getScriptValidationContext().getValidationScriptResourcePath());
+        Assert.assertEquals(action.getStatements().size(), 1);
+        Assert.assertEquals(action.getStatements().toString(), "[SELECT NAME FROM ACTORS]");
+        Assert.assertEquals(action.getJdbcTemplate(), jdbcTemplate);
+        Assert.assertEquals(action.getValidator(), validator);
+
+        verify(validator).validateSqlResultSet(any(List.class), any(ScriptValidationContext.class), any(TestContext.class));
+    }
+}

--- a/validation/citrus-validation-groovy/src/test/java/org/citrusframework/actions/dsl/ReceiveMessageActionBuilderTest.java
+++ b/validation/citrus-validation-groovy/src/test/java/org/citrusframework/actions/dsl/ReceiveMessageActionBuilderTest.java
@@ -55,10 +55,10 @@ import static org.mockito.Mockito.when;
  */
 public class ReceiveMessageActionBuilderTest extends AbstractTestNGUnitTest {
 
-    private Endpoint messageEndpoint = Mockito.mock(Endpoint.class);
-    private Consumer messageConsumer = Mockito.mock(Consumer.class);
-    private EndpointConfiguration configuration = Mockito.mock(EndpointConfiguration.class);
-    private ReferenceResolver referenceResolver = Mockito.mock(ReferenceResolver.class);
+    private final Endpoint messageEndpoint = Mockito.mock(Endpoint.class);
+    private final Consumer messageConsumer = Mockito.mock(Consumer.class);
+    private final EndpointConfiguration configuration = Mockito.mock(EndpointConfiguration.class);
+    private final ReferenceResolver referenceResolver = Mockito.mock(ReferenceResolver.class);
 
     @Test
     public void testReceiveBuilderWithValidationScript() {

--- a/validation/citrus-validation-hamcrest/src/test/java/org/citrusframework/TextEqualsMessageValidator.java
+++ b/validation/citrus-validation-hamcrest/src/test/java/org/citrusframework/TextEqualsMessageValidator.java
@@ -1,0 +1,38 @@
+package org.citrusframework;
+
+import org.citrusframework.context.TestContext;
+import org.citrusframework.message.Message;
+import org.citrusframework.message.MessageType;
+import org.citrusframework.validation.DefaultMessageValidator;
+import org.citrusframework.validation.context.ValidationContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+
+/**
+ * Basic message validator performs String equals on received message payloads. We add this validator in order to have a
+ * matching message validation strategy for integration tests in this module.
+ * @author Christoph Deppisch
+ */
+public class TextEqualsMessageValidator extends DefaultMessageValidator {
+
+    @Override
+    public void validateMessage(Message receivedMessage, Message controlMessage, TestContext context, ValidationContext validationContext) {
+        Logger log = LoggerFactory.getLogger("TextEqualsMessageValidator");
+
+        if (controlMessage.getPayload(String.class).isBlank()) {
+            log.info("Skip text validation as no control message payload specified");
+            return;
+        }
+
+        Assert.assertEquals(receivedMessage.getPayload(String.class), controlMessage.getPayload(String.class), "Validation failed - " +
+                "expected message contents not equal!");
+
+        log.info("Text validation successful: All values OK");
+    }
+
+    @Override
+    public boolean supportsMessageType(String messageType, Message message) {
+        return messageType.equalsIgnoreCase(MessageType.PLAINTEXT.toString());
+    }
+}

--- a/validation/citrus-validation-hamcrest/src/test/java/org/citrusframework/UnitTestSupport.java
+++ b/validation/citrus-validation-hamcrest/src/test/java/org/citrusframework/UnitTestSupport.java
@@ -1,0 +1,33 @@
+package org.citrusframework;
+
+import org.citrusframework.context.TestContext;
+import org.citrusframework.context.TestContextFactory;
+import org.citrusframework.functions.DefaultFunctionLibrary;
+import org.citrusframework.validation.matcher.DefaultValidationMatcherLibrary;
+import org.testng.annotations.BeforeMethod;
+
+/**
+ * @author Christoph Deppisch
+ */
+public abstract class UnitTestSupport {
+
+    protected TestContextFactory testContextFactory;
+    protected TestContext context;
+
+    /**
+     * Setup test execution.
+     */
+    @BeforeMethod
+    public void prepareTest() {
+        testContextFactory = createTestContextFactory();
+        context = testContextFactory.getObject();
+    }
+
+    protected TestContextFactory createTestContextFactory() {
+        TestContextFactory factory = TestContextFactory.newInstance();
+        factory.getFunctionRegistry().addFunctionLibrary(new DefaultFunctionLibrary());
+        factory.getValidationMatcherRegistry().addValidationMatcherLibrary(new DefaultValidationMatcherLibrary());
+        factory.getMessageValidatorRegistry().addMessageValidator("all", new TextEqualsMessageValidator());
+        return factory;
+    }
+}

--- a/validation/citrus-validation-hamcrest/src/test/java/org/citrusframework/actions/ReceiveMessageTestActionBuilderTest.java
+++ b/validation/citrus-validation-hamcrest/src/test/java/org/citrusframework/actions/ReceiveMessageTestActionBuilderTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.actions;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.endpoint.Endpoint;
+import org.citrusframework.endpoint.EndpointConfiguration;
+import org.citrusframework.message.DefaultMessage;
+import org.citrusframework.message.MessageType;
+import org.citrusframework.messaging.Consumer;
+import org.citrusframework.validation.builder.DefaultMessageBuilder;
+import org.citrusframework.validation.context.HeaderValidationContext;
+import org.citrusframework.validation.json.JsonMessageValidationContext;
+import org.citrusframework.validation.json.JsonPathMessageValidationContext;
+import org.hamcrest.core.AnyOf;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.ReceiveMessageAction.Builder.receive;
+import static org.citrusframework.validation.json.JsonMessageValidationContext.Builder.json;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class ReceiveMessageTestActionBuilderTest extends UnitTestSupport {
+
+    private final Endpoint messageEndpoint = Mockito.mock(Endpoint.class);
+    private final Consumer messageConsumer = Mockito.mock(Consumer.class);
+    private final EndpointConfiguration configuration = Mockito.mock(EndpointConfiguration.class);
+
+    @Test
+    public void testReceiveBuilderWithJsonPathExpressions() {
+        reset(messageEndpoint, messageConsumer, configuration);
+        when(messageEndpoint.createConsumer()).thenReturn(messageConsumer);
+        when(messageEndpoint.getEndpointConfiguration()).thenReturn(configuration);
+        when(configuration.getTimeout()).thenReturn(100L);
+        when(messageEndpoint.getActor()).thenReturn(null);
+        when(messageConsumer.receive(any(TestContext.class), anyLong())).thenReturn(
+                new DefaultMessage("{\"text\":\"Hello World!\", \"person\":{\"name\":\"John\",\"surname\":\"Doe\",\"active\": true}, \"index\":5, \"id\":\"x123456789x\"}")
+                        .setHeader("operation", "sayHello"));
+
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(receive().endpoint(messageEndpoint)
+                        .message()
+                        .type(MessageType.JSON)
+                        .body("{\"text\":\"Hello World!\", \"person\":{\"name\":\"John\",\"surname\":\"Doe\",\"active\": true}, \"index\":5, \"id\":\"x123456789x\"}")
+                        .validate(json()
+                                    .expression("$.person.name", "John")
+                                    .expression("$.person.active", true)
+                                    .expression("$.id", anyOf(containsString("123456789"), nullValue()))
+                                    .expression("$.text", "Hello World!")
+                                    .expression("$.index", 5)));
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 1);
+        Assert.assertEquals(test.getActions().get(0).getClass(), ReceiveMessageAction.class);
+
+        ReceiveMessageAction action = ((ReceiveMessageAction)test.getActions().get(0));
+        Assert.assertEquals(action.getName(), "receive");
+
+        Assert.assertEquals(action.getMessageType(), MessageType.JSON.name());
+        Assert.assertEquals(action.getEndpoint(), messageEndpoint);
+        Assert.assertEquals(action.getValidationContexts().size(), 3);
+        Assert.assertTrue(action.getValidationContexts().stream().anyMatch(HeaderValidationContext.class::isInstance));
+        Assert.assertTrue(action.getValidationContexts().stream().anyMatch(JsonMessageValidationContext.class::isInstance));
+        Assert.assertTrue(action.getValidationContexts().stream().anyMatch(JsonPathMessageValidationContext.class::isInstance));
+
+        JsonPathMessageValidationContext validationContext = action.getValidationContexts().stream()
+                .filter(JsonPathMessageValidationContext.class::isInstance).findFirst()
+                .map(JsonPathMessageValidationContext.class::cast)
+                .orElseThrow(() -> new AssertionError("Missing validation context"));
+
+        Assert.assertTrue(action.getMessageBuilder() instanceof DefaultMessageBuilder);
+        Assert.assertEquals(validationContext.getJsonPathExpressions().size(), 5L);
+        Assert.assertEquals(validationContext.getJsonPathExpressions().get("$.person.name"), "John");
+        Assert.assertEquals(validationContext.getJsonPathExpressions().get("$.person.active"), true);
+        Assert.assertEquals(validationContext.getJsonPathExpressions().get("$.text"), "Hello World!");
+        Assert.assertEquals(validationContext.getJsonPathExpressions().get("$.index"), 5);
+        Assert.assertEquals(validationContext.getJsonPathExpressions().get("$.id").getClass(), AnyOf.class);
+    }
+}

--- a/validation/citrus-validation-hamcrest/src/test/java/org/citrusframework/container/ConditionalTestActionBuilderTest.java
+++ b/validation/citrus-validation-hamcrest/src/test/java/org/citrusframework/container/ConditionalTestActionBuilderTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.container;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.CreateVariablesAction.Builder.createVariable;
+import static org.citrusframework.actions.EchoAction.Builder.echo;
+import static org.citrusframework.container.Conditional.Builder.conditional;
+import static org.citrusframework.container.HamcrestConditionExpression.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+
+public class ConditionalTestActionBuilderTest extends UnitTestSupport {
+    @Test
+    public void testConditionalBuilderHamcrestConditionExpression() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.variable("var", 5);
+        builder.variable("noExecution", "true");
+
+        builder.$(conditional().when(assertThat("${var}", is("5")))
+                .actions(echo("${var}"), createVariable("execution", "true")));
+
+        builder.$(conditional().when(assertThat("${var}", lessThan("5")))
+                .actions(echo("${var}"), createVariable("noExecution", "false")));
+
+        Assert.assertNotNull(context.getVariable("noExecution"));
+        Assert.assertEquals(context.getVariable("noExecution"), "true");
+        Assert.assertNotNull(context.getVariable("execution"));
+        Assert.assertEquals(context.getVariable("execution"), "true");
+
+        TestCase test = builder.getTestCase();
+        Assert.assertEquals(test.getActionCount(), 2);
+        Assert.assertEquals(test.getActions().get(0).getClass(), Conditional.class);
+        Assert.assertEquals(test.getActions().get(0).getName(), "conditional");
+        Assert.assertEquals(test.getActions().get(1).getClass(), Conditional.class);
+        Assert.assertEquals(test.getActions().get(1).getName(), "conditional");
+
+        Conditional container = (Conditional)test.getActions().get(0);
+        Assert.assertEquals(container.getActionCount(), 2);
+        Assert.assertNotNull(container.getConditionExpression());
+    }
+}

--- a/validation/citrus-validation-hamcrest/src/test/java/org/citrusframework/container/IterateTestActionBuilderTest.java
+++ b/validation/citrus-validation-hamcrest/src/test/java/org/citrusframework/container/IterateTestActionBuilderTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.container;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.CreateVariablesAction.Builder.createVariable;
+import static org.citrusframework.container.HamcrestConditionExpression.assertThat;
+import static org.citrusframework.container.Iterate.Builder.iterate;
+import static org.hamcrest.Matchers.lessThan;
+import static org.testng.Assert.assertEquals;
+
+public class IterateTestActionBuilderTest extends UnitTestSupport {
+    @Test
+    public void testIterateBuilderWithHamcrestConditionExpression() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.$(iterate().startsWith(0)
+                    .step(1)
+                    .condition(assertThat(lessThan(5)))
+            .actions(createVariable("index", "${i}")));
+
+        Assert.assertNotNull(context.getVariable("i"));
+        Assert.assertEquals(context.getVariable("i"), "4");
+
+        TestCase test = builder.getTestCase();
+        assertEquals(test.getActionCount(), 1);
+        assertEquals(test.getActions().get(0).getClass(), Iterate.class);
+        assertEquals(test.getActions().get(0).getName(), "iterate");
+
+        Iterate container = (Iterate)test.getActions().get(0);
+        assertEquals(container.getActionCount(), 1);
+        assertEquals(container.getIndexName(), "i");
+        assertEquals(container.getStep(), 1);
+        assertEquals(container.getStart(), 0);
+    }
+}

--- a/validation/citrus-validation-hamcrest/src/test/java/org/citrusframework/container/RepeatOnErrorTestActionBuilderTest.java
+++ b/validation/citrus-validation-hamcrest/src/test/java/org/citrusframework/container/RepeatOnErrorTestActionBuilderTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.container;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.actions.EchoAction;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.EchoAction.Builder.echo;
+import static org.citrusframework.actions.SleepAction.Builder.sleep;
+import static org.citrusframework.container.HamcrestConditionExpression.assertThat;
+import static org.citrusframework.container.RepeatOnErrorUntilTrue.Builder.repeatOnError;
+import static org.hamcrest.Matchers.is;
+import static org.testng.Assert.assertEquals;
+
+public class RepeatOnErrorTestActionBuilderTest extends UnitTestSupport {
+    @Test
+    public void testRepeatOnErrorBuilderWithHamcrestConditionExpression() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.variable("var", "foo");
+
+        builder.$(repeatOnError().autoSleep(250)
+                        .until("i gt 5")
+                .actions(echo("${var}"), sleep().milliseconds(50), echo("${var}")));
+
+        builder.$(repeatOnError().autoSleep(200)
+                        .index("k")
+                        .startsWith(2)
+                        .until(assertThat(is(5)))
+                .actions(echo("${var}")));
+
+        Assert.assertNotNull(context.getVariable("i"));
+        Assert.assertEquals(context.getVariable("i"), "1");
+        Assert.assertNotNull(context.getVariable("k"));
+        Assert.assertEquals(context.getVariable("k"), "2");
+
+        TestCase test = builder.getTestCase();
+        assertEquals(test.getActionCount(), 2);
+        assertEquals(test.getActions().get(0).getClass(), RepeatOnErrorUntilTrue.class);
+        assertEquals(test.getActions().get(0).getName(), "repeat-on-error");
+
+        RepeatOnErrorUntilTrue container = (RepeatOnErrorUntilTrue)test.getActions().get(0);
+        assertEquals(container.getActionCount(), 3);
+        assertEquals(container.getAutoSleep(), Long.valueOf(250L));
+        assertEquals(container.getCondition(), "i gt 5");
+        assertEquals(container.getStart(), 1);
+        assertEquals(container.getIndexName(), "i");
+        assertEquals(container.getTestAction(0).getClass(), EchoAction.class);
+
+        container = (RepeatOnErrorUntilTrue)test.getActions().get(1);
+        assertEquals(container.getActionCount(), 1);
+        assertEquals(container.getAutoSleep(), Long.valueOf(200L));
+        assertEquals(container.getStart(), 2);
+        assertEquals(container.getIndexName(), "k");
+        assertEquals(container.getTestAction(0).getClass(), EchoAction.class);
+    }
+}

--- a/validation/citrus-validation-hamcrest/src/test/java/org/citrusframework/container/RepeatTestRunnerTest.java
+++ b/validation/citrus-validation-hamcrest/src/test/java/org/citrusframework/container/RepeatTestRunnerTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.container;
+
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.actions.EchoAction;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.EchoAction.Builder.echo;
+import static org.citrusframework.actions.SleepAction.Builder.sleep;
+import static org.citrusframework.container.HamcrestConditionExpression.assertThat;
+import static org.citrusframework.container.RepeatUntilTrue.Builder.repeat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.testng.Assert.assertEquals;
+
+public class RepeatTestRunnerTest extends UnitTestSupport {
+    @Test
+    public void testRepeatBuilderWithHamcrestConditionExpression() {
+        DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
+        builder.variable("var", "foo");
+
+        builder.$(repeat().index("i")
+                    .startsWith(2)
+                    .until(assertThat(greaterThan(5)))
+                .actions(echo("${var}"), sleep().milliseconds(100), echo("${var}")));
+
+        Assert.assertNotNull(context.getVariable("i"));
+        Assert.assertEquals(context.getVariable("i"), "5");
+
+        TestCase test = builder.getTestCase();
+        assertEquals(test.getActionCount(), 1);
+        assertEquals(test.getActions().get(0).getClass(), RepeatUntilTrue.class);
+        assertEquals(test.getActions().get(0).getName(), "repeat");
+
+        RepeatUntilTrue container = (RepeatUntilTrue)test.getActions().get(0);
+        assertEquals(container.getActionCount(), 3);
+        assertEquals(container.getStart(), 2);
+        assertEquals(container.getIndexName(), "i");
+        assertEquals(container.getTestAction(0).getClass(), EchoAction.class);
+    }
+}

--- a/validation/citrus-validation-hamcrest/src/test/resources/citrus-context.xml
+++ b/validation/citrus-validation-hamcrest/src/test/resources/citrus-context.xml
@@ -11,6 +11,6 @@
     <citrus:queue id="helloQueue"/>
 
     <!-- Text equals message validator -->
-    <bean id="textEqualsMessageValidator" class="org.citrusframework.integration.TextEqualsMessageValidator"/>
+    <bean id="textEqualsMessageValidator" class="org.citrusframework.TextEqualsMessageValidator"/>
 
 </beans>

--- a/validation/citrus-validation-xml/src/main/java/org/citrusframework/validation/xml/XpathPayloadVariableExtractor.java
+++ b/validation/citrus-validation-xml/src/main/java/org/citrusframework/validation/xml/XpathPayloadVariableExtractor.java
@@ -16,13 +16,13 @@
 
 package org.citrusframework.validation.xml;
 
-import javax.xml.namespace.NamespaceContext;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import javax.xml.namespace.NamespaceContext;
 
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;
@@ -113,7 +113,7 @@ public class XpathPayloadVariableExtractor implements VariableExtractor {
                 Node node = XMLUtils.findNodeByName(doc, pathExpression);
 
                 if (node == null) {
-                    throw new UnknownElementException("No element found for expression" + pathExpression);
+                    throw new UnknownElementException("No element found for expression: " + XPathExpressionResult.cutOffPrefix(pathExpression));
                 }
 
                 if (node.getNodeType() == Node.ELEMENT_NODE) {

--- a/validation/citrus-validation-xml/src/test/java/org/citrusframework/actions/dsl/ReceiveMessageActionBuilderTest.java
+++ b/validation/citrus-validation-xml/src/test/java/org/citrusframework/actions/dsl/ReceiveMessageActionBuilderTest.java
@@ -231,7 +231,6 @@ public class ReceiveMessageActionBuilderTest extends UnitTestSupport {
 
         Assert.assertTrue(action.getMessageBuilder() instanceof DefaultMessageBuilder);
         Assert.assertEquals(((DefaultMessageBuilder)action.getMessageBuilder()).buildMessagePayload(context, action.getMessageType()), "<TestRequest><Message>Hello Citrus!</Message></TestRequest>");
-
     }
 
     @Test
@@ -1091,7 +1090,6 @@ public class ReceiveMessageActionBuilderTest extends UnitTestSupport {
         Assert.assertTrue(action.getVariableExtractors().get(0) instanceof XpathPayloadVariableExtractor);
         Assert.assertTrue(((XpathPayloadVariableExtractor) action.getVariableExtractors().get(0)).getXpathExpressions().containsKey("/TestRequest/Message"));
         Assert.assertTrue(((XpathPayloadVariableExtractor) action.getVariableExtractors().get(0)).getXpathExpressions().containsKey("/TestRequest/Message/@lang"));
-
     }
 
     @Test

--- a/validation/citrus-validation-xml/src/test/java/org/citrusframework/endpoint/adapter/behavior/BarTestBehavior.java
+++ b/validation/citrus-validation-xml/src/test/java/org/citrusframework/endpoint/adapter/behavior/BarTestBehavior.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2006-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.endpoint.adapter.behavior;
+
+import org.citrusframework.TestActionRunner;
+import org.citrusframework.TestBehavior;
+import org.citrusframework.message.MessageType;
+import org.springframework.stereotype.Component;
+
+import static org.citrusframework.actions.EchoAction.Builder.echo;
+import static org.citrusframework.actions.ReceiveMessageAction.Builder.receive;
+import static org.citrusframework.actions.SendMessageAction.Builder.send;
+
+@Component("BarTestBehavior")
+public class BarTestBehavior implements TestBehavior {
+
+    @Override
+    public void apply(TestActionRunner runner) {
+        runner.$(receive()
+                .endpoint("inboundDirectEndpoint")
+                .message()
+                .type(MessageType.PLAINTEXT)
+                .body("<TestBehavior name=\"BarTestBehavior\"></TestBehavior>"));
+
+        runner.$(send()
+                .endpoint("inboundDirectEndpoint")
+                .message()
+                .body("<TestBehavior name=\"BarTestBehavior\">OK</TestBehavior>"));
+
+        runner.$(echo("Bar TestBehavior OK!"));
+    }
+}

--- a/validation/citrus-validation-xml/src/test/java/org/citrusframework/endpoint/adapter/behavior/FooBarTestBehavior.java
+++ b/validation/citrus-validation-xml/src/test/java/org/citrusframework/endpoint/adapter/behavior/FooBarTestBehavior.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2006-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.endpoint.adapter.behavior;
+
+import org.citrusframework.TestActionRunner;
+import org.citrusframework.TestBehavior;
+import org.citrusframework.message.MessageType;
+import org.springframework.stereotype.Component;
+
+import static org.citrusframework.actions.EchoAction.Builder.echo;
+import static org.citrusframework.actions.ReceiveMessageAction.Builder.receive;
+import static org.citrusframework.actions.SendMessageAction.Builder.send;
+
+@Component("FooBarTestBehavior")
+public class FooBarTestBehavior implements TestBehavior {
+
+    @Override
+    public void apply(TestActionRunner runner) {
+        runner.$(receive()
+                .endpoint("inboundDirectEndpoint")
+                .message()
+                .type(MessageType.PLAINTEXT)
+                .body("<FooBarTestBehavior></FooBarTestBehavior>"));
+
+        runner.$(send()
+                .endpoint("inboundDirectEndpoint")
+                .message()
+                .body("<FooBarTestBehavior>OK</FooBarTestBehavior>"));
+
+        runner.$(echo("FooBar TestBehavior OK!"));
+    }
+}

--- a/validation/citrus-validation-xml/src/test/java/org/citrusframework/endpoint/adapter/behavior/FooTestBehavior.java
+++ b/validation/citrus-validation-xml/src/test/java/org/citrusframework/endpoint/adapter/behavior/FooTestBehavior.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2006-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.endpoint.adapter.behavior;
+
+import org.citrusframework.TestActionRunner;
+import org.citrusframework.TestBehavior;
+import org.citrusframework.message.MessageType;
+import org.springframework.stereotype.Component;
+
+import static org.citrusframework.actions.EchoAction.Builder.echo;
+import static org.citrusframework.actions.ReceiveMessageAction.Builder.receive;
+import static org.citrusframework.actions.SendMessageAction.Builder.send;
+
+@Component("FooTestBehavior")
+public class FooTestBehavior implements TestBehavior {
+
+    @Override
+    public void apply(TestActionRunner runner) {
+        runner.$(receive()
+                .endpoint("inboundDirectEndpoint")
+                .message()
+                .type(MessageType.PLAINTEXT)
+                .body("<TestBehavior name=\"FooTestBehavior\"></TestBehavior>"));
+
+        runner.$(send()
+                .endpoint("inboundDirectEndpoint")
+                .message()
+                .body("<TestBehavior name=\"FooTestBehavior\">OK</TestBehavior>"));
+
+        runner.$(echo("Foo TestBehavior OK!"));
+    }
+}


### PR DESCRIPTION
- Bring back some unit test coverage from removed java-dsl module
- Add TestBehaviorExecutingEndpointAdapter as a successor of former Java DSL test runner executing endpoint adapter