### PR TITLE
chore: Finish support for polyglot Citrus DSL

### DIFF
--- a/connectors/citrus-selenium/pom.xml
+++ b/connectors/citrus-selenium/pom.xml
@@ -51,6 +51,12 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.citrusframework</groupId>
+      <artifactId>citrus-yaml</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
 
     <!-- Selenium -->
     <dependency>

--- a/connectors/citrus-selenium/pom.xml
+++ b/connectors/citrus-selenium/pom.xml
@@ -51,18 +51,6 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.citrusframework</groupId>
-      <artifactId>citrus-yaml</artifactId>
-      <version>${project.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.citrusframework</groupId>
-      <artifactId>citrus-xml</artifactId>
-      <version>${project.version}</version>
-      <scope>provided</scope>
-    </dependency>
 
     <!-- Selenium -->
     <dependency>
@@ -129,6 +117,24 @@
     <dependency>
       <groupId>org.citrusframework</groupId>
       <artifactId>citrus-http</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.citrusframework</groupId>
+      <artifactId>citrus-groovy</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.citrusframework</groupId>
+      <artifactId>citrus-yaml</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.citrusframework</groupId>
+      <artifactId>citrus-xml</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>

--- a/connectors/citrus-selenium/pom.xml
+++ b/connectors/citrus-selenium/pom.xml
@@ -57,6 +57,12 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.citrusframework</groupId>
+      <artifactId>citrus-xml</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
 
     <!-- Selenium -->
     <dependency>

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/actions/DropDownSelectAction.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/actions/DropDownSelectAction.java
@@ -120,7 +120,7 @@ public class DropDownSelectAction extends FindElementAction {
     public static class Builder extends ElementActionBuilder<DropDownSelectAction, Builder> {
 
         private String option;
-        private List<String> options = new ArrayList<>();
+        private final List<String> options = new ArrayList<>();
 
         public Builder option(String option) {
             this.option = option;

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/actions/FindElementAction.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/actions/FindElementAction.java
@@ -64,27 +64,28 @@ public class FindElementAction extends AbstractSeleniumAction {
         this.displayed = builder.displayed;
         this.enabled = builder.enabled;
         this.text = builder.text;
+        this.tagName = builder.tagName;
     }
 
     /**
      * Constructor with name.
      * @param name
      */
-    public FindElementAction(String name, ElementActionBuilder<?, ?> builder) {
+    protected FindElementAction(String name, ElementActionBuilder<?, ?> builder) {
         super(name, builder);
 
         this.by = builder.by;
         this.property = builder.property;
         this.propertyValue = builder.propertyValue;
-        this.tagName = builder.tagName;
     }
 
     @Override
     protected final void execute(SeleniumBrowser browser, TestContext context) {
-        WebElement element = browser.getWebDriver().findElement(createBy(context));
+        By findBy = createBy(context);
+        WebElement element = browser.getWebDriver().findElement(findBy);
 
         if (element == null) {
-            throw new CitrusRuntimeException(String.format("Failed to find element '%s' on page", property + "=" + propertyValue));
+            throw new CitrusRuntimeException(String.format("Failed to find element '%s' on page", findBy));
         }
 
         validate(element, browser, context);
@@ -262,11 +263,12 @@ public class FindElementAction extends AbstractSeleniumAction {
      */
     public static class Builder extends ElementActionBuilder<FindElementAction, Builder> {
 
-        private Map<String, String> attributes = new HashMap<>();
-        private Map<String, String> styles = new HashMap<>();
+        private final Map<String, String> attributes = new HashMap<>();
+        private final Map<String, String> styles = new HashMap<>();
         private boolean displayed = true;
         private boolean enabled = true;
         private String text;
+        private String tagName;
 
         /**
          * Add text validation.
@@ -275,6 +277,16 @@ public class FindElementAction extends AbstractSeleniumAction {
          */
         public Builder text(String text) {
             this.text = text;
+            return this;
+        }
+
+        /**
+         * Add tag name validation.
+         * @param tagName
+         * @return
+         */
+        public Builder tagName(String tagName) {
+            this.tagName = tagName;
             return this;
         }
 
@@ -336,7 +348,6 @@ public class FindElementAction extends AbstractSeleniumAction {
         protected By by;
         protected String property;
         protected String propertyValue;
-        private String tagName;
 
         public B element(By by) {
             this.by = by;
@@ -346,16 +357,6 @@ public class FindElementAction extends AbstractSeleniumAction {
         public B element(String property, String propertyValue) {
             this.property = property;
             this.propertyValue = propertyValue;
-            return self;
-        }
-
-        /**
-         * Add tag name validation.
-         * @param tagName
-         * @return
-         */
-        public B tagName(String tagName) {
-            this.tagName = tagName;
             return self;
         }
     }

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/actions/JavaScriptAction.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/actions/JavaScriptAction.java
@@ -119,8 +119,8 @@ public class JavaScriptAction extends AbstractSeleniumAction {
     public static class Builder extends AbstractSeleniumAction.Builder<JavaScriptAction, Builder> {
 
         private String script;
-        private List<Object> arguments = new ArrayList<>();
-        private List<String> expectedErrors = new ArrayList<>();
+        private final List<Object> arguments = new ArrayList<>();
+        private final List<String> expectedErrors = new ArrayList<>();
 
         /**
          * Add script.
@@ -129,6 +129,25 @@ public class JavaScriptAction extends AbstractSeleniumAction {
          */
         public Builder script(String script) {
             this.script = script;
+            return this;
+        }
+
+        /**
+         * Add script arguments.
+         * @param args
+         * @return
+         */
+        public Builder arguments(Object... args) {
+            return arguments(Arrays.asList(args));
+        }
+
+        /**
+         * Add script arguments.
+         * @param args
+         * @return
+         */
+        public Builder arguments(List<Object> args) {
+            this.arguments.addAll(args);
             return this;
         }
 
@@ -147,7 +166,7 @@ public class JavaScriptAction extends AbstractSeleniumAction {
          * @param errors
          * @return
          */
-        public Builder errors(String ... errors) {
+        public Builder errors(String... errors) {
             return errors(Arrays.asList(errors));
         }
 
@@ -158,6 +177,16 @@ public class JavaScriptAction extends AbstractSeleniumAction {
          */
         public Builder errors(List<String> errors) {
             this.expectedErrors.addAll(errors);
+            return this;
+        }
+
+        /**
+         * Add expected error.
+         * @param error
+         * @return
+         */
+        public Builder error(String error) {
+            this.expectedErrors.add(error);
             return this;
         }
 

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/actions/PageAction.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/actions/PageAction.java
@@ -165,7 +165,7 @@ public class PageAction extends AbstractSeleniumAction {
         private WebPage page;
         private String type;
         private String action;
-        private List<String> arguments = new ArrayList<>();
+        private final List<String> arguments = new ArrayList<>();
         private PageValidator validator;
 
         /**

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/actions/SeleniumActionBuilder.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/actions/SeleniumActionBuilder.java
@@ -111,6 +111,16 @@ public class SeleniumActionBuilder implements TestActionBuilder.DelegatingTestAc
     /**
      * Navigate action.
      */
+    public NavigateAction.Builder navigate() {
+        NavigateAction.Builder builder = new NavigateAction.Builder()
+                .browser(seleniumBrowser);
+        this.delegate = builder;
+        return builder;
+    }
+
+    /**
+     * Navigate action.
+     */
     public NavigateAction.Builder navigate(String page) {
         NavigateAction.Builder builder = new NavigateAction.Builder()
                 .page(page)
@@ -185,6 +195,26 @@ public class SeleniumActionBuilder implements TestActionBuilder.DelegatingTestAc
     }
 
     /**
+     * Set input action.
+     */
+    public SetInputAction.Builder setInput() {
+		SetInputAction.Builder builder = new SetInputAction.Builder()
+                .browser(seleniumBrowser);
+        this.delegate = builder;
+        return builder;
+    }
+
+    /**
+     * Check input action.
+     */
+    public CheckInputAction.Builder checkInput() {
+		CheckInputAction.Builder builder = new CheckInputAction.Builder()
+                .browser(seleniumBrowser);
+        this.delegate = builder;
+        return builder;
+    }
+
+    /**
      * Check input action.
      */
     public CheckInputAction.Builder checkInput(boolean checked) {
@@ -248,11 +278,31 @@ public class SeleniumActionBuilder implements TestActionBuilder.DelegatingTestAc
 
     /**
      * Store file.
+     */
+    public StoreFileAction.Builder store() {
+        StoreFileAction.Builder builder = new StoreFileAction.Builder()
+                .browser(seleniumBrowser);
+        this.delegate = builder;
+        return builder;
+    }
+
+    /**
+     * Store file.
      * @param filePath
      */
     public StoreFileAction.Builder store(String filePath) {
         StoreFileAction.Builder builder = new StoreFileAction.Builder()
                 .filePath(filePath)
+                .browser(seleniumBrowser);
+        this.delegate = builder;
+        return builder;
+    }
+
+    /**
+     * Get stored file.
+     */
+    public GetStoredFileAction.Builder getStored() {
+        GetStoredFileAction.Builder builder = new GetStoredFileAction.Builder()
                 .browser(seleniumBrowser);
         this.delegate = builder;
         return builder;
@@ -275,6 +325,16 @@ public class SeleniumActionBuilder implements TestActionBuilder.DelegatingTestAc
      */
     public WaitUntilAction.Builder waitUntil() {
         WaitUntilAction.Builder builder = new WaitUntilAction.Builder()
+                .browser(seleniumBrowser);
+        this.delegate = builder;
+        return builder;
+    }
+
+    /**
+     * Execute JavaScript.
+     */
+    public JavaScriptAction.Builder javascript() {
+        JavaScriptAction.Builder builder = new JavaScriptAction.Builder()
                 .browser(seleniumBrowser);
         this.delegate = builder;
         return builder;
@@ -337,6 +397,16 @@ public class SeleniumActionBuilder implements TestActionBuilder.DelegatingTestAc
      * Switch window.
      */
     public SwitchWindowAction.Builder focus() {
+        SwitchWindowAction.Builder builder = new SwitchWindowAction.Builder()
+                .browser(seleniumBrowser);
+        this.delegate = builder;
+        return builder;
+    }
+
+    /**
+     * Switch window.
+     */
+    public SwitchWindowAction.Builder switchWindow() {
         SwitchWindowAction.Builder builder = new SwitchWindowAction.Builder()
                 .browser(seleniumBrowser);
         this.delegate = builder;

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/config/xml/CheckInputActionParser.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/config/xml/CheckInputActionParser.java
@@ -29,9 +29,7 @@ import org.w3c.dom.Element;
 public class CheckInputActionParser extends FindElementActionParser {
 
     @Override
-    protected void parseAction(BeanDefinitionBuilder beanDefinition, Element element, ParserContext parserContext) {
-        super.parseAction(beanDefinition, element, parserContext);
-
+    protected void parseElement(BeanDefinitionBuilder beanDefinition, Element element, ParserContext parserContext) {
         BeanDefinitionParserUtils.setPropertyValue(beanDefinition, element.getAttribute("checked"), "checked");
     }
 

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/config/xml/ClickActionParser.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/config/xml/ClickActionParser.java
@@ -28,8 +28,7 @@ import org.w3c.dom.Element;
 public class ClickActionParser extends FindElementActionParser {
 
     @Override
-    protected void parseAction(BeanDefinitionBuilder beanDefinition, Element element, ParserContext parserContext) {
-        super.parseAction(beanDefinition, element, parserContext);
+    protected void parseElement(BeanDefinitionBuilder beanDefinition, Element element, ParserContext parserContext) {
     }
 
     @Override

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/config/xml/DropDownSelectActionParser.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/config/xml/DropDownSelectActionParser.java
@@ -34,9 +34,7 @@ import org.w3c.dom.Element;
 public class DropDownSelectActionParser extends FindElementActionParser {
 
     @Override
-    protected void parseAction(BeanDefinitionBuilder beanDefinition, Element element, ParserContext parserContext) {
-        super.parseAction(beanDefinition, element, parserContext);
-
+    protected void parseElement(BeanDefinitionBuilder beanDefinition, Element element, ParserContext parserContext) {
         BeanDefinitionParserUtils.setPropertyValue(beanDefinition, element.getAttribute("option"), "option");
 
         List<String> options = new ArrayList<>();

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/config/xml/FindElementActionParser.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/config/xml/FindElementActionParser.java
@@ -35,7 +35,44 @@ import org.w3c.dom.Element;
 public class FindElementActionParser extends AbstractBrowserActionParser {
 
     @Override
-    protected void parseAction(BeanDefinitionBuilder beanDefinition, Element element, ParserContext parserContext) {
+    protected final void parseAction(BeanDefinitionBuilder beanDefinition, Element element, ParserContext parserContext) {
+        parseElementSelector(beanDefinition, element, parserContext);
+        parseElement(beanDefinition, element, parserContext);
+    }
+
+    protected void parseElement(BeanDefinitionBuilder beanDefinition, Element element, ParserContext parserContext) {
+        Element webElement = DomUtils.getChildElementByTagName(element, "element");
+        if (webElement != null) {
+            BeanDefinitionParserUtils.setPropertyValue(beanDefinition, webElement.getAttribute("tag-name"), "tagName");
+            BeanDefinitionParserUtils.setPropertyValue(beanDefinition, webElement.getAttribute("text"), "text");
+            BeanDefinitionParserUtils.setPropertyValue(beanDefinition, webElement.getAttribute("displayed"), "displayed");
+            BeanDefinitionParserUtils.setPropertyValue(beanDefinition, webElement.getAttribute("enabled"), "enabled");
+
+            Element attributesContainerElement = DomUtils.getChildElementByTagName(webElement, "attributes");
+            if (attributesContainerElement != null) {
+                Map<String, String> attributes = new HashMap<>();
+                List<Element> attributeElements = DomUtils.getChildElementsByTagName(attributesContainerElement, "attribute");
+                for (Element attribute : attributeElements) {
+                    attributes.put(attribute.getAttribute("name"), attribute.getAttribute("value"));
+                }
+
+                beanDefinition.addPropertyValue("attributes", attributes);
+            }
+
+            Element stylesContainerElement = DomUtils.getChildElementByTagName(webElement, "styles");
+            if (stylesContainerElement != null) {
+                Map<String, String> styles = new HashMap<>();
+                List<Element> styleElements = DomUtils.getChildElementsByTagName(stylesContainerElement, "style");
+                for (Element style : styleElements) {
+                    styles.put(style.getAttribute("name"), style.getAttribute("value"));
+                }
+
+                beanDefinition.addPropertyValue("styles", styles);
+            }
+        }
+    }
+
+    protected void parseElementSelector(BeanDefinitionBuilder beanDefinition, Element element, ParserContext parserContext) {
         Element webElement = DomUtils.getChildElementByTagName(element, "element");
         if (webElement != null) {
             String propertyValue = null;
@@ -66,33 +103,6 @@ public class FindElementActionParser extends AbstractBrowserActionParser {
 
             beanDefinition.addPropertyValue("property", property);
             beanDefinition.addPropertyValue("propertyValue", propertyValue);
-
-            BeanDefinitionParserUtils.setPropertyValue(beanDefinition, webElement.getAttribute("tag-name"), "tagName");
-            BeanDefinitionParserUtils.setPropertyValue(beanDefinition, webElement.getAttribute("text"), "text");
-            BeanDefinitionParserUtils.setPropertyValue(beanDefinition, webElement.getAttribute("displayed"), "displayed");
-            BeanDefinitionParserUtils.setPropertyValue(beanDefinition, webElement.getAttribute("enabled"), "enabled");
-
-            Element attributesContainerElement = DomUtils.getChildElementByTagName(webElement, "attributes");
-            if (attributesContainerElement != null) {
-                Map<String, String> attributes = new HashMap<>();
-                List<Element> attributeElements = DomUtils.getChildElementsByTagName(attributesContainerElement, "attribute");
-                for (Element attribute : attributeElements) {
-                    attributes.put(attribute.getAttribute("name"), attribute.getAttribute("value"));
-                }
-
-                beanDefinition.addPropertyValue("attributes", attributes);
-            }
-
-            Element stylesContainerElement = DomUtils.getChildElementByTagName(webElement, "styles");
-            if (stylesContainerElement != null) {
-                Map<String, String> styles = new HashMap<>();
-                List<Element> styleElements = DomUtils.getChildElementsByTagName(stylesContainerElement, "style");
-                for (Element style : styleElements) {
-                    styles.put(style.getAttribute("name"), style.getAttribute("value"));
-                }
-
-                beanDefinition.addPropertyValue("styles", styles);
-            }
         }
     }
 
@@ -153,6 +163,15 @@ public class FindElementActionParser extends AbstractBrowserActionParser {
             builder.text(text);
         }
 
+        /**
+         * Sets the tagName.
+         *
+         * @param tagName
+         */
+        public void setTagName(String tagName) {
+            builder.tagName(tagName);
+        }
+
         @Override
         public FindElementAction getObject() throws Exception {
             return getObject(builder);
@@ -197,16 +216,6 @@ public class FindElementActionParser extends AbstractBrowserActionParser {
          */
         public void setPropertyValue(String propertyValue) {
             this.propertyValue = propertyValue;
-        }
-
-
-        /**
-         * Sets the tagName.
-         *
-         * @param tagName
-         */
-        public void setTagName(String tagName) {
-            getBuilder().tagName(tagName);
         }
 
         /**

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/config/xml/HoverActionParser.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/config/xml/HoverActionParser.java
@@ -28,8 +28,7 @@ import org.w3c.dom.Element;
 public class HoverActionParser extends FindElementActionParser {
 
     @Override
-    protected void parseAction(BeanDefinitionBuilder beanDefinition, Element element, ParserContext parserContext) {
-        super.parseAction(beanDefinition, element, parserContext);
+    protected void parseElement(BeanDefinitionBuilder beanDefinition, Element element, ParserContext parserContext) {
     }
 
     @Override

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/config/xml/SetInputActionParser.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/config/xml/SetInputActionParser.java
@@ -29,9 +29,7 @@ import org.w3c.dom.Element;
 public class SetInputActionParser extends FindElementActionParser {
 
     @Override
-    protected void parseAction(BeanDefinitionBuilder beanDefinition, Element element, ParserContext parserContext) {
-        super.parseAction(beanDefinition, element, parserContext);
-
+    protected void parseElement(BeanDefinitionBuilder beanDefinition, Element element, ParserContext parserContext) {
         BeanDefinitionParserUtils.setPropertyValue(beanDefinition, element.getAttribute("value"), "value");
     }
 

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/config/xml/WaitUntilActionParser.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/config/xml/WaitUntilActionParser.java
@@ -29,9 +29,7 @@ import org.w3c.dom.Element;
 public class WaitUntilActionParser extends FindElementActionParser {
 
     @Override
-    protected void parseAction(BeanDefinitionBuilder beanDefinition, Element element, ParserContext parserContext) {
-        super.parseAction(beanDefinition, element, parserContext);
-
+    protected void parseElement(BeanDefinitionBuilder beanDefinition, Element element, ParserContext parserContext) {
         BeanDefinitionParserUtils.setPropertyValue(beanDefinition, element.getAttribute("until"), "condition");
     }
 

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/Alert.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/Alert.java
@@ -1,0 +1,90 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.xml;
+
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import org.citrusframework.TestActor;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.AlertAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+
+@XmlRootElement(name = "alert")
+public class Alert extends AbstractSeleniumAction.Builder<AlertAction, Alert> {
+
+    private final AlertAction.Builder delegate = new AlertAction.Builder();
+
+    /**
+     * Add alert text validation.
+     * @param text
+     */
+    @XmlElement
+    public void setText(String text) {
+        this.delegate.text(text);
+    }
+
+    /**
+     * Accept alert dialog.
+     */
+    @XmlAttribute
+    public void setAccept(boolean accept) {
+        if (accept) {
+            this.delegate.accept();
+        } else {
+            this.delegate.dismiss();
+        }
+    }
+
+    /**
+     * Dismiss alert dialog.
+     */
+    @XmlAttribute
+    public void setDismiss(boolean dismiss) {
+        if (dismiss) {
+            this.delegate.dismiss();
+        } else {
+            this.delegate.accept();
+        }
+    }
+
+    @Override
+    public Alert description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public Alert actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public Alert browser(SeleniumBrowser seleniumBrowser) {
+        delegate.browser(seleniumBrowser);
+        return this;
+    }
+
+    @Override
+    public AlertAction build() {
+        return delegate.build();
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/CheckInput.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/CheckInput.java
@@ -1,0 +1,74 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.xml;
+
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import org.citrusframework.TestActor;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.CheckInputAction;
+import org.citrusframework.selenium.actions.FindElementAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+
+@XmlRootElement(name = "check-input")
+public class CheckInput extends AbstractSeleniumAction.Builder<CheckInputAction, CheckInput> implements ElementAware {
+
+    private final CheckInputAction.Builder delegate = new CheckInputAction.Builder();
+
+    @XmlAttribute
+    public void setChecked(boolean checked) {
+        this.delegate.checked(checked);
+    }
+
+    @Override
+    @XmlElement
+    public void setElement(Element element) {
+        ElementAware.super.setElement(element);
+    }
+
+    @Override
+    public FindElementAction.ElementActionBuilder<?, ?> getElementBuilder() {
+        return delegate;
+    }
+
+    @Override
+    public CheckInput description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public CheckInput actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public CheckInput browser(SeleniumBrowser seleniumBrowser) {
+        delegate.browser(seleniumBrowser);
+        return this;
+    }
+
+    @Override
+    public CheckInputAction build() {
+        return delegate.build();
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/ClearBrowserCache.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/ClearBrowserCache.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.xml;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+import org.citrusframework.TestActor;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.ClearBrowserCacheAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+
+@XmlRootElement(name = "clear-cache")
+public class ClearBrowserCache extends AbstractSeleniumAction.Builder<ClearBrowserCacheAction, ClearBrowserCache> {
+
+    private final ClearBrowserCacheAction.Builder delegate = new ClearBrowserCacheAction.Builder();
+
+    @Override
+    public ClearBrowserCache description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public ClearBrowserCache actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public ClearBrowserCache browser(SeleniumBrowser seleniumBrowser) {
+        delegate.browser(seleniumBrowser);
+        return this;
+    }
+
+    @Override
+    public ClearBrowserCacheAction build() {
+        return delegate.build();
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/Click.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/Click.java
@@ -1,0 +1,68 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.xml;
+
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import org.citrusframework.TestActor;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.ClickAction;
+import org.citrusframework.selenium.actions.FindElementAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+
+@XmlRootElement(name = "click")
+public class Click extends AbstractSeleniumAction.Builder<ClickAction, Click> implements ElementAware {
+
+    private final ClickAction.Builder delegate = new ClickAction.Builder();
+
+    @Override
+    @XmlElement
+    public void setElement(Element element) {
+        ElementAware.super.setElement(element);
+    }
+
+    @Override
+    public FindElementAction.ElementActionBuilder<?, ?> getElementBuilder() {
+        return delegate;
+    }
+
+    @Override
+    public Click description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public Click actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public Click browser(SeleniumBrowser seleniumBrowser) {
+        delegate.browser(seleniumBrowser);
+        return this;
+    }
+
+    @Override
+    public ClickAction build() {
+        return delegate.build();
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/CloseWindow.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/CloseWindow.java
@@ -1,0 +1,66 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.xml;
+
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import org.citrusframework.TestActor;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.CloseWindowAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+
+@XmlRootElement(name = "close-window")
+public class CloseWindow extends AbstractSeleniumAction.Builder<CloseWindowAction, CloseWindow> {
+
+    private final CloseWindowAction.Builder delegate = new CloseWindowAction.Builder();
+
+    @XmlAttribute
+    public void setName(String name) {
+        this.delegate.window(name);
+    }
+
+    @XmlAttribute
+    public void setWindow(String name) {
+        this.delegate.window(name);
+    }
+
+    @Override
+    public CloseWindow description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public CloseWindow actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public CloseWindow browser(SeleniumBrowser seleniumBrowser) {
+        delegate.browser(seleniumBrowser);
+        return this;
+    }
+
+    @Override
+    public CloseWindowAction build() {
+        return delegate.build();
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/DropDownSelect.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/DropDownSelect.java
@@ -1,0 +1,106 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.xml;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
+import org.citrusframework.TestActor;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.DropDownSelectAction;
+import org.citrusframework.selenium.actions.FindElementAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+
+@XmlRootElement(name = "dropdown-select")
+public class DropDownSelect extends AbstractSeleniumAction.Builder<DropDownSelectAction, DropDownSelect> implements ElementAware {
+
+    private final DropDownSelectAction.Builder delegate = new DropDownSelectAction.Builder();
+
+    @XmlAttribute
+    public void setOption(String option) {
+        this.delegate.option(option);
+    }
+
+    @XmlElement(name = "options")
+    public void setOptions(Options options) {
+        delegate.options(options.getOptions());
+    }
+
+    @Override
+    @XmlElement
+    public void setElement(Element element) {
+        ElementAware.super.setElement(element);
+    }
+
+    @Override
+    public FindElementAction.ElementActionBuilder<?, ?> getElementBuilder() {
+        return delegate;
+    }
+
+    @Override
+    public DropDownSelect description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public DropDownSelect actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public DropDownSelect browser(SeleniumBrowser seleniumBrowser) {
+        delegate.browser(seleniumBrowser);
+        return this;
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(name = "", propOrder = {
+            "options"
+    })
+    public static class Options {
+        @XmlElement(name = "option")
+        private List<String> options;
+
+        public void setOptions(List<String> options) {
+            this.options = options;
+        }
+
+        public List<String> getOptions() {
+            if (options == null) {
+                options = new ArrayList<>();
+            }
+
+            return options;
+        }
+    }
+
+    @Override
+    public DropDownSelectAction build() {
+        return delegate.build();
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/ElementAware.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/ElementAware.java
@@ -1,0 +1,184 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.xml;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlType;
+import org.citrusframework.selenium.actions.FindElementAction;
+import org.openqa.selenium.By;
+
+public interface ElementAware {
+
+    /**
+     * Gets the element aware builder to work with.
+     * @return the element aware builder.
+     */
+    FindElementAction.ElementActionBuilder<?, ?> getElementBuilder();
+
+    /**
+     * Sets the element properties on the element aware builder.
+     * @param element
+     */
+    default void setElement(Element element) {
+        if (element.getId() != null) {
+            getElementBuilder().element(By.id(element.id));
+        } else if (element.getName() != null) {
+            getElementBuilder().element(By.name(element.name));
+        } else if (element.getLinkText() != null) {
+            getElementBuilder().element(By.linkText(element.linkText));
+        } else if (element.getPartialLinkText() != null) {
+            getElementBuilder().element(By.partialLinkText(element.partialLinkText));
+        } else if (element.getXpath() != null) {
+            getElementBuilder().element(By.xpath(element.xpath));
+        } else if (element.getCssSelector() != null) {
+            getElementBuilder().element(By.cssSelector(element.cssSelector));
+        } else if (element.getProperty() != null) {
+            getElementBuilder().element(element.getProperty().getName(), element.getProperty().getValue());
+        } else if (element.getClassName() != null) {
+            getElementBuilder().element(By.className(element.className));
+        } else if (element.getTagName() != null) {
+            getElementBuilder().element(By.tagName(element.tagName));
+        }
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(name = "", propOrder = {})
+    class Element {
+        @XmlAttribute
+        private String id;
+        @XmlAttribute
+        private String name;
+        @XmlAttribute(name = "tag-name")
+        private String tagName;
+        @XmlAttribute(name = "class-name")
+        private String className;
+        @XmlElement
+        private Property property;
+
+        @XmlAttribute(name = "link-text")
+        private String linkText;
+        @XmlAttribute(name = "partial-link-text")
+        private String partialLinkText;
+        @XmlAttribute(name = "xpath")
+        private String xpath;
+        @XmlAttribute(name = "css-selector")
+        private String cssSelector;
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getTagName() {
+            return tagName;
+        }
+
+        public void setTagName(String tagName) {
+            this.tagName = tagName;
+        }
+
+        public String getClassName() {
+            return className;
+        }
+
+        public void setClassName(String className) {
+            this.className = className;
+        }
+
+        public void setLinkText(String linkText) {
+            this.linkText = linkText;
+        }
+
+        public String getLinkText() {
+            return linkText;
+        }
+
+        public void setPartialLinkText(String partialLinkText) {
+            this.partialLinkText = partialLinkText;
+        }
+
+        public String getPartialLinkText() {
+            return partialLinkText;
+        }
+
+        public void setXpath(String xpath) {
+            this.xpath = xpath;
+        }
+
+        public String getXpath() {
+            return xpath;
+        }
+
+        public void setCssSelector(String cssSelector) {
+            this.cssSelector = cssSelector;
+        }
+
+        public String getCssSelector() {
+            return cssSelector;
+        }
+
+        public void setProperty(Property property) {
+            this.property = property;
+        }
+
+        public Property getProperty() {
+            return property;
+        }
+
+        @XmlAccessorType(XmlAccessType.FIELD)
+        @XmlType(name = "", propOrder = {})
+        public static class Property {
+            @XmlAttribute
+            private String name;
+            @XmlAttribute
+            private String value;
+
+            public void setName(String name) {
+                this.name = name;
+            }
+
+            public String getName() {
+                return name;
+            }
+
+            public void setValue(String value) {
+                this.value = value;
+            }
+
+            public String getValue() {
+                return value;
+            }
+        }
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/FindElement.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/FindElement.java
@@ -1,0 +1,261 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.xml;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
+import org.citrusframework.TestActor;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.FindElementAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+
+@XmlRootElement(name = "find")
+public class FindElement extends AbstractSeleniumAction.Builder<FindElementAction, FindElement> implements ElementAware {
+
+    private final FindElementAction.Builder delegate = new FindElementAction.Builder();
+
+    @Override
+    @XmlElement
+    public void setElement(Element element) {
+        ElementAware.super.setElement(element);
+    }
+
+    @XmlElement
+    public void setValidate(Validate validate) {
+        if (validate.getText() != null) {
+            delegate.text(validate.text);
+        }
+
+        if (validate.getTagName() != null) {
+            delegate.tagName(validate.tagName);
+        }
+
+        delegate.enabled(validate.enabled);
+        delegate.displayed(validate.displayed);
+
+        if (validate.getAttributes() != null) {
+            for (Attributes.Attribute attribute : validate.getAttributes().attributes) {
+                delegate.attribute(attribute.getName(), attribute.getValue());
+            }
+        }
+
+        if (validate.getStyles() != null) {
+            for (Styles.Style style : validate.getStyles().styles) {
+                delegate.style(style.getName(), style.getValue());
+            }
+        }
+    }
+
+    @Override
+    public FindElementAction.ElementActionBuilder<?, ?> getElementBuilder() {
+        return delegate;
+    }
+
+    @Override
+    public FindElement description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public FindElement actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public FindElement browser(SeleniumBrowser seleniumBrowser) {
+        delegate.browser(seleniumBrowser);
+        return this;
+    }
+
+    @Override
+    public FindElementAction build() {
+        return delegate.build();
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(name = "", propOrder = {
+        "attributes",
+        "styles"
+    })
+    public static class Validate {
+        @XmlAttribute
+        private String text;
+        @XmlAttribute(name = "tag-name")
+        private String tagName;
+        @XmlAttribute
+        private boolean displayed = true;
+        @XmlAttribute
+        private boolean enabled = true;
+
+        @XmlElement
+        private Attributes attributes;
+        @XmlElement
+        private Styles styles;
+
+        public String getText() {
+            return text;
+        }
+
+        public void setText(String text) {
+            this.text = text;
+        }
+
+        public String getTagName() {
+            return tagName;
+        }
+
+        public void setTagName(String tagName) {
+            this.tagName = tagName;
+        }
+
+        public Attributes getAttributes() {
+            return attributes;
+        }
+
+        public void setAttributes(Attributes attributes) {
+            this.attributes = attributes;
+        }
+
+        public Styles getStyles() {
+            return styles;
+        }
+
+        public void setStyles(Styles styles) {
+            this.styles = styles;
+        }
+
+        public boolean isDisplayed() {
+            return displayed;
+        }
+
+        public void setDisplayed(boolean displayed) {
+            this.displayed = displayed;
+        }
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(name = "", propOrder = {
+            "styles"
+    })
+    public static class Styles {
+        @XmlElement(name= "style")
+        private List<Style> styles;
+
+        public List<Style> getStyles() {
+            if (styles == null) {
+                styles = new ArrayList<>();
+            }
+
+            return styles;
+        }
+
+        public void setStyles(List<Style> styles) {
+            this.styles = styles;
+        }
+
+        @XmlAccessorType(XmlAccessType.FIELD)
+        @XmlType(name = "", propOrder = {})
+        public static class Style {
+            @XmlAttribute
+            private String name;
+            @XmlAttribute
+            private String value;
+
+            public void setName(String name) {
+                this.name = name;
+            }
+
+            public String getName() {
+                return name;
+            }
+
+            public void setValue(String value) {
+                this.value = value;
+            }
+
+            public String getValue() {
+                return value;
+            }
+        }
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(name = "", propOrder = {
+            "attributes"
+    })
+    public static class Attributes {
+        @XmlElement(name = "attribute")
+        private List<Attribute> attributes;
+
+        public List<Attribute> getAttributes() {
+            if (attributes == null) {
+                attributes = new ArrayList<>();
+            }
+
+            return attributes;
+        }
+
+        public void setAttributes(List<Attribute> attributes) {
+            this.attributes = attributes;
+        }
+
+        @XmlAccessorType(XmlAccessType.FIELD)
+        @XmlType(name = "", propOrder = {})
+        public static class Attribute {
+            @XmlAttribute
+            private String name;
+            @XmlAttribute
+            private String value;
+
+            public void setName(String name) {
+                this.name = name;
+            }
+
+            public String getName() {
+                return name;
+            }
+
+            public void setValue(String value) {
+                this.value = value;
+            }
+
+            public String getValue() {
+                return value;
+            }
+        }
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/GetStoredFile.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/GetStoredFile.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.xml;
+
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import org.citrusframework.TestActor;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.GetStoredFileAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+
+@XmlRootElement(name = "get-stored-file")
+public class GetStoredFile extends AbstractSeleniumAction.Builder<GetStoredFileAction, GetStoredFile> {
+
+    private final GetStoredFileAction.Builder delegate = new GetStoredFileAction.Builder();
+
+    @XmlAttribute(name = "file-name")
+    public void setFileName(String fileName) {
+        this.delegate.fileName(fileName);
+    }
+
+    @Override
+    public GetStoredFile description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public GetStoredFile actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public GetStoredFile browser(SeleniumBrowser seleniumBrowser) {
+        delegate.browser(seleniumBrowser);
+        return this;
+    }
+
+    @Override
+    public GetStoredFileAction build() {
+        return delegate.build();
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/Hover.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/Hover.java
@@ -1,0 +1,68 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.xml;
+
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import org.citrusframework.TestActor;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.FindElementAction;
+import org.citrusframework.selenium.actions.HoverAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+
+@XmlRootElement(name = "hover")
+public class Hover extends AbstractSeleniumAction.Builder<HoverAction, Hover> implements ElementAware {
+
+    private final HoverAction.Builder delegate = new HoverAction.Builder();
+
+    @Override
+    @XmlElement
+    public void setElement(Element element) {
+        ElementAware.super.setElement(element);
+    }
+
+    @Override
+    public FindElementAction.ElementActionBuilder<?, ?> getElementBuilder() {
+        return delegate;
+    }
+
+    @Override
+    public Hover description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public Hover actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public Hover browser(SeleniumBrowser seleniumBrowser) {
+        delegate.browser(seleniumBrowser);
+        return this;
+    }
+
+    @Override
+    public HoverAction build() {
+        return delegate.build();
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/JavaScript.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/JavaScript.java
@@ -1,0 +1,150 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.xml;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
+import org.citrusframework.TestActor;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.JavaScriptAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+
+@XmlRootElement(name = "javascript")
+public class JavaScript extends AbstractSeleniumAction.Builder<JavaScriptAction, JavaScript> {
+
+    private final JavaScriptAction.Builder delegate = new JavaScriptAction.Builder();
+
+    /**
+     * Add script.
+     * @param script
+     */
+    @XmlElement
+    public void setScript(String script) {
+        this.delegate.script(script);
+    }
+
+    /**
+     * Add script arguments.
+     * @param args
+     */
+    @XmlElement
+    public void setArguments(Arguments args) {
+        delegate.arguments(args.getArguments());
+    }
+
+    /**
+     * Add script argument.
+     * @param arg
+     */
+    @XmlAttribute
+    public void setArgument(String arg) {
+        delegate.argument(arg);
+    }
+
+    /**
+     * Add expected error.
+     * @param error
+     */
+    @XmlAttribute
+    public void setError(String error) {
+        this.delegate.error(error);
+    }
+
+    /**
+     * Add expected error.
+     * @param errors
+     */
+    @XmlElement
+    public void setErrors(Errors errors) {
+        this.delegate.errors(errors.getErrors());
+    }
+
+    @Override
+    public JavaScript description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public JavaScript actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public JavaScript browser(SeleniumBrowser seleniumBrowser) {
+        delegate.browser(seleniumBrowser);
+        return this;
+    }
+
+    @Override
+    public JavaScriptAction build() {
+        return delegate.build();
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(name = "", propOrder = {
+            "arguments"
+    })
+    public static class Arguments {
+        @XmlElement(name = "argument")
+        private List<String> arguments;
+
+        public void setArguments(List<String> arguments) {
+            this.arguments = arguments;
+        }
+
+        public List<String> getArguments() {
+            if (arguments == null) {
+                arguments = new ArrayList<>();
+            }
+
+            return arguments;
+        }
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(name = "", propOrder = {
+            "errors"
+    })
+    public static class Errors {
+        @XmlElement(name = "error")
+        private List<String> errors;
+
+        public void setErrors(List<String> errors) {
+            this.errors = errors;
+        }
+
+        public List<String> getErrors() {
+            if (errors == null) {
+                errors = new ArrayList<>();
+            }
+
+            return errors;
+        }
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/MakeScreenshot.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/MakeScreenshot.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.xml;
+
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import org.citrusframework.TestActor;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.MakeScreenshotAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+
+@XmlRootElement(name = "make-screenshot")
+public class MakeScreenshot extends AbstractSeleniumAction.Builder<MakeScreenshotAction, MakeScreenshot> {
+
+    private final MakeScreenshotAction.Builder delegate = new MakeScreenshotAction.Builder();
+
+    @XmlAttribute(name = "output-dir")
+    public void setOutputDir(String outputDir) {
+        this.delegate.outputDir(outputDir);
+    }
+
+    @Override
+    public MakeScreenshot description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public MakeScreenshot actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public MakeScreenshot browser(SeleniumBrowser seleniumBrowser) {
+        delegate.browser(seleniumBrowser);
+        return this;
+    }
+
+    @Override
+    public MakeScreenshotAction build() {
+        return delegate.build();
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/Navigate.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/Navigate.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.xml;
+
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import org.citrusframework.TestActor;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.NavigateAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+
+@XmlRootElement(name = "navigate")
+public class Navigate extends AbstractSeleniumAction.Builder<NavigateAction, Navigate> {
+
+    private final NavigateAction.Builder delegate = new NavigateAction.Builder();
+
+    @XmlAttribute
+    public void setPage(String page) {
+        this.delegate.page(page);
+    }
+
+    @Override
+    public Navigate description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public Navigate actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public Navigate browser(SeleniumBrowser seleniumBrowser) {
+        delegate.browser(seleniumBrowser);
+        return this;
+    }
+
+    @Override
+    public NavigateAction build() {
+        return delegate.build();
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/ObjectFactory.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/ObjectFactory.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.selenium.xml;
+
+import jakarta.xml.bind.annotation.XmlRegistry;
+
+/**
+ * This object contains factory methods for each
+ * Java content interface and Java element interface
+ * generated in the org.citrusframework.ftp.model package.
+ * <p>An ObjectFactory allows you to programatically
+ * construct new instances of the Java representation
+ * for XML content. The Java representation of XML
+ * content can consist of schema derived interfaces
+ * and classes representing the binding of schema
+ * type definitions, element declarations and model
+ * groups.  Factory methods for each of these are
+ * provided in this class.
+ *
+ */
+@XmlRegistry
+public class ObjectFactory {
+
+    /**
+     * Create a new ObjectFactory that can be used to create new instances of schema derived classes for package: org.citrusframework.xml.actions
+     *
+     */
+    public ObjectFactory() {
+    }
+
+    /**
+     * Create an instance of {@link Selenium }
+     *
+     */
+    public Selenium createSelenium() {
+        return new Selenium();
+    }
+
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/OpenWindow.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/OpenWindow.java
@@ -1,0 +1,66 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.xml;
+
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import org.citrusframework.TestActor;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.OpenWindowAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+
+@XmlRootElement(name = "open-window")
+public class OpenWindow extends AbstractSeleniumAction.Builder<OpenWindowAction, OpenWindow> {
+
+    private final OpenWindowAction.Builder delegate = new OpenWindowAction.Builder();
+
+    @XmlAttribute
+    public void setName(String name) {
+        this.delegate.window(name);
+    }
+
+    @XmlAttribute
+    public void setWindow(String windowName) {
+        this.delegate.window(windowName);
+    }
+
+    @Override
+    public OpenWindow description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public OpenWindow actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public OpenWindow browser(SeleniumBrowser seleniumBrowser) {
+        delegate.browser(seleniumBrowser);
+        return this;
+    }
+
+    @Override
+    public OpenWindowAction build() {
+        return delegate.build();
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/Page.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/Page.java
@@ -1,0 +1,179 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.xml;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
+import org.citrusframework.TestActor;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.PageAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+import org.citrusframework.selenium.model.PageValidator;
+import org.citrusframework.selenium.model.WebPage;
+import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.spi.ReferenceResolverAware;
+
+@XmlRootElement(name = "page")
+public class Page extends AbstractSeleniumAction.Builder<PageAction, Page> implements ReferenceResolverAware {
+
+    private final PageAction.Builder delegate = new PageAction.Builder();
+
+    private String pageName;
+    private String pageValidator;
+
+    private ReferenceResolver referenceResolver;
+
+    /**
+     * Sets the web page by name.
+     *
+     * @param name
+     */
+    @XmlAttribute
+    public void setName(String name) {
+        this.pageName = name;
+    }
+
+    /**
+     * Sets the web page type.
+     *
+     * @param pageType
+     */
+    @XmlAttribute
+    public void setType(String pageType) {
+        this.delegate.type(pageType);
+    }
+
+    /**
+     * Sets the web page action.
+     *
+     * @param action
+     */
+    @XmlAttribute
+    public void setAction(String action) {
+        this.delegate.action(action);
+    }
+
+    /**
+     * Set page validator.
+     *
+     * @param pageValidator
+     */
+    @XmlAttribute
+    public void setValidator(String pageValidator) {
+        this.pageValidator = pageValidator;
+    }
+
+    /**
+     * Set page action method to execute.
+     *
+     * @param method
+     */
+    @XmlAttribute(name = "method")
+    public void setExecute(String method) {
+        this.delegate.action(method);
+    }
+
+    /**
+     * Set page action argument.
+     *
+     * @param arg
+     */
+    @XmlAttribute
+    public void setArgument(String arg) {
+        this.delegate.argument(arg);
+    }
+
+    /**
+     * Set page action arguments.
+     *
+     * @param args
+     */
+    @XmlElement(name = "arguments")
+    public void setArguments(Arguments args) {
+        this.delegate.arguments(args.getArguments());
+    }
+
+    @Override
+    public Page description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public Page actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public Page browser(SeleniumBrowser seleniumBrowser) {
+        delegate.browser(seleniumBrowser);
+        return this;
+    }
+
+    @Override
+    public PageAction build() {
+        if (referenceResolver != null) {
+            if (pageName != null) {
+                this.delegate.page(referenceResolver.resolve(pageName, WebPage.class));
+            }
+
+            if (pageValidator != null) {
+                this.delegate.validator(referenceResolver.resolve(pageValidator, PageValidator.class));
+            }
+        }
+
+        return delegate.build();
+    }
+
+    @Override
+    public void setReferenceResolver(ReferenceResolver referenceResolver) {
+        this.referenceResolver = referenceResolver;
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(name = "", propOrder = {
+            "arguments"
+    })
+    public static class Arguments {
+        @XmlElement(name = "argument")
+        private List<String> arguments;
+
+        public List<String> getArguments() {
+            if (arguments == null) {
+                arguments = new ArrayList<>();
+            }
+
+            return arguments;
+        }
+
+        public void setArguments(List<String> arguments) {
+            this.arguments = arguments;
+        }
+    }
+
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/Selenium.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/Selenium.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.selenium.xml;
+
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import org.citrusframework.TestAction;
+import org.citrusframework.TestActionBuilder;
+import org.citrusframework.TestActionContainerBuilder;
+import org.citrusframework.TestActor;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.SeleniumAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.spi.ReferenceResolverAware;
+
+/**
+ * @author Christoph Deppisch
+ */
+@XmlRootElement(name = "selenium")
+public class Selenium implements TestActionBuilder<TestAction>, ReferenceResolverAware {
+
+    private AbstractSeleniumAction.Builder<?, ?> builder;
+
+    private String description;
+    private String actor;
+
+    private String seleniumBrowser;
+
+    private ReferenceResolver referenceResolver;
+
+    @XmlElement
+    public Selenium setDescription(String value) {
+        this.description = value;
+        return this;
+    }
+
+    @XmlAttribute
+    public Selenium setActor(String actor) {
+        this.actor = actor;
+        return this;
+    }
+
+    @XmlAttribute
+    public Selenium setBrowser(String browser) {
+        this.seleniumBrowser = browser;
+        return this;
+    }
+
+    /**
+     * Start browser instance.
+     */
+    @XmlElement(name = "start")
+    public void setStart(StartBrowser builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Stop browser instance.
+     */
+    @XmlElement(name = "stop")
+    public void setStop(StopBrowser builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Alert element.
+     */
+    @XmlElement(name = "alert")
+    public void setAlert(Alert builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Navigate action.
+     */
+    @XmlElement(name = "navigate")
+    public void setNavigate(Navigate builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Page action.
+     */
+    @XmlElement(name = "page")
+    public void setPage(Page builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Finds element.
+     */
+    @XmlElement(name = "find")
+    public void setFind(FindElement builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Dropdown select single option action.
+     */
+    @XmlElement(name = "dropdown-select")
+    public void setDropdownSelect(DropDownSelect builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Set input action.
+     */
+    @XmlElement(name = "set-input")
+    public void setSetInput(SetInput builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Check input action.
+     */
+    @XmlElement(name = "check-input")
+    public void setCheckInput(CheckInput builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Clicks element.
+     */
+    @XmlElement(name = "click")
+    public void setClick(Click builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Hover element.
+     */
+    @XmlElement(name = "hover")
+    public void setHover(Hover builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Clear browser cache.
+     */
+    @XmlElement(name = "clear-cache")
+    public void setClearCache(ClearBrowserCache builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Make screenshot.
+     */
+    @XmlElement(name = "screenshot")
+    public void setScreenshot(MakeScreenshot builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Store file.
+     */
+    @XmlElement(name = "store-file")
+    public void setStoreFile(StoreFile builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Get stored file.
+     */
+    @XmlElement(name = "get-stored-file")
+    public void setGetStoredFile(GetStoredFile builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Wait until element meets condition.
+     */
+    @XmlElement(name = "wait")
+    public void setWaitUntil(WaitUntil builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Execute JavaScript.
+     */
+    @XmlElement(name = "javascript")
+    public void setJavascript(JavaScript builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Open window.
+     */
+    @XmlElement(name = "open-window")
+    public void setOpenWindow(OpenWindow builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Close window.
+     */
+    @XmlElement(name = "close-window")
+    public void setCloseWindow(CloseWindow builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Focus window.
+     */
+    @XmlElement(name = "focus-window")
+    public void setFocusWindow(SwitchWindow builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Switch window.
+     */
+    @XmlElement(name = "switch-window")
+    public void setSwitchWindow(SwitchWindow builder) {
+        this.builder = builder;
+    }
+
+    @Override
+    public SeleniumAction build() {
+        if (builder == null) {
+            throw new CitrusRuntimeException("Missing Selenium action - please provide proper action details");
+        }
+
+        if (builder instanceof TestActionContainerBuilder<?,?>) {
+            ((TestActionContainerBuilder<?,?>) builder).getActions().stream()
+                    .filter(action -> action instanceof ReferenceResolverAware)
+                    .forEach(action -> ((ReferenceResolverAware) action).setReferenceResolver(referenceResolver));
+        }
+
+        if (builder instanceof ReferenceResolverAware) {
+            ((ReferenceResolverAware) builder).setReferenceResolver(referenceResolver);
+        }
+
+        builder.description(description);
+
+        if (referenceResolver != null) {
+            if (seleniumBrowser != null) {
+                builder.browser(referenceResolver.resolve(seleniumBrowser, SeleniumBrowser.class));
+            }
+
+            if (actor != null) {
+                builder.actor(referenceResolver.resolve(actor, TestActor.class));
+            }
+        }
+
+        return builder.build();
+    }
+
+    @Override
+    public void setReferenceResolver(ReferenceResolver referenceResolver) {
+        this.referenceResolver = referenceResolver;
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/SetInput.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/SetInput.java
@@ -1,0 +1,74 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.xml;
+
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import org.citrusframework.TestActor;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.FindElementAction;
+import org.citrusframework.selenium.actions.SetInputAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+
+@XmlRootElement(name = "set-input")
+public class SetInput extends AbstractSeleniumAction.Builder<SetInputAction, SetInput> implements ElementAware {
+
+    private final SetInputAction.Builder delegate = new SetInputAction.Builder();
+
+    @XmlAttribute
+    public void setValue(String value) {
+        this.delegate.value(value);
+    }
+
+    @Override
+    @XmlElement
+    public void setElement(Element element) {
+        ElementAware.super.setElement(element);
+    }
+
+    @Override
+    public FindElementAction.ElementActionBuilder<?, ?> getElementBuilder() {
+        return delegate;
+    }
+
+    @Override
+    public SetInput description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public SetInput actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public SetInput browser(SeleniumBrowser seleniumBrowser) {
+        delegate.browser(seleniumBrowser);
+        return this;
+    }
+
+    @Override
+    public SetInputAction build() {
+        return delegate.build();
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/StartBrowser.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/StartBrowser.java
@@ -1,0 +1,81 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.xml;
+
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import org.citrusframework.TestActor;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.StartBrowserAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.spi.ReferenceResolverAware;
+
+@XmlRootElement(name = "start")
+public class StartBrowser extends AbstractSeleniumAction.Builder<StartBrowserAction, StartBrowser> implements ReferenceResolverAware {
+
+    private final StartBrowserAction.Builder delegate = new StartBrowserAction.Builder();
+
+    private String seleniumBrowser;
+
+    private ReferenceResolver referenceResolver;
+
+    @XmlAttribute
+    public void setBrowser(String browser) {
+        this.seleniumBrowser = browser;
+    }
+
+    @XmlAttribute(name = "allow-already-started")
+    public void setAllowAlreadyStarted(boolean allow) {
+        this.delegate.allowAlreadyStarted(allow);
+    }
+
+    @Override
+    public StartBrowser description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public StartBrowser actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public StartBrowser browser(SeleniumBrowser seleniumBrowser) {
+        delegate.browser(seleniumBrowser);
+        return this;
+    }
+
+    @Override
+    public StartBrowserAction build() {
+        if (seleniumBrowser != null) {
+            delegate.browser(referenceResolver.resolve(seleniumBrowser, SeleniumBrowser.class));
+        }
+
+        return delegate.build();
+    }
+
+    @Override
+    public void setReferenceResolver(ReferenceResolver referenceResolver) {
+        this.referenceResolver = referenceResolver;
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/StopBrowser.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/StopBrowser.java
@@ -1,0 +1,76 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.xml;
+
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import org.citrusframework.TestActor;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.StopBrowserAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.spi.ReferenceResolverAware;
+
+@XmlRootElement(name = "stop")
+public class StopBrowser extends AbstractSeleniumAction.Builder<StopBrowserAction, StopBrowser> implements ReferenceResolverAware {
+
+    private final StopBrowserAction.Builder delegate = new StopBrowserAction.Builder();
+
+    private String seleniumBrowser;
+
+    private ReferenceResolver referenceResolver;
+
+    @XmlAttribute
+    public void setBrowser(String browser) {
+        this.seleniumBrowser = browser;
+    }
+
+    @Override
+    public StopBrowser description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public StopBrowser actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public StopBrowser browser(SeleniumBrowser seleniumBrowser) {
+        delegate.browser(seleniumBrowser);
+        return this;
+    }
+
+    @Override
+    public StopBrowserAction build() {
+        if (seleniumBrowser != null) {
+            delegate.browser(referenceResolver.resolve(seleniumBrowser, SeleniumBrowser.class));
+        }
+
+        return delegate.build();
+    }
+
+    @Override
+    public void setReferenceResolver(ReferenceResolver referenceResolver) {
+        this.referenceResolver = referenceResolver;
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/StoreFile.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/StoreFile.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.xml;
+
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import org.citrusframework.TestActor;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.StoreFileAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+
+@XmlRootElement(name = "store-file")
+public class StoreFile extends AbstractSeleniumAction.Builder<StoreFileAction, StoreFile> {
+
+    private final StoreFileAction.Builder delegate = new StoreFileAction.Builder();
+
+    @XmlAttribute(name = "file-path")
+    public void setFilePath(String filePath) {
+        this.delegate.filePath(filePath);
+    }
+
+    @Override
+    public StoreFile description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public StoreFile actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public StoreFile browser(SeleniumBrowser seleniumBrowser) {
+        delegate.browser(seleniumBrowser);
+        return this;
+    }
+
+    @Override
+    public StoreFileAction build() {
+        return delegate.build();
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/SwitchWindow.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/SwitchWindow.java
@@ -1,0 +1,66 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.xml;
+
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import org.citrusframework.TestActor;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.SwitchWindowAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+
+@XmlRootElement(name = "switch-window")
+public class SwitchWindow extends AbstractSeleniumAction.Builder<SwitchWindowAction, SwitchWindow> {
+
+    private final SwitchWindowAction.Builder delegate = new SwitchWindowAction.Builder();
+
+    @XmlAttribute
+    public void setName(String name) {
+        this.delegate.window(name);
+    }
+
+    @XmlAttribute
+    public void setWindow(String name) {
+        this.delegate.window(name);
+    }
+
+    @Override
+    public SwitchWindow description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public SwitchWindow actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public SwitchWindow browser(SeleniumBrowser seleniumBrowser) {
+        delegate.browser(seleniumBrowser);
+        return this;
+    }
+
+    @Override
+    public SwitchWindowAction build() {
+        return delegate.build();
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/WaitUntil.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/WaitUntil.java
@@ -1,0 +1,79 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.xml;
+
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import org.citrusframework.TestActor;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.FindElementAction;
+import org.citrusframework.selenium.actions.WaitUntilAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+
+@XmlRootElement(name = "wait")
+public class WaitUntil extends AbstractSeleniumAction.Builder<WaitUntilAction, WaitUntil> implements ElementAware {
+
+    private final WaitUntilAction.Builder delegate = new WaitUntilAction.Builder();
+
+    @Override
+    @XmlElement
+    public void setElement(Element element) {
+        ElementAware.super.setElement(element);
+    }
+
+    @XmlAttribute
+    public void setTimeout(long timeout) {
+        this.delegate.timeout(timeout);
+    }
+
+    @XmlAttribute
+    public void setUntil(String condition) {
+        this.delegate.condition(condition);
+    }
+
+    @Override
+    public FindElementAction.ElementActionBuilder<?, ?> getElementBuilder() {
+        return delegate;
+    }
+
+    @Override
+    public WaitUntil description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public WaitUntil actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public WaitUntil browser(SeleniumBrowser seleniumBrowser) {
+        delegate.browser(seleniumBrowser);
+        return this;
+    }
+
+    @Override
+    public WaitUntilAction build() {
+        return delegate.build();
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/package-info.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@jakarta.xml.bind.annotation.XmlSchema(namespace = "http://citrusframework.org/schema/xml/testcase", elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
+package org.citrusframework.selenium.xml;

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/Alert.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/Alert.java
@@ -1,0 +1,83 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.yaml;
+
+import org.citrusframework.TestActor;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.AlertAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+
+public class Alert extends AbstractSeleniumAction.Builder<AlertAction, Alert> {
+
+    private final AlertAction.Builder delegate = new AlertAction.Builder();
+
+    /**
+     * Add alert text validation.
+     * @param text
+     */
+    public void setText(String text) {
+        this.delegate.text(text);
+    }
+
+    /**
+     * Accept alert dialog.
+     */
+    public void setAccept(boolean accept) {
+        if (accept) {
+            this.delegate.accept();
+        } else {
+            this.delegate.dismiss();
+        }
+    }
+
+    /**
+     * Dismiss alert dialog.
+     */
+    public void setDismiss(boolean dismiss) {
+        if (dismiss) {
+            this.delegate.dismiss();
+        } else {
+            this.delegate.accept();
+        }
+    }
+
+    @Override
+    public Alert description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public Alert actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public Alert browser(SeleniumBrowser seleniumBrowser) {
+        delegate.browser(seleniumBrowser);
+        return this;
+    }
+
+    @Override
+    public AlertAction build() {
+        return delegate.build();
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/CheckInput.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/CheckInput.java
@@ -1,0 +1,68 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.yaml;
+
+import org.citrusframework.TestActor;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.CheckInputAction;
+import org.citrusframework.selenium.actions.FindElementAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+
+public class CheckInput extends AbstractSeleniumAction.Builder<CheckInputAction, CheckInput> implements ElementAware {
+
+    private final CheckInputAction.Builder delegate = new CheckInputAction.Builder();
+
+    public void setChecked(boolean checked) {
+        this.delegate.checked(checked);
+    }
+
+    @Override
+    public void setElement(Element element) {
+        ElementAware.super.setElement(element);
+    }
+
+    @Override
+    public FindElementAction.ElementActionBuilder<?, ?> getElementBuilder() {
+        return delegate;
+    }
+
+    @Override
+    public CheckInput description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public CheckInput actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public CheckInput browser(SeleniumBrowser seleniumBrowser) {
+        delegate.browser(seleniumBrowser);
+        return this;
+    }
+
+    @Override
+    public CheckInputAction build() {
+        return delegate.build();
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/ClearBrowserCache.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/ClearBrowserCache.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.yaml;
+
+import org.citrusframework.TestActor;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.ClearBrowserCacheAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+
+public class ClearBrowserCache extends AbstractSeleniumAction.Builder<ClearBrowserCacheAction, ClearBrowserCache> {
+
+    private final ClearBrowserCacheAction.Builder delegate = new ClearBrowserCacheAction.Builder();
+
+    @Override
+    public ClearBrowserCache description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public ClearBrowserCache actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public ClearBrowserCache browser(SeleniumBrowser seleniumBrowser) {
+        delegate.browser(seleniumBrowser);
+        return this;
+    }
+
+    @Override
+    public ClearBrowserCacheAction build() {
+        return delegate.build();
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/Click.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/Click.java
@@ -1,0 +1,64 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.yaml;
+
+import org.citrusframework.TestActor;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.ClickAction;
+import org.citrusframework.selenium.actions.FindElementAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+
+public class Click extends AbstractSeleniumAction.Builder<ClickAction, Click> implements ElementAware {
+
+    private final ClickAction.Builder delegate = new ClickAction.Builder();
+
+    @Override
+    public void setElement(Element element) {
+        ElementAware.super.setElement(element);
+    }
+
+    @Override
+    public FindElementAction.ElementActionBuilder<?, ?> getElementBuilder() {
+        return delegate;
+    }
+
+    @Override
+    public Click description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public Click actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public Click browser(SeleniumBrowser seleniumBrowser) {
+        delegate.browser(seleniumBrowser);
+        return this;
+    }
+
+    @Override
+    public ClickAction build() {
+        return delegate.build();
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/CloseWindow.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/CloseWindow.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.yaml;
+
+import org.citrusframework.TestActor;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.CloseWindowAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+
+public class CloseWindow extends AbstractSeleniumAction.Builder<CloseWindowAction, CloseWindow> {
+
+    private final CloseWindowAction.Builder delegate = new CloseWindowAction.Builder();
+
+    public void setName(String name) {
+        this.delegate.window(name);
+    }
+
+    public void setWindow(String name) {
+        this.delegate.window(name);
+    }
+
+    @Override
+    public CloseWindow description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public CloseWindow actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public CloseWindow browser(SeleniumBrowser seleniumBrowser) {
+        delegate.browser(seleniumBrowser);
+        return this;
+    }
+
+    @Override
+    public CloseWindowAction build() {
+        return delegate.build();
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/DropDownSelect.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/DropDownSelect.java
@@ -1,0 +1,74 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.yaml;
+
+import java.util.List;
+
+import org.citrusframework.TestActor;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.DropDownSelectAction;
+import org.citrusframework.selenium.actions.FindElementAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+
+public class DropDownSelect extends AbstractSeleniumAction.Builder<DropDownSelectAction, DropDownSelect> implements ElementAware {
+
+    private final DropDownSelectAction.Builder delegate = new DropDownSelectAction.Builder();
+
+    public void setOption(String option) {
+        this.delegate.option(option);
+    }
+
+    public void setOptions(List<String> options) {
+        this.delegate.options(options);
+    }
+
+    @Override
+    public void setElement(Element element) {
+        ElementAware.super.setElement(element);
+    }
+
+    @Override
+    public FindElementAction.ElementActionBuilder<?, ?> getElementBuilder() {
+        return delegate;
+    }
+
+    @Override
+    public DropDownSelect description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public DropDownSelect actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public DropDownSelect browser(SeleniumBrowser seleniumBrowser) {
+        delegate.browser(seleniumBrowser);
+        return this;
+    }
+
+    @Override
+    public DropDownSelectAction build() {
+        return delegate.build();
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/ElementAware.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/ElementAware.java
@@ -1,0 +1,164 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.yaml;
+
+import org.citrusframework.selenium.actions.FindElementAction;
+import org.openqa.selenium.By;
+
+public interface ElementAware {
+
+    /**
+     * Gets the element aware builder to work with.
+     * @return the element aware builder.
+     */
+    FindElementAction.ElementActionBuilder<?, ?> getElementBuilder();
+
+    /**
+     * Sets the element properties on the element aware builder.
+     * @param element
+     */
+    default void setElement(Element element) {
+        if (element.getId() != null) {
+            getElementBuilder().element(By.id(element.id));
+        } else if (element.getName() != null) {
+            getElementBuilder().element(By.name(element.name));
+        } else if (element.getLinkText() != null) {
+            getElementBuilder().element(By.linkText(element.linkText));
+        } else if (element.getPartialLinkText() != null) {
+            getElementBuilder().element(By.partialLinkText(element.partialLinkText));
+        } else if (element.getXpath() != null) {
+            getElementBuilder().element(By.xpath(element.xpath));
+        } else if (element.getCssSelector() != null) {
+            getElementBuilder().element(By.cssSelector(element.cssSelector));
+        } else if (element.getProperty() != null) {
+            getElementBuilder().element(element.getProperty().getName(), element.getProperty().getValue());
+        } else if (element.getClassName() != null) {
+            getElementBuilder().element(By.className(element.className));
+        } else if (element.getTagName() != null) {
+            getElementBuilder().element(By.tagName(element.tagName));
+        }
+    }
+
+    class Element {
+        private String id;
+        private String name;
+        private String tagName;
+        private String className;
+        private Property property;
+
+        private String linkText;
+        private String partialLinkText;
+        private String xpath;
+        private String cssSelector;
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getTagName() {
+            return tagName;
+        }
+
+        public void setTagName(String tagName) {
+            this.tagName = tagName;
+        }
+
+        public String getClassName() {
+            return className;
+        }
+
+        public void setClassName(String className) {
+            this.className = className;
+        }
+
+        public void setLinkText(String linkText) {
+            this.linkText = linkText;
+        }
+
+        public String getLinkText() {
+            return linkText;
+        }
+
+        public void setPartialLinkText(String partialLinkText) {
+            this.partialLinkText = partialLinkText;
+        }
+
+        public String getPartialLinkText() {
+            return partialLinkText;
+        }
+
+        public void setXpath(String xpath) {
+            this.xpath = xpath;
+        }
+
+        public String getXpath() {
+            return xpath;
+        }
+
+        public void setCssSelector(String cssSelector) {
+            this.cssSelector = cssSelector;
+        }
+
+        public String getCssSelector() {
+            return cssSelector;
+        }
+
+        public void setProperty(Property property) {
+            this.property = property;
+        }
+
+        public Property getProperty() {
+            return property;
+        }
+
+        public static class Property {
+            private String name;
+            private String value;
+
+            public void setName(String name) {
+                this.name = name;
+            }
+
+            public String getName() {
+                return name;
+            }
+
+            public void setValue(String value) {
+                this.value = value;
+            }
+
+            public String getValue() {
+                return value;
+            }
+        }
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/FindElement.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/FindElement.java
@@ -1,0 +1,195 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.yaml;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.citrusframework.TestActor;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.FindElementAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+
+public class FindElement extends AbstractSeleniumAction.Builder<FindElementAction, FindElement> implements ElementAware {
+
+    private final FindElementAction.Builder delegate = new FindElementAction.Builder();
+
+    @Override
+    public void setElement(Element element) {
+        ElementAware.super.setElement(element);
+    }
+
+    public void setValidate(Validate validate) {
+        if (validate.getText() != null) {
+            delegate.text(validate.text);
+        }
+
+        if (validate.getTagName() != null) {
+            delegate.tagName(validate.tagName);
+        }
+
+        delegate.enabled(validate.enabled);
+        delegate.displayed(validate.displayed);
+
+        for (Attribute attribute : validate.getAttributes()) {
+            delegate.attribute(attribute.getName(), attribute.getValue());
+        }
+
+        for (Style style : validate.getStyles()) {
+            delegate.style(style.getName(), style.getValue());
+        }
+    }
+
+    @Override
+    public FindElementAction.ElementActionBuilder<?, ?> getElementBuilder() {
+        return delegate;
+    }
+
+    @Override
+    public FindElement description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public FindElement actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public FindElement browser(SeleniumBrowser seleniumBrowser) {
+        delegate.browser(seleniumBrowser);
+        return this;
+    }
+
+    @Override
+    public FindElementAction build() {
+        return delegate.build();
+    }
+
+    public static class Validate {
+        private String text;
+        private String tagName;
+        private boolean displayed = true;
+        private boolean enabled = true;
+
+        private List<Attribute> attributes;
+        private List<Style> styles;
+
+        public String getText() {
+            return text;
+        }
+
+        public void setText(String text) {
+            this.text = text;
+        }
+
+        public String getTagName() {
+            return tagName;
+        }
+
+        public void setTagName(String tagName) {
+            this.tagName = tagName;
+        }
+
+        public List<Attribute> getAttributes() {
+            if (attributes == null) {
+                attributes = new ArrayList<>();
+            }
+
+            return attributes;
+        }
+
+        public void setAttributes(List<Attribute> attributes) {
+            this.attributes = attributes;
+        }
+
+        public List<Style> getStyles() {
+            if (styles == null) {
+                styles = new ArrayList<>();
+            }
+
+            return styles;
+        }
+
+        public void setStyles(List<Style> styles) {
+            this.styles = styles;
+        }
+
+        public boolean isDisplayed() {
+            return displayed;
+        }
+
+        public void setDisplayed(boolean displayed) {
+            this.displayed = displayed;
+        }
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+    }
+
+    public static class Style {
+        private String name;
+        private String value;
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+
+    public static class Attribute {
+        private String name;
+        private String value;
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/GetStoredFile.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/GetStoredFile.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.yaml;
+
+import org.citrusframework.TestActor;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.GetStoredFileAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+
+public class GetStoredFile extends AbstractSeleniumAction.Builder<GetStoredFileAction, GetStoredFile> {
+
+    private final GetStoredFileAction.Builder delegate = new GetStoredFileAction.Builder();
+
+    public void setFileName(String fileName) {
+        this.delegate.fileName(fileName);
+    }
+
+    @Override
+    public GetStoredFile description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public GetStoredFile actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public GetStoredFile browser(SeleniumBrowser seleniumBrowser) {
+        delegate.browser(seleniumBrowser);
+        return this;
+    }
+
+    @Override
+    public GetStoredFileAction build() {
+        return delegate.build();
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/Hover.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/Hover.java
@@ -1,0 +1,64 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.yaml;
+
+import org.citrusframework.TestActor;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.FindElementAction;
+import org.citrusframework.selenium.actions.HoverAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+
+public class Hover extends AbstractSeleniumAction.Builder<HoverAction, Hover> implements ElementAware {
+
+    private final HoverAction.Builder delegate = new HoverAction.Builder();
+
+    @Override
+    public void setElement(Element element) {
+        ElementAware.super.setElement(element);
+    }
+
+    @Override
+    public FindElementAction.ElementActionBuilder<?, ?> getElementBuilder() {
+        return delegate;
+    }
+
+    @Override
+    public Hover description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public Hover actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public Hover browser(SeleniumBrowser seleniumBrowser) {
+        delegate.browser(seleniumBrowser);
+        return this;
+    }
+
+    @Override
+    public HoverAction build() {
+        return delegate.build();
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/JavaScript.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/JavaScript.java
@@ -1,0 +1,95 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.yaml;
+
+import java.util.List;
+
+import org.citrusframework.TestActor;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.JavaScriptAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+
+public class JavaScript extends AbstractSeleniumAction.Builder<JavaScriptAction, JavaScript> {
+
+    private final JavaScriptAction.Builder delegate = new JavaScriptAction.Builder();
+
+    /**
+     * Add script.
+     * @param script
+     */
+    public void setScript(String script) {
+        this.delegate.script(script);
+    }
+
+    /**
+     * Add script argument.
+     * @param arg
+     */
+    public void setArgument(Object arg) {
+        this.delegate.argument(arg);
+    }
+
+    /**
+     * Add script arguments.
+     * @param args
+     */
+    public void setArguments(List<Object> args) {
+        this.delegate.arguments(args);
+    }
+
+    /**
+     * Add expected error.
+     * @param error
+     */
+    public void setError(String error) {
+        this.delegate.error(error);
+    }
+
+    /**
+     * Add expected error.
+     * @param errors
+     */
+    public void setErrors(List<String> errors) {
+        this.delegate.errors(errors);
+    }
+
+    @Override
+    public JavaScript description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public JavaScript actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public JavaScript browser(SeleniumBrowser seleniumBrowser) {
+        delegate.browser(seleniumBrowser);
+        return this;
+    }
+
+    @Override
+    public JavaScriptAction build() {
+        return delegate.build();
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/MakeScreenshot.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/MakeScreenshot.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.yaml;
+
+import org.citrusframework.TestActor;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.MakeScreenshotAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+
+public class MakeScreenshot extends AbstractSeleniumAction.Builder<MakeScreenshotAction, MakeScreenshot> {
+
+    private final MakeScreenshotAction.Builder delegate = new MakeScreenshotAction.Builder();
+
+    public void setOutputDir(String outputDir) {
+        this.delegate.outputDir(outputDir);
+    }
+
+    @Override
+    public MakeScreenshot description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public MakeScreenshot actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public MakeScreenshot browser(SeleniumBrowser seleniumBrowser) {
+        delegate.browser(seleniumBrowser);
+        return this;
+    }
+
+    @Override
+    public MakeScreenshotAction build() {
+        return delegate.build();
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/Navigate.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/Navigate.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.yaml;
+
+import org.citrusframework.TestActor;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.NavigateAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+
+public class Navigate extends AbstractSeleniumAction.Builder<NavigateAction, Navigate> {
+
+    private final NavigateAction.Builder delegate = new NavigateAction.Builder();
+
+    public void setPage(String page) {
+        this.delegate.page(page);
+    }
+
+    @Override
+    public Navigate description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public Navigate actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public Navigate browser(SeleniumBrowser seleniumBrowser) {
+        delegate.browser(seleniumBrowser);
+        return this;
+    }
+
+    @Override
+    public NavigateAction build() {
+        return delegate.build();
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/OpenWindow.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/OpenWindow.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.yaml;
+
+import org.citrusframework.TestActor;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.OpenWindowAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+
+public class OpenWindow extends AbstractSeleniumAction.Builder<OpenWindowAction, OpenWindow> {
+
+    private final OpenWindowAction.Builder delegate = new OpenWindowAction.Builder();
+
+    public void setName(String name) {
+        this.delegate.window(name);
+    }
+
+    public void setWindow(String windowName) {
+        this.delegate.window(windowName);
+    }
+
+    @Override
+    public OpenWindow description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public OpenWindow actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public OpenWindow browser(SeleniumBrowser seleniumBrowser) {
+        delegate.browser(seleniumBrowser);
+        return this;
+    }
+
+    @Override
+    public OpenWindowAction build() {
+        return delegate.build();
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/Page.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/Page.java
@@ -1,0 +1,142 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.yaml;
+
+import java.util.List;
+
+import org.citrusframework.TestActor;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.PageAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+import org.citrusframework.selenium.model.PageValidator;
+import org.citrusframework.selenium.model.WebPage;
+import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.spi.ReferenceResolverAware;
+
+public class Page extends AbstractSeleniumAction.Builder<PageAction, Page> implements ReferenceResolverAware {
+
+    private final PageAction.Builder delegate = new PageAction.Builder();
+
+    private String pageName;
+    private String pageValidator;
+
+    private ReferenceResolver referenceResolver;
+
+    /**
+     * Sets the web page by name.
+     * @param name
+     */
+    public void setName(String name) {
+        this.pageName = name;
+    }
+
+    /**
+     * Sets the web page type.
+     * @param pageType
+     */
+    public void setType(String pageType) {
+        this.delegate.type(pageType);
+    }
+
+    /**
+     * Sets the web page action.
+     * @param action
+     */
+    public void setAction(String action) {
+        this.delegate.action(action);
+    }
+
+    /**
+     * Perform page validation.
+     */
+    public void setValidate() {
+        this.delegate.action("validate");
+    }
+
+    /**
+     * Set page validator.
+     * @param pageValidator
+     */
+    public void setValidator(String pageValidator) {
+        this.pageValidator = pageValidator;
+    }
+
+    /**
+     * Set page action method to execute.
+     * @param method
+     */
+    public void setExecute(String method) {
+        this.delegate.action(method);
+    }
+
+    /**
+     * Set page action argument.
+     * @param arg
+     */
+    public void setArgument(String arg) {
+        this.delegate.argument(arg);
+    }
+
+    /**
+     * Set page action arguments.
+     * @param args
+     */
+    public void setArguments(List<String> args) {
+        this.delegate.arguments(args);
+    }
+
+    @Override
+    public Page description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public Page actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public Page browser(SeleniumBrowser seleniumBrowser) {
+        delegate.browser(seleniumBrowser);
+        return this;
+    }
+
+    @Override
+    public PageAction build() {
+        if (referenceResolver != null) {
+            if (pageName != null) {
+                this.delegate.page(referenceResolver.resolve(pageName, WebPage.class));
+            }
+
+            if (pageValidator != null) {
+                this.delegate.validator(referenceResolver.resolve(pageValidator, PageValidator.class));
+            }
+        }
+
+        return delegate.build();
+    }
+
+    @Override
+    public void setReferenceResolver(ReferenceResolver referenceResolver) {
+        this.referenceResolver = referenceResolver;
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/Selenium.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/Selenium.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.selenium.yaml;
+
+import org.citrusframework.TestActionBuilder;
+import org.citrusframework.TestActionContainerBuilder;
+import org.citrusframework.TestActor;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.SeleniumAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.spi.ReferenceResolverAware;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class Selenium implements TestActionBuilder<SeleniumAction>, ReferenceResolverAware {
+
+    private AbstractSeleniumAction.Builder<?, ?> builder;
+
+    private String description;
+    private String actor;
+
+    private String seleniumBrowser;
+
+    private ReferenceResolver referenceResolver;
+
+    public void setDescription(String value) {
+        this.description = value;
+    }
+
+    public void setActor(String actor) {
+        this.actor = actor;
+    }
+
+    /**
+     * Use a custom selenium browser.
+     */
+    public void setBrowser(String browser) {
+        this.seleniumBrowser = browser;
+    }
+
+    /**
+     * Start browser instance.
+     */
+    public void setStart(StartBrowser builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Stop browser instance.
+     */
+    public void setStop(StopBrowser builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Alert element.
+     */
+    public void setAlert(Alert builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Navigate action.
+     */
+    public void setNavigate(Navigate builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Page action.
+     */
+    public void setPage(Page builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Finds element.
+     */
+    public void setFind(FindElement builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Dropdown select single option action.
+     */
+    public void setDropdownSelect(DropDownSelect builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Set input action.
+     */
+    public void setSetInput(SetInput builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Check input action.
+     */
+    public void setCheckInput(CheckInput builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Clicks element.
+     */
+    public void setClick(Click builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Hover element.
+     */
+    public void setHover(Hover builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Clear browser cache.
+     */
+    public void setClearCache(ClearBrowserCache builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Make screenshot.
+     */
+    public void setScreenshot(MakeScreenshot builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Store file.
+     */
+    public void setStoreFile(StoreFile builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Get stored file.
+     */
+    public void setGetStoredFile(GetStoredFile builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Wait until element meets condition.
+     */
+    public void setWaitUntil(WaitUntil builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Execute JavaScript.
+     */
+    public void setJavaScript(JavaScript builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Open window.
+     */
+    public void setOpenWindow(OpenWindow builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Close window.
+     */
+    public void setCloseWindow(CloseWindow builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Focus window.
+     */
+    public void setFocusWindow(SwitchWindow builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Switch window.
+     */
+    public void setSwitchWindow(SwitchWindow builder) {
+        this.builder = builder;
+    }
+
+    @Override
+    public SeleniumAction build() {
+        if (builder == null) {
+            throw new CitrusRuntimeException("Missing client or server Soap action - please provide proper action details");
+        }
+
+        if (builder instanceof TestActionContainerBuilder<?,?>) {
+            ((TestActionContainerBuilder<?,?>) builder).getActions().stream()
+                    .filter(action -> action instanceof ReferenceResolverAware)
+                    .forEach(action -> ((ReferenceResolverAware) action).setReferenceResolver(referenceResolver));
+        }
+
+        if (builder instanceof ReferenceResolverAware) {
+            ((ReferenceResolverAware) builder).setReferenceResolver(referenceResolver);
+        }
+
+        builder.description(description);
+
+        if (referenceResolver != null) {
+            if (seleniumBrowser != null) {
+                builder.browser(referenceResolver.resolve(seleniumBrowser, SeleniumBrowser.class));
+            }
+
+            if (actor != null) {
+                builder.actor(referenceResolver.resolve(actor, TestActor.class));
+            }
+        }
+
+        return builder.build();
+    }
+
+    @Override
+    public void setReferenceResolver(ReferenceResolver referenceResolver) {
+        this.referenceResolver = referenceResolver;
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/SetInput.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/SetInput.java
@@ -1,0 +1,68 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.yaml;
+
+import org.citrusframework.TestActor;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.FindElementAction;
+import org.citrusframework.selenium.actions.SetInputAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+
+public class SetInput extends AbstractSeleniumAction.Builder<SetInputAction, SetInput> implements ElementAware {
+
+    private final SetInputAction.Builder delegate = new SetInputAction.Builder();
+
+    public void setValue(String value) {
+        this.delegate.value(value);
+    }
+
+    @Override
+    public void setElement(Element element) {
+        ElementAware.super.setElement(element);
+    }
+
+    @Override
+    public FindElementAction.ElementActionBuilder<?, ?> getElementBuilder() {
+        return delegate;
+    }
+
+    @Override
+    public SetInput description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public SetInput actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public SetInput browser(SeleniumBrowser seleniumBrowser) {
+        delegate.browser(seleniumBrowser);
+        return this;
+    }
+
+    @Override
+    public SetInputAction build() {
+        return delegate.build();
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/StartBrowser.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/StartBrowser.java
@@ -1,0 +1,76 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.yaml;
+
+import org.citrusframework.TestActor;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.StartBrowserAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.spi.ReferenceResolverAware;
+
+public class StartBrowser extends AbstractSeleniumAction.Builder<StartBrowserAction, StartBrowser> implements ReferenceResolverAware {
+
+    private final StartBrowserAction.Builder delegate = new StartBrowserAction.Builder();
+
+    private String seleniumBrowser;
+
+    private ReferenceResolver referenceResolver;
+
+    public void setBrowser(String browser) {
+        this.seleniumBrowser = browser;
+    }
+
+    public void setAllowAlreadyStarted(boolean allow) {
+        this.delegate.allowAlreadyStarted(allow);
+    }
+
+    @Override
+    public StartBrowser description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public StartBrowser actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public StartBrowser browser(SeleniumBrowser seleniumBrowser) {
+        delegate.browser(seleniumBrowser);
+        return this;
+    }
+
+    @Override
+    public StartBrowserAction build() {
+        if (seleniumBrowser != null) {
+            delegate.browser(referenceResolver.resolve(seleniumBrowser, SeleniumBrowser.class));
+        }
+
+        return delegate.build();
+    }
+
+    @Override
+    public void setReferenceResolver(ReferenceResolver referenceResolver) {
+        this.referenceResolver = referenceResolver;
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/StopBrowser.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/StopBrowser.java
@@ -1,0 +1,72 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.yaml;
+
+import org.citrusframework.TestActor;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.StopBrowserAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.spi.ReferenceResolverAware;
+
+public class StopBrowser extends AbstractSeleniumAction.Builder<StopBrowserAction, StopBrowser> implements ReferenceResolverAware {
+
+    private final StopBrowserAction.Builder delegate = new StopBrowserAction.Builder();
+
+    private String seleniumBrowser;
+
+    private ReferenceResolver referenceResolver;
+
+    public void setBrowser(String browser) {
+        this.seleniumBrowser = browser;
+    }
+
+    @Override
+    public StopBrowser description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public StopBrowser actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public StopBrowser browser(SeleniumBrowser seleniumBrowser) {
+        delegate.browser(seleniumBrowser);
+        return this;
+    }
+
+    @Override
+    public StopBrowserAction build() {
+        if (seleniumBrowser != null) {
+            delegate.browser(referenceResolver.resolve(seleniumBrowser, SeleniumBrowser.class));
+        }
+
+        return delegate.build();
+    }
+
+    @Override
+    public void setReferenceResolver(ReferenceResolver referenceResolver) {
+        this.referenceResolver = referenceResolver;
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/StoreFile.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/StoreFile.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.yaml;
+
+import org.citrusframework.TestActor;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.StoreFileAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+
+public class StoreFile extends AbstractSeleniumAction.Builder<StoreFileAction, StoreFile> {
+
+    private final StoreFileAction.Builder delegate = new StoreFileAction.Builder();
+
+    public void setFilePath(String filePath) {
+        this.delegate.filePath(filePath);
+    }
+
+    @Override
+    public StoreFile description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public StoreFile actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public StoreFile browser(SeleniumBrowser seleniumBrowser) {
+        delegate.browser(seleniumBrowser);
+        return this;
+    }
+
+    @Override
+    public StoreFileAction build() {
+        return delegate.build();
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/SwitchWindow.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/SwitchWindow.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.yaml;
+
+import org.citrusframework.TestActor;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.SwitchWindowAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+
+public class SwitchWindow extends AbstractSeleniumAction.Builder<SwitchWindowAction, SwitchWindow> {
+
+    private final SwitchWindowAction.Builder delegate = new SwitchWindowAction.Builder();
+
+    public void setName(String name) {
+        this.delegate.window(name);
+    }
+
+    public void setWindow(String name) {
+        this.delegate.window(name);
+    }
+
+    @Override
+    public SwitchWindow description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public SwitchWindow actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public SwitchWindow browser(SeleniumBrowser seleniumBrowser) {
+        delegate.browser(seleniumBrowser);
+        return this;
+    }
+
+    @Override
+    public SwitchWindowAction build() {
+        return delegate.build();
+    }
+}

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/WaitUntil.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/WaitUntil.java
@@ -1,0 +1,72 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.yaml;
+
+import org.citrusframework.TestActor;
+import org.citrusframework.selenium.actions.AbstractSeleniumAction;
+import org.citrusframework.selenium.actions.FindElementAction;
+import org.citrusframework.selenium.actions.WaitUntilAction;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+
+public class WaitUntil extends AbstractSeleniumAction.Builder<WaitUntilAction, WaitUntil> implements ElementAware {
+
+    private final WaitUntilAction.Builder delegate = new WaitUntilAction.Builder();
+
+    @Override
+    public void setElement(Element element) {
+        ElementAware.super.setElement(element);
+    }
+
+    @Override
+    public FindElementAction.ElementActionBuilder<?, ?> getElementBuilder() {
+        return delegate;
+    }
+
+    public void setTimeout(long timeout) {
+        this.delegate.timeout(timeout);
+    }
+
+    public void setCondition(String condition) {
+        this.delegate.condition(condition);
+    }
+
+    @Override
+    public WaitUntil description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public WaitUntil actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public WaitUntil browser(SeleniumBrowser seleniumBrowser) {
+        delegate.browser(seleniumBrowser);
+        return this;
+    }
+
+    @Override
+    public WaitUntilAction build() {
+        return delegate.build();
+    }
+}

--- a/connectors/citrus-selenium/src/main/resources/META-INF/citrus/xml/builder/selenium
+++ b/connectors/citrus-selenium/src/main/resources/META-INF/citrus/xml/builder/selenium
@@ -1,0 +1,2 @@
+type=org.citrusframework.selenium.xml.Selenium
+ns=http://citrusframework.org/schema/xml/testcase

--- a/connectors/citrus-selenium/src/main/resources/META-INF/citrus/yaml/builder/selenium
+++ b/connectors/citrus-selenium/src/main/resources/META-INF/citrus/yaml/builder/selenium
@@ -1,0 +1,1 @@
+type=org.citrusframework.selenium.yaml.Selenium

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/ClickActionTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/ClickActionTest.java
@@ -35,9 +35,9 @@ import static org.mockito.Mockito.*;
  */
 public class ClickActionTest extends AbstractTestNGUnitTest {
 
-    private SeleniumBrowser seleniumBrowser = new SeleniumBrowser();
-    private WebDriver webDriver = Mockito.mock(WebDriver.class);
-    private WebElement element = Mockito.mock(WebElement.class);
+    private final SeleniumBrowser seleniumBrowser = new SeleniumBrowser();
+    private final WebDriver webDriver = Mockito.mock(WebDriver.class);
+    private final WebElement element = Mockito.mock(WebElement.class);
 
     @BeforeMethod
     public void setup() {
@@ -72,7 +72,7 @@ public class ClickActionTest extends AbstractTestNGUnitTest {
         verify(element).click();
     }
 
-    @Test(expectedExceptions = CitrusRuntimeException.class, expectedExceptionsMessageRegExp = "Failed to find element 'id=myButton' on page")
+    @Test(expectedExceptions = CitrusRuntimeException.class, expectedExceptionsMessageRegExp = "Failed to find element 'By.id: myButton' on page")
     public void testElementNotFound() {
         when(webDriver.findElement(any(By.class))).thenReturn(null);
 

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/FindElementActionTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/FindElementActionTest.java
@@ -40,9 +40,9 @@ import static org.mockito.Mockito.when;
  */
 public class FindElementActionTest extends AbstractTestNGUnitTest {
 
-    private SeleniumBrowser seleniumBrowser = new SeleniumBrowser();
-    private WebDriver webDriver = Mockito.mock(WebDriver.class);
-    private WebElement element = Mockito.mock(WebElement.class);
+    private final SeleniumBrowser seleniumBrowser = new SeleniumBrowser();
+    private final WebDriver webDriver = Mockito.mock(WebDriver.class);
+    private final WebElement element = Mockito.mock(WebElement.class);
 
     @BeforeMethod
     public void setup() {
@@ -192,7 +192,7 @@ public class FindElementActionTest extends AbstractTestNGUnitTest {
         };
     }
 
-    @Test(expectedExceptions = CitrusRuntimeException.class, expectedExceptionsMessageRegExp = "Failed to find element 'id=myButton' on page")
+    @Test(expectedExceptions = CitrusRuntimeException.class, expectedExceptionsMessageRegExp = "Failed to find element 'By.id: myButton' on page")
     public void testElementNotFound() {
         when(webDriver.findElement(any(By.class))).thenReturn(null);
 

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/HoverActionTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/HoverActionTest.java
@@ -67,7 +67,7 @@ public class HoverActionTest extends AbstractTestNGUnitTest {
         action.execute(context);
     }
 
-    @Test(expectedExceptions = CitrusRuntimeException.class, expectedExceptionsMessageRegExp = "Failed to find element 'id=myButton' on page")
+    @Test(expectedExceptions = CitrusRuntimeException.class, expectedExceptionsMessageRegExp = "Failed to find element 'By.id: myButton' on page")
     public void testElementNotFound() {
         when(webDriver.findElement(any(By.class))).thenReturn(null);
 

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/groovy/AbstractGroovyActionDslTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/groovy/AbstractGroovyActionDslTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.selenium.groovy;
+
+import org.citrusframework.Citrus;
+import org.citrusframework.CitrusContext;
+import org.citrusframework.CitrusInstanceManager;
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.annotations.CitrusAnnotations;
+import org.citrusframework.context.StaticTestContextFactory;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.citrusframework.testng.AbstractTestNGUnitTest;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeClass;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class AbstractGroovyActionDslTest extends AbstractTestNGUnitTest {
+
+    protected Citrus citrus;
+
+    @Mock
+    protected CitrusContext citrusContext;
+
+    @BeforeClass
+    public void setupMocks() {
+        MockitoAnnotations.openMocks(this);
+        citrus = CitrusInstanceManager.newInstance(() -> citrusContext);
+    }
+
+    @Override
+    protected TestContext createTestContext() {
+        TestContext context = super.createTestContext();
+        doAnswer(invocation -> {
+            context.getReferenceResolver().bind(invocation.getArgument(0, String.class), invocation.getArgument(1));
+            return null;
+        }).when(citrusContext).bind(any(String.class), any());
+
+        when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
+        when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
+        when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        CitrusAnnotations.injectAll(this, citrus, context);
+        return context;
+    }
+
+    protected GroovyTestLoader createTestLoader(String sourcePath) {
+        GroovyTestLoader testLoader = new GroovyTestLoader().source(sourcePath);
+        CitrusAnnotations.injectAll(testLoader, citrus, context);
+        CitrusAnnotations.injectTestRunner(testLoader, new DefaultTestCaseRunner(context));
+
+        return testLoader;
+    }
+}

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/groovy/SeleniumTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/groovy/SeleniumTest.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.selenium.groovy;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.citrusframework.selenium.actions.*;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+import org.citrusframework.selenium.endpoint.SeleniumBrowserConfiguration;
+import org.citrusframework.selenium.model.PageValidator;
+import org.citrusframework.selenium.model.WebPage;
+import org.citrusframework.selenium.pages.UserFormPage;
+import org.mockito.Mock;
+import org.openqa.selenium.Alert;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.htmlunit.HtmlUnitDriver;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class SeleniumTest extends AbstractGroovyActionDslTest {
+
+    @Mock
+    private SeleniumBrowser browser;
+
+    @Mock
+    private HtmlUnitDriver webDriver;
+
+    @Mock
+    private WebDriver.TargetLocator targetLocator;
+
+    @Mock
+    private Alert alert;
+
+    @Mock
+    private WebElement webElement;
+
+    @Mock
+    private WebElement option;
+
+    @Mock
+    private WebPage webPage;
+
+    @Mock
+    private PageValidator<?> pageValidator;
+
+    @Mock
+    private WebDriver.Navigation navigation;
+
+    @Mock
+    private WebDriver.Options options;
+
+    @BeforeClass
+    @Override
+    public void setupMocks() {
+        super.setupMocks();
+
+        SeleniumBrowserConfiguration configuration = new SeleniumBrowserConfiguration();
+        when(browser.getEndpointConfiguration()).thenReturn(configuration);
+        when(browser.getName()).thenReturn("seleniumBrowser");
+        when(browser.getWebDriver()).thenReturn(webDriver);
+        when(webDriver.switchTo()).thenReturn(targetLocator);
+        when(targetLocator.alert()).thenReturn(alert);
+        when(alert.getText()).thenReturn("This is a warning message!");
+        when(webDriver.findElement(any(By.class))).thenReturn(webElement);
+        when(webElement.getText()).thenReturn("Ok");
+        when(webElement.isDisplayed()).thenReturn(true, true, true, true, true, true, true, true, true, true, true, true, true)
+                .thenReturn(false);
+        when(webElement.isEnabled()).thenReturn(true);
+        when(webElement.getAttribute("type")).thenReturn("submit");
+        when(webElement.getAttribute("value")).thenReturn("Foo");
+        when(webElement.getAttribute("enabled")).thenReturn("true");
+        when(webElement.getCssValue("color")).thenReturn("#000000");
+        when(webElement.getTagName()).thenReturn("button", "select");
+        when(webElement.findElements(any(By.class))).thenReturn(List.of(option));
+        when(option.isEnabled()).thenReturn(true);
+        when(option.getText()).thenReturn("new-value");
+        when(webDriver.executeScript(any(String.class), any(Object[].class))).thenReturn(Collections.emptyList()).thenReturn(List.of("Something went wrong"));
+        when(webDriver.navigate()).thenReturn(navigation);
+        when(webDriver.getWindowHandles()).thenReturn(Set.of("switchWindow", "closeWindow")).thenReturn(Set.of("newWindow", "switchWindow", "closeWindow"));
+        when(webDriver.getWindowHandle()).thenReturn("newWindow", "switchWindow", "closeWindow");
+        when(targetLocator.window(any(String.class))).thenReturn(webDriver);
+        when(browser.getStoredFile(any(String.class))).thenReturn("file.txt");
+        when(webDriver.manage()).thenReturn(options);
+    }
+
+    @Test
+    public void shouldLoadSeleniumActions() throws IOException {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/selenium/groovy/selenium.test.groovy");
+
+        context.getReferenceResolver().bind("seleniumBrowser", browser);
+        context.getReferenceResolver().bind("userForm", webPage);
+        context.getReferenceResolver().bind("pageValidator", pageValidator);
+
+        context.setVariable("switchWindow", "switchWindow");
+        context.setVariable("closeWindow", "closeWindow");
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "SeleniumTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 23L);
+
+        int actionIndex = 0;
+
+        StartBrowserAction startAction = (StartBrowserAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(startAction.getBrowser());
+        Assert.assertEquals(startAction.getName(), "selenium:start");
+
+        AlertAction alertAction = (AlertAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(alertAction.getBrowser());
+        Assert.assertEquals(alertAction.getName(), "selenium:alert");
+        Assert.assertNull(alertAction.getText());
+        Assert.assertTrue(alertAction.isAccept());
+
+        alertAction = (AlertAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(alertAction.getBrowser());
+        Assert.assertEquals(alertAction.getName(), "selenium:alert");
+        Assert.assertEquals(alertAction.getText(), "This is a warning message!");
+        Assert.assertFalse(alertAction.isAccept());
+
+        FindElementAction findElementAction = (FindElementAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(findElementAction.getBrowser());
+        Assert.assertEquals(findElementAction.getName(), "selenium:find");
+        Assert.assertEquals(findElementAction.getBy().toString(), "By.className: clickable");
+        Assert.assertEquals(findElementAction.getTagName(), "button");
+        Assert.assertEquals(findElementAction.getText(), "Ok");
+        Assert.assertEquals(findElementAction.getAttributes().size(), 1L);
+        Assert.assertEquals(findElementAction.getAttributes().get("type"), "submit");
+        Assert.assertEquals(findElementAction.getStyles().size(), 1L);
+        Assert.assertEquals(findElementAction.getStyles().get("color"), "#000000");
+        Assert.assertTrue(findElementAction.isDisplayed());
+        Assert.assertTrue(findElementAction.isEnabled());
+
+        PageAction pageAction = (PageAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(pageAction.getBrowser());
+        Assert.assertEquals(pageAction.getName(), "selenium:page");
+        Assert.assertEquals(pageAction.getAction(), "setUserName");
+        Assert.assertEquals(pageAction.getPage(), context.getReferenceResolver().resolve("userForm"));
+        Assert.assertNull(pageAction.getType());
+        Assert.assertEquals(pageAction.getArguments().size(), 1L);
+        Assert.assertEquals(pageAction.getArguments().get(0), "${username}");
+        Assert.assertNull(pageAction.getValidator());
+
+        pageAction = (PageAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(pageAction.getBrowser());
+        Assert.assertEquals(pageAction.getName(), "selenium:page");
+        Assert.assertEquals(pageAction.getAction(), "validate");
+        Assert.assertNull(pageAction.getPage());
+        Assert.assertEquals(pageAction.getType(), UserFormPage.class.getName());
+        Assert.assertEquals(pageAction.getArguments().size(), 0L);
+        Assert.assertEquals(pageAction.getValidator(), context.getReferenceResolver().resolve("pageValidator"));
+
+        ClickAction clickAction = (ClickAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(clickAction.getBrowser());
+        Assert.assertEquals(clickAction.getName(), "selenium:click");
+        Assert.assertEquals(clickAction.getBy().toString(), "By.id: edit-link");
+
+        HoverAction hoverAction = (HoverAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(hoverAction.getBrowser());
+        Assert.assertEquals(hoverAction.getName(), "selenium:hover");
+        Assert.assertEquals(hoverAction.getBy().toString(), "By.id: edit-link");
+
+        SetInputAction setInputAction = (SetInputAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(setInputAction.getBrowser());
+        Assert.assertEquals(setInputAction.getName(), "selenium:set-input");
+        Assert.assertEquals(setInputAction.getBy().toString(), "By.tagName: input");
+        Assert.assertEquals(setInputAction.getValue(), "new-value");
+
+        CheckInputAction checkInputAction = (CheckInputAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(checkInputAction.getBrowser());
+        Assert.assertEquals(checkInputAction.getName(), "selenium:check-input");
+        Assert.assertEquals(checkInputAction.getBy().toString(), "By.xpath: //input[@type: 'checkbox']");
+        Assert.assertTrue(checkInputAction.isChecked());
+
+        DropDownSelectAction dropDownSelect = (DropDownSelectAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(dropDownSelect.getBrowser());
+        Assert.assertEquals(dropDownSelect.getName(), "selenium:dropdown-select");
+        Assert.assertEquals(dropDownSelect.getBy().toString(), "By.name: gender");
+        Assert.assertEquals(dropDownSelect.getOption(), "male");
+        Assert.assertEquals(dropDownSelect.getOptions().size(), 0L);
+
+        DropDownSelectAction dropDownMultiSelect = (DropDownSelectAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(dropDownMultiSelect.getBrowser());
+        Assert.assertEquals(dropDownMultiSelect.getName(), "selenium:dropdown-select");
+        Assert.assertEquals(dropDownMultiSelect.getBy().toString(), "By.id: title");
+        Assert.assertNull(dropDownMultiSelect.getOption());
+        Assert.assertEquals(dropDownMultiSelect.getOptions().size(), 2L);
+
+        WaitUntilAction waitUntilAction = (WaitUntilAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(waitUntilAction.getBrowser());
+        Assert.assertEquals(waitUntilAction.getName(), "selenium:wait");
+        Assert.assertEquals(waitUntilAction.getBy().toString(), "By.id: dialog");
+        Assert.assertEquals(waitUntilAction.getCondition(), "hidden");
+
+        JavaScriptAction javaScriptAction = (JavaScriptAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(javaScriptAction.getBrowser());
+        Assert.assertEquals(javaScriptAction.getName(), "selenium:javascript");
+        Assert.assertEquals(javaScriptAction.getScript(), "alert('This is awesome!')");
+        Assert.assertEquals(javaScriptAction.getExpectedErrors().size(), 1L);
+        Assert.assertEquals(javaScriptAction.getExpectedErrors().get(0), "Something went wrong");
+
+        MakeScreenshotAction screenshotAction = (MakeScreenshotAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(screenshotAction.getBrowser());
+        Assert.assertEquals(screenshotAction.getName(), "selenium:screenshot");
+        Assert.assertEquals(screenshotAction.getOutputDir(), "/tmp/storage");
+
+        NavigateAction navigateAction = (NavigateAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(navigateAction.getBrowser());
+        Assert.assertEquals(navigateAction.getName(), "selenium:navigate");
+        Assert.assertEquals(navigateAction.getPage(), "back");
+
+        OpenWindowAction openWindowAction = (OpenWindowAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(openWindowAction.getBrowser());
+        Assert.assertEquals(openWindowAction.getName(), "selenium:open-window");
+        Assert.assertEquals(openWindowAction.getWindowName(), "newWindow");
+
+        SwitchWindowAction switchWindowAction = (SwitchWindowAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(switchWindowAction.getBrowser());
+        Assert.assertEquals(switchWindowAction.getName(), "selenium:switch-window");
+        Assert.assertEquals(switchWindowAction.getWindowName(), "switchWindow");
+
+        CloseWindowAction closeWindowAction = (CloseWindowAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(closeWindowAction.getBrowser());
+        Assert.assertEquals(closeWindowAction.getName(), "selenium:close-window");
+        Assert.assertEquals(closeWindowAction.getWindowName(), "closeWindow");
+
+        StoreFileAction storeFileAction = (StoreFileAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(storeFileAction.getBrowser());
+        Assert.assertEquals(storeFileAction.getName(), "selenium:store-file");
+        Assert.assertEquals(storeFileAction.getFilePath(), "classpath:download/file.txt");
+
+        GetStoredFileAction getStoredFileAction = (GetStoredFileAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(getStoredFileAction.getBrowser());
+        Assert.assertEquals(getStoredFileAction.getName(), "selenium:get-stored-file");
+        Assert.assertEquals(getStoredFileAction.getFileName(), "file.txt");
+
+        ClearBrowserCacheAction clearCacheAction = (ClearBrowserCacheAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(clearCacheAction.getBrowser());
+        Assert.assertEquals(clearCacheAction.getName(), "selenium:clear-cache");
+
+        StopBrowserAction stopAction = (StopBrowserAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(stopAction.getBrowser());
+        Assert.assertEquals(stopAction.getName(), "selenium:stop");
+    }
+
+}

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/pages/UserFormPage.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/pages/UserFormPage.java
@@ -38,7 +38,7 @@ public class UserFormPage implements WebPage, PageValidator<UserFormPage> {
     private WebElement userName;
 
     /**
-     * Sets the user name.
+     * Sets the username.
      */
     public void setUserName(String value, TestContext context) {
         userName.clear();

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/xml/AbstractXmlActionTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/xml/AbstractXmlActionTest.java
@@ -1,0 +1,71 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.selenium.xml;
+
+import org.citrusframework.Citrus;
+import org.citrusframework.CitrusContext;
+import org.citrusframework.CitrusInstanceManager;
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.annotations.CitrusAnnotations;
+import org.citrusframework.context.StaticTestContextFactory;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.testng.AbstractTestNGUnitTest;
+import org.citrusframework.xml.XmlTestLoader;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeClass;
+
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class AbstractXmlActionTest extends AbstractTestNGUnitTest {
+
+    protected Citrus citrus;
+
+    @Mock
+    protected CitrusContext citrusContext;
+
+    @BeforeClass
+    public void setupMocks() {
+        MockitoAnnotations.openMocks(this);
+        citrus = CitrusInstanceManager.newInstance(() -> citrusContext);
+    }
+
+    @Override
+    protected TestContext createTestContext() {
+        TestContext context = super.createTestContext();
+        when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
+        when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
+        when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        CitrusAnnotations.injectAll(this, citrus, context);
+        return context;
+    }
+
+    protected XmlTestLoader createTestLoader(String sourcePath) {
+        XmlTestLoader testLoader = new XmlTestLoader(this.getClass(), "Test", this.getClass().getPackageName());
+        CitrusAnnotations.injectAll(testLoader, citrus, context);
+        CitrusAnnotations.injectTestRunner(testLoader, new DefaultTestCaseRunner(context));
+        testLoader.setSource(sourcePath);
+
+        return testLoader;
+    }
+}

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/xml/SeleniumTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/xml/SeleniumTest.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.selenium.xml;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.selenium.actions.*;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+import org.citrusframework.selenium.endpoint.SeleniumBrowserConfiguration;
+import org.citrusframework.selenium.model.PageValidator;
+import org.citrusframework.selenium.model.WebPage;
+import org.citrusframework.selenium.pages.UserFormPage;
+import org.citrusframework.xml.XmlTestLoader;
+import org.citrusframework.xml.actions.XmlTestActionBuilder;
+import org.mockito.Mock;
+import org.openqa.selenium.Alert;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.htmlunit.HtmlUnitDriver;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class SeleniumTest extends AbstractXmlActionTest {
+
+    @Mock
+    private SeleniumBrowser browser;
+
+    @Mock
+    private HtmlUnitDriver webDriver;
+
+    @Mock
+    private WebDriver.TargetLocator targetLocator;
+
+    @Mock
+    private Alert alert;
+
+    @Mock
+    private WebElement webElement;
+
+    @Mock
+    private WebElement option;
+
+    @Mock
+    private WebPage webPage;
+
+    @Mock
+    private PageValidator<?> pageValidator;
+
+    @Mock
+    private WebDriver.Navigation navigation;
+
+    @Mock
+    private WebDriver.Options options;
+
+    @BeforeClass
+    @Override
+    public void setupMocks() {
+        super.setupMocks();
+
+        SeleniumBrowserConfiguration configuration = new SeleniumBrowserConfiguration();
+        when(browser.getEndpointConfiguration()).thenReturn(configuration);
+        when(browser.getName()).thenReturn("seleniumBrowser");
+        when(browser.getWebDriver()).thenReturn(webDriver);
+        when(webDriver.switchTo()).thenReturn(targetLocator);
+        when(targetLocator.alert()).thenReturn(alert);
+        when(alert.getText()).thenReturn("This is a warning message!");
+        when(webDriver.findElement(any(By.class))).thenReturn(webElement);
+        when(webElement.getText()).thenReturn("Ok");
+        when(webElement.isDisplayed()).thenReturn(true, true, true, true, true, true, true, true, true, true, true, true, true)
+                .thenReturn(false);
+        when(webElement.isEnabled()).thenReturn(true);
+        when(webElement.getAttribute("type")).thenReturn("submit");
+        when(webElement.getAttribute("value")).thenReturn("Foo");
+        when(webElement.getAttribute("enabled")).thenReturn("true");
+        when(webElement.getCssValue("color")).thenReturn("#000000");
+        when(webElement.getTagName()).thenReturn("button", "select");
+        when(webElement.findElements(any(By.class))).thenReturn(List.of(option));
+        when(option.isEnabled()).thenReturn(true);
+        when(option.getText()).thenReturn("new-value");
+        when(webDriver.executeScript(any(String.class), any(Object[].class))).thenReturn(Collections.emptyList()).thenReturn(List.of("Something went wrong"));
+        when(webDriver.navigate()).thenReturn(navigation);
+        when(webDriver.getWindowHandles()).thenReturn(Set.of("switchWindow", "closeWindow")).thenReturn(Set.of("newWindow", "switchWindow", "closeWindow"));
+        when(webDriver.getWindowHandle()).thenReturn("newWindow", "switchWindow", "closeWindow");
+        when(targetLocator.window(any(String.class))).thenReturn(webDriver);
+        when(browser.getStoredFile(any(String.class))).thenReturn("file.txt");
+        when(webDriver.manage()).thenReturn(options);
+    }
+
+    @Test
+    public void shouldLoadSeleniumActions() throws IOException {
+        XmlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/selenium/xml/selenium-test.xml");
+
+        context.getReferenceResolver().bind("seleniumBrowser", browser);
+        context.getReferenceResolver().bind("userForm", webPage);
+        context.getReferenceResolver().bind("pageValidator", pageValidator);
+
+        context.setVariable("switchWindow", "switchWindow");
+        context.setVariable("closeWindow", "closeWindow");
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "SeleniumTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 23L);
+
+        int actionIndex = 0;
+
+        StartBrowserAction startAction = (StartBrowserAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(startAction.getBrowser());
+        Assert.assertEquals(startAction.getName(), "selenium:start");
+
+        AlertAction alertAction = (AlertAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(alertAction.getBrowser());
+        Assert.assertEquals(alertAction.getName(), "selenium:alert");
+        Assert.assertNull(alertAction.getText());
+        Assert.assertTrue(alertAction.isAccept());
+
+        alertAction = (AlertAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(alertAction.getBrowser());
+        Assert.assertEquals(alertAction.getName(), "selenium:alert");
+        Assert.assertEquals(alertAction.getText(), "This is a warning message!");
+        Assert.assertFalse(alertAction.isAccept());
+
+        FindElementAction findElementAction = (FindElementAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(findElementAction.getBrowser());
+        Assert.assertEquals(findElementAction.getName(), "selenium:find");
+        Assert.assertEquals(findElementAction.getBy().toString(), "By.className: clickable");
+        Assert.assertEquals(findElementAction.getTagName(), "button");
+        Assert.assertEquals(findElementAction.getText(), "Ok");
+        Assert.assertEquals(findElementAction.getAttributes().size(), 1L);
+        Assert.assertEquals(findElementAction.getAttributes().get("type"), "submit");
+        Assert.assertEquals(findElementAction.getStyles().size(), 1L);
+        Assert.assertEquals(findElementAction.getStyles().get("color"), "#000000");
+        Assert.assertTrue(findElementAction.isDisplayed());
+        Assert.assertTrue(findElementAction.isEnabled());
+
+        PageAction pageAction = (PageAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(pageAction.getBrowser());
+        Assert.assertEquals(pageAction.getName(), "selenium:page");
+        Assert.assertEquals(pageAction.getAction(), "setUserName");
+        Assert.assertEquals(pageAction.getPage(), context.getReferenceResolver().resolve("userForm"));
+        Assert.assertNull(pageAction.getType());
+        Assert.assertEquals(pageAction.getArguments().size(), 1L);
+        Assert.assertEquals(pageAction.getArguments().get(0), "${username}");
+        Assert.assertNull(pageAction.getValidator());
+
+        pageAction = (PageAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(pageAction.getBrowser());
+        Assert.assertEquals(pageAction.getName(), "selenium:page");
+        Assert.assertEquals(pageAction.getAction(), "validate");
+        Assert.assertNull(pageAction.getPage());
+        Assert.assertEquals(pageAction.getType(), UserFormPage.class.getName());
+        Assert.assertEquals(pageAction.getArguments().size(), 0L);
+        Assert.assertEquals(pageAction.getValidator(), context.getReferenceResolver().resolve("pageValidator"));
+
+        ClickAction clickAction = (ClickAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(clickAction.getBrowser());
+        Assert.assertEquals(clickAction.getName(), "selenium:click");
+        Assert.assertEquals(clickAction.getBy().toString(), "By.id: edit-link");
+
+        HoverAction hoverAction = (HoverAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(hoverAction.getBrowser());
+        Assert.assertEquals(hoverAction.getName(), "selenium:hover");
+        Assert.assertEquals(hoverAction.getBy().toString(), "By.id: edit-link");
+
+        SetInputAction setInputAction = (SetInputAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(setInputAction.getBrowser());
+        Assert.assertEquals(setInputAction.getName(), "selenium:set-input");
+        Assert.assertEquals(setInputAction.getBy().toString(), "By.tagName: input");
+        Assert.assertEquals(setInputAction.getValue(), "new-value");
+
+        CheckInputAction checkInputAction = (CheckInputAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(checkInputAction.getBrowser());
+        Assert.assertEquals(checkInputAction.getName(), "selenium:check-input");
+        Assert.assertEquals(checkInputAction.getBy().toString(), "By.xpath: //input[@type='checkbox']");
+        Assert.assertTrue(checkInputAction.isChecked());
+
+        DropDownSelectAction dropDownSelect = (DropDownSelectAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(dropDownSelect.getBrowser());
+        Assert.assertEquals(dropDownSelect.getName(), "selenium:dropdown-select");
+        Assert.assertEquals(dropDownSelect.getBy().toString(), "By.name: gender");
+        Assert.assertEquals(dropDownSelect.getOption(), "male");
+        Assert.assertEquals(dropDownSelect.getOptions().size(), 0L);
+
+        DropDownSelectAction dropDownMultiSelect = (DropDownSelectAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(dropDownMultiSelect.getBrowser());
+        Assert.assertEquals(dropDownMultiSelect.getName(), "selenium:dropdown-select");
+        Assert.assertEquals(dropDownMultiSelect.getBy().toString(), "By.id: title");
+        Assert.assertNull(dropDownMultiSelect.getOption());
+        Assert.assertEquals(dropDownMultiSelect.getOptions().size(), 2L);
+
+        WaitUntilAction waitUntilAction = (WaitUntilAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(waitUntilAction.getBrowser());
+        Assert.assertEquals(waitUntilAction.getName(), "selenium:wait");
+        Assert.assertEquals(waitUntilAction.getBy().toString(), "By.id: dialog");
+        Assert.assertEquals(waitUntilAction.getCondition(), "hidden");
+
+        JavaScriptAction javaScriptAction = (JavaScriptAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(javaScriptAction.getBrowser());
+        Assert.assertEquals(javaScriptAction.getName(), "selenium:javascript");
+        Assert.assertEquals(javaScriptAction.getScript(), "alert('This is awesome!')");
+        Assert.assertEquals(javaScriptAction.getExpectedErrors().size(), 1L);
+        Assert.assertEquals(javaScriptAction.getExpectedErrors().get(0), "Something went wrong");
+
+        MakeScreenshotAction screenshotAction = (MakeScreenshotAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(screenshotAction.getBrowser());
+        Assert.assertEquals(screenshotAction.getName(), "selenium:screenshot");
+        Assert.assertEquals(screenshotAction.getOutputDir(), "/tmp/storage");
+
+        NavigateAction navigateAction = (NavigateAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(navigateAction.getBrowser());
+        Assert.assertEquals(navigateAction.getName(), "selenium:navigate");
+        Assert.assertEquals(navigateAction.getPage(), "back");
+
+        OpenWindowAction openWindowAction = (OpenWindowAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(openWindowAction.getBrowser());
+        Assert.assertEquals(openWindowAction.getName(), "selenium:open-window");
+        Assert.assertEquals(openWindowAction.getWindowName(), "newWindow");
+
+        SwitchWindowAction switchWindowAction = (SwitchWindowAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(switchWindowAction.getBrowser());
+        Assert.assertEquals(switchWindowAction.getName(), "selenium:switch-window");
+        Assert.assertEquals(switchWindowAction.getWindowName(), "switchWindow");
+
+        CloseWindowAction closeWindowAction = (CloseWindowAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(closeWindowAction.getBrowser());
+        Assert.assertEquals(closeWindowAction.getName(), "selenium:close-window");
+        Assert.assertEquals(closeWindowAction.getWindowName(), "closeWindow");
+
+        StoreFileAction storeFileAction = (StoreFileAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(storeFileAction.getBrowser());
+        Assert.assertEquals(storeFileAction.getName(), "selenium:store-file");
+        Assert.assertEquals(storeFileAction.getFilePath(), "classpath:download/file.txt");
+
+        GetStoredFileAction getStoredFileAction = (GetStoredFileAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(getStoredFileAction.getBrowser());
+        Assert.assertEquals(getStoredFileAction.getName(), "selenium:get-stored-file");
+        Assert.assertEquals(getStoredFileAction.getFileName(), "file.txt");
+
+        ClearBrowserCacheAction clearCacheAction = (ClearBrowserCacheAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(clearCacheAction.getBrowser());
+        Assert.assertEquals(clearCacheAction.getName(), "selenium:clear-cache");
+
+        StopBrowserAction stopAction = (StopBrowserAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(stopAction.getBrowser());
+        Assert.assertEquals(stopAction.getName(), "selenium:stop");
+    }
+
+    @Test
+    public void shouldLookupTestActionBuilder() {
+        Assert.assertTrue(XmlTestActionBuilder.lookup("selenium").isPresent());
+        Assert.assertEquals(XmlTestActionBuilder.lookup("selenium").get().getClass(), Selenium.class);
+    }
+
+}

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/yaml/AbstractYamlActionTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/yaml/AbstractYamlActionTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.selenium.yaml;
+
+import org.citrusframework.Citrus;
+import org.citrusframework.CitrusContext;
+import org.citrusframework.CitrusInstanceManager;
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.annotations.CitrusAnnotations;
+import org.citrusframework.context.StaticTestContextFactory;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.testng.AbstractTestNGUnitTest;
+import org.citrusframework.yaml.YamlTestLoader;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeClass;
+
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class AbstractYamlActionTest extends AbstractTestNGUnitTest {
+
+    protected Citrus citrus;
+
+    @Mock
+    protected CitrusContext citrusContext;
+
+    @BeforeClass
+    public void setupMocks() {
+        MockitoAnnotations.openMocks(this);
+        citrus = CitrusInstanceManager.newInstance(() -> citrusContext);
+    }
+
+    @Override
+    protected TestContext createTestContext() {
+        TestContext context = super.createTestContext();
+        when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
+        when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
+        when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        CitrusAnnotations.injectAll(this, citrus, context);
+        return context;
+    }
+
+    protected YamlTestLoader createTestLoader(String sourcePath) {
+        YamlTestLoader testLoader = new YamlTestLoader(this.getClass(), "Test", this.getClass().getPackageName());
+        CitrusAnnotations.injectAll(testLoader, citrus, context);
+        CitrusAnnotations.injectTestRunner(testLoader, new DefaultTestCaseRunner(context));
+        testLoader.setSource(sourcePath);
+
+        return testLoader;
+    }
+}

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/yaml/SeleniumTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/yaml/SeleniumTest.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.selenium.yaml;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.selenium.actions.*;
+import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+import org.citrusframework.selenium.endpoint.SeleniumBrowserConfiguration;
+import org.citrusframework.selenium.model.PageValidator;
+import org.citrusframework.selenium.model.WebPage;
+import org.citrusframework.selenium.pages.UserFormPage;
+import org.citrusframework.yaml.YamlTestLoader;
+import org.citrusframework.yaml.actions.YamlTestActionBuilder;
+import org.mockito.Mock;
+import org.openqa.selenium.Alert;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.htmlunit.HtmlUnitDriver;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class SeleniumTest extends AbstractYamlActionTest {
+
+    @Mock
+    private SeleniumBrowser browser;
+
+    @Mock
+    private HtmlUnitDriver webDriver;
+
+    @Mock
+    private WebDriver.TargetLocator targetLocator;
+
+    @Mock
+    private Alert alert;
+
+    @Mock
+    private WebElement webElement;
+
+    @Mock
+    private WebElement option;
+
+    @Mock
+    private WebPage webPage;
+
+    @Mock
+    private PageValidator<?> pageValidator;
+
+    @Mock
+    private WebDriver.Navigation navigation;
+
+    @Mock
+    private WebDriver.Options options;
+
+    @BeforeClass
+    @Override
+    public void setupMocks() {
+        super.setupMocks();
+
+        SeleniumBrowserConfiguration configuration = new SeleniumBrowserConfiguration();
+        when(browser.getEndpointConfiguration()).thenReturn(configuration);
+        when(browser.getName()).thenReturn("seleniumBrowser");
+        when(browser.getWebDriver()).thenReturn(webDriver);
+        when(webDriver.switchTo()).thenReturn(targetLocator);
+        when(targetLocator.alert()).thenReturn(alert);
+        when(alert.getText()).thenReturn("This is a warning message!");
+        when(webDriver.findElement(any(By.class))).thenReturn(webElement);
+        when(webElement.getText()).thenReturn("Ok");
+        when(webElement.isDisplayed()).thenReturn(true, true, true, true, true, true, true, true, true, true, true, true, true)
+                .thenReturn(false);
+        when(webElement.isEnabled()).thenReturn(true);
+        when(webElement.getAttribute("type")).thenReturn("submit");
+        when(webElement.getAttribute("value")).thenReturn("Foo");
+        when(webElement.getAttribute("enabled")).thenReturn("true");
+        when(webElement.getCssValue("color")).thenReturn("#000000");
+        when(webElement.getTagName()).thenReturn("button", "select");
+        when(webElement.findElements(any(By.class))).thenReturn(List.of(option));
+        when(option.isEnabled()).thenReturn(true);
+        when(option.getText()).thenReturn("new-value");
+        when(webDriver.executeScript(any(String.class), any(Object[].class))).thenReturn(Collections.emptyList()).thenReturn(List.of("Something went wrong"));
+        when(webDriver.navigate()).thenReturn(navigation);
+        when(webDriver.getWindowHandles()).thenReturn(Set.of("switchWindow", "closeWindow")).thenReturn(Set.of("newWindow", "switchWindow", "closeWindow"));
+        when(webDriver.getWindowHandle()).thenReturn("newWindow", "switchWindow", "closeWindow");
+        when(targetLocator.window(any(String.class))).thenReturn(webDriver);
+        when(browser.getStoredFile(any(String.class))).thenReturn("file.txt");
+        when(webDriver.manage()).thenReturn(options);
+    }
+
+    @Test
+    public void shouldLoadSeleniumActions() throws IOException {
+        YamlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/selenium/yaml/selenium-test.yaml");
+
+        context.getReferenceResolver().bind("seleniumBrowser", browser);
+        context.getReferenceResolver().bind("userForm", webPage);
+        context.getReferenceResolver().bind("pageValidator", pageValidator);
+
+        context.setVariable("switchWindow", "switchWindow");
+        context.setVariable("closeWindow", "closeWindow");
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "SeleniumTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 23L);
+
+        int actionIndex = 0;
+
+        StartBrowserAction startAction = (StartBrowserAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(startAction.getBrowser());
+        Assert.assertEquals(startAction.getName(), "selenium:start");
+
+        AlertAction alertAction = (AlertAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(alertAction.getBrowser());
+        Assert.assertEquals(alertAction.getName(), "selenium:alert");
+        Assert.assertNull(alertAction.getText());
+        Assert.assertTrue(alertAction.isAccept());
+
+        alertAction = (AlertAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(alertAction.getBrowser());
+        Assert.assertEquals(alertAction.getName(), "selenium:alert");
+        Assert.assertEquals(alertAction.getText(), "This is a warning message!");
+        Assert.assertFalse(alertAction.isAccept());
+
+        FindElementAction findElementAction = (FindElementAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(findElementAction.getBrowser());
+        Assert.assertEquals(findElementAction.getName(), "selenium:find");
+        Assert.assertEquals(findElementAction.getBy().toString(), "By.className: clickable");
+        Assert.assertEquals(findElementAction.getTagName(), "button");
+        Assert.assertEquals(findElementAction.getText(), "Ok");
+        Assert.assertEquals(findElementAction.getAttributes().size(), 1L);
+        Assert.assertEquals(findElementAction.getAttributes().get("type"), "submit");
+        Assert.assertEquals(findElementAction.getStyles().size(), 1L);
+        Assert.assertEquals(findElementAction.getStyles().get("color"), "#000000");
+        Assert.assertTrue(findElementAction.isDisplayed());
+        Assert.assertTrue(findElementAction.isEnabled());
+
+        PageAction pageAction = (PageAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(pageAction.getBrowser());
+        Assert.assertEquals(pageAction.getName(), "selenium:page");
+        Assert.assertEquals(pageAction.getAction(), "setUserName");
+        Assert.assertEquals(pageAction.getPage(), context.getReferenceResolver().resolve("userForm"));
+        Assert.assertNull(pageAction.getType());
+        Assert.assertEquals(pageAction.getArguments().size(), 1L);
+        Assert.assertEquals(pageAction.getArguments().get(0), "${username}");
+        Assert.assertNull(pageAction.getValidator());
+
+        pageAction = (PageAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(pageAction.getBrowser());
+        Assert.assertEquals(pageAction.getName(), "selenium:page");
+        Assert.assertEquals(pageAction.getAction(), "validate");
+        Assert.assertNull(pageAction.getPage());
+        Assert.assertEquals(pageAction.getType(), UserFormPage.class.getName());
+        Assert.assertEquals(pageAction.getArguments().size(), 0L);
+        Assert.assertEquals(pageAction.getValidator(), context.getReferenceResolver().resolve("pageValidator"));
+
+        ClickAction clickAction = (ClickAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(clickAction.getBrowser());
+        Assert.assertEquals(clickAction.getName(), "selenium:click");
+        Assert.assertEquals(clickAction.getBy().toString(), "By.id: edit-link");
+
+        HoverAction hoverAction = (HoverAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(hoverAction.getBrowser());
+        Assert.assertEquals(hoverAction.getName(), "selenium:hover");
+        Assert.assertEquals(hoverAction.getBy().toString(), "By.id: edit-link");
+
+        SetInputAction setInputAction = (SetInputAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(setInputAction.getBrowser());
+        Assert.assertEquals(setInputAction.getName(), "selenium:set-input");
+        Assert.assertEquals(setInputAction.getBy().toString(), "By.tagName: input");
+        Assert.assertEquals(setInputAction.getValue(), "new-value");
+
+        CheckInputAction checkInputAction = (CheckInputAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(checkInputAction.getBrowser());
+        Assert.assertEquals(checkInputAction.getName(), "selenium:check-input");
+        Assert.assertEquals(checkInputAction.getBy().toString(), "By.xpath: //input[@type: 'checkbox']");
+        Assert.assertTrue(checkInputAction.isChecked());
+
+        DropDownSelectAction dropDownSelect = (DropDownSelectAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(dropDownSelect.getBrowser());
+        Assert.assertEquals(dropDownSelect.getName(), "selenium:dropdown-select");
+        Assert.assertEquals(dropDownSelect.getBy().toString(), "By.name: gender");
+        Assert.assertEquals(dropDownSelect.getOption(), "male");
+        Assert.assertEquals(dropDownSelect.getOptions().size(), 0L);
+
+        DropDownSelectAction dropDownMultiSelect = (DropDownSelectAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(dropDownMultiSelect.getBrowser());
+        Assert.assertEquals(dropDownMultiSelect.getName(), "selenium:dropdown-select");
+        Assert.assertEquals(dropDownMultiSelect.getBy().toString(), "By.id: title");
+        Assert.assertNull(dropDownMultiSelect.getOption());
+        Assert.assertEquals(dropDownMultiSelect.getOptions().size(), 2L);
+
+        WaitUntilAction waitUntilAction = (WaitUntilAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(waitUntilAction.getBrowser());
+        Assert.assertEquals(waitUntilAction.getName(), "selenium:wait");
+        Assert.assertEquals(waitUntilAction.getBy().toString(), "By.id: dialog");
+        Assert.assertEquals(waitUntilAction.getCondition(), "hidden");
+
+        JavaScriptAction javaScriptAction = (JavaScriptAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(javaScriptAction.getBrowser());
+        Assert.assertEquals(javaScriptAction.getName(), "selenium:javascript");
+        Assert.assertEquals(javaScriptAction.getScript(), "alert('This is awesome!')");
+        Assert.assertEquals(javaScriptAction.getExpectedErrors().size(), 1L);
+        Assert.assertEquals(javaScriptAction.getExpectedErrors().get(0), "Something went wrong");
+
+        MakeScreenshotAction screenshotAction = (MakeScreenshotAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(screenshotAction.getBrowser());
+        Assert.assertEquals(screenshotAction.getName(), "selenium:screenshot");
+        Assert.assertEquals(screenshotAction.getOutputDir(), "/tmp/storage");
+
+        NavigateAction navigateAction = (NavigateAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(navigateAction.getBrowser());
+        Assert.assertEquals(navigateAction.getName(), "selenium:navigate");
+        Assert.assertEquals(navigateAction.getPage(), "back");
+
+        OpenWindowAction openWindowAction = (OpenWindowAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(openWindowAction.getBrowser());
+        Assert.assertEquals(openWindowAction.getName(), "selenium:open-window");
+        Assert.assertEquals(openWindowAction.getWindowName(), "newWindow");
+
+        SwitchWindowAction switchWindowAction = (SwitchWindowAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(switchWindowAction.getBrowser());
+        Assert.assertEquals(switchWindowAction.getName(), "selenium:switch-window");
+        Assert.assertEquals(switchWindowAction.getWindowName(), "switchWindow");
+
+        CloseWindowAction closeWindowAction = (CloseWindowAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(closeWindowAction.getBrowser());
+        Assert.assertEquals(closeWindowAction.getName(), "selenium:close-window");
+        Assert.assertEquals(closeWindowAction.getWindowName(), "closeWindow");
+
+        StoreFileAction storeFileAction = (StoreFileAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(storeFileAction.getBrowser());
+        Assert.assertEquals(storeFileAction.getName(), "selenium:store-file");
+        Assert.assertEquals(storeFileAction.getFilePath(), "classpath:download/file.txt");
+
+        GetStoredFileAction getStoredFileAction = (GetStoredFileAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(getStoredFileAction.getBrowser());
+        Assert.assertEquals(getStoredFileAction.getName(), "selenium:get-stored-file");
+        Assert.assertEquals(getStoredFileAction.getFileName(), "file.txt");
+
+        ClearBrowserCacheAction clearCacheAction = (ClearBrowserCacheAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(clearCacheAction.getBrowser());
+        Assert.assertEquals(clearCacheAction.getName(), "selenium:clear-cache");
+
+        StopBrowserAction stopAction = (StopBrowserAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(stopAction.getBrowser());
+        Assert.assertEquals(stopAction.getName(), "selenium:stop");
+    }
+
+    @Test
+    public void shouldLookupTestActionBuilder() {
+        Assert.assertTrue(YamlTestActionBuilder.lookup().containsKey("selenium"));
+        Assert.assertTrue(YamlTestActionBuilder.lookup("selenium").isPresent());
+        Assert.assertEquals(YamlTestActionBuilder.lookup("selenium").get().getClass(), Selenium.class);
+    }
+
+}

--- a/connectors/citrus-selenium/src/test/resources/org/citrusframework/selenium/groovy/selenium.test.groovy
+++ b/connectors/citrus-selenium/src/test/resources/org/citrusframework/selenium/groovy/selenium.test.groovy
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.selenium.groovy
+
+import org.openqa.selenium.By
+
+import static org.citrusframework.selenium.actions.SeleniumActionBuilder.selenium
+
+name "SeleniumTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+actions {
+    $(selenium()
+        .browser(seleniumBrowser)
+        .start()
+    )
+
+    $(selenium()
+        .alert()
+        .accept()
+    )
+
+    $(selenium()
+        .alert()
+        .dismiss()
+        .text("This is a warning message!")
+    )
+
+    $(selenium()
+        .find()
+          .element(By.className("clickable"))
+          .tagName("button")
+          .text("Ok")
+          .displayed(true)
+          .enabled(true)
+          .attribute("type", "submit")
+          .style("color", "#000000")
+    )
+
+    $(selenium()
+        .page(userForm)
+        .action("setUserName")
+        .argument('${username}')
+    )
+
+    $(selenium()
+        .page(org.citrusframework.selenium.pages.UserFormPage.class)
+        .action("validate")
+        .validator(pageValidator)
+    )
+
+    $(selenium()
+        .click()
+        .element(By.id("edit-link"))
+    )
+
+    $(selenium()
+        .hover()
+        .element(By.id("edit-link"))
+    )
+
+    $(selenium()
+        .setInput()
+        .value("new-value")
+        .element(By.tagName("input"))
+    )
+
+    $(selenium()
+        .checkInput()
+        .checked(true)
+        .element(By.xpath("//input[@type: 'checkbox']"))
+    )
+
+    $(selenium()
+        .select()
+        .option("male")
+        .element(By.name("gender"))
+    )
+
+    $(selenium()
+        .select()
+        .element(By.id("title"))
+        .options("Mr.", "Dr.")
+    )
+
+    $(selenium()
+        .waitUntil()
+        .hidden()
+        .element(By.id("dialog"))
+    )
+
+    $(selenium()
+        .javascript()
+        .script("alert('This is awesome!')")
+        .error("Something went wrong")
+    )
+
+    $(selenium()
+        .browser(seleniumBrowser)
+        .screenshot()
+        .outputDir("/tmp/storage")
+    )
+
+    $(selenium()
+        .navigate()
+        .page("back")
+    )
+
+    $(selenium()
+        .open()
+        .window("newWindow")
+    )
+
+    $(selenium()
+        .focus()
+        .window("switchWindow")
+    )
+
+    $(selenium()
+        .close()
+        .window( "closeWindow")
+    )
+
+    $(selenium()
+        .store()
+        .filePath("classpath:download/file.txt")
+    )
+
+    $(selenium()
+        .getStored()
+        .fileName("file.txt")
+    )
+
+    $(selenium()
+        .clearCache()
+    )
+
+    $(selenium()
+        .stop()
+        .browser(seleniumBrowser)
+    )
+}

--- a/connectors/citrus-selenium/src/test/resources/org/citrusframework/selenium/xml/selenium-test.xml
+++ b/connectors/citrus-selenium/src/test/resources/org/citrusframework/selenium/xml/selenium-test.xml
@@ -1,0 +1,158 @@
+<!--
+  ~ Copyright 2021 the original author or authors.
+  ~
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements. See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License. You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<test name="SeleniumTest" author="Christoph" status="FINAL" xmlns="http://citrusframework.org/schema/xml/testcase"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://citrusframework.org/schema/xml/testcase http://citrusframework.org/schema/xml/testcase/citrus-testcase.xsd">
+  <description>Sample test in XML</description>
+  <actions>
+    <selenium>
+      <start browser="seleniumBrowser"/>
+    </selenium>
+
+    <selenium>
+      <alert accept="true"/>
+    </selenium>
+
+    <selenium>
+      <alert accept="false">
+        <text>This is a warning message!</text>
+      </alert>
+    </selenium>
+
+    <selenium>
+      <find>
+        <element class-name="clickable"/>
+        <validate text="Ok" displayed="true" enabled="true" tag-name="button">
+          <attributes>
+            <attribute name="type" value="submit"/>
+          </attributes>
+          <styles>
+            <style name="color" value="#000000"/>
+          </styles>
+        </validate>
+      </find>
+    </selenium>
+
+    <selenium>
+      <page name="userForm" action="setUserName">
+        <arguments>
+          <argument>${username}</argument>
+        </arguments>
+      </page>
+    </selenium>
+
+    <selenium>
+      <page type="org.citrusframework.selenium.pages.UserFormPage"
+             action="validate"
+             validator="pageValidator"/>
+    </selenium>
+
+    <selenium>
+      <click>
+        <element id="edit-link"/>
+      </click>
+    </selenium>
+
+    <selenium>
+      <hover>
+        <element id="edit-link"/>
+      </hover>
+    </selenium>
+
+    <selenium>
+      <set-input value="new-value">
+        <element tag-name="input"/>
+      </set-input>
+    </selenium>
+
+    <selenium>
+      <check-input checked="true">
+        <element xpath="//input[@type='checkbox']"/>
+      </check-input>
+    </selenium>
+
+    <selenium>
+      <dropdown-select option="male">
+        <element name="gender"/>
+      </dropdown-select>
+    </selenium>
+
+    <selenium>
+      <dropdown-select>
+        <element id="title"/>
+        <options>
+          <option>Mr.</option>
+          <option>Dr.</option>
+        </options>
+      </dropdown-select>
+    </selenium>
+
+    <selenium>
+      <wait until="hidden">
+        <element id="dialog"/>
+      </wait>
+    </selenium>
+
+    <selenium>
+      <javascript>
+        <script>alert('This is awesome!')</script>
+        <errors>
+          <error>Something went wrong</error>
+        </errors>
+      </javascript>
+    </selenium>
+
+    <selenium browser="seleniumBrowser" >
+      <screenshot output-dir="/tmp/storage"/>
+    </selenium>
+
+    <selenium>
+      <navigate page="back"/>
+    </selenium>
+
+    <selenium>
+      <open-window name="newWindow"/>
+    </selenium>
+
+    <selenium>
+      <switch-window name="switchWindow"/>
+    </selenium>
+
+    <selenium>
+      <close-window name="closeWindow"/>
+    </selenium>
+
+    <selenium>
+      <store-file file-path="classpath:download/file.txt"/>
+    </selenium>
+
+    <selenium>
+      <get-stored-file file-name="file.txt"/>
+    </selenium>
+
+    <selenium>
+      <clear-cache/>
+    </selenium>
+
+    <selenium>
+      <stop browser="seleniumBrowser"/>
+    </selenium>
+  </actions>
+</test>

--- a/connectors/citrus-selenium/src/test/resources/org/citrusframework/selenium/yaml/selenium-test.yaml
+++ b/connectors/citrus-selenium/src/test/resources/org/citrusframework/selenium/yaml/selenium-test.yaml
@@ -1,0 +1,125 @@
+name: "SeleniumTest"
+author: "Christoph"
+status: "FINAL"
+actions:
+  - selenium:
+      browser: "seleniumBrowser"
+      start: {}
+
+  - selenium:
+      alert:
+        accept: true
+
+  - selenium:
+      alert:
+        accept: false
+        text: This is a warning message!
+
+  - selenium:
+      find:
+        element:
+          class-name: "clickable"
+        validate:
+          tag-name: "button"
+          text: "Ok"
+          displayed: true
+          enabled: true
+          attributes:
+            - name: "type"
+              value: "submit"
+          styles:
+            - name: "color"
+              value: "#000000"
+
+  - selenium:
+      page:
+        name: "userForm"
+        action: "setUserName"
+        argument: ${username}
+
+  - selenium:
+      page:
+        type: "org.citrusframework.selenium.pages.UserFormPage"
+        action: "validate"
+        validator: "pageValidator"
+
+  - selenium:
+      click:
+        element:
+          id: "edit-link"
+
+  - selenium:
+      hover:
+        element:
+          id: "edit-link"
+
+  - selenium:
+      set-input:
+        value: "new-value"
+        element:
+          tag-name: "input"
+
+  - selenium:
+      check-input:
+        checked: true
+        element:
+          xpath: "//input[@type: 'checkbox']"
+
+  - selenium:
+      dropdown-select:
+        option: "male"
+        element:
+          name: "gender"
+
+  - selenium:
+      dropdown-select:
+        element:
+          id: "title"
+        options:
+          - "Mr."
+          - "Dr."
+
+  - selenium:
+      wait-until:
+        condition: "hidden"
+        element:
+          id: "dialog"
+
+  - selenium:
+      javaScript:
+        script: "alert('This is awesome!')"
+        errors:
+          - Something went wrong
+
+  - selenium:
+      browser: seleniumBrowser
+      screenshot:
+        output-dir: "/tmp/storage"
+
+  - selenium:
+      navigate:
+        page: "back"
+
+  - selenium:
+      open-window:
+        name: "newWindow"
+  - selenium:
+      switch-window:
+        name: "switchWindow"
+  - selenium:
+      close-window:
+        name: "closeWindow"
+
+  - selenium:
+      store-file:
+        file-path: "classpath:download/file.txt"
+  - selenium:
+      get-stored-file:
+        file-name: "file.txt"
+
+  - selenium:
+      clear-cache: {}
+
+  - selenium:
+      stop:
+        browser: "seleniumBrowser"

--- a/connectors/citrus-sql/pom.xml
+++ b/connectors/citrus-sql/pom.xml
@@ -39,6 +39,12 @@
     </dependency>
     <dependency>
       <groupId>org.citrusframework</groupId>
+      <artifactId>citrus-groovy</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.citrusframework</groupId>
       <artifactId>citrus-xml</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/connectors/citrus-sql/src/test/java/org/citrusframework/sql/groovy/AbstractGroovyActionDslTest.java
+++ b/connectors/citrus-sql/src/test/java/org/citrusframework/sql/groovy/AbstractGroovyActionDslTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.sql.groovy;
+
+import org.citrusframework.Citrus;
+import org.citrusframework.CitrusContext;
+import org.citrusframework.CitrusInstanceManager;
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.annotations.CitrusAnnotations;
+import org.citrusframework.context.StaticTestContextFactory;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.citrusframework.testng.AbstractTestNGUnitTest;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeClass;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class AbstractGroovyActionDslTest extends AbstractTestNGUnitTest {
+
+    protected Citrus citrus;
+
+    @Mock
+    protected CitrusContext citrusContext;
+
+    @BeforeClass
+    public void setupMocks() {
+        MockitoAnnotations.openMocks(this);
+        citrus = CitrusInstanceManager.newInstance(() -> citrusContext);
+    }
+
+    @Override
+    protected TestContext createTestContext() {
+        TestContext context = super.createTestContext();
+        doAnswer(invocation -> {
+            context.getReferenceResolver().bind(invocation.getArgument(0, String.class), invocation.getArgument(1));
+            return null;
+        }).when(citrusContext).bind(any(String.class), any());
+
+        when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
+        when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
+        when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        CitrusAnnotations.injectAll(this, citrus, context);
+        return context;
+    }
+
+    protected GroovyTestLoader createTestLoader(String sourcePath) {
+        GroovyTestLoader testLoader = new GroovyTestLoader().source(sourcePath);
+        CitrusAnnotations.injectAll(testLoader, citrus, context);
+        CitrusAnnotations.injectTestRunner(testLoader, new DefaultTestCaseRunner(context));
+
+        return testLoader;
+    }
+}

--- a/connectors/citrus-sql/src/test/java/org/citrusframework/sql/groovy/PlsqlTest.java
+++ b/connectors/citrus-sql/src/test/java/org/citrusframework/sql/groovy/PlsqlTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.sql.groovy;
+
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.actions.ExecutePLSQLAction;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.citrusframework.spi.BindToRegistry;
+import org.mockito.Mockito;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class PlsqlTest extends AbstractGroovyActionDslTest {
+
+    @BindToRegistry
+    private final BasicDataSource dataSource = new BasicDataSource();
+
+    @BindToRegistry
+    private final PlatformTransactionManager mockTransactionManager = Mockito.mock(PlatformTransactionManager.class);
+
+    @BeforeClass
+    public void setupDataSource() {
+        dataSource.setDriverClassName("org.hsqldb.jdbcDriver");
+        dataSource.setUrl("jdbc:hsqldb:mem:plsql-groovy-test");
+        dataSource.setUsername("sa");
+        dataSource.setPassword("");
+    }
+
+    @Test
+    public void shouldLoadPlsql() {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/sql/groovy/plsql.test.groovy");
+
+        testLoader.load();
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "PlsqlTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 2L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), ExecutePLSQLAction.class);
+
+        int actionIndex = 0;
+
+        ExecutePLSQLAction action = (ExecutePLSQLAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getName(), "plsql");
+        Assert.assertNotNull(action.getDataSource());
+        Assert.assertEquals(action.getDataSource(), dataSource);
+        Assert.assertNotNull(action.getSqlResourcePath());
+        Assert.assertNull(action.getScript());
+        Assert.assertTrue(action.isIgnoreErrors());
+        Assert.assertNull(action.getTransactionManager());
+        Assert.assertEquals(action.getTransactionTimeout(), "-1");
+        Assert.assertEquals(action.getTransactionIsolationLevel(), "ISOLATION_DEFAULT");
+
+        action = (ExecutePLSQLAction) result.getTestAction(actionIndex);
+        Assert.assertEquals(action.getName(), "plsql");
+        Assert.assertNotNull(action.getDataSource());
+        Assert.assertEquals(action.getDataSource(), dataSource);
+        Assert.assertNull(action.getSqlResourcePath());
+        Assert.assertTrue(action.getScript().length() > 0);
+        Assert.assertTrue(action.isIgnoreErrors());
+        Assert.assertEquals(action.getTransactionManager(), mockTransactionManager);
+        Assert.assertEquals(action.getTransactionTimeout(), "5000");
+        Assert.assertEquals(action.getTransactionIsolationLevel(), "ISOLATION_READ_COMMITTED");
+    }
+
+}

--- a/connectors/citrus-sql/src/test/java/org/citrusframework/sql/groovy/SqlTest.java
+++ b/connectors/citrus-sql/src/test/java/org/citrusframework/sql/groovy/SqlTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.sql.groovy;
+
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.actions.ExecuteSQLAction;
+import org.citrusframework.actions.ExecuteSQLQueryAction;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.citrusframework.spi.BindToRegistry;
+import org.citrusframework.validation.script.sql.SqlResultSetScriptValidator;
+import org.mockito.Mockito;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class SqlTest extends AbstractGroovyActionDslTest {
+
+    @BindToRegistry
+    private final BasicDataSource dataSource = new BasicDataSource();
+
+    @BindToRegistry
+    private final PlatformTransactionManager mockTransactionManager = Mockito.mock(PlatformTransactionManager.class);
+
+    @BindToRegistry
+    private final SqlResultSetScriptValidator validator = Mockito.mock(SqlResultSetScriptValidator.class);
+
+    @BeforeClass
+    public void setupDataSource() {
+        dataSource.setDriverClassName("org.hsqldb.jdbcDriver");
+        dataSource.setUrl("jdbc:hsqldb:mem:sql-groovy-test");
+        dataSource.setUsername("sa");
+        dataSource.setPassword("");
+
+        new JdbcTemplate(dataSource).update("create table message (id integer, text varchar(50))");
+    }
+
+    @Test
+    public void shouldLoadSql() {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/sql/groovy/sql.test.groovy");
+
+        testLoader.load();
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "SqlTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 2L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), ExecuteSQLAction.class);
+
+        int actionIndex = 0;
+
+        ExecuteSQLAction action = (ExecuteSQLAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getDataSource());
+        Assert.assertEquals(action.getDataSource(), dataSource);
+        Assert.assertNull(action.getSqlResourcePath());
+        Assert.assertEquals(action.getStatements().size(), 2);
+        Assert.assertEquals(action.getStatements().get(0), "insert into message values (100, 'Hello from Citrus!')");
+        Assert.assertEquals(action.getStatements().get(1), "update message set text='Hello' where id=100");
+        Assert.assertFalse(action.isIgnoreErrors());
+        Assert.assertNull(action.getTransactionManager());
+        Assert.assertEquals(action.getTransactionTimeout(), "-1");
+        Assert.assertEquals(action.getTransactionIsolationLevel(), "ISOLATION_DEFAULT");
+
+        action = (ExecuteSQLAction) result.getTestAction(actionIndex);
+        Assert.assertNotNull(action.getDataSource());
+        Assert.assertEquals(action.getDataSource(), dataSource);
+        Assert.assertNotNull(action.getSqlResourcePath());
+        Assert.assertEquals(action.getSqlResourcePath(), "classpath:org/citrusframework/sql/test-statements.sql");
+        Assert.assertEquals(action.getStatements().size(), 0);
+        Assert.assertTrue(action.isIgnoreErrors());
+        Assert.assertEquals(action.getTransactionManager(), mockTransactionManager);
+        Assert.assertEquals(action.getTransactionTimeout(), "5000");
+        Assert.assertEquals(action.getTransactionIsolationLevel(), "ISOLATION_READ_COMMITTED");
+    }
+
+    @Test
+    public void shouldLoadSqlQuery() {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/sql/groovy/sql-query.test.groovy");
+
+        testLoader.load();
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "SqlQueryTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 6L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), ExecuteSQLAction.class);
+
+        int actionIndex = 0;
+
+        ExecuteSQLAction action = (ExecuteSQLAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getDataSource());
+        Assert.assertEquals(action.getDataSource(), dataSource);
+        Assert.assertNull(action.getSqlResourcePath());
+        Assert.assertEquals(action.getStatements().size(), 2);
+        Assert.assertEquals(action.getStatements().get(0), "insert into message values (1000, 'Hello from Citrus!')");
+        Assert.assertEquals(action.getStatements().get(1), "insert into message values (1001, 'Citrus rocks!')");
+        Assert.assertFalse(action.isIgnoreErrors());
+        Assert.assertNull(action.getTransactionManager());
+        Assert.assertEquals(action.getTransactionTimeout(), "-1");
+        Assert.assertEquals(action.getTransactionIsolationLevel(), "ISOLATION_DEFAULT");
+
+        ExecuteSQLQueryAction queryAction = (ExecuteSQLQueryAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(queryAction.getDataSource());
+        Assert.assertEquals(queryAction.getDataSource(), dataSource);
+        Assert.assertNull(queryAction.getSqlResourcePath());
+        Assert.assertEquals(queryAction.getStatements().size(), 1);
+        Assert.assertEquals(queryAction.getStatements().get(0), "select text from message where id=1000");
+        Assert.assertEquals(queryAction.getControlResultSet().size(), 1L);
+        Assert.assertEquals(queryAction.getControlResultSet().get("text").size(), 1L);
+        Assert.assertEquals(queryAction.getControlResultSet().get("text").get(0), "Hello from Citrus!");
+        Assert.assertEquals(queryAction.getExtractVariables().size(), 1);
+        Assert.assertEquals(queryAction.getExtractVariables().get("text"), "greeting");
+
+        Assert.assertEquals(context.getVariable("greeting"), "Hello from Citrus!");
+
+        queryAction = (ExecuteSQLQueryAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(queryAction.getDataSource());
+        Assert.assertEquals(queryAction.getDataSource(), dataSource);
+        Assert.assertNull(queryAction.getSqlResourcePath());
+        Assert.assertEquals(queryAction.getStatements().size(), 1);
+        Assert.assertEquals(queryAction.getStatements().get(0), "select text from message where id>=1000");
+        Assert.assertEquals(queryAction.getControlResultSet().size(), 1L);
+        Assert.assertEquals(queryAction.getControlResultSet().get("text").size(), 2L);
+        Assert.assertEquals(queryAction.getControlResultSet().get("text").get(0), "Hello from Citrus!");
+        Assert.assertEquals(queryAction.getControlResultSet().get("text").get(1), "Citrus rocks!");
+
+        queryAction = (ExecuteSQLQueryAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(queryAction.getDataSource());
+        Assert.assertEquals(queryAction.getDataSource(), dataSource);
+        Assert.assertNull(queryAction.getSqlResourcePath());
+        Assert.assertEquals(queryAction.getStatements().size(), 1);
+        Assert.assertEquals(queryAction.getStatements().get(0), "select * from message where id>=1000");
+        Assert.assertEquals(queryAction.getControlResultSet().size(), 2L);
+        Assert.assertEquals(queryAction.getControlResultSet().get("id").size(), 2L);
+        Assert.assertEquals(queryAction.getControlResultSet().get("id").get(0), "1000");
+        Assert.assertEquals(queryAction.getControlResultSet().get("id").get(1), "1001");
+        Assert.assertEquals(queryAction.getControlResultSet().get("text").size(), 2L);
+        Assert.assertEquals(queryAction.getControlResultSet().get("text").get(0), "Hello from Citrus!");
+        Assert.assertEquals(queryAction.getControlResultSet().get("text").get(1), "Citrus rocks!");
+
+        queryAction = (ExecuteSQLQueryAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(queryAction.getDataSource());
+        Assert.assertEquals(queryAction.getDataSource(), dataSource);
+        Assert.assertNull(queryAction.getSqlResourcePath());
+        Assert.assertEquals(queryAction.getStatements().size(), 1);
+        Assert.assertEquals(queryAction.getStatements().get(0), "select * from message where id>=1000");
+        Assert.assertEquals(queryAction.getControlResultSet().size(), 0L);
+        Assert.assertNotNull(queryAction.getScriptValidationContext());
+        Assert.assertEquals(queryAction.getScriptValidationContext().getValidationScript().trim(), "assert rows.size() == 2");
+
+        queryAction = (ExecuteSQLQueryAction) result.getTestAction(actionIndex);
+        Assert.assertNotNull(queryAction.getDataSource());
+        Assert.assertEquals(queryAction.getDataSource(), dataSource);
+        Assert.assertNull(queryAction.getSqlResourcePath());
+        Assert.assertEquals(queryAction.getStatements().size(), 1);
+        Assert.assertEquals(queryAction.getStatements().get(0), "select * from message where id>=1000");
+        Assert.assertEquals(queryAction.getControlResultSet().size(), 0L);
+        Assert.assertNotNull(queryAction.getScriptValidationContext());
+        Assert.assertEquals(queryAction.getScriptValidationContext().getValidationScriptResourcePath(), "classpath:org/citrusframework/sql/validate.groovy");
+    }
+
+}

--- a/connectors/citrus-sql/src/test/resources/org/citrusframework/sql/groovy/plsql.test.groovy
+++ b/connectors/citrus-sql/src/test/resources/org/citrusframework/sql/groovy/plsql.test.groovy
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.sql.groovy
+
+import static org.citrusframework.actions.ExecutePLSQLAction.Builder.plsql
+
+name "PlsqlTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+actions {
+    $(plsql()
+        .dataSource(dataSource)
+        .ignoreErrors(true)
+        .sqlResource("classpath:org/citrusframework/integration/actions/plsql.sql")
+    )
+
+    $(plsql()
+        .dataSource(dataSource)
+        .ignoreErrors(true)
+        .transactionManager(mockTransactionManager)
+        .transactionTimeout(5000)
+        .transactionIsolationLevel("ISOLATION_READ_COMMITTED")
+        .sqlScript("""
+BEGIN
+    EXECUTE IMMEDIATE 'create or replace function test (v_id in number) return number is
+      begin
+       if v_id  is null then
+        return 0;
+        end if;
+        return v_id;
+      end;';
+END;
+/"""))
+}

--- a/connectors/citrus-sql/src/test/resources/org/citrusframework/sql/groovy/sql-query.test.groovy
+++ b/connectors/citrus-sql/src/test/resources/org/citrusframework/sql/groovy/sql-query.test.groovy
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.sql.groovy
+
+import java.nio.charset.StandardCharsets
+
+import static org.citrusframework.actions.ExecuteSQLAction.Builder.sql
+import static org.citrusframework.actions.ExecuteSQLQueryAction.Builder.query
+
+name "SqlQueryTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+actions {
+    $(sql()
+        .dataSource(dataSource)
+        .statement("insert into message values (1000, 'Hello from Citrus!')")
+        .statement("insert into message values (1001, 'Citrus rocks!')")
+    )
+
+    $(query()
+        .dataSource(dataSource)
+        .statement("select text from message where id=1000")
+        .validate("text", "Hello from Citrus!")
+        .extract("text", "greeting")
+    )
+
+    $(query()
+        .dataSource(dataSource)
+        .statement("select text from message where id>=1000")
+        .validate("text", "Hello from Citrus!", "Citrus rocks!")
+    )
+
+    $(query()
+        .dataSource(dataSource)
+        .statement("select * from message where id>=1000")
+        .validate("id", "1000", "1001")
+        .validate("text", "Hello from Citrus!", "Citrus rocks!")
+    )
+
+    $(query()
+        .dataSource(dataSource)
+        .statement("select * from message where id>=1000")
+        .validateScript("assert rows.size() == 2", "groovy")
+    )
+
+    $(query()
+        .dataSource(dataSource)
+        .statement("select * from message where id>=1000")
+        .validateScriptResource("classpath:org/citrusframework/sql/validate.groovy", "groovy", StandardCharsets.UTF_8)
+    )
+}

--- a/connectors/citrus-sql/src/test/resources/org/citrusframework/sql/groovy/sql.test.groovy
+++ b/connectors/citrus-sql/src/test/resources/org/citrusframework/sql/groovy/sql.test.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.sql.groovy
+
+import static org.citrusframework.actions.ExecuteSQLAction.Builder.sql
+
+name "SqlTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+actions {
+    $(sql()
+        .dataSource(dataSource)
+        .statement("insert into message values (100, 'Hello from Citrus!')")
+        .statement("update message set text='Hello' where id=100")
+    )
+
+    $(sql()
+        .dataSource(dataSource)
+        .ignoreErrors(true)
+        .transactionManager(mockTransactionManager)
+        .transactionTimeout(5000)
+        .transactionIsolationLevel("ISOLATION_READ_COMMITTED")
+        .sqlResource("classpath:org/citrusframework/sql/test-statements.sql")
+    )
+}

--- a/core/citrus-base/src/main/java/org/citrusframework/actions/CreateVariablesAction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/actions/CreateVariablesAction.java
@@ -84,7 +84,7 @@ public class CreateVariablesAction extends AbstractTestAction {
      */
     public static final class Builder extends AbstractTestActionBuilder<CreateVariablesAction, Builder> {
 
-        private Map<String, String> variables = new LinkedHashMap<>();
+        private final Map<String, String> variables = new LinkedHashMap<>();
 
         public static Builder createVariable(String variableName, String value) {
             Builder builder = new Builder();

--- a/core/citrus-base/src/main/java/org/citrusframework/actions/EchoAction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/actions/EchoAction.java
@@ -90,6 +90,25 @@ public class EchoAction extends AbstractTestAction {
             return builder;
         }
 
+        /**
+         * Fluent API action building entry method used in Java DSL.
+         * @return
+         */
+        public static Builder print() {
+            return new Builder();
+        }
+
+        /**
+         * Fluent API action building entry method used in Java DSL.
+         * @param message
+         * @return
+         */
+        public static Builder print(String message) {
+            Builder builder = new Builder();
+            builder.message(message);
+            return builder;
+        }
+
         public Builder message(String message) {
             this.message = message;
             return this;

--- a/core/citrus-base/src/main/java/org/citrusframework/actions/FailAction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/actions/FailAction.java
@@ -60,6 +60,14 @@ public class FailAction extends AbstractTestAction {
 
         /**
          * Fluent API action building entry method used in Java DSL.
+         * @return
+         */
+        public static FailAction.Builder fail() {
+            return new Builder();
+        }
+
+        /**
+         * Fluent API action building entry method used in Java DSL.
          * @param message
          * @return
          */

--- a/core/citrus-base/src/main/java/org/citrusframework/actions/ReceiveMessageAction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/actions/ReceiveMessageAction.java
@@ -614,6 +614,17 @@ public class ReceiveMessageAction extends AbstractTestAction {
          * @param validators
          * @return
          */
+        public final B validators(final String... validators) {
+            Arrays.stream(validators).forEach(this::validator);
+            return self;
+        }
+
+        /**
+         * Sets explicit message validators for this receive action.
+         *
+         * @param validators
+         * @return
+         */
         @SafeVarargs
         public final B validators(final MessageValidator<? extends ValidationContext>... validators) {
             return validators(Arrays.asList(validators));
@@ -631,14 +642,25 @@ public class ReceiveMessageAction extends AbstractTestAction {
         }
 
         /**
-         * Sets explicit message validators by name.
+         * Sets explicit message validators for this receive action.
          *
-         * @param validatorNames
+         * @param validators
+         * @return
+         */
+        public final B validators(final HeaderValidator... validators) {
+            Stream.of(validators).forEach(this::validator);
+            return self;
+        }
+
+        /**
+         * Sets explicit message validator by name.
+         *
+         * @param validatorName
          * @return
          */
         @SuppressWarnings("unchecked")
-        public B validator(final String... validatorNames) {
-            this.validatorNames.addAll(Arrays.asList(validatorNames));
+        public B validator(final String validatorName) {
+            this.validatorNames.add(validatorName);
             return self;
         }
 
@@ -648,7 +670,7 @@ public class ReceiveMessageAction extends AbstractTestAction {
          * @param validators
          * @return
          */
-        public B validator(final HeaderValidator... validators) {
+        public B validator(final HeaderValidator validators) {
             Stream.of(validators).forEach(getHeaderValidationContext()::addHeaderValidator);
             return self;
         }

--- a/core/citrus-base/src/main/java/org/citrusframework/actions/ReceiveMessageAction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/actions/ReceiveMessageAction.java
@@ -107,7 +107,7 @@ public class ReceiveMessageAction extends AbstractTestAction {
     /** List of variable extractors responsible for creating variables from received message content */
     private final List<VariableExtractor> variableExtractors;
 
-    /** List of processors that handle the receive message */
+    /** List of processors that handle the received message */
     private final List<MessageProcessor> messageProcessors;
 
     /** List of processors that handle the control message builder */

--- a/core/citrus-base/src/main/java/org/citrusframework/actions/SleepAction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/actions/SleepAction.java
@@ -107,6 +107,10 @@ public class SleepAction extends AbstractTestAction {
         private String time = "5000";
         private TimeUnit timeUnit = TimeUnit.MILLISECONDS;
 
+        public static Builder delay() {
+            return new Builder();
+        }
+
         public static Builder sleep() {
             return new Builder();
         }

--- a/core/citrus-base/src/main/java/org/citrusframework/container/TemplateLoader.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/container/TemplateLoader.java
@@ -1,0 +1,52 @@
+package org.citrusframework.container;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.functions.Function;
+import org.citrusframework.spi.ReferenceResolverAware;
+import org.citrusframework.spi.ResourcePathTypeResolver;
+import org.citrusframework.spi.TypeResolver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public interface TemplateLoader extends ReferenceResolverAware {
+
+    /** Logger */
+    Logger LOG = LoggerFactory.getLogger(Function.class);
+
+    /** Function resource lookup path */
+    String RESOURCE_PATH = "META-INF/citrus/template/loader";
+
+    Map<String, Function> loaders = new HashMap<>();
+
+    /** Type resolver to find custom message validators on classpath via resource path lookup */
+    TypeResolver TYPE_RESOLVER = new ResourcePathTypeResolver(RESOURCE_PATH);
+
+    /**
+     * Resolves template loader from resource path lookup with given resource name. Scans classpath for meta information
+     * with given name and returns an instance of the loader. Returns optional instead of throwing exception when no template loader
+     * could be found.
+     * @param name
+     * @return
+     */
+    static Optional<TemplateLoader> lookup(String name) {
+        try {
+            TemplateLoader instance = TYPE_RESOLVER.resolve(name);
+            return Optional.of(instance);
+        } catch (CitrusRuntimeException e) {
+            LOG.warn(String.format("Failed to resolve template loader from resource '%s/%s'", RESOURCE_PATH, name));
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * Loads the template from given file.
+     * @param filePath
+     * @return
+     */
+    Template load(String filePath);
+}

--- a/core/citrus-base/src/main/java/org/citrusframework/container/Timer.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/container/Timer.java
@@ -229,6 +229,16 @@ public class Timer extends AbstractActionContainer implements StopTimer {
          *
          * @param timerId a unique timer id within the test context
          */
+        public Builder id(String timerId) {
+            this.timerId = timerId;
+            return this;
+        }
+
+        /**
+         * Set the timer's id. This is useful when referencing the timer from other test actions like stop-timer
+         *
+         * @param timerId a unique timer id within the test context
+         */
         public Builder timerId(String timerId) {
             this.timerId = timerId;
             return this;

--- a/core/citrus-base/src/main/java/org/citrusframework/dsl/PathExpressionSupport.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/dsl/PathExpressionSupport.java
@@ -22,15 +22,19 @@ package org.citrusframework.dsl;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import org.citrusframework.builder.PathExpressionAdapter;
 import org.citrusframework.builder.WithExpressions;
+import org.citrusframework.message.DelegatingPathExpressionProcessor;
+import org.citrusframework.message.MessageProcessor;
 import org.citrusframework.validation.DelegatingPayloadVariableExtractor;
+import org.citrusframework.validation.PathExpressionValidationContext;
+import org.citrusframework.validation.context.ValidationContext;
 import org.citrusframework.variable.VariableExtractor;
-import org.citrusframework.variable.VariableExtractorAdapter;
 
 /**
  * @author Christoph Deppisch
  */
-public class PathExpressionSupport implements WithExpressions<PathExpressionSupport>, VariableExtractorAdapter {
+public class PathExpressionSupport implements WithExpressions<PathExpressionSupport>, PathExpressionAdapter {
 
     private final Map<String, Object> expressions = new LinkedHashMap<>();
 
@@ -45,6 +49,20 @@ public class PathExpressionSupport implements WithExpressions<PathExpressionSupp
     @Override
     public VariableExtractor asExtractor() {
         return new DelegatingPayloadVariableExtractor.Builder()
+                .expressions(expressions)
+                .build();
+    }
+
+    @Override
+    public ValidationContext asValidationContext() {
+        return new PathExpressionValidationContext.Builder()
+                .expressions(expressions)
+                .build();
+    }
+
+    @Override
+    public MessageProcessor asProcessor() {
+        return new DelegatingPathExpressionProcessor.Builder()
                 .expressions(expressions)
                 .build();
     }

--- a/core/citrus-base/src/main/java/org/citrusframework/message/DelegatingPathExpressionProcessor.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/message/DelegatingPathExpressionProcessor.java
@@ -40,11 +40,11 @@ public class DelegatingPathExpressionProcessor implements MessageProcessor {
     private final Map<String, Object> pathExpressions;
 
     public DelegatingPathExpressionProcessor() {
-        this(new HashMap<>());
+        this(new Builder());
     }
 
-    public DelegatingPathExpressionProcessor(Map<String, Object> pathExpressions) {
-        this.pathExpressions = pathExpressions;
+    public DelegatingPathExpressionProcessor(Builder builder) {
+        this.pathExpressions = builder.expressions;
     }
 
     @Override
@@ -78,7 +78,7 @@ public class DelegatingPathExpressionProcessor implements MessageProcessor {
         }
 
         if (!xpathExpressions.isEmpty()) {
-            final Builder<?, ?> xpathProcessor = lookupMessageProcessor("xpath", context);
+            final MessageProcessor.Builder<?, ?> xpathProcessor = lookupMessageProcessor("xpath", context);
 
             if (xpathProcessor instanceof WithExpressions) {
                 ((WithExpressions<?>) xpathProcessor).expressions(xpathExpressions);
@@ -113,4 +113,36 @@ public class DelegatingPathExpressionProcessor implements MessageProcessor {
         return pathExpressions;
     }
 
+    /**
+     * Fluent builder.
+     */
+    public static final class Builder implements MessageProcessor.Builder<DelegatingPathExpressionProcessor, Builder>, WithExpressions<Builder> {
+
+        private final Map<String, Object> expressions = new HashMap<>();
+
+        /**
+         * Static entry method for fluent builder API.
+         * @return
+         */
+        public static Builder xpath() {
+            return new Builder();
+        }
+
+        @Override
+        public Builder expressions(Map<String, Object> expressions) {
+            this.expressions.putAll(expressions);
+            return this;
+        }
+
+        @Override
+        public Builder expression(final String expression, final Object value) {
+            this.expressions.put(expression, value);
+            return this;
+        }
+
+        @Override
+        public DelegatingPathExpressionProcessor build() {
+            return new DelegatingPathExpressionProcessor(this);
+        }
+    }
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/message/builder/ReceiveMessageBuilderSupport.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/message/builder/ReceiveMessageBuilderSupport.java
@@ -161,6 +161,28 @@ public class ReceiveMessageBuilderSupport<T extends ReceiveMessageAction, B exte
     }
 
     /**
+     * Sets explicit message validator names for this receive action.
+     *
+     * @param validators
+     * @return The modified receive message action builder
+     */
+    public final S validators(final String... validators) {
+        delegate.validators(validators);
+        return self;
+    }
+
+    /**
+     * Sets explicit header validators for this receive action.
+     *
+     * @param validators
+     * @return The modified receive message action builder
+     */
+    public final S validators(final HeaderValidator... validators) {
+        delegate.validators(validators);
+        return self;
+    }
+
+    /**
      * Sets explicit message validators for this receive action.
      *
      * @param validators
@@ -172,24 +194,24 @@ public class ReceiveMessageBuilderSupport<T extends ReceiveMessageAction, B exte
     }
 
     /**
-     * Sets explicit message validators by name.
+     * Sets explicit message validator by name.
      *
-     * @param validatorNames
+     * @param validatorName
      * @return The modified receive message action builder
      */
-    public S validator(final String... validatorNames) {
-        delegate.validator(validatorNames);
+    public S validator(final String validatorName) {
+        delegate.validator(validatorName);
         return self;
     }
 
     /**
      * Sets explicit header validator for this receive action.
      *
-     * @param validators
+     * @param validator
      * @return The modified receive message action builder
      */
-    public S validator(final HeaderValidator... validators) {
-        delegate.validator(validators);
+    public S validator(final HeaderValidator validator) {
+        delegate.validator(validator);
         return self;
     }
 

--- a/core/citrus-base/src/main/java/org/citrusframework/validation/json/JsonPathMessageValidationContext.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/validation/json/JsonPathMessageValidationContext.java
@@ -20,8 +20,14 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.citrusframework.builder.WithExpressions;
+import org.citrusframework.message.DelegatingPathExpressionProcessor;
+import org.citrusframework.message.MessageProcessor;
+import org.citrusframework.message.MessageProcessorAdapter;
+import org.citrusframework.validation.DelegatingPayloadVariableExtractor;
 import org.citrusframework.validation.context.DefaultValidationContext;
 import org.citrusframework.validation.context.ValidationContext;
+import org.citrusframework.variable.VariableExtractor;
+import org.citrusframework.variable.VariableExtractorAdapter;
 import org.springframework.util.StringUtils;
 
 /**
@@ -53,7 +59,7 @@ public class JsonPathMessageValidationContext extends DefaultValidationContext {
      * Fluent builder.
      */
     public static final class Builder
-            implements ValidationContext.Builder<JsonPathMessageValidationContext, Builder>, WithExpressions<Builder> {
+            implements ValidationContext.Builder<JsonPathMessageValidationContext, Builder>, WithExpressions<Builder>, VariableExtractorAdapter, MessageProcessorAdapter {
 
         private final Map<String, Object> expressions = new HashMap<>();
 
@@ -75,6 +81,20 @@ public class JsonPathMessageValidationContext extends DefaultValidationContext {
         public Builder expression(final String expression, final Object value) {
             this.expressions.put(expression, value);
             return this;
+        }
+
+        @Override
+        public MessageProcessor asProcessor() {
+            return new DelegatingPathExpressionProcessor.Builder()
+                    .expressions(expressions)
+                    .build();
+        }
+
+        @Override
+        public VariableExtractor asExtractor() {
+            return new DelegatingPayloadVariableExtractor.Builder()
+                    .expressions(expressions)
+                    .build();
         }
 
         @Override

--- a/core/citrus-base/src/main/java/org/citrusframework/validation/xml/XpathMessageValidationContext.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/validation/xml/XpathMessageValidationContext.java
@@ -20,6 +20,12 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.citrusframework.builder.WithExpressions;
+import org.citrusframework.message.DelegatingPathExpressionProcessor;
+import org.citrusframework.message.MessageProcessor;
+import org.citrusframework.message.MessageProcessorAdapter;
+import org.citrusframework.validation.DelegatingPayloadVariableExtractor;
+import org.citrusframework.variable.VariableExtractor;
+import org.citrusframework.variable.VariableExtractorAdapter;
 import org.springframework.util.StringUtils;
 
 /**
@@ -52,7 +58,7 @@ public class XpathMessageValidationContext extends XmlMessageValidationContext {
      * Fluent builder.
      */
     public static final class Builder extends XmlValidationContextBuilder<XpathMessageValidationContext, Builder>
-            implements WithExpressions<Builder> {
+            implements WithExpressions<Builder>, VariableExtractorAdapter, MessageProcessorAdapter {
 
         private final Map<String, Object> expressions = new HashMap<>();
 
@@ -74,6 +80,19 @@ public class XpathMessageValidationContext extends XmlMessageValidationContext {
         public Builder expression(final String expression, final Object value) {
             this.expressions.put(expression, value);
             return this;
+        }
+        @Override
+        public MessageProcessor asProcessor() {
+            return new DelegatingPathExpressionProcessor.Builder()
+                    .expressions(expressions)
+                    .build();
+        }
+
+        @Override
+        public VariableExtractor asExtractor() {
+            return new DelegatingPayloadVariableExtractor.Builder()
+                    .expressions(expressions)
+                    .build();
         }
 
         @Override

--- a/core/citrus-base/src/main/resources/META-INF/citrus/action/builder/createVariable
+++ b/core/citrus-base/src/main/resources/META-INF/citrus/action/builder/createVariable
@@ -1,0 +1,2 @@
+name=createVariable
+type=org.citrusframework.actions.CreateVariablesAction$Builder

--- a/core/citrus-base/src/main/resources/META-INF/citrus/action/builder/print
+++ b/core/citrus-base/src/main/resources/META-INF/citrus/action/builder/print
@@ -1,0 +1,2 @@
+name=print
+type=org.citrusframework.actions.EchoAction$Builder

--- a/core/citrus-base/src/main/resources/META-INF/citrus/action/builder/waitFor
+++ b/core/citrus-base/src/main/resources/META-INF/citrus/action/builder/waitFor
@@ -1,1 +1,2 @@
+name=waitFor
 type=org.citrusframework.container.Wait$Builder

--- a/core/citrus-base/src/test/java/org/citrusframework/actions/ReceiveMessageBuilderTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/actions/ReceiveMessageBuilderTest.java
@@ -809,7 +809,7 @@ class ReceiveMessageBuilderTest {
 		ReflectionTestUtils.setField(builder, "referenceResolver", referenceResolver);
 
 		//WHEN
-		builder.validator(name1, name2, name3);
+		builder.validators(name1, name2, name3);
 
 		//THEN
 		assertEquals(3, builder.build().getValidators().size());
@@ -825,7 +825,7 @@ class ReceiveMessageBuilderTest {
 		final HeaderValidator validator3 = mock(HeaderValidator.class);
 
 		//WHEN
-		builder.validator(validator1, validator2, validator3);
+		builder.validators(validator1, validator2, validator3);
 
 		//THEN
 
@@ -852,7 +852,7 @@ class ReceiveMessageBuilderTest {
 		ReflectionTestUtils.setField(builder, "referenceResolver", referenceResolver);
 
 		//WHEN
-		builder.validator(name1, name2, name3);
+		builder.validators(name1, name2, name3);
 
 		//THEN
 

--- a/core/citrus-spring/src/main/java/org/citrusframework/config/xml/AbstractMessageActionParser.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/config/xml/AbstractMessageActionParser.java
@@ -152,7 +152,7 @@ public abstract class AbstractMessageActionParser implements BeanDefinitionParse
 
             List<MessageProcessor> messageProcessors = new ArrayList<>();
             if (!pathExpressions.isEmpty()) {
-                messageProcessors.add(new DelegatingPathExpressionProcessor(pathExpressions));
+                messageProcessors.add(new DelegatingPathExpressionProcessor.Builder().expressions(pathExpressions).build());
             }
 
             String messageType = messageElement.getAttribute("type");

--- a/core/citrus-spring/src/main/java/org/citrusframework/config/xml/PurgeEndpointActionParser.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/config/xml/PurgeEndpointActionParser.java
@@ -50,7 +50,8 @@ public class PurgeEndpointActionParser implements BeanDefinitionParser {
         DescriptionElementParser.doParse(element, beanDefinition);
         MessageSelectorParser.doParse(element, beanDefinition);
 
-        BeanDefinitionParserUtils.setPropertyValue(beanDefinition, element.getAttribute("receive-timeout"), "receiveTimeout");
+        BeanDefinitionParserUtils.setPropertyValue(beanDefinition, element.getAttribute("timeout"), "receiveTimeout");
+        BeanDefinitionParserUtils.setPropertyValue(beanDefinition, element.getAttribute("sleep"), "sleepTime");
 
         List<String> endpointNames = new ArrayList<>();
         ManagedList<BeanDefinition> endpointRefs = new ManagedList<>();

--- a/core/citrus-spring/src/main/resources/org/citrusframework/schema/citrus-testcase-4.0.0-SNAPSHOT.xsd
+++ b/core/citrus-spring/src/main/resources/org/citrusframework/schema/citrus-testcase-4.0.0-SNAPSHOT.xsd
@@ -83,6 +83,9 @@
                     <xs:attribute name="name" type="xs:string"/>
                     <xs:attribute name="type" default="xml" type="xs:string"/>
                     <xs:attribute name="data-dictionary" type="xs:string"/>
+                    <xs:attribute name="schema-validation" type="xs:boolean"/>
+                    <xs:attribute name="schema" type="xs:string"/>
+                    <xs:attribute name="schema-repository" type="xs:string"/>
                 </xs:complexType>
             </xs:element>
             <xs:element name="header" minOccurs="0">
@@ -474,7 +477,8 @@
             </xs:element>
         </xs:sequence>
         <xs:attribute name="connection-factory" type="xs:string"/>
-        <xs:attribute name="receive-timeout" type="xs:int"/>
+        <xs:attribute name="timeout" type="xs:int"/>
+        <xs:attribute name="sleep" type="xs:int"/>
     </xs:complexType>
 
     <xs:complexType name="PurgeChannelActionType">

--- a/core/citrus-spring/src/main/resources/org/citrusframework/schema/citrus-testcase.xsd
+++ b/core/citrus-spring/src/main/resources/org/citrusframework/schema/citrus-testcase.xsd
@@ -477,7 +477,8 @@
             </xs:element>
         </xs:sequence>
         <xs:attribute name="connection-factory" type="xs:string"/>
-        <xs:attribute name="receive-timeout" type="xs:int"/>
+        <xs:attribute name="timeout" type="xs:int"/>
+        <xs:attribute name="sleep" type="xs:int"/>
     </xs:complexType>
 
     <xs:complexType name="PurgeChannelActionType">

--- a/endpoints/citrus-camel/pom.xml
+++ b/endpoints/citrus-camel/pom.xml
@@ -68,6 +68,12 @@
     </dependency>
     <dependency>
       <groupId>org.citrusframework</groupId>
+      <artifactId>citrus-yaml</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.citrusframework</groupId>
       <artifactId>citrus-validation-xml</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/endpoints/citrus-camel/pom.xml
+++ b/endpoints/citrus-camel/pom.xml
@@ -80,6 +80,12 @@
     </dependency>
     <dependency>
       <groupId>org.citrusframework</groupId>
+      <artifactId>citrus-groovy</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.citrusframework</groupId>
       <artifactId>citrus-validation-xml</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/endpoints/citrus-camel/pom.xml
+++ b/endpoints/citrus-camel/pom.xml
@@ -74,6 +74,12 @@
     </dependency>
     <dependency>
       <groupId>org.citrusframework</groupId>
+      <artifactId>citrus-xml</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.citrusframework</groupId>
       <artifactId>citrus-validation-xml</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelControlBusAction.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelControlBusAction.java
@@ -179,11 +179,11 @@ public class CamelControlBusAction extends AbstractCamelRouteAction {
 
         /**
          * Sets a simple language expression to execute.
-         * @param simpleExpression
+         * @param expression
          * @return
          */
-        public Builder language(String simpleExpression) {
-            language("simple", simpleExpression);
+        public Builder simple(String expression) {
+            language("simple", expression);
             return this;
         }
 

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CreateCamelRouteAction.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CreateCamelRouteAction.java
@@ -19,14 +19,14 @@ package org.citrusframework.camel.actions;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.citrusframework.context.TestContext;
-import org.citrusframework.exceptions.CitrusRuntimeException;
-import org.citrusframework.xml.StringSource;
-import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.RouteDefinition;
 import org.apache.camel.spring.xml.CamelRouteContextFactoryBean;
+import org.citrusframework.camel.util.CamelUtils;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.xml.StringSource;
 import org.springframework.beans.factory.BeanDefinitionStoreException;
 import org.springframework.util.StringUtils;
 
@@ -41,8 +41,6 @@ public class CreateCamelRouteAction extends AbstractCamelRouteAction {
 
     /** Route context as XML */
     private final String routeContext;
-
-    private volatile JAXBContext context;
 
     /**
      * Default constructor.
@@ -61,7 +59,7 @@ public class CreateCamelRouteAction extends AbstractCamelRouteAction {
         if (StringUtils.hasText(routeContext)) {
             // now lets parse the routes with JAXB
             try {
-                Object value = getJaxbContext().createUnmarshaller().unmarshal(new StringSource(context.replaceDynamicContentInString(routeContext)));
+                Object value = CamelUtils.getJaxbContext().createUnmarshaller().unmarshal(new StringSource(context.replaceDynamicContentInString(routeContext)));
                 if (value instanceof CamelRouteContextFactoryBean) {
                     CamelRouteContextFactoryBean factoryBean = (CamelRouteContextFactoryBean) value;
                     routesToUse = factoryBean.getRoutes();
@@ -93,24 +91,6 @@ public class CreateCamelRouteAction extends AbstractCamelRouteAction {
         } catch (Exception e) {
             throw new CitrusRuntimeException(String.format("Failed to create route definitions in context '%s'", camelContext.getName()), e);
         }
-    }
-
-    /**
-     * Creates new Camel JaxB context.
-     * @return
-     * @throws JAXBException
-     */
-    public JAXBContext getJaxbContext() throws JAXBException {
-        if (context == null) {
-            synchronized (this) {
-                context = JAXBContext.newInstance("org.apache.camel:org.apache.camel.model:org.apache.camel.model.cloud:" +
-                        "org.apache.camel.model.config:org.apache.camel.model.dataformat:org.apache.camel.model.language:" +
-                        "org.apache.camel.model.loadbalancer:org.apache.camel.model.rest:org.apache.camel.model.transformer:" +
-                        "org.apache.camel.model.validator:org.apache.camel.core.xml:org.apache.camel.spring.xml", this.getClass().getClassLoader());
-            }
-        }
-
-        return context;
     }
 
     /**

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/util/CamelUtils.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/util/CamelUtils.java
@@ -1,0 +1,49 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.camel.util;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+
+/**
+ * Camel utilities.
+ */
+public class CamelUtils {
+
+    private static volatile JAXBContext context;
+
+    /**
+     * Creates new Camel JaxB context.
+     * @return
+     * @throws JAXBException
+     */
+    public static JAXBContext getJaxbContext() throws JAXBException {
+        if (context == null) {
+            synchronized(CamelUtils.class) {
+                context = JAXBContext.newInstance("org.apache.camel:org.apache.camel.model:org.apache.camel.model.cloud:" +
+                        "org.apache.camel.model.config:org.apache.camel.model.dataformat:org.apache.camel.model.language:" +
+                        "org.apache.camel.model.loadbalancer:org.apache.camel.model.rest:org.apache.camel.model.transformer:" +
+                        "org.apache.camel.model.validator:org.apache.camel.core.xml:org.apache.camel.spring.xml", CamelUtils.class.getClassLoader());
+            }
+        }
+
+        return context;
+    }
+}

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/Camel.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/Camel.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.xml;
+
+import java.util.stream.Collectors;
+
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import org.apache.camel.CamelContext;
+import org.apache.camel.spring.xml.CamelRouteContextFactoryBean;
+import org.citrusframework.TestAction;
+import org.citrusframework.TestActionBuilder;
+import org.citrusframework.TestActor;
+import org.citrusframework.camel.actions.AbstractCamelRouteAction;
+import org.citrusframework.camel.actions.CamelControlBusAction;
+import org.citrusframework.camel.actions.CreateCamelRouteAction;
+import org.citrusframework.camel.actions.RemoveCamelRouteAction;
+import org.citrusframework.camel.actions.StartCamelRouteAction;
+import org.citrusframework.camel.actions.StopCamelRouteAction;
+import org.citrusframework.camel.util.CamelUtils;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.spi.ReferenceResolverAware;
+
+/**
+ * @author Christoph Deppisch
+ */
+@XmlRootElement(name = "camel")
+public class Camel implements TestActionBuilder<TestAction>, ReferenceResolverAware {
+
+    private AbstractCamelRouteAction.Builder<?, ?> builder;
+
+    private String description;
+    private String actor;
+    private String camelContext;
+
+    private ReferenceResolver referenceResolver;
+
+    @XmlElement
+    public Camel setDescription(String value) {
+        this.description = value;
+        return this;
+    }
+
+    @XmlAttribute(name = "actor")
+    public Camel setActor(String actor) {
+        this.actor = actor;
+        return this;
+    }
+
+    @XmlAttribute(name = "camel-context")
+    public Camel setCamelContext(String camelContext) {
+        this.camelContext = camelContext;
+        return this;
+    }
+
+    @XmlElement(name = "control-bus")
+    public Camel setControlBus(ControlBus controlBus) {
+        CamelControlBusAction.Builder builder = new CamelControlBusAction.Builder()
+                .result(controlBus.getResult());
+
+        if (controlBus.route != null) {
+            builder.route(controlBus.getRoute().getId(), controlBus.getRoute().getAction());
+        }
+
+        if (controlBus.language != null) {
+            builder.language(controlBus.getLanguage().getType(), controlBus.getLanguage().getExpression());
+        }
+
+        this.builder = builder;
+        return this;
+    }
+
+    @XmlElement(name = "create-routes")
+    public Camel setCreateRoutes(CreateRoutes createRoutes) {
+        CreateCamelRouteAction.Builder builder = new CreateCamelRouteAction.Builder();
+
+        if (createRoutes.routeContext != null) {
+            try {
+                CamelRouteContextFactoryBean factoryBean = (CamelRouteContextFactoryBean) CamelUtils.getJaxbContext().createUnmarshaller().unmarshal(createRoutes.routeContext);
+                builder.routes(factoryBean.getRoutes());
+            } catch (JAXBException e) {
+                throw new CitrusRuntimeException("Failed to parse routes from given route context", e);
+            }
+        }
+
+        this.builder = builder;
+        return this;
+    }
+
+    @XmlElement(name = "start-routes")
+    public Camel setStartRoutes(Routes startRoutes) {
+        StartCamelRouteAction.Builder builder = new StartCamelRouteAction.Builder();
+
+        builder.routeIds(startRoutes.getRoutes().stream().map(Route::getId).collect(Collectors.toList()));
+
+        this.builder = builder;
+        return this;
+    }
+
+    @XmlElement(name = "stop-routes")
+    public Camel setStopRoutes(Routes stopRoutes) {
+        StopCamelRouteAction.Builder builder = new StopCamelRouteAction.Builder();
+
+        builder.routeIds(stopRoutes.getRoutes().stream().map(Route::getId).collect(Collectors.toList()));
+
+        this.builder = builder;
+        return this;
+    }
+
+    @XmlElement(name = "remove-routes")
+    public Camel setRemoveRoutes(Routes removeRoutes) {
+        RemoveCamelRouteAction.Builder builder = new RemoveCamelRouteAction.Builder();
+
+        builder.routeIds(removeRoutes.getRoutes().stream().map(Route::getId).collect(Collectors.toList()));
+
+        this.builder = builder;
+        return this;
+    }
+
+    @Override
+    public TestAction build() {
+        if (builder == null) {
+            throw new CitrusRuntimeException("Missing Camel action - please provide proper action details");
+        }
+
+        builder.setReferenceResolver(referenceResolver);
+        builder.description(description);
+
+        if (referenceResolver != null) {
+            if (actor != null) {
+                builder.actor(referenceResolver.resolve(actor, TestActor.class));
+            }
+
+            if (camelContext != null) {
+                builder.context(referenceResolver.resolve(camelContext, CamelContext.class));
+            }
+        }
+
+        return builder.build();
+    }
+
+    @Override
+    public void setReferenceResolver(ReferenceResolver referenceResolver) {
+        this.referenceResolver = referenceResolver;
+    }
+
+}

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/ControlBus.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/ControlBus.java
@@ -1,0 +1,96 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.camel.xml;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlValue;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+        "route",
+        "language",
+        "result"
+})
+public class ControlBus {
+    @XmlElement
+    protected Route route;
+
+    @XmlElement
+    protected Language language;
+
+    @XmlElement(name = "result")
+    protected String result;
+
+    public Route getRoute() {
+        return route;
+    }
+
+    public void setRoute(Route route) {
+        this.route = route;
+    }
+
+    public void setLanguage(Language language) {
+        this.language = language;
+    }
+
+    public Language getLanguage() {
+        return language;
+    }
+
+    public String getResult() {
+        return result;
+    }
+
+    public void setResult(String result) {
+        this.result = result;
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(name = "", propOrder = {
+            "type"
+    })
+    public static class Language {
+        @XmlAttribute
+        protected String type = "simple";
+
+        @XmlValue
+        protected String expression;
+
+        public void setType(String type) {
+            this.type = type;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public void setExpression(String expression) {
+            this.expression = expression;
+        }
+
+        public String getExpression() {
+            return expression;
+        }
+    }
+}

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/CreateRoutes.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/CreateRoutes.java
@@ -17,21 +17,27 @@
  *  limitations under the License.
  */
 
-package org.citrusframework.camel.yaml;
+package org.citrusframework.camel.xml;
 
-import java.util.List;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAnyElement;
+import jakarta.xml.bind.annotation.XmlType;
 
-import org.citrusframework.camel.actions.RemoveCamelRouteAction;
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+        "routeContext"
+})
+public class CreateRoutes {
 
-public class RemoveRoutes implements CamelRouteActionBuilderWrapper<RemoveCamelRouteAction.Builder> {
-    private final RemoveCamelRouteAction.Builder builder = new RemoveCamelRouteAction.Builder();
+    @XmlAnyElement(lax = true)
+    protected org.w3c.dom.Element routeContext;
 
-    public void setRoutes(List<String> routeIds) {
-        builder.routeIds(routeIds);
+    public org.w3c.dom.Element getRouteContext() {
+        return routeContext;
     }
 
-    @Override
-    public RemoveCamelRouteAction.Builder getBuilder() {
-        return builder;
+    public void setRouteContext(org.w3c.dom.Element routeContext) {
+        this.routeContext = routeContext;
     }
 }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/ObjectFactory.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/ObjectFactory.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.xml;
+
+import jakarta.xml.bind.annotation.XmlRegistry;
+
+/**
+ * This object contains factory methods for each
+ * Java content interface and Java element interface
+ * generated in the org.citrusframework.ftp.model package.
+ * <p>An ObjectFactory allows you to programatically
+ * construct new instances of the Java representation
+ * for XML content. The Java representation of XML
+ * content can consist of schema derived interfaces
+ * and classes representing the binding of schema
+ * type definitions, element declarations and model
+ * groups.  Factory methods for each of these are
+ * provided in this class.
+ *
+ */
+@XmlRegistry
+public class ObjectFactory {
+
+    /**
+     * Create a new ObjectFactory that can be used to create new instances of schema derived classes for package: org.citrusframework.xml.actions
+     *
+     */
+    public ObjectFactory() {
+    }
+
+    /**
+     * Create an instance of {@link Camel }
+     *
+     */
+    public Camel createCamel() {
+        return new Camel();
+    }
+
+}

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/Route.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/Route.java
@@ -17,21 +17,38 @@
  *  limitations under the License.
  */
 
-package org.citrusframework.camel.yaml;
+package org.citrusframework.camel.xml;
 
-import java.util.List;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
 
-import org.citrusframework.camel.actions.RemoveCamelRouteAction;
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+        "id",
+        "action"
+})
+public class Route {
+    @XmlAttribute(required = true)
+    protected String id;
 
-public class RemoveRoutes implements CamelRouteActionBuilderWrapper<RemoveCamelRouteAction.Builder> {
-    private final RemoveCamelRouteAction.Builder builder = new RemoveCamelRouteAction.Builder();
+    @XmlAttribute
+    protected String action;
 
-    public void setRoutes(List<String> routeIds) {
-        builder.routeIds(routeIds);
+    public void setId(String id) {
+        this.id = id;
     }
 
-    @Override
-    public RemoveCamelRouteAction.Builder getBuilder() {
-        return builder;
+    public String getId() {
+        return id;
+    }
+
+    public void setAction(String action) {
+        this.action = action;
+    }
+
+    public String getAction() {
+        return action;
     }
 }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/Routes.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/Routes.java
@@ -17,21 +17,33 @@
  *  limitations under the License.
  */
 
-package org.citrusframework.camel.yaml;
+package org.citrusframework.camel.xml;
 
+import java.util.ArrayList;
 import java.util.List;
 
-import org.citrusframework.camel.actions.RemoveCamelRouteAction;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlType;
 
-public class RemoveRoutes implements CamelRouteActionBuilderWrapper<RemoveCamelRouteAction.Builder> {
-    private final RemoveCamelRouteAction.Builder builder = new RemoveCamelRouteAction.Builder();
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+        "route"
+})
+public class Routes {
+    @XmlElement
+    protected List<Route> route;
 
-    public void setRoutes(List<String> routeIds) {
-        builder.routeIds(routeIds);
+    public List<Route> getRoutes() {
+        if (route == null) {
+            route = new ArrayList<>();
+        }
+
+        return route;
     }
 
-    @Override
-    public RemoveCamelRouteAction.Builder getBuilder() {
-        return builder;
+    public void setRoutes(List<Route> routes) {
+        this.route = routes;
     }
 }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/package-info.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@jakarta.xml.bind.annotation.XmlSchema(namespace = "http://citrusframework.org/schema/xml/testcase", elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
+package org.citrusframework.camel.xml;

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/Camel.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/Camel.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.yaml;
+
+import org.apache.camel.CamelContext;
+import org.citrusframework.TestAction;
+import org.citrusframework.TestActionBuilder;
+import org.citrusframework.TestActor;
+import org.citrusframework.camel.actions.AbstractCamelRouteAction;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.spi.ReferenceResolverAware;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class Camel implements TestActionBuilder<TestAction>, ReferenceResolverAware {
+
+    private CamelRouteActionBuilderWrapper<?> delegate;
+
+    private String description;
+    private String actor;
+
+    private String camelContext;
+
+    private ReferenceResolver referenceResolver;
+
+    public void setDescription(String value) {
+        this.description = value;
+    }
+
+    public void setActor(String actor) {
+        this.actor = actor;
+    }
+
+    public void setCamelContext(String camelContext) {
+        this.camelContext = camelContext;
+    }
+
+    public void setControlBus(ControlBus builder) {
+        this.delegate = builder;
+    }
+
+    public void setCreateRoutes(CreateRoutes builder) {
+        this.delegate = builder;
+    }
+
+    public void setStartRoutes(StartRoutes builder) {
+        this.delegate = builder;
+    }
+
+    public void setStopRoutes(StopRoutes builder) {
+        this.delegate = builder;
+    }
+
+    public void setRemoveRoutes(RemoveRoutes builder) {
+        this.delegate = builder;
+    }
+
+    @Override
+    public TestAction build() {
+        if (delegate == null) {
+            throw new CitrusRuntimeException("Missing Camel action - please provide proper action details");
+        }
+
+        AbstractCamelRouteAction.Builder<?, ?> builder = delegate.getBuilder();
+
+        builder.setReferenceResolver(referenceResolver);
+        builder.description(description);
+
+        if (referenceResolver != null) {
+            if (actor != null) {
+                builder.actor(referenceResolver.resolve(actor, TestActor.class));
+            }
+
+            if (camelContext != null) {
+                builder.context(referenceResolver.resolve(camelContext, CamelContext.class));
+            }
+        }
+
+        return builder.build();
+    }
+
+    @Override
+    public void setReferenceResolver(ReferenceResolver referenceResolver) {
+        this.referenceResolver = referenceResolver;
+    }
+
+}

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/CamelRouteActionBuilderWrapper.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/CamelRouteActionBuilderWrapper.java
@@ -1,0 +1,17 @@
+package org.citrusframework.camel.yaml;
+
+import org.citrusframework.camel.actions.AbstractCamelRouteAction;
+
+/**
+ * Special wrapper holding a Camel route action builder for future reference.
+ * @param <B>
+ */
+public interface CamelRouteActionBuilderWrapper<B extends AbstractCamelRouteAction.Builder<?, ?>> {
+
+    /**
+     * Gets the wrapped Camel route action builder.
+     * @return
+     */
+    B getBuilder();
+
+}

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/CamelRouteActionBuilderWrapper.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/CamelRouteActionBuilderWrapper.java
@@ -1,3 +1,22 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package org.citrusframework.camel.yaml;
 
 import org.citrusframework.camel.actions.AbstractCamelRouteAction;

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/ControlBus.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/ControlBus.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.yaml;
+
+import org.citrusframework.camel.actions.CamelControlBusAction;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class ControlBus implements CamelRouteActionBuilderWrapper<CamelControlBusAction.Builder> {
+
+    private final CamelControlBusAction.Builder builder = new CamelControlBusAction.Builder();
+
+    private CamelControlBusAction.Builder.ControlBusRouteActionBuilder routeActionBuilder;
+
+    public void setDescription(String value) {
+        builder.description(value);
+    }
+
+    public void setRoute(String id) {
+        routeActionBuilder = builder.route(id);
+    }
+
+    public void setAction(String action) {
+        if (routeActionBuilder != null) {
+            routeActionBuilder.action(action);
+        }
+    }
+
+    public void setResult(String result) {
+        builder.result(result);
+    }
+
+    public void setSimple(String expression) {
+        builder.simple(expression);
+    }
+
+    public void setLanguage(Language language) {
+        builder.language(language.getName(), language.getExpression());
+    }
+
+    @Override
+    public CamelControlBusAction.Builder getBuilder() {
+        return builder;
+    }
+
+    public static class Language {
+
+        private String name;
+        private String expression;
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setExpression(String expression) {
+            this.expression = expression;
+        }
+
+        public String getExpression() {
+            return expression;
+        }
+    }
+}

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/CreateRoutes.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/CreateRoutes.java
@@ -1,3 +1,22 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package org.citrusframework.camel.yaml;
 
 import org.citrusframework.camel.actions.CreateCamelRouteAction;

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/CreateRoutes.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/CreateRoutes.java
@@ -1,0 +1,17 @@
+package org.citrusframework.camel.yaml;
+
+import org.citrusframework.camel.actions.CreateCamelRouteAction;
+
+public class CreateRoutes implements CamelRouteActionBuilderWrapper<CreateCamelRouteAction.Builder> {
+    private final CreateCamelRouteAction.Builder builder = new CreateCamelRouteAction.Builder();
+
+    public void setRouteContext(String routeContext) {
+        builder.routeContext(routeContext);
+    }
+
+    @Override
+    public CreateCamelRouteAction.Builder getBuilder() {
+        return builder;
+    }
+
+}

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/RemoveRoutes.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/RemoveRoutes.java
@@ -1,0 +1,18 @@
+package org.citrusframework.camel.yaml;
+
+import java.util.List;
+
+import org.citrusframework.camel.actions.RemoveCamelRouteAction;
+
+public class RemoveRoutes implements CamelRouteActionBuilderWrapper<RemoveCamelRouteAction.Builder> {
+    private final RemoveCamelRouteAction.Builder builder = new RemoveCamelRouteAction.Builder();
+
+    public void setRoutes(List<String> routeIds) {
+        builder.routeIds(routeIds);
+    }
+
+    @Override
+    public RemoveCamelRouteAction.Builder getBuilder() {
+        return builder;
+    }
+}

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/StartRoutes.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/StartRoutes.java
@@ -1,0 +1,18 @@
+package org.citrusframework.camel.yaml;
+
+import java.util.List;
+
+import org.citrusframework.camel.actions.StartCamelRouteAction;
+
+public class StartRoutes implements CamelRouteActionBuilderWrapper<StartCamelRouteAction.Builder> {
+    private final StartCamelRouteAction.Builder builder = new StartCamelRouteAction.Builder();
+
+    public void setRoutes(List<String> routeIds) {
+        builder.routeIds(routeIds);
+    }
+
+    @Override
+    public StartCamelRouteAction.Builder getBuilder() {
+        return builder;
+    }
+}

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/StartRoutes.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/StartRoutes.java
@@ -1,3 +1,22 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package org.citrusframework.camel.yaml;
 
 import java.util.List;

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/StopRoutes.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/StopRoutes.java
@@ -1,0 +1,18 @@
+package org.citrusframework.camel.yaml;
+
+import java.util.List;
+
+import org.citrusframework.camel.actions.StopCamelRouteAction;
+
+public class StopRoutes implements CamelRouteActionBuilderWrapper<StopCamelRouteAction.Builder> {
+    private final StopCamelRouteAction.Builder builder = new StopCamelRouteAction.Builder();
+
+    public void setRoutes(List<String> routeIds) {
+        builder.routeIds(routeIds);
+    }
+
+    @Override
+    public StopCamelRouteAction.Builder getBuilder() {
+        return builder;
+    }
+}

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/StopRoutes.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/StopRoutes.java
@@ -1,3 +1,22 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package org.citrusframework.camel.yaml;
 
 import java.util.List;

--- a/endpoints/citrus-camel/src/main/resources/META-INF/citrus/xml/builder/camel
+++ b/endpoints/citrus-camel/src/main/resources/META-INF/citrus/xml/builder/camel
@@ -1,0 +1,2 @@
+type=org.citrusframework.camel.xml.Camel
+ns=http://citrusframework.org/schema/xml/testcase

--- a/endpoints/citrus-camel/src/main/resources/META-INF/citrus/yaml/builder/camel
+++ b/endpoints/citrus-camel/src/main/resources/META-INF/citrus/yaml/builder/camel
@@ -1,0 +1,1 @@
+type=org.citrusframework.camel.yaml.Camel

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/actions/CamelControlBusActionTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/actions/CamelControlBusActionTest.java
@@ -199,7 +199,7 @@ public class CamelControlBusActionTest extends AbstractTestNGUnitTest {
 
         CamelControlBusAction action = new CamelControlBusAction.Builder()
                 .context(camelContext)
-                .language("${camelContext.getRouteStatus('${routeId}')}")
+                .simple("${camelContext.getRouteStatus('${routeId}')}")
                 .build();
         action.execute(context);
     }
@@ -229,7 +229,7 @@ public class CamelControlBusActionTest extends AbstractTestNGUnitTest {
 
         CamelControlBusAction action = new CamelControlBusAction.Builder()
                 .context(camelContext)
-                .language("${camelContext.getRouteStatus('myRoute')}")
+                .simple("${camelContext.getRouteStatus('myRoute')}")
                 .result("Started")
                 .build();
         action.execute(context);

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/actions/dsl/CamelRouteTestActionRunnerTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/actions/dsl/CamelRouteTestActionRunnerTest.java
@@ -232,7 +232,7 @@ public class CamelRouteTestActionRunnerTest extends UnitTestSupport {
 
         builder.$(camel().camelContext(camelContext)
                 .controlBus()
-                .language("${camelContext.getRouteStatus('route_1')}")
+                .simple("${camelContext.getRouteStatus('route_1')}")
                 .result(ServiceStatus.Started));
 
         TestCase test = builder.getTestCase();

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/config/xml/CamelControlBusActionParserTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/config/xml/CamelControlBusActionParserTest.java
@@ -54,7 +54,7 @@ public class CamelControlBusActionParserTest extends AbstractActionParserTest<Ca
         Assert.assertNotNull(action.getCamelContext());
         Assert.assertEquals(action.getCamelContext(), beanDefinitionContext.getBean("camelContext", CamelContext.class));
         Assert.assertEquals(action.getLanguageType(), "simple");
-        Assert.assertEquals(action.getLanguageExpression(), "${camelContext.getRouteStatus('route_3')}");
+        Assert.assertEquals(action.getLanguageExpression(), "${camelContext.getRouteController().getRouteStatus('route_3')}");
         Assert.assertEquals(action.getResult(), "Started");
     }
 }

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/groovy/AbstractGroovyActionDslTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/groovy/AbstractGroovyActionDslTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.groovy;
+
+import org.citrusframework.Citrus;
+import org.citrusframework.CitrusContext;
+import org.citrusframework.CitrusInstanceManager;
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.annotations.CitrusAnnotations;
+import org.citrusframework.context.StaticTestContextFactory;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.citrusframework.testng.AbstractTestNGUnitTest;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeClass;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class AbstractGroovyActionDslTest extends AbstractTestNGUnitTest {
+
+    protected Citrus citrus;
+
+    @Mock
+    protected CitrusContext citrusContext;
+
+    @BeforeClass
+    public void setupMocks() {
+        MockitoAnnotations.openMocks(this);
+        citrus = CitrusInstanceManager.newInstance(() -> citrusContext);
+    }
+
+    @Override
+    protected TestContext createTestContext() {
+        TestContext context = super.createTestContext();
+        doAnswer(invocation -> {
+            context.getReferenceResolver().bind(invocation.getArgument(0, String.class), invocation.getArgument(1));
+            return null;
+        }).when(citrusContext).bind(any(String.class), any());
+
+        when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
+        when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
+        when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        CitrusAnnotations.injectAll(this, citrus, context);
+        return context;
+    }
+
+    protected GroovyTestLoader createTestLoader(String sourcePath) {
+        GroovyTestLoader testLoader = new GroovyTestLoader().source(sourcePath);
+        CitrusAnnotations.injectAll(testLoader, citrus, context);
+        CitrusAnnotations.injectTestRunner(testLoader, new DefaultTestCaseRunner(context));
+
+        return testLoader;
+    }
+}

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/groovy/ControlBusTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/groovy/ControlBusTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.groovy;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.camel.actions.CamelControlBusAction;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class ControlBusTest extends AbstractGroovyActionDslTest {
+
+    @Test
+    public void shouldLoadCamelActions() throws Exception {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/camel/groovy/camel-control-bus.test.groovy");
+
+        CamelContext citrusCamelContext = new DefaultCamelContext();
+        citrusCamelContext.addRoutes(new RouteBuilder(citrusCamelContext) {
+            @Override
+            public void configure() throws Exception {
+                from("direct:hello")
+                        .routeId("route_1")
+                        .to("log:info");
+
+                from("direct:goodbye")
+                        .routeId("route_2")
+                        .autoStartup(false)
+                        .to("log:info");
+
+                from("direct:goodnight")
+                        .routeId("route_3")
+                        .to("log:info");
+            }
+        });
+
+        citrusCamelContext.start();
+
+        context.getReferenceResolver().bind("citrusCamelContext", citrusCamelContext);
+        context.getReferenceResolver().bind("camelContext", citrusCamelContext);
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "CamelControlBusTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 4L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), CamelControlBusAction.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "controlbus");
+
+        int actionIndex = 0;
+
+        CamelControlBusAction action = (CamelControlBusAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve("citrusCamelContext", CamelContext.class));
+        Assert.assertEquals(action.getRouteId(), "route_1");
+        Assert.assertEquals(action.getAction(), "start");
+        Assert.assertNull(action.getResult());
+
+        action = (CamelControlBusAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve("camelContext", CamelContext.class));
+        Assert.assertEquals(action.getRouteId(), "route_2");
+        Assert.assertEquals(action.getAction(), "status");
+        Assert.assertEquals(action.getResult(), "Stopped");
+
+        action = (CamelControlBusAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve("camelContext", CamelContext.class));
+        Assert.assertEquals(action.getLanguageType(), "simple");
+        Assert.assertEquals(action.getLanguageExpression(), "${camelContext.getRouteController().getRouteStatus(\"route_3\")}");
+        Assert.assertEquals(action.getResult(), "Started");
+
+        action = (CamelControlBusAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve("citrusCamelContext", CamelContext.class));
+        Assert.assertEquals(action.getLanguageType(), "simple");
+        Assert.assertEquals(action.getLanguageExpression(), "${camelContext.stop()}");
+        Assert.assertNull(action.getResult());
+
+    }
+}

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/groovy/CreateRoutesTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/groovy/CreateRoutesTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.groovy;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.camel.actions.CreateCamelRouteAction;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.springframework.util.StringUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class CreateRoutesTest extends AbstractGroovyActionDslTest {
+
+    @Test
+    public void shouldLoadCamelActions() throws Exception {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/camel/groovy/camel-create-routes.test.groovy");
+
+        CamelContext citrusCamelContext = new DefaultCamelContext();
+        citrusCamelContext.start();
+
+        context.getReferenceResolver().bind("citrusCamelContext", citrusCamelContext);
+        context.getReferenceResolver().bind("camelContext", citrusCamelContext);
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "CamelCreateRouteTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 2L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), CreateCamelRouteAction.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "create-routes");
+
+        int actionIndex = 0;
+
+        CreateCamelRouteAction action = (CreateCamelRouteAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve("citrusCamelContext", CamelContext.class));
+        Assert.assertEquals(StringUtils.trimAllWhitespace(action.getRouteContext()), ("<routeContext xmlns=\"http://camel.apache.org/schema/spring\">" +
+                    "<route id=\"route_1\">" +
+                        "<from uri=\"direct:test1\"/>" +
+                        "<to uri=\"mock:test1\"/>" +
+                    "</route>" +
+                    "<route id=\"route_2\">" +
+                        "<from uri=\"direct:test2\"/>" +
+                        "<to uri=\"mock:test2\"/>" +
+                    "</route>" +
+                "</routeContext>").replaceAll("\\s", ""));
+        Assert.assertEquals(action.getRoutes().size(), 0);
+
+        action = (CreateCamelRouteAction) result.getTestAction(actionIndex);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve("camelContext", CamelContext.class));
+        Assert.assertEquals(StringUtils.trimAllWhitespace(action.getRouteContext()), ("<routeContext xmlns=\"http://camel.apache.org/schema/spring\">" +
+                    "<route>" +
+                        "<from uri=\"direct:test3\"/>" +
+                        "<to uri=\"mock:test3\"/>" +
+                    "</route>" +
+                "</routeContext>").replaceAll("\\s", ""));
+        Assert.assertEquals(action.getRoutes().size(), 0);
+
+    }
+}

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/groovy/RemoveRoutesTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/groovy/RemoveRoutesTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.groovy;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.camel.actions.RemoveCamelRouteAction;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class RemoveRoutesTest extends AbstractGroovyActionDslTest {
+
+    @Test
+    public void shouldLoadCamelActions() throws Exception {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/camel/groovy/camel-remove-routes.test.groovy");
+
+        CamelContext citrusCamelContext = new DefaultCamelContext();
+        citrusCamelContext.addRoutes(new RouteBuilder(citrusCamelContext) {
+            @Override
+            public void configure() throws Exception {
+                from("direct:hello")
+                        .routeId("route_1")
+                        .autoStartup(false)
+                        .to("log:info");
+
+                from("direct:goodbye")
+                        .routeId("route_2")
+                        .autoStartup(false)
+                        .to("log:info");
+
+                from("direct:goodnight")
+                        .routeId("route_3")
+                        .autoStartup(false)
+                        .to("log:info");
+            }
+        });
+
+        citrusCamelContext.start();
+
+        context.getReferenceResolver().bind("citrusCamelContext", citrusCamelContext);
+        context.getReferenceResolver().bind("camelContext", citrusCamelContext);
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "CamelRemoveRouteTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 2L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), RemoveCamelRouteAction.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "remove-routes");
+
+        int actionIndex = 0;
+
+        RemoveCamelRouteAction action = (RemoveCamelRouteAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve("citrusCamelContext", CamelContext.class));
+        Assert.assertEquals(action.getRouteIds().size(), 1);
+
+        action = (RemoveCamelRouteAction) result.getTestAction(actionIndex);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve("camelContext", CamelContext.class));
+        Assert.assertEquals(action.getRouteIds().size(), 2);
+
+    }
+}

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/groovy/StartRoutesTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/groovy/StartRoutesTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.groovy;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.camel.actions.StartCamelRouteAction;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class StartRoutesTest extends AbstractGroovyActionDslTest {
+
+    @Test
+    public void shouldLoadCamelActions() throws Exception {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/camel/groovy/camel-start-routes.test.groovy");
+
+        CamelContext citrusCamelContext = new DefaultCamelContext();
+        citrusCamelContext.addRoutes(new RouteBuilder(citrusCamelContext) {
+            @Override
+            public void configure() throws Exception {
+                from("direct:hello")
+                        .routeId("route_1")
+                        .autoStartup(false)
+                        .to("log:info");
+
+                from("direct:goodbye")
+                        .routeId("route_2")
+                        .autoStartup(false)
+                        .to("log:info");
+
+                from("direct:goodnight")
+                        .routeId("route_3")
+                        .autoStartup(false)
+                        .to("log:info");
+            }
+        });
+
+        citrusCamelContext.start();
+
+        context.getReferenceResolver().bind("citrusCamelContext", citrusCamelContext);
+        context.getReferenceResolver().bind("camelContext", citrusCamelContext);
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "CamelStartRouteTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 2L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), StartCamelRouteAction.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "start-routes");
+
+        int actionIndex = 0;
+
+        StartCamelRouteAction action = (StartCamelRouteAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve("citrusCamelContext", CamelContext.class));
+        Assert.assertEquals(action.getRouteIds().size(), 1);
+
+        action = (StartCamelRouteAction) result.getTestAction(actionIndex);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve("camelContext", CamelContext.class));
+        Assert.assertEquals(action.getRouteIds().size(), 2);
+
+    }
+}

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/groovy/StopRoutesTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/groovy/StopRoutesTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.groovy;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.camel.actions.StopCamelRouteAction;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class StopRoutesTest extends AbstractGroovyActionDslTest {
+
+    @Test
+    public void shouldLoadCamelActions() throws Exception {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/camel/groovy/camel-stop-routes.test.groovy");
+
+        CamelContext citrusCamelContext = new DefaultCamelContext();
+        citrusCamelContext.addRoutes(new RouteBuilder(citrusCamelContext) {
+            @Override
+            public void configure() throws Exception {
+                from("direct:hello")
+                        .routeId("route_1")
+                        .to("log:info");
+
+                from("direct:goodbye")
+                        .routeId("route_2")
+                        .to("log:info");
+
+                from("direct:goodnight")
+                        .routeId("route_3")
+                        .to("log:info");
+            }
+        });
+
+        citrusCamelContext.start();
+
+        context.getReferenceResolver().bind("citrusCamelContext", citrusCamelContext);
+        context.getReferenceResolver().bind("camelContext", citrusCamelContext);
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "CamelStopRouteTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 2L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), StopCamelRouteAction.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "stop-routes");
+
+        int actionIndex = 0;
+
+        StopCamelRouteAction action = (StopCamelRouteAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve("citrusCamelContext", CamelContext.class));
+        Assert.assertEquals(action.getRouteIds().size(), 1);
+
+        action = (StopCamelRouteAction) result.getTestAction(actionIndex);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve("camelContext", CamelContext.class));
+        Assert.assertEquals(action.getRouteIds().size(), 2);
+
+    }
+}

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/util/TypeConverterTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/util/TypeConverterTest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import org.citrusframework.CitrusSettings;
 import org.citrusframework.util.DefaultTypeConverter;
+import org.citrusframework.util.GroovyTypeConverter;
 import org.citrusframework.util.SpringBeanTypeConverter;
 import org.citrusframework.util.TypeConversionUtils;
 import org.citrusframework.util.TypeConverter;
@@ -43,10 +44,11 @@ public class TypeConverterTest {
             TypeConversionUtils.loadDefaultConverter();
 
             Map<String, TypeConverter> converters = TypeConverter.lookup();
-            Assert.assertEquals(converters.size(), 2L);
+            Assert.assertEquals(converters.size(), 3L);
             Assert.assertEquals(converters.get(TypeConverter.APACHE_CAMEL).getClass(), CamelTypeConverter.class);
             Assert.assertEquals(converters.get(TypeConverter.APACHE_CAMEL), TypeConverter.lookupDefault());
 
+            Assert.assertEquals(converters.get(TypeConverter.GROOVY).getClass(), GroovyTypeConverter.class);
             Assert.assertEquals(converters.get(TypeConverter.SPRING).getClass(), SpringBeanTypeConverter.class);
 
             Assert.assertFalse(TypeConverter.lookup().containsKey(TypeConverter.DEFAULT));

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/xml/AbstractXmlActionTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/xml/AbstractXmlActionTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.xml;
+
+import org.citrusframework.Citrus;
+import org.citrusframework.CitrusContext;
+import org.citrusframework.CitrusInstanceManager;
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.annotations.CitrusAnnotations;
+import org.citrusframework.context.StaticTestContextFactory;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.testng.AbstractTestNGUnitTest;
+import org.citrusframework.xml.XmlTestLoader;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeClass;
+
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class AbstractXmlActionTest extends AbstractTestNGUnitTest {
+
+    protected Citrus citrus;
+
+    @Mock
+    protected CitrusContext citrusContext;
+
+    @BeforeClass
+    public void setupMocks() {
+        MockitoAnnotations.openMocks(this);
+        citrus = CitrusInstanceManager.newInstance(() -> citrusContext);
+    }
+
+    @Override
+    protected TestContext createTestContext() {
+        TestContext context = super.createTestContext();
+        when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
+        when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
+        when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        CitrusAnnotations.injectAll(this, citrus, context);
+        return context;
+    }
+
+    protected XmlTestLoader createTestLoader(String sourcePath) {
+        XmlTestLoader testLoader = new XmlTestLoader(this.getClass(), "Test", this.getClass().getPackageName());
+        CitrusAnnotations.injectAll(testLoader, citrus, context);
+        CitrusAnnotations.injectTestRunner(testLoader, new DefaultTestCaseRunner(context));
+        testLoader.setSource(sourcePath);
+
+        return testLoader;
+    }
+}

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/xml/CamelTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/xml/CamelTest.java
@@ -17,21 +17,17 @@
  *  limitations under the License.
  */
 
-package org.citrusframework.camel.yaml;
+package org.citrusframework.camel.xml;
 
-import java.util.List;
+import org.citrusframework.xml.actions.XmlTestActionBuilder;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
-import org.citrusframework.camel.actions.RemoveCamelRouteAction;
+public class CamelTest {
 
-public class RemoveRoutes implements CamelRouteActionBuilderWrapper<RemoveCamelRouteAction.Builder> {
-    private final RemoveCamelRouteAction.Builder builder = new RemoveCamelRouteAction.Builder();
-
-    public void setRoutes(List<String> routeIds) {
-        builder.routeIds(routeIds);
-    }
-
-    @Override
-    public RemoveCamelRouteAction.Builder getBuilder() {
-        return builder;
+    @Test
+    public void shouldLookupTestActionBuilder() {
+        Assert.assertTrue(XmlTestActionBuilder.lookup("camel").isPresent());
+        Assert.assertEquals(XmlTestActionBuilder.lookup("camel").get().getClass(), Camel.class);
     }
 }

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/xml/ControlBusTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/xml/ControlBusTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.xml;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.camel.actions.CamelControlBusAction;
+import org.citrusframework.xml.XmlTestLoader;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class ControlBusTest extends AbstractXmlActionTest {
+
+    @Test
+    public void shouldLoadCamelActions() throws Exception {
+        XmlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/camel/xml/camel-control-bus-test.xml");
+
+        CamelContext citrusCamelContext = new DefaultCamelContext();
+        citrusCamelContext.addRoutes(new RouteBuilder(citrusCamelContext) {
+            @Override
+            public void configure() throws Exception {
+                from("direct:hello")
+                        .routeId("route_1")
+                        .to("log:info");
+
+                from("direct:goodbye")
+                        .routeId("route_2")
+                        .autoStartup(false)
+                        .to("log:info");
+
+                from("direct:goodnight")
+                        .routeId("route_3")
+                        .to("log:info");
+            }
+        });
+
+        citrusCamelContext.start();
+
+        context.getReferenceResolver().bind("citrusCamelContext", citrusCamelContext);
+        context.getReferenceResolver().bind("camelContext", citrusCamelContext);
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "CamelControlBusTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 4L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), CamelControlBusAction.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "controlbus");
+
+        int actionIndex = 0;
+
+        CamelControlBusAction action = (CamelControlBusAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve("citrusCamelContext", CamelContext.class));
+        Assert.assertEquals(action.getRouteId(), "route_1");
+        Assert.assertEquals(action.getAction(), "start");
+        Assert.assertNull(action.getResult());
+
+        action = (CamelControlBusAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve("camelContext", CamelContext.class));
+        Assert.assertEquals(action.getRouteId(), "route_2");
+        Assert.assertEquals(action.getAction(), "status");
+        Assert.assertEquals(action.getResult(), "Stopped");
+
+        action = (CamelControlBusAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve("camelContext", CamelContext.class));
+        Assert.assertEquals(action.getLanguageType(), "simple");
+        Assert.assertEquals(action.getLanguageExpression(), "${camelContext.getRouteController().getRouteStatus('route_3')}");
+        Assert.assertEquals(action.getResult(), "Started");
+
+        action = (CamelControlBusAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve("citrusCamelContext", CamelContext.class));
+        Assert.assertEquals(action.getLanguageType(), "simple");
+        Assert.assertEquals(action.getLanguageExpression(), "${camelContext.stop()}");
+        Assert.assertNull(action.getResult());
+
+    }
+}

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/xml/CreateRoutesTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/xml/CreateRoutesTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.xml;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.camel.actions.CreateCamelRouteAction;
+import org.citrusframework.xml.XmlTestLoader;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class CreateRoutesTest extends AbstractXmlActionTest {
+
+    @Test
+    public void shouldLoadCamelActions() throws Exception {
+        XmlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/camel/xml/camel-create-routes-test.xml");
+
+        CamelContext citrusCamelContext = new DefaultCamelContext();
+        citrusCamelContext.start();
+
+        context.getReferenceResolver().bind("citrusCamelContext", citrusCamelContext);
+        context.getReferenceResolver().bind("camelContext", citrusCamelContext);
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "CamelCreateRouteTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 2L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), CreateCamelRouteAction.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "create-routes");
+
+        int actionIndex = 0;
+
+        CreateCamelRouteAction action = (CreateCamelRouteAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve("citrusCamelContext", CamelContext.class));
+        Assert.assertNull(action.getRouteContext());
+        Assert.assertNotNull(action.getRoutes());
+        Assert.assertEquals(action.getRoutes().size(), 2L);
+        Assert.assertEquals(action.getRoutes().get(0).getRouteId(), "route_1");
+        Assert.assertEquals(action.getRoutes().get(1).getRouteId(), "route_2");
+
+        action = (CreateCamelRouteAction) result.getTestAction(actionIndex);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve("camelContext", CamelContext.class));
+        Assert.assertNull(action.getRouteContext());
+        Assert.assertNotNull(action.getRoutes());
+        Assert.assertEquals(action.getRoutes().size(), 1L);
+        Assert.assertEquals(action.getRoutes().get(0).getEndpointUrl(), "direct:test3");
+    }
+}

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/xml/RemoveRoutesTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/xml/RemoveRoutesTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.xml;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.camel.actions.RemoveCamelRouteAction;
+import org.citrusframework.xml.XmlTestLoader;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class RemoveRoutesTest extends AbstractXmlActionTest {
+
+    @Test
+    public void shouldLoadCamelActions() throws Exception {
+        XmlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/camel/xml/camel-remove-routes-test.xml");
+
+        CamelContext citrusCamelContext = new DefaultCamelContext();
+        citrusCamelContext.addRoutes(new RouteBuilder(citrusCamelContext) {
+            @Override
+            public void configure() throws Exception {
+                from("direct:hello")
+                        .routeId("route_1")
+                        .autoStartup(false)
+                        .to("log:info");
+
+                from("direct:goodbye")
+                        .routeId("route_2")
+                        .autoStartup(false)
+                        .to("log:info");
+
+                from("direct:goodnight")
+                        .routeId("route_3")
+                        .autoStartup(false)
+                        .to("log:info");
+            }
+        });
+
+        citrusCamelContext.start();
+
+        context.getReferenceResolver().bind("citrusCamelContext", citrusCamelContext);
+        context.getReferenceResolver().bind("camelContext", citrusCamelContext);
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "CamelRemoveRouteTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 2L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), RemoveCamelRouteAction.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "remove-routes");
+
+        int actionIndex = 0;
+
+        RemoveCamelRouteAction action = (RemoveCamelRouteAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve("citrusCamelContext", CamelContext.class));
+        Assert.assertEquals(action.getRouteIds().size(), 1);
+
+        action = (RemoveCamelRouteAction) result.getTestAction(actionIndex);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve("camelContext", CamelContext.class));
+        Assert.assertEquals(action.getRouteIds().size(), 2);
+    }
+}

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/xml/StartRoutesTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/xml/StartRoutesTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.xml;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.camel.actions.StartCamelRouteAction;
+import org.citrusframework.xml.XmlTestLoader;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class StartRoutesTest extends AbstractXmlActionTest {
+
+    @Test
+    public void shouldLoadCamelActions() throws Exception {
+        XmlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/camel/xml/camel-start-routes-test.xml");
+
+        CamelContext citrusCamelContext = new DefaultCamelContext();
+        citrusCamelContext.addRoutes(new RouteBuilder(citrusCamelContext) {
+            @Override
+            public void configure() throws Exception {
+                from("direct:hello")
+                        .routeId("route_1")
+                        .autoStartup(false)
+                        .to("log:info");
+
+                from("direct:goodbye")
+                        .routeId("route_2")
+                        .autoStartup(false)
+                        .to("log:info");
+
+                from("direct:goodnight")
+                        .routeId("route_3")
+                        .autoStartup(false)
+                        .to("log:info");
+            }
+        });
+
+        citrusCamelContext.start();
+
+        context.getReferenceResolver().bind("citrusCamelContext", citrusCamelContext);
+        context.getReferenceResolver().bind("camelContext", citrusCamelContext);
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "CamelStartRouteTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 2L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), StartCamelRouteAction.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "start-routes");
+
+        int actionIndex = 0;
+
+        StartCamelRouteAction action = (StartCamelRouteAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve("citrusCamelContext", CamelContext.class));
+        Assert.assertEquals(action.getRouteIds().size(), 1);
+
+        action = (StartCamelRouteAction) result.getTestAction(actionIndex);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve("camelContext", CamelContext.class));
+        Assert.assertEquals(action.getRouteIds().size(), 2);
+    }
+}

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/xml/StopRoutesTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/xml/StopRoutesTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.xml;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.camel.actions.StopCamelRouteAction;
+import org.citrusframework.xml.XmlTestLoader;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class StopRoutesTest extends AbstractXmlActionTest {
+
+    @Test
+    public void shouldLoadCamelActions() throws Exception {
+        XmlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/camel/xml/camel-stop-routes-test.xml");
+
+        CamelContext citrusCamelContext = new DefaultCamelContext();
+        citrusCamelContext.addRoutes(new RouteBuilder(citrusCamelContext) {
+            @Override
+            public void configure() throws Exception {
+                from("direct:hello")
+                        .routeId("route_1")
+                        .to("log:info");
+
+                from("direct:goodbye")
+                        .routeId("route_2")
+                        .to("log:info");
+
+                from("direct:goodnight")
+                        .routeId("route_3")
+                        .to("log:info");
+            }
+        });
+
+        citrusCamelContext.start();
+
+        context.getReferenceResolver().bind("citrusCamelContext", citrusCamelContext);
+        context.getReferenceResolver().bind("camelContext", citrusCamelContext);
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "CamelStopRouteTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 2L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), StopCamelRouteAction.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "stop-routes");
+
+        int actionIndex = 0;
+
+        StopCamelRouteAction action = (StopCamelRouteAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve("citrusCamelContext", CamelContext.class));
+        Assert.assertEquals(action.getRouteIds().size(), 1);
+
+        action = (StopCamelRouteAction) result.getTestAction(actionIndex);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve("camelContext", CamelContext.class));
+        Assert.assertEquals(action.getRouteIds().size(), 2);
+    }
+}

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/yaml/AbstractYamlActionTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/yaml/AbstractYamlActionTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.yaml;
+
+import org.citrusframework.Citrus;
+import org.citrusframework.CitrusContext;
+import org.citrusframework.CitrusInstanceManager;
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.annotations.CitrusAnnotations;
+import org.citrusframework.context.StaticTestContextFactory;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.testng.AbstractTestNGUnitTest;
+import org.citrusframework.yaml.YamlTestLoader;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeClass;
+
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class AbstractYamlActionTest extends AbstractTestNGUnitTest {
+
+    protected Citrus citrus;
+
+    @Mock
+    protected CitrusContext citrusContext;
+
+    @BeforeClass
+    public void setupMocks() {
+        MockitoAnnotations.openMocks(this);
+        citrus = CitrusInstanceManager.newInstance(() -> citrusContext);
+    }
+
+    @Override
+    protected TestContext createTestContext() {
+        TestContext context = super.createTestContext();
+        when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
+        when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
+        when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        CitrusAnnotations.injectAll(this, citrus, context);
+        return context;
+    }
+
+    protected YamlTestLoader createTestLoader(String sourcePath) {
+        YamlTestLoader testLoader = new YamlTestLoader(this.getClass(), "Test", this.getClass().getPackageName());
+        CitrusAnnotations.injectAll(testLoader, citrus, context);
+        CitrusAnnotations.injectTestRunner(testLoader, new DefaultTestCaseRunner(context));
+        testLoader.setSource(sourcePath);
+
+        return testLoader;
+    }
+}

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/yaml/CamelTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/yaml/CamelTest.java
@@ -1,0 +1,15 @@
+package org.citrusframework.camel.yaml;
+
+import org.citrusframework.yaml.actions.YamlTestActionBuilder;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class CamelTest {
+
+    @Test
+    public void shouldLookupTestActionBuilder() {
+        Assert.assertTrue(YamlTestActionBuilder.lookup().containsKey("camel"));
+        Assert.assertTrue(YamlTestActionBuilder.lookup("camel").isPresent());
+        Assert.assertEquals(YamlTestActionBuilder.lookup("camel").get().getClass(), Camel.class);
+    }
+}

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/yaml/ControlBusTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/yaml/ControlBusTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.yaml;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.camel.actions.CamelControlBusAction;
+import org.citrusframework.yaml.YamlTestLoader;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class ControlBusTest extends AbstractYamlActionTest {
+
+    @Test
+    public void shouldLoadCamelActions() throws Exception {
+        YamlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/camel/yaml/camel-control-bus-test.yaml");
+
+        CamelContext citrusCamelContext = new DefaultCamelContext();
+        citrusCamelContext.addRoutes(new RouteBuilder(citrusCamelContext) {
+            @Override
+            public void configure() throws Exception {
+                from("direct:hello")
+                        .routeId("route_1")
+                        .to("log:info");
+
+                from("direct:goodbye")
+                        .routeId("route_2")
+                        .autoStartup(false)
+                        .to("log:info");
+
+                from("direct:goodnight")
+                        .routeId("route_3")
+                        .to("log:info");
+            }
+        });
+
+        citrusCamelContext.start();
+
+        context.getReferenceResolver().bind("citrusCamelContext", citrusCamelContext);
+        context.getReferenceResolver().bind("camelContext", citrusCamelContext);
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "CamelControlBusTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 4L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), CamelControlBusAction.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "controlbus");
+
+        int actionIndex = 0;
+
+        CamelControlBusAction action = (CamelControlBusAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve("citrusCamelContext", CamelContext.class));
+        Assert.assertEquals(action.getRouteId(), "route_1");
+        Assert.assertEquals(action.getAction(), "start");
+        Assert.assertNull(action.getResult());
+
+        action = (CamelControlBusAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve("camelContext", CamelContext.class));
+        Assert.assertEquals(action.getRouteId(), "route_2");
+        Assert.assertEquals(action.getAction(), "status");
+        Assert.assertEquals(action.getResult(), "Stopped");
+
+        action = (CamelControlBusAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve("camelContext", CamelContext.class));
+        Assert.assertEquals(action.getLanguageType(), "simple");
+        Assert.assertEquals(action.getLanguageExpression(), "${camelContext.getRouteController().getRouteStatus('route_3')}");
+        Assert.assertEquals(action.getResult(), "Started");
+
+        action = (CamelControlBusAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve("citrusCamelContext", CamelContext.class));
+        Assert.assertEquals(action.getLanguageType(), "simple");
+        Assert.assertEquals(action.getLanguageExpression(), "${camelContext.stop()}");
+        Assert.assertNull(action.getResult());
+
+    }
+}

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/yaml/CreateRoutesTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/yaml/CreateRoutesTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.yaml;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.camel.actions.CreateCamelRouteAction;
+import org.citrusframework.yaml.YamlTestLoader;
+import org.springframework.util.StringUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class CreateRoutesTest extends AbstractYamlActionTest {
+
+    @Test
+    public void shouldLoadCamelActions() throws Exception {
+        YamlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/camel/yaml/camel-create-route-test.yaml");
+
+        CamelContext citrusCamelContext = new DefaultCamelContext();
+        citrusCamelContext.start();
+
+        context.getReferenceResolver().bind("citrusCamelContext", citrusCamelContext);
+        context.getReferenceResolver().bind("camelContext", citrusCamelContext);
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "CamelCreateRouteTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 2L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), CreateCamelRouteAction.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "create-routes");
+
+        int actionIndex = 0;
+
+        CreateCamelRouteAction action = (CreateCamelRouteAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve("citrusCamelContext", CamelContext.class));
+        Assert.assertEquals(StringUtils.trimAllWhitespace(action.getRouteContext()), ("<routeContext xmlns=\"http://camel.apache.org/schema/spring\">" +
+                    "<route id=\"route_1\">" +
+                        "<from uri=\"direct:test1\"/>" +
+                        "<to uri=\"mock:test1\"/>" +
+                    "</route>" +
+                    "<route id=\"route_2\">" +
+                        "<from uri=\"direct:test2\"/>" +
+                        "<to uri=\"mock:test2\"/>" +
+                    "</route>" +
+                "</routeContext>").replaceAll("\\s", ""));
+        Assert.assertEquals(action.getRoutes().size(), 0);
+
+        action = (CreateCamelRouteAction) result.getTestAction(actionIndex);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve("camelContext", CamelContext.class));
+        Assert.assertEquals(StringUtils.trimAllWhitespace(action.getRouteContext()), ("<routeContext xmlns=\"http://camel.apache.org/schema/spring\">" +
+                    "<route>" +
+                        "<from uri=\"direct:test3\"/>" +
+                        "<to uri=\"mock:test3\"/>" +
+                    "</route>" +
+                "</routeContext>").replaceAll("\\s", ""));
+        Assert.assertEquals(action.getRoutes().size(), 0);
+
+    }
+}

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/yaml/RemoveRouteTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/yaml/RemoveRouteTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.yaml;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.camel.actions.RemoveCamelRouteAction;
+import org.citrusframework.yaml.YamlTestLoader;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class RemoveRouteTest extends AbstractYamlActionTest {
+
+    @Test
+    public void shouldLoadCamelActions() throws Exception {
+        YamlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/camel/yaml/camel-remove-route-test.yaml");
+
+        CamelContext citrusCamelContext = new DefaultCamelContext();
+        citrusCamelContext.addRoutes(new RouteBuilder(citrusCamelContext) {
+            @Override
+            public void configure() throws Exception {
+                from("direct:hello")
+                        .routeId("route_1")
+                        .autoStartup(false)
+                        .to("log:info");
+
+                from("direct:goodbye")
+                        .routeId("route_2")
+                        .autoStartup(false)
+                        .to("log:info");
+
+                from("direct:goodnight")
+                        .routeId("route_3")
+                        .autoStartup(false)
+                        .to("log:info");
+            }
+        });
+
+        citrusCamelContext.start();
+
+        context.getReferenceResolver().bind("citrusCamelContext", citrusCamelContext);
+        context.getReferenceResolver().bind("camelContext", citrusCamelContext);
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "CamelRemoveRouteTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 2L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), RemoveCamelRouteAction.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "remove-routes");
+
+        int actionIndex = 0;
+
+        RemoveCamelRouteAction action = (RemoveCamelRouteAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve("citrusCamelContext", CamelContext.class));
+        Assert.assertEquals(action.getRouteIds().size(), 1);
+
+        action = (RemoveCamelRouteAction) result.getTestAction(actionIndex);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve("camelContext", CamelContext.class));
+        Assert.assertEquals(action.getRouteIds().size(), 2);
+
+    }
+}

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/yaml/StartRouteTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/yaml/StartRouteTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.yaml;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.camel.actions.StartCamelRouteAction;
+import org.citrusframework.yaml.YamlTestLoader;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class StartRouteTest extends AbstractYamlActionTest {
+
+    @Test
+    public void shouldLoadCamelActions() throws Exception {
+        YamlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/camel/yaml/camel-start-route-test.yaml");
+
+        CamelContext citrusCamelContext = new DefaultCamelContext();
+        citrusCamelContext.addRoutes(new RouteBuilder(citrusCamelContext) {
+            @Override
+            public void configure() throws Exception {
+                from("direct:hello")
+                        .routeId("route_1")
+                        .autoStartup(false)
+                        .to("log:info");
+
+                from("direct:goodbye")
+                        .routeId("route_2")
+                        .autoStartup(false)
+                        .to("log:info");
+
+                from("direct:goodnight")
+                        .routeId("route_3")
+                        .autoStartup(false)
+                        .to("log:info");
+            }
+        });
+
+        citrusCamelContext.start();
+
+        context.getReferenceResolver().bind("citrusCamelContext", citrusCamelContext);
+        context.getReferenceResolver().bind("camelContext", citrusCamelContext);
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "CamelStartRouteTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 2L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), StartCamelRouteAction.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "start-routes");
+
+        int actionIndex = 0;
+
+        StartCamelRouteAction action = (StartCamelRouteAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve("citrusCamelContext", CamelContext.class));
+        Assert.assertEquals(action.getRouteIds().size(), 1);
+
+        action = (StartCamelRouteAction) result.getTestAction(actionIndex);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve("camelContext", CamelContext.class));
+        Assert.assertEquals(action.getRouteIds().size(), 2);
+
+    }
+}

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/yaml/StopRouteTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/yaml/StopRouteTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.yaml;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.camel.actions.StopCamelRouteAction;
+import org.citrusframework.yaml.YamlTestLoader;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class StopRouteTest extends AbstractYamlActionTest {
+
+    @Test
+    public void shouldLoadCamelActions() throws Exception {
+        YamlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/camel/yaml/camel-stop-route-test.yaml");
+
+        CamelContext citrusCamelContext = new DefaultCamelContext();
+        citrusCamelContext.addRoutes(new RouteBuilder(citrusCamelContext) {
+            @Override
+            public void configure() throws Exception {
+                from("direct:hello")
+                        .routeId("route_1")
+                        .to("log:info");
+
+                from("direct:goodbye")
+                        .routeId("route_2")
+                        .to("log:info");
+
+                from("direct:goodnight")
+                        .routeId("route_3")
+                        .to("log:info");
+            }
+        });
+
+        citrusCamelContext.start();
+
+        context.getReferenceResolver().bind("citrusCamelContext", citrusCamelContext);
+        context.getReferenceResolver().bind("camelContext", citrusCamelContext);
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "CamelStopRouteTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 2L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), StopCamelRouteAction.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "stop-routes");
+
+        int actionIndex = 0;
+
+        StopCamelRouteAction action = (StopCamelRouteAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve("citrusCamelContext", CamelContext.class));
+        Assert.assertEquals(action.getRouteIds().size(), 1);
+
+        action = (StopCamelRouteAction) result.getTestAction(actionIndex);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve("camelContext", CamelContext.class));
+        Assert.assertEquals(action.getRouteIds().size(), 2);
+
+    }
+}

--- a/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/config/xml/CamelControlBusActionParserTest-context.xml
+++ b/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/config/xml/CamelControlBusActionParserTest-context.xml
@@ -24,7 +24,7 @@
           </camel:control-bus>
 
           <camel:control-bus camel-context="camelContext">
-            <camel:language type="simple">${camelContext.getRouteStatus('route_3')}</camel:language>
+            <camel:language type="simple">${camelContext.getRouteController().getRouteStatus('route_3')}</camel:language>
             <camel:result>Started</camel:result>
           </camel:control-bus>
         </actions>

--- a/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/groovy/camel-control-bus.test.groovy
+++ b/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/groovy/camel-control-bus.test.groovy
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.groovy
+
+import static org.citrusframework.camel.actions.CamelActionBuilder.camel
+
+name "CamelControlBusTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+actions {
+    $(camel()
+        .controlBus()
+        .route("route_1")
+        .action("start")
+    )
+
+    $(camel().camelContext(camelContext)
+        .controlBus()
+        .route("route_2")
+        .action("status")
+        .result("Stopped")
+    )
+
+    $(camel()
+        .controlBus()
+        .language("simple", '${camelContext.getRouteController().getRouteStatus("route_3")}')
+        .result("Started")
+    )
+
+    $(camel()
+        .controlBus()
+        .simple('${camelContext.stop()}')
+    )
+}

--- a/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/groovy/camel-create-routes.test.groovy
+++ b/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/groovy/camel-create-routes.test.groovy
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.groovy
+
+import static org.citrusframework.camel.actions.CamelActionBuilder.camel
+
+name "CamelCreateRouteTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+actions {
+    $(camel()
+        .route()
+        .create("""
+          <routeContext xmlns="http://camel.apache.org/schema/spring">
+            <route id="route_1">
+              <from uri="direct:test1"/>
+              <to uri="mock:test1"/>
+            </route>
+  
+            <route id="route_2">
+              <from uri="direct:test2"/>
+              <to uri="mock:test2"/>
+            </route>
+          </routeContext>
+        """))
+
+    $(camel()
+        .camelContext(camelContext)
+        .route()
+        .create("""
+          <routeContext xmlns="http://camel.apache.org/schema/spring">
+            <route>
+              <from uri="direct:test3"/>
+              <to uri="mock:test3"/>
+            </route>
+          </routeContext>
+        """))
+}

--- a/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/groovy/camel-remove-routes.test.groovy
+++ b/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/groovy/camel-remove-routes.test.groovy
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.groovy
+
+import static org.citrusframework.camel.actions.CamelActionBuilder.camel
+
+name "CamelRemoveRouteTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+actions {
+    $(camel()
+        .route()
+        .remove("route_1"))
+
+    $(camel()
+        .camelContext(camelContext)
+        .route()
+        .remove("route_2", "route_3"))
+}

--- a/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/groovy/camel-start-routes.test.groovy
+++ b/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/groovy/camel-start-routes.test.groovy
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.groovy
+
+import static org.citrusframework.camel.actions.CamelActionBuilder.camel
+
+name "CamelStartRouteTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+actions {
+    $(camel()
+        .route()
+        .start("route_1"))
+
+    $(camel()
+        .camelContext(camelContext)
+        .route()
+        .start("route_2", "route_3"))
+}

--- a/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/groovy/camel-stop-routes.test.groovy
+++ b/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/groovy/camel-stop-routes.test.groovy
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.groovy
+
+import static org.citrusframework.camel.actions.CamelActionBuilder.camel
+
+name "CamelStopRouteTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+actions {
+    $(camel()
+        .route()
+        .stop("route_1"))
+
+    $(camel()
+        .camelContext(camelContext)
+        .route()
+        .stop("route_2", "route_3"))
+}

--- a/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/xml/camel-control-bus-test.xml
+++ b/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/xml/camel-control-bus-test.xml
@@ -1,0 +1,51 @@
+<!--
+  ~ Copyright 2021 the original author or authors.
+  ~
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements. See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License. You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<test name="CamelControlBusTest" author="Christoph" status="FINAL" xmlns="http://citrusframework.org/schema/xml/testcase"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://citrusframework.org/schema/xml/testcase http://citrusframework.org/schema/xml/testcase/citrus-testcase.xsd">
+  <description>Sample test in XML</description>
+  <actions>
+    <camel>
+      <control-bus>
+        <route id="route_1" action="start"/>
+      </control-bus>
+    </camel>
+
+    <camel camel-context="camelContext">
+      <control-bus>
+        <route id="route_2" action="status"/>
+        <result>Stopped</result>
+      </control-bus>
+    </camel>
+
+    <camel camel-context="camelContext">
+      <control-bus>
+        <language type="simple">${camelContext.getRouteController().getRouteStatus('route_3')}</language>
+        <result>Started</result>
+      </control-bus>
+    </camel>
+
+    <camel>
+      <control-bus>
+        <language type="simple">${camelContext.stop()}</language>
+      </control-bus>
+    </camel>
+  </actions>
+</test>

--- a/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/xml/camel-create-routes-test.xml
+++ b/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/xml/camel-create-routes-test.xml
@@ -1,0 +1,53 @@
+<!--
+  ~ Copyright 2021 the original author or authors.
+  ~
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements. See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License. You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<test name="CamelCreateRouteTest" author="Christoph" status="FINAL" xmlns="http://citrusframework.org/schema/xml/testcase"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://citrusframework.org/schema/xml/testcase http://citrusframework.org/schema/xml/testcase/citrus-testcase.xsd
+                          http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
+  <description>Sample test in XML</description>
+  <actions>
+    <camel>
+      <create-routes>
+        <routeContext xmlns="http://camel.apache.org/schema/spring">
+          <route id="route_1">
+            <from uri="direct:test1"/>
+            <to uri="mock:test1"/>
+          </route>
+
+          <route id="route_2">
+            <from uri="direct:test2"/>
+            <to uri="mock:test2"/>
+          </route>
+        </routeContext>
+      </create-routes>
+    </camel>
+
+    <camel camel-context="camelContext">
+      <create-routes>
+        <routeContext xmlns="http://camel.apache.org/schema/spring">
+          <route>
+            <from uri="direct:test3"/>
+            <to uri="mock:test3"/>
+          </route>
+        </routeContext>
+      </create-routes>
+    </camel>
+  </actions>
+</test>

--- a/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/xml/camel-remove-routes-test.xml
+++ b/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/xml/camel-remove-routes-test.xml
@@ -1,0 +1,38 @@
+<!--
+  ~ Copyright 2021 the original author or authors.
+  ~
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements. See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License. You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<test name="CamelRemoveRouteTest" author="Christoph" status="FINAL" xmlns="http://citrusframework.org/schema/xml/testcase"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://citrusframework.org/schema/xml/testcase http://citrusframework.org/schema/xml/testcase/citrus-testcase.xsd">
+  <description>Sample test in XML</description>
+  <actions>
+    <camel>
+      <remove-routes>
+        <route id="route_1"/>
+      </remove-routes>
+    </camel>
+
+    <camel camel-context="camelContext">
+      <remove-routes>
+        <route id="route_2"/>
+        <route id="route_3"/>
+      </remove-routes>
+    </camel>
+  </actions>
+</test>

--- a/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/xml/camel-start-routes-test.xml
+++ b/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/xml/camel-start-routes-test.xml
@@ -1,0 +1,38 @@
+<!--
+  ~ Copyright 2021 the original author or authors.
+  ~
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements. See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License. You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<test name="CamelStartRouteTest" author="Christoph" status="FINAL" xmlns="http://citrusframework.org/schema/xml/testcase"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://citrusframework.org/schema/xml/testcase http://citrusframework.org/schema/xml/testcase/citrus-testcase.xsd">
+  <description>Sample test in XML</description>
+  <actions>
+    <camel>
+      <start-routes>
+        <route id="route_1"/>
+      </start-routes>
+    </camel>
+
+    <camel camel-context="camelContext">
+      <start-routes>
+        <route id="route_2"/>
+        <route id="route_3"/>
+      </start-routes>
+    </camel>
+  </actions>
+</test>

--- a/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/xml/camel-stop-routes-test.xml
+++ b/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/xml/camel-stop-routes-test.xml
@@ -1,0 +1,38 @@
+<!--
+  ~ Copyright 2021 the original author or authors.
+  ~
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements. See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License. You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<test name="CamelStopRouteTest" author="Christoph" status="FINAL" xmlns="http://citrusframework.org/schema/xml/testcase"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://citrusframework.org/schema/xml/testcase http://citrusframework.org/schema/xml/testcase/citrus-testcase.xsd">
+  <description>Sample test in XML</description>
+  <actions>
+    <camel>
+      <stop-routes>
+        <route id="route_1"/>
+      </stop-routes>
+    </camel>
+
+    <camel camel-context="camelContext">
+      <stop-routes>
+        <route id="route_2"/>
+        <route id="route_3"/>
+      </stop-routes>
+    </camel>
+  </actions>
+</test>

--- a/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/yaml/camel-control-bus-test.yaml
+++ b/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/yaml/camel-control-bus-test.yaml
@@ -1,0 +1,26 @@
+name: "CamelControlBusTest"
+author: "Christoph"
+status: "FINAL"
+actions:
+  - camel:
+      controlBus:
+        route: "route_1"
+        action: "start"
+
+  - camel:
+      camelContext: "camelContext"
+      controlBus:
+        route: "route_2"
+        action: "status"
+        result: "Stopped"
+
+  - camel:
+      controlBus:
+        language:
+          name: "simple"
+          expression: "${camelContext.getRouteController().getRouteStatus('route_3')}"
+        result: "Started"
+
+  - camel:
+      controlBus:
+        simple: "${camelContext.stop()}"

--- a/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/yaml/camel-create-route-test.yaml
+++ b/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/yaml/camel-create-route-test.yaml
@@ -1,0 +1,29 @@
+name: "CamelCreateRouteTest"
+author: "Christoph"
+status: "FINAL"
+actions:
+  - camel:
+      createRoutes:
+        routeContext: |
+          <routeContext xmlns="http://camel.apache.org/schema/spring">
+            <route id="route_1">
+              <from uri="direct:test1"/>
+              <to uri="mock:test1"/>
+            </route>
+  
+            <route id="route_2">
+              <from uri="direct:test2"/>
+              <to uri="mock:test2"/>
+            </route>
+          </routeContext>
+
+  - camel:
+      camelContext: "camelContext"
+      createRoutes:
+        routeContext: |
+          <routeContext xmlns="http://camel.apache.org/schema/spring">
+            <route>
+              <from uri="direct:test3"/>
+              <to uri="mock:test3"/>
+            </route>
+          </routeContext>

--- a/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/yaml/camel-remove-route-test.yaml
+++ b/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/yaml/camel-remove-route-test.yaml
@@ -1,0 +1,15 @@
+name: "CamelRemoveRouteTest"
+author: "Christoph"
+status: "FINAL"
+actions:
+  - camel:
+      removeRoutes:
+        routes:
+          - "route_1"
+
+  - camel:
+      camelContext: "camelContext"
+      removeRoutes:
+        routes:
+          - "route_2"
+          - "route_3"

--- a/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/yaml/camel-start-route-test.yaml
+++ b/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/yaml/camel-start-route-test.yaml
@@ -1,0 +1,15 @@
+name: "CamelStartRouteTest"
+author: "Christoph"
+status: "FINAL"
+actions:
+  - camel:
+      startRoutes:
+        routes:
+          - "route_1"
+
+  - camel:
+      camelContext: "camelContext"
+      startRoutes:
+        routes:
+          - "route_2"
+          - "route_3"

--- a/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/yaml/camel-stop-route-test.yaml
+++ b/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/yaml/camel-stop-route-test.yaml
@@ -1,0 +1,15 @@
+name: "CamelStopRouteTest"
+author: "Christoph"
+status: "FINAL"
+actions:
+  - camel:
+      stopRoutes:
+        routes:
+          - "route_1"
+
+  - camel:
+      camelContext: "camelContext"
+      stopRoutes:
+        routes:
+          - "route_2"
+          - "route_3"

--- a/endpoints/citrus-http/pom.xml
+++ b/endpoints/citrus-http/pom.xml
@@ -139,6 +139,12 @@
     </dependency>
     <dependency>
       <groupId>org.citrusframework</groupId>
+      <artifactId>citrus-groovy</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.citrusframework</groupId>
       <artifactId>citrus-validation-xml</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/actions/HttpClientActionBuilder.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/actions/HttpClientActionBuilder.java
@@ -85,6 +85,7 @@ public class HttpClientActionBuilder implements TestActionBuilder.DelegatingTest
             builder.endpoint(httpClientUri);
         }
 
+        builder.name("http:send-request");
         builder.withReferenceResolver(referenceResolver);
         builder.method(method);
 
@@ -239,6 +240,7 @@ public class HttpClientActionBuilder implements TestActionBuilder.DelegatingTest
                 builder.endpoint(httpClientUri);
             }
 
+            builder.name("http:receive-response");
             builder.withReferenceResolver(referenceResolver);
             HttpClientActionBuilder.this.delegate = builder;
             return builder;
@@ -256,6 +258,7 @@ public class HttpClientActionBuilder implements TestActionBuilder.DelegatingTest
                 builder.endpoint(httpClientUri);
             }
 
+            builder.name("http:receive-response");
             builder.withReferenceResolver(referenceResolver);
             builder.message().status(status);
             HttpClientActionBuilder.this.delegate = builder;

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/actions/HttpServerActionBuilder.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/actions/HttpServerActionBuilder.java
@@ -101,6 +101,7 @@ public class HttpServerActionBuilder implements TestActionBuilder.DelegatingTest
             builder.endpoint(httpServerUri);
         }
 
+        builder.name("http:receive-request");
         builder.withReferenceResolver(referenceResolver);
         builder.message().method(method);
 
@@ -137,6 +138,7 @@ public class HttpServerActionBuilder implements TestActionBuilder.DelegatingTest
                 builder.endpoint(httpServerUri);
             }
 
+            builder.name("http:send-response");
             builder.withReferenceResolver(referenceResolver);
 
             HttpServerActionBuilder.this.delegate = builder;
@@ -155,6 +157,7 @@ public class HttpServerActionBuilder implements TestActionBuilder.DelegatingTest
                 builder.endpoint(httpServerUri);
             }
 
+            builder.name("http:send-response");
             builder.withReferenceResolver(referenceResolver);
             builder.message().status(status);
 

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/xml/Http.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/xml/Http.java
@@ -19,16 +19,16 @@
 
 package org.citrusframework.http.xml;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlType;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-
 import org.citrusframework.TestAction;
 import org.citrusframework.TestActionBuilder;
 import org.citrusframework.actions.ReceiveMessageAction;
@@ -721,6 +721,10 @@ public class Http implements TestActionBuilder<TestAction>, ReferenceResolverAwa
             }
 
             return validates;
+        }
+
+        public void setValidates(List<Receive.Validate> validates) {
+            this.validates = validates;
         }
 
         public Message.Extract getExtract() {

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/actions/dsl/ReceiveHttpMessageTestActionBuilderTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/actions/dsl/ReceiveHttpMessageTestActionBuilderTest.java
@@ -85,7 +85,7 @@ public class ReceiveHttpMessageTestActionBuilderTest extends UnitTestSupport {
         Assert.assertEquals(test.getActions().get(0).getClass(), ReceiveMessageAction.class);
 
         ReceiveMessageAction action = (ReceiveMessageAction) test.getActions().get(0);
-        Assert.assertEquals(action.getName(), "receive");
+        Assert.assertEquals(action.getName(), "http:receive-request");
 
         Assert.assertEquals(action.getEndpoint(), httpServer);
         Assert.assertEquals(action.getValidationContexts().size(), 3L);
@@ -131,7 +131,7 @@ public class ReceiveHttpMessageTestActionBuilderTest extends UnitTestSupport {
         Assert.assertEquals(test.getActions().get(0).getClass(), ReceiveMessageAction.class);
 
         ReceiveMessageAction action = (ReceiveMessageAction) test.getActions().get(0);
-        Assert.assertEquals(action.getName(), "receive");
+        Assert.assertEquals(action.getName(), "http:receive-request");
 
         Assert.assertEquals(action.getEndpoint(), httpServer);
         Assert.assertEquals(action.getValidationContexts().size(), 3L);
@@ -180,7 +180,7 @@ public class ReceiveHttpMessageTestActionBuilderTest extends UnitTestSupport {
         Assert.assertEquals(test.getActions().get(0).getClass(), ReceiveMessageAction.class);
 
         ReceiveMessageAction action = (ReceiveMessageAction) test.getActions().get(0);
-        Assert.assertEquals(action.getName(), "receive");
+        Assert.assertEquals(action.getName(), "http:receive-response");
 
         Assert.assertEquals(action.getEndpoint(), httpClient);
         Assert.assertEquals(action.getValidationContexts().size(), 3L);

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/actions/dsl/SendHttpMessageTestActionBuilderTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/actions/dsl/SendHttpMessageTestActionBuilderTest.java
@@ -87,7 +87,7 @@ public class SendHttpMessageTestActionBuilderTest extends UnitTestSupport {
         Assert.assertEquals(test.getActions().get(1).getClass(), SendMessageAction.class);
 
         SendMessageAction action = ((SendMessageAction)(test.getActions().get(0)));
-        Assert.assertEquals(action.getName(), "send");
+        Assert.assertEquals(action.getName(), "http:send-request");
 
         Assert.assertEquals(action.getEndpoint(), httpClient);
         Assert.assertEquals(action.getMessageBuilder().getClass(), HttpMessageBuilder.class);
@@ -103,7 +103,7 @@ public class SendHttpMessageTestActionBuilderTest extends UnitTestSupport {
         Assert.assertFalse(action.isForkMode());
 
         action = ((SendMessageAction)test.getActions().get(1));
-        Assert.assertEquals(action.getName(), "send");
+        Assert.assertEquals(action.getName(), "http:send-request");
 
         messageBuilder = (HttpMessageBuilder) action.getMessageBuilder();
         Assert.assertEquals(action.getEndpoint(), httpClient);
@@ -144,7 +144,7 @@ public class SendHttpMessageTestActionBuilderTest extends UnitTestSupport {
         Assert.assertEquals(test.getActions().get(0).getClass(), SendMessageAction.class);
 
         SendMessageAction action = ((SendMessageAction)(test.getActions().get(0)));
-        Assert.assertEquals(action.getName(), "send");
+        Assert.assertEquals(action.getName(), "http:send-request");
 
         Assert.assertEquals(action.getEndpoint(), httpClient);
         Assert.assertEquals(action.getMessageBuilder().getClass(), HttpMessageBuilder.class);
@@ -188,7 +188,7 @@ public class SendHttpMessageTestActionBuilderTest extends UnitTestSupport {
         Assert.assertEquals(test.getActions().get(0).getClass(), SendMessageAction.class);
 
         SendMessageAction action = ((SendMessageAction)test.getActions().get(0));
-        Assert.assertEquals(action.getName(), "send");
+        Assert.assertEquals(action.getName(), "http:send-request");
 
         Assert.assertEquals(action.getEndpoint(), httpClient);
         Assert.assertEquals(action.getMessageBuilder().getClass(), HttpMessageBuilder.class);
@@ -225,7 +225,7 @@ public class SendHttpMessageTestActionBuilderTest extends UnitTestSupport {
         Assert.assertEquals(test.getActions().get(0).getClass(), SendMessageAction.class);
 
         SendMessageAction action = ((SendMessageAction)test.getActions().get(0));
-        Assert.assertEquals(action.getName(), "send");
+        Assert.assertEquals(action.getName(), "http:send-request");
 
         Assert.assertEquals(action.getEndpoint(), httpClient);
         Assert.assertEquals(action.getMessageBuilder().getClass(), HttpMessageBuilder.class);
@@ -266,7 +266,7 @@ public class SendHttpMessageTestActionBuilderTest extends UnitTestSupport {
         Assert.assertEquals(test.getActions().get(0).getClass(), SendMessageAction.class);
 
         SendMessageAction action = ((SendMessageAction)test.getActions().get(0));
-        Assert.assertEquals(action.getName(), "send");
+        Assert.assertEquals(action.getName(), "http:send-request");
 
         Assert.assertEquals(action.getEndpoint(), httpClient);
         Assert.assertEquals(action.getMessageBuilder().getClass(), HttpMessageBuilder.class);

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/groovy/AbstractGroovyActionDslTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/groovy/AbstractGroovyActionDslTest.java
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-package org.citrusframework.http.xml;
+package org.citrusframework.http.groovy;
 
 import org.citrusframework.Citrus;
 import org.citrusframework.CitrusContext;
@@ -26,18 +26,20 @@ import org.citrusframework.DefaultTestCaseRunner;
 import org.citrusframework.annotations.CitrusAnnotations;
 import org.citrusframework.context.StaticTestContextFactory;
 import org.citrusframework.context.TestContext;
+import org.citrusframework.groovy.GroovyTestLoader;
 import org.citrusframework.testng.AbstractTestNGUnitTest;
-import org.citrusframework.xml.XmlTestLoader;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeClass;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
 /**
  * @author Christoph Deppisch
  */
-public class AbstractXmlActionTest extends AbstractTestNGUnitTest {
+public class AbstractGroovyActionDslTest extends AbstractTestNGUnitTest {
 
     protected Citrus citrus;
 
@@ -53,6 +55,11 @@ public class AbstractXmlActionTest extends AbstractTestNGUnitTest {
     @Override
     protected TestContext createTestContext() {
         TestContext context = super.createTestContext();
+        doAnswer(invocation -> {
+            context.getReferenceResolver().bind(invocation.getArgument(0, String.class), invocation.getArgument(1));
+            return null;
+        }).when(citrusContext).bind(any(String.class), any());
+
         when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
         when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
         when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
@@ -60,11 +67,10 @@ public class AbstractXmlActionTest extends AbstractTestNGUnitTest {
         return context;
     }
 
-    protected XmlTestLoader createTestLoader(String sourcePath) {
-        XmlTestLoader testLoader = new XmlTestLoader(this.getClass(), "Test", this.getClass().getPackageName());
+    protected GroovyTestLoader createTestLoader(String sourcePath) {
+        GroovyTestLoader testLoader = new GroovyTestLoader().source(sourcePath);
         CitrusAnnotations.injectAll(testLoader, citrus, context);
         CitrusAnnotations.injectTestRunner(testLoader, new DefaultTestCaseRunner(context));
-        testLoader.setSource(sourcePath);
 
         return testLoader;
     }

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/groovy/HttpClientTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/groovy/HttpClientTest.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.http.groovy;
+
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
+
+import org.citrusframework.TestActor;
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.actions.ReceiveMessageAction;
+import org.citrusframework.actions.SendMessageAction;
+import org.citrusframework.actions.SleepAction;
+import org.citrusframework.endpoint.EndpointAdapter;
+import org.citrusframework.endpoint.direct.DirectEndpointAdapter;
+import org.citrusframework.endpoint.direct.DirectSyncEndpointConfiguration;
+import org.citrusframework.endpoint.resolver.EndpointUriResolver;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.citrusframework.http.client.HttpClient;
+import org.citrusframework.http.message.HttpMessage;
+import org.citrusframework.http.message.HttpMessageBuilder;
+import org.citrusframework.http.message.HttpMessageHeaders;
+import org.citrusframework.http.server.HttpServer;
+import org.citrusframework.http.validation.TextEqualsMessageValidator;
+import org.citrusframework.message.DefaultMessage;
+import org.citrusframework.message.DefaultMessageQueue;
+import org.citrusframework.message.Message;
+import org.citrusframework.message.MessageHeaders;
+import org.citrusframework.message.MessageQueue;
+import org.citrusframework.spi.BindToRegistry;
+import org.citrusframework.util.SocketUtils;
+import org.citrusframework.validation.DefaultMessageHeaderValidator;
+import org.citrusframework.validation.DelegatingPayloadVariableExtractor;
+import org.citrusframework.validation.context.DefaultValidationContext;
+import org.citrusframework.validation.context.HeaderValidationContext;
+import org.citrusframework.validation.json.JsonMessageValidationContext;
+import org.citrusframework.validation.xml.XmlMessageValidationContext;
+import org.mockito.Mockito;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.http.endpoint.builder.HttpEndpoints.http;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class HttpClientTest extends AbstractGroovyActionDslTest {
+
+    @BindToRegistry
+    final TestActor testActor = Mockito.mock(TestActor.class);
+
+    @BindToRegistry
+    private final DefaultMessageHeaderValidator headerValidator = new DefaultMessageHeaderValidator();
+
+    @BindToRegistry
+    private final TextEqualsMessageValidator validator = new TextEqualsMessageValidator().enableTrim();
+
+    private final int port = SocketUtils.findAvailableTcpPort(8080);
+    private final String uri = "http://localhost:" + port + "/test";
+
+    private HttpServer httpServer;
+    private HttpClient httpClient;
+
+    private final MessageQueue inboundQueue = new DefaultMessageQueue("inboundQueue");
+
+    private final Queue<HttpMessage> responses = new ArrayBlockingQueue<>(6);
+
+    @BeforeClass
+    public void setupEndpoints() {
+        EndpointAdapter endpointAdapter = new DirectEndpointAdapter(new DirectSyncEndpointConfiguration()) {
+            @Override
+            public Message handleMessageInternal(Message request) {
+                inboundQueue.send(request);
+                return responses.isEmpty() ? new HttpMessage().status(HttpStatus.OK) : responses.remove();
+            }
+        };
+
+        httpServer = http().server()
+                .port(port)
+                .timeout(500L)
+                .endpointAdapter(endpointAdapter)
+                .autoStart(true)
+                .name("httpServer")
+                .build();
+        httpServer.initialize();
+
+        httpClient = http().client()
+                .requestUrl(uri)
+                .name("httpClient")
+                .build();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void cleanupEndpoints() {
+        if (httpServer != null) {
+            httpServer.stop();
+        }
+    }
+
+    @Test
+    public void shouldLoadHttpClientActions() {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/http/groovy/http-client.test.groovy");
+
+        context.setVariable("port", port);
+
+        context.getReferenceResolver().bind("httpClient", httpClient);
+        context.getReferenceResolver().bind("httpServer", httpServer);
+
+        responses.add(new HttpMessage().status(HttpStatus.OK));
+        responses.add(new HttpMessage("<order><id>12345</id><item>foo</item></order>").status(HttpStatus.OK).contentType("application/xml"));
+        responses.add(new HttpMessage().status(HttpStatus.NOT_FOUND).header("userId", "1001"));
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "HttpClientTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 10L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), SendMessageAction.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "http:send-request");
+
+        Assert.assertEquals(result.getTestAction(1).getClass(), ReceiveMessageAction.class);
+        Assert.assertEquals(result.getTestAction(1).getName(), "http:receive-response");
+
+        int actionIndex = 0;
+
+        SendMessageAction sendMessageAction = (SendMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertFalse(sendMessageAction.isForkMode());
+        Assert.assertTrue(sendMessageAction.getMessageBuilder() instanceof HttpMessageBuilder);
+        HttpMessageBuilder httpMessageBuilder = ((HttpMessageBuilder)sendMessageAction.getMessageBuilder());
+        Assert.assertNotNull(httpMessageBuilder);
+        Assert.assertEquals(httpMessageBuilder.buildMessagePayload(context, sendMessageAction.getMessageType()), "");
+        Assert.assertEquals(httpMessageBuilder.getMessage().getHeaders().size(), 3L);
+        Assert.assertNotNull(httpMessageBuilder.getMessage().getHeaders().get(MessageHeaders.ID));
+        Assert.assertNotNull(httpMessageBuilder.getMessage().getHeaders().get(MessageHeaders.TIMESTAMP));
+        Assert.assertEquals(httpMessageBuilder.getMessage().getHeaders().get(HttpMessageHeaders.HTTP_REQUEST_METHOD), HttpMethod.GET.name());
+        Assert.assertNull(httpMessageBuilder.getMessage().getHeaders().get(EndpointUriResolver.REQUEST_PATH_HEADER_NAME));
+        Assert.assertNull(httpMessageBuilder.getMessage().getHeaders().get(HttpMessageHeaders.HTTP_QUERY_PARAMS));
+        Assert.assertNull(httpMessageBuilder.getMessage().getHeaders().get(EndpointUriResolver.ENDPOINT_URI_HEADER_NAME));
+        Assert.assertNull(sendMessageAction.getEndpointUri());
+        Assert.assertEquals(sendMessageAction.getEndpoint(), context.getReferenceResolver().resolve("httpClient", HttpClient.class));
+
+        Message controlMessage = new DefaultMessage("");
+        Message request = inboundQueue.receive();
+        headerValidator.validateMessage(request, controlMessage, context, new HeaderValidationContext());
+        validator.validateMessage(request, controlMessage, context, new DefaultValidationContext());
+
+        ReceiveMessageAction receiveMessageAction = (ReceiveMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(receiveMessageAction.getValidationContexts().size(), 3);
+        Assert.assertEquals(receiveMessageAction.getReceiveTimeout(), 0L);
+        Assert.assertTrue(receiveMessageAction.getValidationContexts().get(0) instanceof HeaderValidationContext);
+        Assert.assertTrue(receiveMessageAction.getValidationContexts().get(1) instanceof XmlMessageValidationContext);
+        Assert.assertTrue(receiveMessageAction.getValidationContexts().get(2) instanceof JsonMessageValidationContext);
+
+        httpMessageBuilder = ((HttpMessageBuilder)receiveMessageAction.getMessageBuilder());
+        Assert.assertNotNull(httpMessageBuilder);
+
+        Assert.assertEquals(httpMessageBuilder.buildMessagePayload(context, receiveMessageAction.getMessageType()), "");
+        Assert.assertEquals(httpMessageBuilder.getMessage().getHeaders().size(), 2L);
+        Assert.assertNotNull(httpMessageBuilder.getMessage().getHeaders().get(MessageHeaders.ID));
+        Assert.assertNotNull(httpMessageBuilder.getMessage().getHeaders().get(MessageHeaders.TIMESTAMP));
+        Assert.assertNull(receiveMessageAction.getEndpoint());
+        Assert.assertEquals(receiveMessageAction.getEndpointUri(), "httpClient");
+        Assert.assertEquals(receiveMessageAction.getMessageProcessors().size(), 0);
+        Assert.assertEquals(receiveMessageAction.getControlMessageProcessors().size(), 0);
+
+        sendMessageAction = (SendMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertTrue(sendMessageAction.isForkMode());
+        httpMessageBuilder = ((HttpMessageBuilder)sendMessageAction.getMessageBuilder());
+        Assert.assertNotNull(httpMessageBuilder);
+        Assert.assertEquals(httpMessageBuilder.buildMessagePayload(context, sendMessageAction.getMessageType()), "");
+        Assert.assertNotNull(httpMessageBuilder.getMessage().getHeaders().get(MessageHeaders.ID));
+        Assert.assertNotNull(httpMessageBuilder.getMessage().getHeaders().get(MessageHeaders.TIMESTAMP));
+
+        Map<String, Object> requestHeaders = httpMessageBuilder.buildMessageHeaders(context);
+        Assert.assertEquals(requestHeaders.size(), 9L);
+        Assert.assertEquals(requestHeaders.get(HttpMessageHeaders.HTTP_REQUEST_METHOD), HttpMethod.GET.name());
+        Assert.assertEquals(requestHeaders.get(EndpointUriResolver.REQUEST_PATH_HEADER_NAME), "/order/12345");
+        Assert.assertEquals(requestHeaders.get(HttpMessageHeaders.HTTP_REQUEST_URI), "/order/12345");
+        Assert.assertEquals(requestHeaders.get(HttpMessageHeaders.HTTP_CONTENT_TYPE), "application/xml");
+        Assert.assertEquals(requestHeaders.get(HttpMessageHeaders.HTTP_ACCEPT), "application/xml");
+        Assert.assertEquals(requestHeaders.get(HttpMessageHeaders.HTTP_VERSION), "HTTP/1.1");
+        Assert.assertEquals(requestHeaders.get(HttpMessageHeaders.HTTP_QUERY_PARAMS), "id=12345,type=gold");
+        Assert.assertEquals(requestHeaders.get(EndpointUriResolver.QUERY_PARAM_HEADER_NAME), "id=12345,type=gold");
+        Assert.assertEquals(requestHeaders.get(EndpointUriResolver.ENDPOINT_URI_HEADER_NAME), uri);
+        Assert.assertNull(sendMessageAction.getEndpoint());
+        Assert.assertEquals(sendMessageAction.getEndpointUri(), "httpClient");
+
+        Assert.assertEquals(result.getTestAction(actionIndex++).getClass(), SleepAction.class);
+
+        receiveMessageAction = (ReceiveMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(receiveMessageAction.getValidationContexts().size(), 3);
+        Assert.assertTrue(receiveMessageAction.getValidationContexts().get(0) instanceof HeaderValidationContext);
+        Assert.assertTrue(receiveMessageAction.getValidationContexts().get(1) instanceof XmlMessageValidationContext);
+        Assert.assertTrue(receiveMessageAction.getValidationContexts().get(2) instanceof JsonMessageValidationContext);
+
+        httpMessageBuilder = ((HttpMessageBuilder)receiveMessageAction.getMessageBuilder());
+        Assert.assertNotNull(httpMessageBuilder);
+        Assert.assertEquals(httpMessageBuilder.buildMessagePayload(context, receiveMessageAction.getMessageType()), "<order><id>12345</id><item>foo</item></order>");
+        Assert.assertNotNull(httpMessageBuilder.getMessage().getHeaders().get(MessageHeaders.ID));
+        Assert.assertNotNull(httpMessageBuilder.getMessage().getHeaders().get(MessageHeaders.TIMESTAMP));
+        Map<String, Object> responseHeaders = httpMessageBuilder.buildMessageHeaders(context);
+        Assert.assertEquals(responseHeaders.size(), 4L);
+        Assert.assertEquals(responseHeaders.get(HttpMessageHeaders.HTTP_STATUS_CODE), 200);
+        Assert.assertEquals(responseHeaders.get(HttpMessageHeaders.HTTP_REASON_PHRASE), "OK");
+        Assert.assertEquals(responseHeaders.get(HttpMessageHeaders.HTTP_VERSION), "HTTP/1.1");
+        Assert.assertEquals(responseHeaders.get(HttpMessageHeaders.HTTP_CONTENT_TYPE), "application/xml");
+        Assert.assertNull(receiveMessageAction.getEndpoint());
+        Assert.assertEquals(receiveMessageAction.getEndpointUri(), "httpClient");
+
+        Assert.assertEquals(receiveMessageAction.getVariableExtractors().size(), 1L);
+        Assert.assertEquals(((DelegatingPayloadVariableExtractor)receiveMessageAction.getVariableExtractors().get(0)).getPathExpressions().size(), 1L);
+        Assert.assertEquals(((DelegatingPayloadVariableExtractor)receiveMessageAction.getVariableExtractors().get(0)).getPathExpressions().get("/order/id"), "orderId");
+
+        Assert.assertEquals(context.getVariable("orderId"), "12345");
+
+        sendMessageAction = (SendMessageAction) result.getTestAction(actionIndex++);
+        httpMessageBuilder = ((HttpMessageBuilder)sendMessageAction.getMessageBuilder());
+        Assert.assertNotNull(httpMessageBuilder);
+        Assert.assertEquals(httpMessageBuilder.buildMessagePayload(context, sendMessageAction.getMessageType()), "<user><id>1001</id><name>new_user</name></user>");
+        Assert.assertEquals(httpMessageBuilder.getMessage().getHeaders().get(HttpMessageHeaders.HTTP_REQUEST_METHOD), HttpMethod.POST.name());
+        Assert.assertEquals(httpMessageBuilder.getMessage().getHeaders().get(EndpointUriResolver.REQUEST_PATH_HEADER_NAME), "/user");
+        Assert.assertEquals(httpMessageBuilder.buildMessageHeaders(context).get("userId"), "1001");
+        Assert.assertNull(httpMessageBuilder.getMessage().getHeaders().get(HttpMessageHeaders.HTTP_QUERY_PARAMS));
+        Assert.assertEquals(sendMessageAction.getEndpointUri(), "httpClient");
+
+        receiveMessageAction = (ReceiveMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(receiveMessageAction.getValidationContexts().size(), 3);
+        Assert.assertEquals(receiveMessageAction.getReceiveTimeout(), 2000L);
+        Assert.assertTrue(receiveMessageAction.getValidationContexts().get(0) instanceof HeaderValidationContext);
+        Assert.assertTrue(receiveMessageAction.getValidationContexts().get(1) instanceof XmlMessageValidationContext);
+        Assert.assertTrue(receiveMessageAction.getValidationContexts().get(2) instanceof JsonMessageValidationContext);
+
+        httpMessageBuilder = ((HttpMessageBuilder)receiveMessageAction.getMessageBuilder());
+        Assert.assertNotNull(httpMessageBuilder);
+        Assert.assertEquals(httpMessageBuilder.buildMessagePayload(context, receiveMessageAction.getMessageType()), "");
+        Assert.assertNotNull(httpMessageBuilder.getMessage().getHeaders().get(MessageHeaders.ID));
+        Assert.assertNotNull(httpMessageBuilder.getMessage().getHeaders().get(MessageHeaders.TIMESTAMP));
+        responseHeaders = httpMessageBuilder.buildMessageHeaders(context);
+        Assert.assertEquals(responseHeaders.size(), 3L);
+        Assert.assertEquals(responseHeaders.get(HttpMessageHeaders.HTTP_STATUS_CODE), 404);
+        Assert.assertEquals(responseHeaders.get(HttpMessageHeaders.HTTP_REASON_PHRASE), "NOT_FOUND");
+        Assert.assertEquals(responseHeaders.get("userId"), "1001");
+        Assert.assertNull(receiveMessageAction.getEndpoint());
+        Assert.assertEquals(receiveMessageAction.getEndpointUri(), "httpClient");
+
+        sendMessageAction = (SendMessageAction) result.getTestAction(actionIndex++);
+        httpMessageBuilder = ((HttpMessageBuilder)sendMessageAction.getMessageBuilder());
+        Assert.assertNotNull(httpMessageBuilder);
+        Assert.assertEquals(httpMessageBuilder.buildMessagePayload(context, sendMessageAction.getMessageType()), "");
+        Assert.assertEquals(httpMessageBuilder.getMessage().getHeaders().get(HttpMessageHeaders.HTTP_REQUEST_METHOD), HttpMethod.DELETE.name());
+        Assert.assertEquals(httpMessageBuilder.getMessage().getHeaders().get(EndpointUriResolver.REQUEST_PATH_HEADER_NAME), "/user/${id}");
+        Assert.assertNull(httpMessageBuilder.getMessage().getHeaders().get(HttpMessageHeaders.HTTP_QUERY_PARAMS));
+        Assert.assertEquals(sendMessageAction.getEndpointUri(), "httpClient");
+
+        sendMessageAction = (SendMessageAction) result.getTestAction(actionIndex++);
+        httpMessageBuilder = ((HttpMessageBuilder)sendMessageAction.getMessageBuilder());
+        Assert.assertNotNull(httpMessageBuilder);
+        Assert.assertEquals(httpMessageBuilder.buildMessagePayload(context, sendMessageAction.getMessageType()), "");
+        requestHeaders = httpMessageBuilder.buildMessageHeaders(context);
+        Assert.assertEquals(requestHeaders.get(HttpMessageHeaders.HTTP_REQUEST_METHOD), HttpMethod.HEAD.name());
+        Assert.assertNull(requestHeaders.get(EndpointUriResolver.REQUEST_PATH_HEADER_NAME));
+        Assert.assertNull(requestHeaders.get(HttpMessageHeaders.HTTP_QUERY_PARAMS));
+        Assert.assertEquals(requestHeaders.get(EndpointUriResolver.ENDPOINT_URI_HEADER_NAME), uri);
+        Assert.assertEquals(sendMessageAction.getEndpointUri(), "httpClient");
+
+        sendMessageAction = (SendMessageAction) result.getTestAction(actionIndex);
+        httpMessageBuilder = ((HttpMessageBuilder)sendMessageAction.getMessageBuilder());
+        Assert.assertNotNull(httpMessageBuilder);
+        Assert.assertEquals(httpMessageBuilder.buildMessagePayload(context, sendMessageAction.getMessageType()), "");
+        Assert.assertEquals(httpMessageBuilder.getMessage().getHeaders().get(HttpMessageHeaders.HTTP_REQUEST_METHOD), HttpMethod.OPTIONS.name());
+        Assert.assertNull(httpMessageBuilder.getMessage().getHeaders().get(EndpointUriResolver.REQUEST_PATH_HEADER_NAME));
+        Assert.assertNull(httpMessageBuilder.getMessage().getHeaders().get(HttpMessageHeaders.HTTP_QUERY_PARAMS));
+        Assert.assertEquals(sendMessageAction.getEndpointUri(), "http://localhost:${port}/test");
+        Assert.assertEquals(sendMessageAction.getActor(), testActor);
+    }
+}

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/groovy/HttpServerTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/groovy/HttpServerTest.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.http.groovy;
+
+import java.util.Map;
+
+import org.citrusframework.TestActor;
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.actions.ReceiveMessageAction;
+import org.citrusframework.actions.SendMessageAction;
+import org.citrusframework.endpoint.AbstractEndpointAdapter;
+import org.citrusframework.endpoint.EndpointAdapter;
+import org.citrusframework.endpoint.direct.DirectEndpointAdapter;
+import org.citrusframework.endpoint.resolver.EndpointUriResolver;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.citrusframework.http.message.HttpMessage;
+import org.citrusframework.http.message.HttpMessageBuilder;
+import org.citrusframework.http.message.HttpMessageHeaders;
+import org.citrusframework.http.server.HttpServer;
+import org.citrusframework.http.validation.TextEqualsMessageValidator;
+import org.citrusframework.message.DefaultMessageQueue;
+import org.citrusframework.message.MessageHeaders;
+import org.citrusframework.message.MessageQueue;
+import org.citrusframework.spi.BindToRegistry;
+import org.citrusframework.validation.DefaultMessageHeaderValidator;
+import org.citrusframework.validation.DelegatingPayloadVariableExtractor;
+import org.citrusframework.validation.context.HeaderValidationContext;
+import org.citrusframework.validation.json.JsonMessageValidationContext;
+import org.citrusframework.validation.xml.XmlMessageValidationContext;
+import org.mockito.Mockito;
+import org.springframework.http.HttpMethod;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.endpoint.direct.DirectEndpoints.direct;
+import static org.citrusframework.http.endpoint.builder.HttpEndpoints.http;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class HttpServerTest extends AbstractGroovyActionDslTest {
+
+    @BindToRegistry
+    final TestActor testActor = Mockito.mock(TestActor.class);
+
+    @BindToRegistry
+    private final DefaultMessageHeaderValidator headerValidator = new DefaultMessageHeaderValidator();
+
+    @BindToRegistry
+    private final TextEqualsMessageValidator validator = new TextEqualsMessageValidator().enableTrim();
+
+    private HttpServer httpServer;
+
+    private final MessageQueue inboundQueue = new DefaultMessageQueue("inboundQueue");
+    private final EndpointAdapter endpointAdapter = new DirectEndpointAdapter(direct()
+            .synchronous()
+            .timeout(100L)
+            .queue(inboundQueue)
+            .build());
+
+    @BeforeClass
+    public void setupEndpoints() {
+        ((AbstractEndpointAdapter) endpointAdapter).setTestContextFactory(testContextFactory);
+
+        httpServer = http().server()
+                .timeout(100L)
+                .endpointAdapter(endpointAdapter)
+                .autoStart(true)
+                .name("httpServer")
+                .build();
+    }
+
+    @Test
+    public void shouldLoadHttpServerActions() {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/http/groovy/http-server.test.groovy");
+
+        context.getReferenceResolver().bind("httpServer", httpServer);
+
+        endpointAdapter.handleMessage(new HttpMessage().method(HttpMethod.GET));
+        endpointAdapter.handleMessage(new HttpMessage()
+                        .method(HttpMethod.GET)
+                        .path("/test/order/12345")
+                        .version("HTTP/1.1")
+                        .queryParam("id", "12345")
+                        .queryParam("type", "gold")
+                        .accept("application/xml")
+                        .contentType("application/xml"));
+        endpointAdapter.handleMessage(new HttpMessage("<user><id>1001</id><name>new_user</name></user>")
+                        .method(HttpMethod.POST)
+                        .path("/user")
+                        .header("userId", "1001")
+                        .contentType("application/xml"));
+        endpointAdapter.handleMessage(new HttpMessage()
+                        .method(HttpMethod.DELETE)
+                        .path("/user/12345"));
+        endpointAdapter.handleMessage(new HttpMessage()
+                        .method(HttpMethod.HEAD)
+                        .path("/test"));
+        endpointAdapter.handleMessage(new HttpMessage()
+                        .method(HttpMethod.OPTIONS));
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "HttpServerTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 9L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), ReceiveMessageAction.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "http:receive-request");
+
+        Assert.assertEquals(result.getTestAction(1).getClass(), SendMessageAction.class);
+        Assert.assertEquals(result.getTestAction(1).getName(), "http:send-response");
+
+        int actionIndex = 0;
+
+        ReceiveMessageAction receiveMessageAction = (ReceiveMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(receiveMessageAction.getValidationContexts().size(), 3);
+        Assert.assertTrue(receiveMessageAction.getValidationContexts().get(0) instanceof HeaderValidationContext);
+        Assert.assertTrue(receiveMessageAction.getValidationContexts().get(1) instanceof XmlMessageValidationContext);
+        Assert.assertTrue(receiveMessageAction.getValidationContexts().get(2) instanceof JsonMessageValidationContext);
+        Assert.assertEquals(receiveMessageAction.getReceiveTimeout(), 0L);
+
+        Assert.assertTrue(receiveMessageAction.getMessageBuilder() instanceof HttpMessageBuilder);
+        HttpMessageBuilder httpMessageBuilder = ((HttpMessageBuilder)receiveMessageAction.getMessageBuilder());
+        Assert.assertNotNull(httpMessageBuilder);
+        Assert.assertEquals(httpMessageBuilder.buildMessagePayload(context, receiveMessageAction.getMessageType()), "");
+        Assert.assertEquals(httpMessageBuilder.getMessage().getHeaders().size(), 3L);
+        Assert.assertNotNull(httpMessageBuilder.getMessage().getHeaders().get(MessageHeaders.ID));
+        Assert.assertNotNull(httpMessageBuilder.getMessage().getHeaders().get(MessageHeaders.TIMESTAMP));
+        Assert.assertEquals(httpMessageBuilder.getMessage().getHeaders().get(HttpMessageHeaders.HTTP_REQUEST_METHOD), HttpMethod.GET.name());
+        Assert.assertNull(httpMessageBuilder.getMessage().getHeaders().get(EndpointUriResolver.REQUEST_PATH_HEADER_NAME));
+        Assert.assertNull(httpMessageBuilder.getMessage().getHeaders().get(HttpMessageHeaders.HTTP_QUERY_PARAMS));
+        Assert.assertNull(httpMessageBuilder.getMessage().getHeaders().get(EndpointUriResolver.ENDPOINT_URI_HEADER_NAME));
+        Assert.assertNull(receiveMessageAction.getEndpointUri());
+        Assert.assertEquals(receiveMessageAction.getEndpoint(), context.getReferenceResolver().resolve("httpServer", HttpServer.class));
+        Assert.assertEquals(receiveMessageAction.getControlMessageProcessors().size(), 0);
+
+        SendMessageAction sendMessageAction = (SendMessageAction) result.getTestAction(actionIndex++);
+        httpMessageBuilder = ((HttpMessageBuilder)sendMessageAction.getMessageBuilder());
+        Assert.assertNotNull(httpMessageBuilder);
+
+        Assert.assertEquals(httpMessageBuilder.buildMessagePayload(context, sendMessageAction.getMessageType()), "");
+        Assert.assertEquals(httpMessageBuilder.getMessage().getHeaders().size(), 2L);
+        Assert.assertNotNull(httpMessageBuilder.getMessage().getHeaders().get(MessageHeaders.ID));
+        Assert.assertNotNull(httpMessageBuilder.getMessage().getHeaders().get(MessageHeaders.TIMESTAMP));
+        Assert.assertNull(sendMessageAction.getEndpoint());
+        Assert.assertEquals(sendMessageAction.getEndpointUri(), "httpServer");
+        Assert.assertEquals(sendMessageAction.getMessageProcessors().size(), 0);
+
+        receiveMessageAction = (ReceiveMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(receiveMessageAction.getValidationContexts().size(), 3);
+        Assert.assertTrue(receiveMessageAction.getValidationContexts().get(0) instanceof HeaderValidationContext);
+        Assert.assertTrue(receiveMessageAction.getValidationContexts().get(1) instanceof XmlMessageValidationContext);
+        Assert.assertTrue(receiveMessageAction.getValidationContexts().get(2) instanceof JsonMessageValidationContext);
+        Assert.assertEquals(receiveMessageAction.getReceiveTimeout(), 2000L);
+
+        httpMessageBuilder = ((HttpMessageBuilder)receiveMessageAction.getMessageBuilder());
+        Assert.assertNotNull(httpMessageBuilder);
+        Assert.assertEquals(httpMessageBuilder.buildMessagePayload(context, receiveMessageAction.getMessageType()), "");
+        Assert.assertNotNull(httpMessageBuilder.getMessage().getHeaders().get(MessageHeaders.ID));
+        Assert.assertNotNull(httpMessageBuilder.getMessage().getHeaders().get(MessageHeaders.TIMESTAMP));
+
+        Map<String, Object> requestHeaders = httpMessageBuilder.buildMessageHeaders(context);
+        Assert.assertEquals(requestHeaders.size(), 8L);
+        Assert.assertEquals(requestHeaders.get(HttpMessageHeaders.HTTP_REQUEST_METHOD), HttpMethod.GET.name());
+        Assert.assertEquals(requestHeaders.get(EndpointUriResolver.REQUEST_PATH_HEADER_NAME), "/test/order/12345");
+        Assert.assertEquals(requestHeaders.get(HttpMessageHeaders.HTTP_REQUEST_URI), "/test/order/12345");
+        Assert.assertEquals(requestHeaders.get(HttpMessageHeaders.HTTP_CONTENT_TYPE), "application/xml");
+        Assert.assertEquals(requestHeaders.get(HttpMessageHeaders.HTTP_ACCEPT), "application/xml");
+        Assert.assertEquals(requestHeaders.get(HttpMessageHeaders.HTTP_VERSION), "HTTP/1.1");
+        Assert.assertEquals(requestHeaders.get(HttpMessageHeaders.HTTP_QUERY_PARAMS), "id=12345,type=gold");
+        Assert.assertEquals(requestHeaders.get(EndpointUriResolver.QUERY_PARAM_HEADER_NAME), "id=12345,type=gold");
+        Assert.assertNull(receiveMessageAction.getEndpoint());
+        Assert.assertEquals(receiveMessageAction.getEndpointUri(), "httpServer");
+
+        sendMessageAction = (SendMessageAction) result.getTestAction(actionIndex++);
+        httpMessageBuilder = ((HttpMessageBuilder)sendMessageAction.getMessageBuilder());
+        Assert.assertNotNull(httpMessageBuilder);
+        Assert.assertEquals(httpMessageBuilder.buildMessagePayload(context, sendMessageAction.getMessageType()), "<order><id>12345</id><item>foo</item></order>");
+        Assert.assertNotNull(httpMessageBuilder.getMessage().getHeaders().get(MessageHeaders.ID));
+        Assert.assertNotNull(httpMessageBuilder.getMessage().getHeaders().get(MessageHeaders.TIMESTAMP));
+        Map<String, Object> responseHeaders = httpMessageBuilder.buildMessageHeaders(context);
+        Assert.assertEquals(responseHeaders.size(), 4L);
+        Assert.assertEquals(responseHeaders.get(HttpMessageHeaders.HTTP_STATUS_CODE), 200);
+        Assert.assertEquals(responseHeaders.get(HttpMessageHeaders.HTTP_REASON_PHRASE), "OK");
+        Assert.assertEquals(responseHeaders.get(HttpMessageHeaders.HTTP_VERSION), "HTTP/1.1");
+        Assert.assertEquals(responseHeaders.get(HttpMessageHeaders.HTTP_CONTENT_TYPE), "application/xml");
+        Assert.assertNull(sendMessageAction.getEndpoint());
+        Assert.assertEquals(sendMessageAction.getEndpointUri(), "httpServer");
+
+        receiveMessageAction = (ReceiveMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(receiveMessageAction.getValidationContexts().size(), 3);
+        Assert.assertTrue(receiveMessageAction.getValidationContexts().get(0) instanceof HeaderValidationContext);
+        Assert.assertTrue(receiveMessageAction.getValidationContexts().get(1) instanceof XmlMessageValidationContext);
+        Assert.assertTrue(receiveMessageAction.getValidationContexts().get(2) instanceof JsonMessageValidationContext);
+
+        httpMessageBuilder = ((HttpMessageBuilder)receiveMessageAction.getMessageBuilder());
+        Assert.assertNotNull(httpMessageBuilder);
+        Assert.assertEquals(httpMessageBuilder.buildMessagePayload(context, receiveMessageAction.getMessageType()), "<user><id>1001</id><name>new_user</name></user>");
+        Assert.assertEquals(httpMessageBuilder.getMessage().getHeaders().get(HttpMessageHeaders.HTTP_REQUEST_METHOD), HttpMethod.POST.name());
+        Assert.assertEquals(httpMessageBuilder.getMessage().getHeaders().get(EndpointUriResolver.REQUEST_PATH_HEADER_NAME), "/user");
+        Assert.assertEquals(httpMessageBuilder.buildMessageHeaders(context).get("userId"), "1001");
+        Assert.assertNull(httpMessageBuilder.getMessage().getHeaders().get(HttpMessageHeaders.HTTP_QUERY_PARAMS));
+        Assert.assertEquals(receiveMessageAction.getEndpointUri(), "httpServer");
+
+        Assert.assertEquals(receiveMessageAction.getVariableExtractors().size(), 1L);
+        Assert.assertEquals(((DelegatingPayloadVariableExtractor)receiveMessageAction.getVariableExtractors().get(0)).getPathExpressions().size(), 1L);
+        Assert.assertEquals(((DelegatingPayloadVariableExtractor)receiveMessageAction.getVariableExtractors().get(0)).getPathExpressions().get("/user/id"), "userId");
+
+        Assert.assertEquals(context.getVariable("userId"), "1001");
+
+        sendMessageAction = (SendMessageAction) result.getTestAction(actionIndex++);
+        httpMessageBuilder = ((HttpMessageBuilder)sendMessageAction.getMessageBuilder());
+        Assert.assertNotNull(httpMessageBuilder);
+        Assert.assertEquals(httpMessageBuilder.buildMessagePayload(context, sendMessageAction.getMessageType()), "");
+        Assert.assertNotNull(httpMessageBuilder.getMessage().getHeaders().get(MessageHeaders.ID));
+        Assert.assertNotNull(httpMessageBuilder.getMessage().getHeaders().get(MessageHeaders.TIMESTAMP));
+        responseHeaders = httpMessageBuilder.buildMessageHeaders(context);
+        Assert.assertEquals(responseHeaders.size(), 3L);
+        Assert.assertEquals(responseHeaders.get(HttpMessageHeaders.HTTP_STATUS_CODE), 404);
+        Assert.assertEquals(responseHeaders.get(HttpMessageHeaders.HTTP_REASON_PHRASE), "NOT_FOUND");
+        Assert.assertEquals(responseHeaders.get("userId"), "1001");
+        Assert.assertNull(sendMessageAction.getEndpoint());
+        Assert.assertEquals(sendMessageAction.getEndpointUri(), "httpServer");
+
+        receiveMessageAction = (ReceiveMessageAction) result.getTestAction(actionIndex++);
+        httpMessageBuilder = ((HttpMessageBuilder)receiveMessageAction.getMessageBuilder());
+        Assert.assertNotNull(httpMessageBuilder);
+        Assert.assertEquals(httpMessageBuilder.buildMessagePayload(context, receiveMessageAction.getMessageType()), "");
+        Assert.assertEquals(httpMessageBuilder.getMessage().getHeaders().get(HttpMessageHeaders.HTTP_REQUEST_METHOD), HttpMethod.DELETE.name());
+        Assert.assertEquals(httpMessageBuilder.getMessage().getHeaders().get(EndpointUriResolver.REQUEST_PATH_HEADER_NAME), "/user/${id}");
+        Assert.assertNull(httpMessageBuilder.getMessage().getHeaders().get(HttpMessageHeaders.HTTP_QUERY_PARAMS));
+        Assert.assertEquals(receiveMessageAction.getEndpointUri(), "httpServer");
+
+        receiveMessageAction = (ReceiveMessageAction) result.getTestAction(actionIndex++);
+        httpMessageBuilder = ((HttpMessageBuilder)receiveMessageAction.getMessageBuilder());
+        Assert.assertNotNull(httpMessageBuilder);
+        Assert.assertEquals(httpMessageBuilder.buildMessagePayload(context, receiveMessageAction.getMessageType()), "");
+        requestHeaders = httpMessageBuilder.buildMessageHeaders(context);
+        Assert.assertEquals(requestHeaders.get(HttpMessageHeaders.HTTP_REQUEST_METHOD), HttpMethod.HEAD.name());
+        Assert.assertEquals(requestHeaders.get(EndpointUriResolver.REQUEST_PATH_HEADER_NAME), "/test");
+        Assert.assertNull(requestHeaders.get(HttpMessageHeaders.HTTP_QUERY_PARAMS));
+        Assert.assertEquals(receiveMessageAction.getEndpointUri(), "httpServer");
+
+        receiveMessageAction = (ReceiveMessageAction) result.getTestAction(actionIndex);
+        httpMessageBuilder = ((HttpMessageBuilder)receiveMessageAction.getMessageBuilder());
+        Assert.assertNotNull(httpMessageBuilder);
+        Assert.assertEquals(httpMessageBuilder.buildMessagePayload(context, receiveMessageAction.getMessageType()), "");
+        Assert.assertEquals(httpMessageBuilder.getMessage().getHeaders().get(HttpMessageHeaders.HTTP_REQUEST_METHOD), HttpMethod.OPTIONS.name());
+        Assert.assertNull(httpMessageBuilder.getMessage().getHeaders().get(EndpointUriResolver.REQUEST_PATH_HEADER_NAME));
+        Assert.assertNull(httpMessageBuilder.getMessage().getHeaders().get(HttpMessageHeaders.HTTP_QUERY_PARAMS));
+        Assert.assertEquals(receiveMessageAction.getEndpointUri(), "httpServer");
+        Assert.assertEquals(receiveMessageAction.getActor(), testActor);
+    }
+}

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/yaml/AbstractYamlActionTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/yaml/AbstractYamlActionTest.java
@@ -23,8 +23,6 @@ import org.citrusframework.Citrus;
 import org.citrusframework.CitrusContext;
 import org.citrusframework.CitrusInstanceManager;
 import org.citrusframework.DefaultTestCaseRunner;
-import org.citrusframework.TestAction;
-import org.citrusframework.TestActionBuilder;
 import org.citrusframework.annotations.CitrusAnnotations;
 import org.citrusframework.context.StaticTestContextFactory;
 import org.citrusframework.context.TestContext;
@@ -65,20 +63,9 @@ public class AbstractYamlActionTest extends AbstractTestNGUnitTest {
     protected YamlTestLoader createTestLoader(String sourcePath) {
         YamlTestLoader testLoader = new YamlTestLoader(this.getClass(), "Test", this.getClass().getPackageName());
         CitrusAnnotations.injectAll(testLoader, citrus, context);
-        CitrusAnnotations.injectTestRunner(testLoader, new NoopTestCaseRunner(context));
+        CitrusAnnotations.injectTestRunner(testLoader, new DefaultTestCaseRunner(context));
         testLoader.setSource(sourcePath);
 
         return testLoader;
-    }
-
-    protected static class NoopTestCaseRunner extends DefaultTestCaseRunner {
-        public NoopTestCaseRunner(TestContext context) {
-            super(context);
-        }
-
-        @Override
-        public <T extends TestAction> T run(TestActionBuilder<T> builder) {
-            return builder.build();
-        }
     }
 }

--- a/endpoints/citrus-http/src/test/resources/citrus-context.xml
+++ b/endpoints/citrus-http/src/test/resources/citrus-context.xml
@@ -168,7 +168,7 @@
 
   <citrus:before-test id="defaultBeforeTest">
     <citrus:actions>
-      <citrus-jms-test:purge-jms-queues connection-factory="connectionFactory" receive-timeout="10">
+      <citrus-jms-test:purge-jms-queues connection-factory="connectionFactory" timeout="10">
         <citrus-jms-test:queue name="${jms.queue.http.request.forward}"/>
         <citrus-jms-test:queue name="${jms.queue.http.request.ack}"/>
       </citrus-jms-test:purge-jms-queues>

--- a/endpoints/citrus-http/src/test/resources/org/citrusframework/http/groovy/http-client.test.groovy
+++ b/endpoints/citrus-http/src/test/resources/org/citrusframework/http/groovy/http-client.test.groovy
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.http.groovy
+
+import static org.citrusframework.actions.SleepAction.Builder.delay
+import static org.citrusframework.http.actions.HttpActionBuilder.http
+
+import static org.citrusframework.dsl.PathExpressionSupport.path
+
+name "HttpClientTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+variables {
+    id="12345"
+}
+
+actions {
+    $(http().client(httpClient)
+        .send()
+        .get())
+    $(http().client("httpClient")
+        .receive()
+        .response())
+
+    $(http().client("httpClient")
+        .send()
+        .get()
+            .fork(true)
+            .uri('http://localhost:${port}/test')
+            .path('/order/${id}')
+            .message()
+                .contentType("application/xml")
+                .accept("application/xml")
+                .version("HTTP/1.1")
+                .queryParam("id", '${id}')
+                .queryParam("type", "gold")
+    )
+
+    $(delay().milliseconds(1000L))
+
+    $(http().client("httpClient")
+        .receive()
+        .response()
+            .message()
+                .statusCode(200)
+                .reasonPhrase("OK")
+                .version("HTTP/1.1")
+                .contentType("application/xml")
+                .body('<order><id>${id}</id><item>foo</item></order>')
+                .extract(path().expression("/order/id", "orderId"))
+    )
+
+    $(http().client("httpClient")
+        .send()
+        .post("/user")
+            .message()
+            .header("userId", "1001")
+            .body("<user><id>1001</id><name>new_user</name></user>")
+    )
+
+    $(http().client("httpClient")
+        .receive()
+            .response()
+            .timeout(2000L)
+            .message()
+                .statusCode(404)
+                .reasonPhrase("NOT_FOUND")
+                .header("userId", "1001")
+    )
+
+    $(http().client("httpClient")
+        .send()
+        .delete()
+            .path('/user/${id}')
+    )
+
+    $(http().client("httpClient")
+        .send()
+        .head()
+            .uri('http://localhost:${port}/test')
+    )
+
+    $(http().client('http://localhost:${port}/test')
+        .send()
+        .options()
+        .actor(testActor)
+    )
+}

--- a/endpoints/citrus-http/src/test/resources/org/citrusframework/http/groovy/http-server.test.groovy
+++ b/endpoints/citrus-http/src/test/resources/org/citrusframework/http/groovy/http-server.test.groovy
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.http.groovy
+
+
+import static org.citrusframework.dsl.PathExpressionSupport.path
+import static org.citrusframework.http.actions.HttpActionBuilder.http
+
+name "HttpServerTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+variables {
+    id="12345"
+}
+
+actions {
+    $(http().server(httpServer)
+        .receive()
+        .get())
+    $(http().server("httpServer")
+        .send()
+        .response())
+
+    $(http().server("httpServer")
+        .receive()
+        .get()
+            .path('/test/order/${id}')
+            .timeout(2000L)
+            .message()
+                .contentType("application/xml")
+                .accept("application/xml")
+                .version("HTTP/1.1")
+                .queryParam("id", '${id}')
+                .queryParam("type", "gold")
+    )
+
+    $(http().server("httpServer")
+        .send()
+        .response()
+            .message()
+                .statusCode(200)
+                .reasonPhrase("OK")
+                .version("HTTP/1.1")
+                .contentType("application/xml")
+                .body('<order><id>${id}</id><item>foo</item></order>')
+    )
+
+    $(http().server("httpServer")
+        .receive()
+        .post("/user")
+            .message()
+            .header("userId", "1001")
+            .body("<user><id>1001</id><name>new_user</name></user>")
+            .extract(path().expression("/user/id", "userId"))
+    )
+
+    $(http().server("httpServer")
+        .send()
+            .response()
+            .message()
+                .statusCode(404)
+                .reasonPhrase("NOT_FOUND")
+                .header("userId", "1001")
+    )
+
+    $(http().server("httpServer")
+        .receive()
+        .delete()
+            .path('/user/${id}')
+    )
+
+    $(http().server("httpServer")
+        .receive()
+        .head("/test")
+    )
+
+    $(http().server("httpServer")
+        .receive()
+        .options()
+        .actor(testActor)
+    )
+}

--- a/endpoints/citrus-jms/pom.xml
+++ b/endpoints/citrus-jms/pom.xml
@@ -112,6 +112,12 @@
     </dependency>
     <dependency>
       <groupId>org.citrusframework</groupId>
+      <artifactId>citrus-yaml</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.citrusframework</groupId>
       <artifactId>citrus-spring-integration</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/endpoints/citrus-jms/pom.xml
+++ b/endpoints/citrus-jms/pom.xml
@@ -122,6 +122,13 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.citrusframework</groupId>
+      <artifactId>citrus-groovy</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.citrusframework</groupId>
       <artifactId>citrus-spring-integration</artifactId>

--- a/endpoints/citrus-jms/pom.xml
+++ b/endpoints/citrus-jms/pom.xml
@@ -118,6 +118,12 @@
     </dependency>
     <dependency>
       <groupId>org.citrusframework</groupId>
+      <artifactId>citrus-xml</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.citrusframework</groupId>
       <artifactId>citrus-spring-integration</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/endpoints/citrus-jms/pom.xml
+++ b/endpoints/citrus-jms/pom.xml
@@ -112,6 +112,12 @@
     </dependency>
     <dependency>
       <groupId>org.citrusframework</groupId>
+      <artifactId>citrus-groovy</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.citrusframework</groupId>
       <artifactId>citrus-yaml</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
@@ -119,13 +125,6 @@
     <dependency>
       <groupId>org.citrusframework</groupId>
       <artifactId>citrus-xml</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.citrusframework</groupId>
-      <artifactId>citrus-groovy</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>

--- a/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/actions/PurgeJmsQueuesAction.java
+++ b/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/actions/PurgeJmsQueuesAction.java
@@ -16,6 +16,10 @@
 
 package org.citrusframework.jms.actions;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import jakarta.jms.Connection;
 import jakarta.jms.ConnectionFactory;
 import jakarta.jms.Destination;
@@ -25,15 +29,11 @@ import jakarta.jms.Queue;
 import jakarta.jms.QueueConnection;
 import jakarta.jms.QueueConnectionFactory;
 import jakarta.jms.Session;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import org.citrusframework.AbstractTestActionBuilder;
 import org.citrusframework.actions.AbstractTestAction;
-import org.citrusframework.spi.ReferenceResolver;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.spi.ReferenceResolver;
 import org.citrusframework.spi.ReferenceResolverAware;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -255,8 +255,8 @@ public class PurgeJmsQueuesAction extends AbstractTestAction {
      */
     public static final class Builder extends AbstractTestActionBuilder<PurgeJmsQueuesAction, Builder> implements ReferenceResolverAware {
 
-        private List<String> queueNames = new ArrayList<>();
-        private List<Queue> queues = new ArrayList<>();
+        private final List<String> queueNames = new ArrayList<>();
+        private final List<Queue> queues = new ArrayList<>();
         private ConnectionFactory connectionFactory;
         private long receiveTimeout = 100;
         private long sleepTime = 350;
@@ -365,7 +365,8 @@ public class PurgeJmsQueuesAction extends AbstractTestAction {
 
         @Override
         public PurgeJmsQueuesAction build() {
-            if (referenceResolver != null
+            if (connectionFactory == null &&
+                    referenceResolver != null
                     && referenceResolver.isResolvable("connectionFactory")) {
                 connectionFactory(referenceResolver.resolve("connectionFactory", ConnectionFactory.class));
             }

--- a/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/config/xml/PurgeJmsQueuesActionParser.java
+++ b/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/config/xml/PurgeJmsQueuesActionParser.java
@@ -16,11 +16,11 @@
 
 package org.citrusframework.jms.config.xml;
 
-import jakarta.jms.ConnectionFactory;
-import jakarta.jms.Queue;
 import java.util.ArrayList;
 import java.util.List;
 
+import jakarta.jms.ConnectionFactory;
+import jakarta.jms.Queue;
 import org.citrusframework.config.util.BeanDefinitionParserUtils;
 import org.citrusframework.config.xml.AbstractTestActionFactoryBean;
 import org.citrusframework.config.xml.DescriptionElementParser;
@@ -61,7 +61,8 @@ public class PurgeJmsQueuesActionParser implements BeanDefinitionParser {
 
         beanDefinition.addPropertyReference("connectionFactory", connectionFactory);
 
-        BeanDefinitionParserUtils.setPropertyValue(beanDefinition, element.getAttribute("receive-timeout"), "receiveTimeout");
+        BeanDefinitionParserUtils.setPropertyValue(beanDefinition, element.getAttribute("timeout"), "receiveTimeout");
+        BeanDefinitionParserUtils.setPropertyValue(beanDefinition, element.getAttribute("sleep"), "sleepTime");
 
         List<String> queueNames = new ArrayList<String>();
         ManagedList<BeanDefinition> queueRefs = new ManagedList<BeanDefinition>();

--- a/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/xml/ObjectFactory.java
+++ b/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/xml/ObjectFactory.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.jms.xml;
+
+import jakarta.xml.bind.annotation.XmlRegistry;
+
+/**
+ * This object contains factory methods for each
+ * Java content interface and Java element interface
+ * generated in the org.citrusframework.ftp.model package.
+ * <p>An ObjectFactory allows you to programatically
+ * construct new instances of the Java representation
+ * for XML content. The Java representation of XML
+ * content can consist of schema derived interfaces
+ * and classes representing the binding of schema
+ * type definitions, element declarations and model
+ * groups.  Factory methods for each of these are
+ * provided in this class.
+ *
+ */
+@XmlRegistry
+public class ObjectFactory {
+
+    /**
+     * Create a new ObjectFactory that can be used to create new instances of schema derived classes for package: org.citrusframework.xml.actions
+     *
+     */
+    public ObjectFactory() {
+    }
+
+    /**
+     * Create an instance of {@link PurgeQueues }
+     *
+     */
+    public PurgeQueues createPurgeQueues() {
+        return new PurgeQueues();
+    }
+
+}

--- a/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/xml/PurgeQueues.java
+++ b/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/xml/PurgeQueues.java
@@ -1,0 +1,191 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.jms.xml;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.jms.ConnectionFactory;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
+import org.citrusframework.TestAction;
+import org.citrusframework.TestActionBuilder;
+import org.citrusframework.TestActor;
+import org.citrusframework.jms.actions.PurgeJmsQueuesAction;
+import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.spi.ReferenceResolverAware;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+        "description",
+        "queue",
+})
+@XmlRootElement(name = "purge-jms-queues")
+public class PurgeQueues implements TestActionBuilder<TestAction>, ReferenceResolverAware {
+
+    @XmlTransient
+    private final PurgeJmsQueuesAction.Builder builder = new PurgeJmsQueuesAction.Builder();
+
+    @XmlElement
+    private String description;
+    @XmlAttribute
+    private String actor;
+
+    @XmlAttribute
+    protected String connectionFactory;
+
+    @XmlAttribute
+    protected String timeout;
+
+    @XmlAttribute
+    protected String sleep;
+
+    @XmlElement
+    protected List<Queue> queue;
+
+    @XmlTransient
+    private ReferenceResolver referenceResolver;
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setActor(String actor) {
+        this.actor = actor;
+    }
+
+    public String getActor() {
+        return actor;
+    }
+
+    public void setConnectionFactory(String connectionFactory) {
+        this.connectionFactory = connectionFactory;
+    }
+
+    public String getConnectionFactory() {
+        return connectionFactory;
+    }
+
+    public void setTimeout(String timeout) {
+        this.timeout = timeout;
+    }
+
+    public String getTimeout() {
+        return timeout;
+    }
+
+    public void setSleep(String sleep) {
+        this.sleep = sleep;
+    }
+
+    public String getSleep() {
+        return sleep;
+    }
+
+    public void setQueue(List<Queue> queue) {
+        this.queue = queue;
+    }
+
+    public List<Queue> getQueue() {
+        if (queue == null) {
+            queue = new ArrayList<>();
+        }
+
+        return queue;
+    }
+
+    @Override
+    public TestAction build() {
+        builder.setReferenceResolver(referenceResolver);
+        builder.description(description);
+
+        for (Queue queue : getQueue()) {
+            if (queue.name != null) {
+                builder.queue(queue.getName());
+            }
+
+            if (queue.ref != null && referenceResolver != null) {
+                builder.queue(referenceResolver.resolve(queue.ref, jakarta.jms.Queue.class));
+            }
+        }
+
+        if (timeout != null) {
+            builder.timeout(Long.parseLong(timeout));
+        }
+
+        if (sleep != null) {
+            builder.sleep(Long.parseLong(sleep));
+        }
+
+        if (referenceResolver != null) {
+            if (actor != null) {
+                builder.actor(referenceResolver.resolve(actor, TestActor.class));
+            }
+
+            if (connectionFactory != null) {
+                builder.connectionFactory(referenceResolver.resolve(connectionFactory, ConnectionFactory.class));
+            }
+        }
+
+        return builder.build();
+    }
+
+    @Override
+    public void setReferenceResolver(ReferenceResolver referenceResolver) {
+        this.referenceResolver = referenceResolver;
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(name = "", propOrder = {
+            "name"
+    })
+    public static class Queue {
+        @XmlAttribute
+        protected String name;
+
+        @XmlAttribute
+        protected String ref;
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setRef(String ref) {
+            this.ref = ref;
+        }
+
+        public String getRef() {
+            return ref;
+        }
+    }
+}

--- a/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/xml/package-info.java
+++ b/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/xml/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@jakarta.xml.bind.annotation.XmlSchema(namespace = "http://citrusframework.org/schema/xml/testcase", elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
+package org.citrusframework.jms.xml;

--- a/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/yaml/PurgeQueues.java
+++ b/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/yaml/PurgeQueues.java
@@ -1,0 +1,93 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.jms.yaml;
+
+import java.util.List;
+
+import jakarta.jms.ConnectionFactory;
+import org.citrusframework.TestAction;
+import org.citrusframework.TestActionBuilder;
+import org.citrusframework.TestActor;
+import org.citrusframework.jms.actions.PurgeJmsQueuesAction;
+import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.spi.ReferenceResolverAware;
+
+public class PurgeQueues implements TestActionBuilder<TestAction>, ReferenceResolverAware {
+
+    private final PurgeJmsQueuesAction.Builder builder = new PurgeJmsQueuesAction.Builder();
+
+    private String description;
+    private String actor;
+
+    private String connectionFactory;
+
+    private ReferenceResolver referenceResolver;
+
+    public void setDescription(String value) {
+        this.description = value;
+    }
+
+    public void setActor(String actor) {
+        this.actor = actor;
+    }
+
+    public void setConnectionFactory(String connectionFactory) {
+        this.connectionFactory = connectionFactory;
+    }
+
+    public void setQueue(String queue) {
+        builder.queue(queue);
+    }
+
+    public void setQueues(List<String> queues) {
+        builder.queueNames(queues);
+    }
+
+    public void setTimeout(long timeout) {
+        builder.timeout(timeout);
+    }
+
+    public void setSleep(long sleep) {
+        builder.sleep(sleep);
+    }
+
+    @Override
+    public TestAction build() {
+        builder.setReferenceResolver(referenceResolver);
+        builder.description(description);
+
+        if (referenceResolver != null) {
+            if (actor != null) {
+                builder.actor(referenceResolver.resolve(actor, TestActor.class));
+            }
+
+            if (connectionFactory != null) {
+                builder.connectionFactory(referenceResolver.resolve(connectionFactory, ConnectionFactory.class));
+            }
+        }
+
+        return builder.build();
+    }
+
+    @Override
+    public void setReferenceResolver(ReferenceResolver referenceResolver) {
+        this.referenceResolver = referenceResolver;
+    }
+}

--- a/endpoints/citrus-jms/src/main/resources/META-INF/citrus/xml/builder/purge-jms-queues
+++ b/endpoints/citrus-jms/src/main/resources/META-INF/citrus/xml/builder/purge-jms-queues
@@ -1,0 +1,2 @@
+type=org.citrusframework.jms.xml.PurgeQueues
+ns=http://citrusframework.org/schema/xml/testcase

--- a/endpoints/citrus-jms/src/main/resources/META-INF/citrus/xml/builder/purgeQueues
+++ b/endpoints/citrus-jms/src/main/resources/META-INF/citrus/xml/builder/purgeQueues
@@ -1,0 +1,2 @@
+type=org.citrusframework.jms.xml.PurgeQueues
+ns=http://citrusframework.org/schema/xml/testcase

--- a/endpoints/citrus-jms/src/main/resources/META-INF/citrus/yaml/builder/purgeQueues
+++ b/endpoints/citrus-jms/src/main/resources/META-INF/citrus/yaml/builder/purgeQueues
@@ -1,0 +1,1 @@
+type=org.citrusframework.jms.yaml.PurgeQueues

--- a/endpoints/citrus-jms/src/main/resources/org/citrusframework/schema/citrus-jms-testcase-4.0.0-SNAPSHOT.xsd
+++ b/endpoints/citrus-jms/src/main/resources/org/citrusframework/schema/citrus-jms-testcase-4.0.0-SNAPSHOT.xsd
@@ -37,7 +37,7 @@
         </xs:element>
       </xs:sequence>
       <xs:attribute name="connection-factory" type="xs:string"/>
-      <xs:attribute name="receive-timeout" type="xs:int"/>
+      <xs:attribute name="timeout" type="xs:int"/>
     </xs:complexType>
   </xs:element>
 

--- a/endpoints/citrus-jms/src/main/resources/org/citrusframework/schema/citrus-jms-testcase.xsd
+++ b/endpoints/citrus-jms/src/main/resources/org/citrusframework/schema/citrus-jms-testcase.xsd
@@ -37,7 +37,8 @@
         </xs:element>
       </xs:sequence>
       <xs:attribute name="connection-factory" type="xs:string"/>
-      <xs:attribute name="receive-timeout" type="xs:int"/>
+      <xs:attribute name="timeout" type="xs:int"/>
+      <xs:attribute name="sleep" type="xs:int"/>
     </xs:complexType>
   </xs:element>
 

--- a/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/config/xml/PurgeJmsQueuesActionParserTest.java
+++ b/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/config/xml/PurgeJmsQueuesActionParserTest.java
@@ -34,8 +34,9 @@ public class PurgeJmsQueuesActionParserTest extends AbstractActionParserTest<Pur
         assertActionClassAndName(PurgeJmsQueuesAction.class, "purge-queue");
 
         PurgeJmsQueuesAction action = getNextTestActionFromTest();
-        Assert.assertNotNull(action.getReceiveTimeout());
         Assert.assertNotNull(action.getConnectionFactory());
+        Assert.assertEquals(action.getReceiveTimeout(), 100);
+        Assert.assertEquals(action.getSleepTime(), 350L);
         Assert.assertEquals(action.getQueues().size(), 0);
         Assert.assertEquals(action.getQueueNames().size(), 3);
         Assert.assertEquals(action.getQueueNames().get(0), "JMS.Queue.1");
@@ -43,8 +44,8 @@ public class PurgeJmsQueuesActionParserTest extends AbstractActionParserTest<Pur
         Assert.assertEquals(action.getQueueNames().get(2), "JMS.Queue.3");
 
         action = getNextTestActionFromTest();
-        Assert.assertNotNull(action.getReceiveTimeout());
         Assert.assertEquals(action.getReceiveTimeout(), 125);
+        Assert.assertEquals(action.getSleepTime(), 250L);
         Assert.assertNotNull(action.getConnectionFactory());
         Assert.assertEquals(action.getQueues().size(), 0);
         Assert.assertEquals(action.getQueueNames().size(), 3);

--- a/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/groovy/AbstractGroovyActionDslTest.java
+++ b/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/groovy/AbstractGroovyActionDslTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.jms.groovy;
+
+import org.citrusframework.Citrus;
+import org.citrusframework.CitrusContext;
+import org.citrusframework.CitrusInstanceManager;
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.annotations.CitrusAnnotations;
+import org.citrusframework.context.StaticTestContextFactory;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.citrusframework.testng.AbstractTestNGUnitTest;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeClass;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class AbstractGroovyActionDslTest extends AbstractTestNGUnitTest {
+
+    protected Citrus citrus;
+
+    @Mock
+    protected CitrusContext citrusContext;
+
+    @BeforeClass
+    public void setupMocks() {
+        MockitoAnnotations.openMocks(this);
+        citrus = CitrusInstanceManager.newInstance(() -> citrusContext);
+    }
+
+    @Override
+    protected TestContext createTestContext() {
+        TestContext context = super.createTestContext();
+        doAnswer(invocation -> {
+            context.getReferenceResolver().bind(invocation.getArgument(0, String.class), invocation.getArgument(1));
+            return null;
+        }).when(citrusContext).bind(any(String.class), any());
+
+        when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
+        when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
+        when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        CitrusAnnotations.injectAll(this, citrus, context);
+        return context;
+    }
+
+    protected GroovyTestLoader createTestLoader(String sourcePath) {
+        GroovyTestLoader testLoader = new GroovyTestLoader().source(sourcePath);
+        CitrusAnnotations.injectAll(testLoader, citrus, context);
+        CitrusAnnotations.injectTestRunner(testLoader, new DefaultTestCaseRunner(context));
+
+        return testLoader;
+    }
+}

--- a/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/groovy/PurgeQueuesTest.java
+++ b/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/groovy/PurgeQueuesTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.jms.groovy;
+
+import java.util.HashMap;
+
+import jakarta.jms.Connection;
+import jakarta.jms.ConnectionFactory;
+import jakarta.jms.Destination;
+import jakarta.jms.MessageConsumer;
+import jakarta.jms.Queue;
+import jakarta.jms.Session;
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.citrusframework.jms.actions.PurgeJmsQueuesAction;
+import org.citrusframework.jms.endpoint.TextMessageImpl;
+import org.mockito.Mock;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class PurgeQueuesTest extends AbstractGroovyActionDslTest {
+
+    @Mock
+    private ConnectionFactory connectionFactory;
+    @Mock
+    private Connection connection;
+    @Mock
+    private Session session;
+    @Mock
+    private Destination destination;
+    @Mock
+    private Queue queue;
+    @Mock
+    private MessageConsumer messageConsumer;
+
+    @Test
+    public void shouldLoadJmsActions() throws Exception {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/jms/groovy/purge-queues.test.groovy");
+
+        context.getReferenceResolver().bind("connectionFactory", connectionFactory);
+        context.getReferenceResolver().bind("myConnectionFactory", connectionFactory);
+
+        reset(connectionFactory, connection, session, messageConsumer);
+
+        when(connectionFactory.createConnection()).thenReturn(connection);
+        when(connection.createSession(anyBoolean(), anyInt())).thenReturn(session);
+        when(session.createQueue(anyString())).thenReturn(queue);
+        when(session.createConsumer(queue)).thenReturn(messageConsumer);
+        when(messageConsumer.receive(100L)).thenReturn(new TextMessageImpl("Hello Citrus!", new HashMap<>())).thenReturn(null);
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "PurgeQueuesTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 2L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), PurgeJmsQueuesAction.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "purge-queue");
+
+        int actionIndex = 0;
+
+        PurgeJmsQueuesAction action = (PurgeJmsQueuesAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getConnectionFactory());
+        Assert.assertEquals(action.getReceiveTimeout(), 100L);
+        Assert.assertEquals(action.getSleepTime(), 350L);
+        Assert.assertEquals(action.getQueues().size(), 0);
+        Assert.assertEquals(action.getQueueNames().size(), 1);
+        Assert.assertEquals(action.getQueueNames().get(0), "JMS.Queue.1");
+
+        action = (PurgeJmsQueuesAction) result.getTestAction(actionIndex);
+        Assert.assertEquals(action.getReceiveTimeout(), 125L);
+        Assert.assertEquals(action.getSleepTime(), 250L);
+        Assert.assertNotNull(action.getConnectionFactory());
+        Assert.assertEquals(action.getQueues().size(), 0);
+        Assert.assertEquals(action.getQueueNames().size(), 2);
+        Assert.assertEquals(action.getQueueNames().get(0), "JMS.Queue.2");
+        Assert.assertEquals(action.getQueueNames().get(1), "JMS.Queue.3");
+
+    }
+}

--- a/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/xml/AbstractXmlActionTest.java
+++ b/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/xml/AbstractXmlActionTest.java
@@ -1,0 +1,71 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.jms.xml;
+
+import org.citrusframework.Citrus;
+import org.citrusframework.CitrusContext;
+import org.citrusframework.CitrusInstanceManager;
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.annotations.CitrusAnnotations;
+import org.citrusframework.context.StaticTestContextFactory;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.testng.AbstractTestNGUnitTest;
+import org.citrusframework.xml.XmlTestLoader;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeClass;
+
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class AbstractXmlActionTest extends AbstractTestNGUnitTest {
+
+    protected Citrus citrus;
+
+    @Mock
+    protected CitrusContext citrusContext;
+
+    @BeforeClass
+    public void setupMocks() {
+        MockitoAnnotations.openMocks(this);
+        citrus = CitrusInstanceManager.newInstance(() -> citrusContext);
+    }
+
+    @Override
+    protected TestContext createTestContext() {
+        TestContext context = super.createTestContext();
+        when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
+        when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
+        when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        CitrusAnnotations.injectAll(this, citrus, context);
+        return context;
+    }
+
+    protected XmlTestLoader createTestLoader(String sourcePath) {
+        XmlTestLoader testLoader = new XmlTestLoader(this.getClass(), "Test", this.getClass().getPackageName());
+        CitrusAnnotations.injectAll(testLoader, citrus, context);
+        CitrusAnnotations.injectTestRunner(testLoader, new DefaultTestCaseRunner(context));
+        testLoader.setSource(sourcePath);
+
+        return testLoader;
+    }
+}

--- a/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/xml/PurgeQueuesTest.java
+++ b/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/xml/PurgeQueuesTest.java
@@ -1,4 +1,23 @@
-package org.citrusframework.jms.yaml;
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.jms.xml;
 
 import java.util.HashMap;
 
@@ -12,8 +31,8 @@ import org.citrusframework.TestCase;
 import org.citrusframework.TestCaseMetaInfo;
 import org.citrusframework.jms.actions.PurgeJmsQueuesAction;
 import org.citrusframework.jms.endpoint.TextMessageImpl;
-import org.citrusframework.yaml.YamlTestLoader;
-import org.citrusframework.yaml.actions.YamlTestActionBuilder;
+import org.citrusframework.xml.XmlTestLoader;
+import org.citrusframework.xml.actions.XmlTestActionBuilder;
 import org.mockito.Mock;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -24,7 +43,10 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
-public class PurgeQueuesTest extends AbstractYamlActionTest {
+/**
+ * @author Christoph Deppisch
+ */
+public class PurgeQueuesTest extends AbstractXmlActionTest {
 
     @Mock
     private ConnectionFactory connectionFactory;
@@ -41,10 +63,11 @@ public class PurgeQueuesTest extends AbstractYamlActionTest {
 
     @Test
     public void shouldLoadJmsActions() throws Exception {
-        YamlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/jms/yaml/purge-queues-test.yaml");
+        XmlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/jms/xml/purge-queues-test.xml");
 
         context.getReferenceResolver().bind("connectionFactory", connectionFactory);
         context.getReferenceResolver().bind("myConnectionFactory", connectionFactory);
+        context.getReferenceResolver().bind("myQueue", queue);
 
         reset(connectionFactory, connection, session, messageConsumer);
 
@@ -60,7 +83,7 @@ public class PurgeQueuesTest extends AbstractYamlActionTest {
         Assert.assertEquals(result.getName(), "PurgeQueuesTest");
         Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
         Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
-        Assert.assertEquals(result.getActionCount(), 2L);
+        Assert.assertEquals(result.getActionCount(), 3L);
         Assert.assertEquals(result.getTestAction(0).getClass(), PurgeJmsQueuesAction.class);
         Assert.assertEquals(result.getTestAction(0).getName(), "purge-queue");
 
@@ -74,7 +97,7 @@ public class PurgeQueuesTest extends AbstractYamlActionTest {
         Assert.assertEquals(action.getQueueNames().size(), 1);
         Assert.assertEquals(action.getQueueNames().get(0), "JMS.Queue.1");
 
-        action = (PurgeJmsQueuesAction) result.getTestAction(actionIndex);
+        action = (PurgeJmsQueuesAction) result.getTestAction(actionIndex++);
         Assert.assertEquals(action.getReceiveTimeout(), 125L);
         Assert.assertEquals(action.getSleepTime(), 250L);
         Assert.assertNotNull(action.getConnectionFactory());
@@ -82,12 +105,19 @@ public class PurgeQueuesTest extends AbstractYamlActionTest {
         Assert.assertEquals(action.getQueueNames().size(), 2);
         Assert.assertEquals(action.getQueueNames().get(0), "JMS.Queue.2");
         Assert.assertEquals(action.getQueueNames().get(1), "JMS.Queue.3");
+
+        action = (PurgeJmsQueuesAction) result.getTestAction(actionIndex);
+        Assert.assertNotNull(action.getConnectionFactory());
+        Assert.assertEquals(action.getQueues().size(), 1);
+        Assert.assertEquals(action.getQueues().get(0), queue);
+        Assert.assertEquals(action.getQueueNames().size(), 0);
     }
 
     @Test
     public void shouldLookupTestActionBuilder() {
-        Assert.assertTrue(YamlTestActionBuilder.lookup().containsKey("purgeQueues"));
-        Assert.assertTrue(YamlTestActionBuilder.lookup("purgeQueues").isPresent());
-        Assert.assertEquals(YamlTestActionBuilder.lookup("purgeQueues").get().getClass(), PurgeQueues.class);
+        Assert.assertTrue(XmlTestActionBuilder.lookup("purge-jms-queues").isPresent());
+        Assert.assertEquals(XmlTestActionBuilder.lookup("purge-jms-queues").get().getClass(), PurgeQueues.class);
+        Assert.assertTrue(XmlTestActionBuilder.lookup("purgeQueues").isPresent());
+        Assert.assertEquals(XmlTestActionBuilder.lookup("purgeQueues").get().getClass(), PurgeQueues.class);
     }
 }

--- a/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/yaml/AbstractYamlActionTest.java
+++ b/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/yaml/AbstractYamlActionTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.jms.yaml;
+
+import org.citrusframework.Citrus;
+import org.citrusframework.CitrusContext;
+import org.citrusframework.CitrusInstanceManager;
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.annotations.CitrusAnnotations;
+import org.citrusframework.context.StaticTestContextFactory;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.testng.AbstractTestNGUnitTest;
+import org.citrusframework.yaml.YamlTestLoader;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeClass;
+
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class AbstractYamlActionTest extends AbstractTestNGUnitTest {
+
+    protected Citrus citrus;
+
+    @Mock
+    protected CitrusContext citrusContext;
+
+    @BeforeClass
+    public void setupMocks() {
+        MockitoAnnotations.openMocks(this);
+        citrus = CitrusInstanceManager.newInstance(() -> citrusContext);
+    }
+
+    @Override
+    protected TestContext createTestContext() {
+        TestContext context = super.createTestContext();
+        when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
+        when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
+        when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        CitrusAnnotations.injectAll(this, citrus, context);
+        return context;
+    }
+
+    protected YamlTestLoader createTestLoader(String sourcePath) {
+        YamlTestLoader testLoader = new YamlTestLoader(this.getClass(), "Test", this.getClass().getPackageName());
+        CitrusAnnotations.injectAll(testLoader, citrus, context);
+        CitrusAnnotations.injectTestRunner(testLoader, new DefaultTestCaseRunner(context));
+        testLoader.setSource(sourcePath);
+
+        return testLoader;
+    }
+}

--- a/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/yaml/PurgeQueuesTest.java
+++ b/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/yaml/PurgeQueuesTest.java
@@ -1,0 +1,94 @@
+package org.citrusframework.jms.yaml;
+
+import java.util.HashMap;
+
+import jakarta.jms.Connection;
+import jakarta.jms.ConnectionFactory;
+import jakarta.jms.Destination;
+import jakarta.jms.MessageConsumer;
+import jakarta.jms.Queue;
+import jakarta.jms.Session;
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.jms.actions.PurgeJmsQueuesAction;
+import org.citrusframework.jms.endpoint.TextMessageImpl;
+import org.citrusframework.yaml.YamlTestLoader;
+import org.citrusframework.yaml.actions.YamlTestActionBuilder;
+import org.mockito.Mock;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+public class PurgeQueuesTest extends AbstractYamlActionTest {
+
+    @Mock
+    private ConnectionFactory connectionFactory;
+    @Mock
+    private Connection connection;
+    @Mock
+    private Session session;
+    @Mock
+    private Destination destination;
+    @Mock
+    private Queue queue;
+    @Mock
+    private MessageConsumer messageConsumer;
+
+    @Test
+    public void shouldLoadCamelActions() throws Exception {
+        YamlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/jms/yaml/purge-queues-test.yaml");
+
+        context.getReferenceResolver().bind("connectionFactory", connectionFactory);
+        context.getReferenceResolver().bind("myConnectionFactory", connectionFactory);
+
+        reset(connectionFactory, connection, session, messageConsumer);
+
+        when(connectionFactory.createConnection()).thenReturn(connection);
+        when(connection.createSession(anyBoolean(), anyInt())).thenReturn(session);
+        when(session.createQueue(anyString())).thenReturn(queue);
+        when(session.createConsumer(queue)).thenReturn(messageConsumer);
+        when(messageConsumer.receive(100L)).thenReturn(new TextMessageImpl("Hello Citrus!", new HashMap<>())).thenReturn(null);
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "PurgeQueuesTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 2L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), PurgeJmsQueuesAction.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "purge-queue");
+
+        int actionIndex = 0;
+
+        PurgeJmsQueuesAction action = (PurgeJmsQueuesAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getConnectionFactory());
+        Assert.assertEquals(action.getReceiveTimeout(), 100L);
+        Assert.assertEquals(action.getSleepTime(), 350L);
+        Assert.assertEquals(action.getQueues().size(), 0);
+        Assert.assertEquals(action.getQueueNames().size(), 1);
+        Assert.assertEquals(action.getQueueNames().get(0), "JMS.Queue.1");
+
+        action = (PurgeJmsQueuesAction) result.getTestAction(actionIndex);
+        Assert.assertEquals(action.getReceiveTimeout(), 125L);
+        Assert.assertEquals(action.getSleepTime(), 250L);
+        Assert.assertNotNull(action.getConnectionFactory());
+        Assert.assertEquals(action.getQueues().size(), 0);
+        Assert.assertEquals(action.getQueueNames().size(), 2);
+        Assert.assertEquals(action.getQueueNames().get(0), "JMS.Queue.2");
+        Assert.assertEquals(action.getQueueNames().get(1), "JMS.Queue.3");
+    }
+
+
+    @Test
+    public void shouldLookupTestActionBuilder() {
+        Assert.assertTrue(YamlTestActionBuilder.lookup().containsKey("purgeQueues"));
+        Assert.assertTrue(YamlTestActionBuilder.lookup("purgeQueues").isPresent());
+        Assert.assertEquals(YamlTestActionBuilder.lookup("purgeQueues").get().getClass(), PurgeQueues.class);
+    }
+}

--- a/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/yaml/PurgeQueuesTest.java
+++ b/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/yaml/PurgeQueuesTest.java
@@ -1,3 +1,22 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package org.citrusframework.jms.yaml;
 
 import java.util.HashMap;

--- a/endpoints/citrus-jms/src/test/resources/citrus-context.xml
+++ b/endpoints/citrus-jms/src/test/resources/citrus-context.xml
@@ -158,7 +158,7 @@
 
   <citrus:before-test id="defaultBeforeTest">
     <citrus:actions>
-      <citrus-jms-test:purge-jms-queues connection-factory="connectionFactory" receive-timeout="10">
+      <citrus-jms-test:purge-jms-queues connection-factory="connectionFactory" timeout="10">
         <citrus-jms-test:queue name="Citrus.HelloService.Request.Queue"/>
         <citrus-jms-test:queue name="Citrus.HelloService.Response.Queue"/>
         <citrus-jms-test:queue name="Citrus.HelloService.InOut.Queue"/>

--- a/endpoints/citrus-jms/src/test/resources/org/citrusframework/jms/config/xml/PurgeJmsQueuesActionParserTest-context.xml
+++ b/endpoints/citrus-jms/src/test/resources/org/citrusframework/jms/config/xml/PurgeJmsQueuesActionParserTest-context.xml
@@ -15,7 +15,7 @@
                 <jms:queue name="JMS.Queue.3"/>
             </jms:purge-jms-queues>
 
-            <jms:purge-jms-queues connection-factory="myConnectionFactory" receive-timeout="125">
+            <jms:purge-jms-queues connection-factory="myConnectionFactory" timeout="125" sleep="250">
                 <jms:queue name="JMS.Queue.1"/>
                 <jms:queue name="JMS.Queue.2"/>
                 <jms:queue name="JMS.Queue.3"/>

--- a/endpoints/citrus-jms/src/test/resources/org/citrusframework/jms/groovy/purge-queues.test.groovy
+++ b/endpoints/citrus-jms/src/test/resources/org/citrusframework/jms/groovy/purge-queues.test.groovy
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.jms.groovy
+
+import static org.citrusframework.jms.actions.PurgeJmsQueuesAction.Builder.purgeQueues
+
+name "PurgeQueuesTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+actions {
+    $(purgeQueues()
+        .queue("JMS.Queue.1"))
+
+    $(purgeQueues()
+        .connectionFactory(connectionFactory)
+        .timeout(125L)
+        .sleep(250L)
+        .queue("JMS.Queue.2")
+        .queue("JMS.Queue.3"))
+}

--- a/endpoints/citrus-jms/src/test/resources/org/citrusframework/jms/integration/PurgeJmsQueuesIT.xml
+++ b/endpoints/citrus-jms/src/test/resources/org/citrusframework/jms/integration/PurgeJmsQueuesIT.xml
@@ -2,7 +2,7 @@
 <spring:beans xmlns="http://www.citrusframework.org/schema/testcase"
               xmlns:jms="http://www.citrusframework.org/schema/jms/testcase"
               xmlns:spring="http://www.springframework.org/schema/beans"
-              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
               http://www.citrusframework.org/schema/testcase http://www.citrusframework.org/schema/testcase/citrus-testcase.xsd
               http://www.citrusframework.org/schema/jms/testcase http://www.citrusframework.org/schema/jms/testcase/citrus-jms-testcase.xsd">
@@ -15,7 +15,7 @@
 			<last-updated-by>Christoph Deppisch</last-updated-by>
 			<last-updated-on>2008-04-25T00:00:00</last-updated-on>
 		</meta-info>
-		
+
         <description>
           It might be essential to purge some jms queues before or during the test case.
           The bean org.citrusframework.jms.actions.PurgeJmsQueuesAction offers this functionality.
@@ -45,8 +45,8 @@
                 <jms:queue name="Citrus.Queue.Dummy.Three.In"/>
                 <jms:queue name="Citrus.Queue.Dummy.Three.Out"/>
             </jms:purge-jms-queues>
-            
-            <jms:purge-jms-queues connection-factory="connectionFactory" receive-timeout="150">
+
+            <jms:purge-jms-queues connection-factory="connectionFactory" timeout="150">
                 <jms:queue name="Citrus.Queue.Dummy"/>
                 <jms:queue name="Citrus.Queue.Dummy.One.In"/>
                 <jms:queue name="Citrus.Queue.Dummy.One.Out"/>
@@ -55,7 +55,7 @@
                 <jms:queue name="Citrus.Queue.Dummy.Three.In"/>
                 <jms:queue name="Citrus.Queue.Dummy.Three.Out"/>
             </jms:purge-jms-queues>
-            
+
             <jms:purge-jms-queues>
                 <jms:queue ref="testQueue1"/>
                 <jms:queue ref="testQueue2"/>
@@ -67,5 +67,5 @@
             </jms:purge-jms-queues>
         </actions>
     </testcase>
-    
+
 </spring:beans>

--- a/endpoints/citrus-jms/src/test/resources/org/citrusframework/jms/xml/purge-queues-test.xml
+++ b/endpoints/citrus-jms/src/test/resources/org/citrusframework/jms/xml/purge-queues-test.xml
@@ -1,0 +1,38 @@
+<!--
+  ~ Copyright 2021 the original author or authors.
+  ~
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements. See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License. You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<test name="PurgeQueuesTest" author="Christoph" status="FINAL" xmlns="http://citrusframework.org/schema/xml/testcase"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://citrusframework.org/schema/xml/testcase http://citrusframework.org/schema/xml/testcase/citrus-testcase.xsd">
+  <description>Sample test in XML</description>
+  <actions>
+    <purge-jms-queues>
+      <queue name="JMS.Queue.1"/>
+    </purge-jms-queues>
+
+    <purge-jms-queues connection-factory="myConnectionFactory" timeout="125" sleep="250">
+      <queue name="JMS.Queue.2"/>
+      <queue name="JMS.Queue.3"/>
+    </purge-jms-queues>
+
+    <purge-jms-queues>
+      <queue ref="myQueue"/>
+    </purge-jms-queues>
+  </actions>
+</test>

--- a/endpoints/citrus-jms/src/test/resources/org/citrusframework/jms/yaml/purge-queues-test.yaml
+++ b/endpoints/citrus-jms/src/test/resources/org/citrusframework/jms/yaml/purge-queues-test.yaml
@@ -1,0 +1,14 @@
+name: "PurgeQueuesTest"
+author: "Christoph"
+status: "FINAL"
+actions:
+  - purgeQueues:
+      queue: "JMS.Queue.1"
+
+  - purgeQueues:
+      connectionFactory: "myConnectionFactory"
+      timeout: 125
+      sleep: 250
+      queues:
+        - "JMS.Queue.2"
+        - "JMS.Queue.3"

--- a/endpoints/citrus-spring-integration/pom.xml
+++ b/endpoints/citrus-spring-integration/pom.xml
@@ -52,18 +52,6 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.citrusframework</groupId>
-      <artifactId>citrus-yaml</artifactId>
-      <version>${project.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.citrusframework</groupId>
-      <artifactId>citrus-xml</artifactId>
-      <version>${project.version}</version>
-      <scope>provided</scope>
-    </dependency>
 
     <dependency>
       <groupId>org.citrusframework</groupId>
@@ -113,6 +101,24 @@
     <dependency>
       <groupId>org.citrusframework</groupId>
       <artifactId>citrus-validation-text</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.citrusframework</groupId>
+      <artifactId>citrus-groovy</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.citrusframework</groupId>
+      <artifactId>citrus-yaml</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.citrusframework</groupId>
+      <artifactId>citrus-xml</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>

--- a/endpoints/citrus-spring-integration/pom.xml
+++ b/endpoints/citrus-spring-integration/pom.xml
@@ -52,6 +52,12 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.citrusframework</groupId>
+      <artifactId>citrus-yaml</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.citrusframework</groupId>

--- a/endpoints/citrus-spring-integration/pom.xml
+++ b/endpoints/citrus-spring-integration/pom.xml
@@ -58,6 +58,12 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.citrusframework</groupId>
+      <artifactId>citrus-xml</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.citrusframework</groupId>

--- a/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/actions/PurgeMessageChannelAction.java
+++ b/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/actions/PurgeMessageChannelAction.java
@@ -21,8 +21,8 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.citrusframework.AbstractTestActionBuilder;
-import org.citrusframework.spi.ReferenceResolver;
 import org.citrusframework.context.TestContext;
+import org.citrusframework.spi.ReferenceResolver;
 import org.citrusframework.spi.ReferenceResolverAware;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,9 +49,6 @@ public class PurgeMessageChannelAction extends AbstractTestAction {
     /** List of channels to be purged */
     private final List<MessageChannel> channels;
 
-    /** The parent bean factory used for channel name resolving */
-    private final BeanFactory beanFactory;
-
     /** Channel resolver instance */
     private final DestinationResolver<MessageChannel> channelResolver;
 
@@ -71,7 +68,6 @@ public class PurgeMessageChannelAction extends AbstractTestAction {
 
         this.channelNames = builder.channelNames;
         this.channels = builder.channels;
-        this.beanFactory = builder.beanFactory;
         this.channelResolver = builder.channelResolver;
         this.messageSelector = builder.messageSelector;
     }
@@ -274,11 +270,6 @@ public class PurgeMessageChannelAction extends AbstractTestAction {
 
         public Builder beanFactory(BeanFactory beanFactory) {
             this.beanFactory = beanFactory;
-
-            if (channelResolver == null) {
-                channelResolver = new BeanFactoryChannelResolver(beanFactory);
-            }
-
             return this;
         }
 
@@ -294,8 +285,12 @@ public class PurgeMessageChannelAction extends AbstractTestAction {
 
         @Override
         public PurgeMessageChannelAction build() {
-            if (!channelNames.isEmpty() && channelResolver == null && referenceResolver != null) {
-                this.channelResolver = channelName -> referenceResolver.resolve(channelName, MessageChannel.class);
+            if (channelResolver == null) {
+                if (beanFactory != null) {
+                    channelResolver = new BeanFactoryChannelResolver(beanFactory);
+                } else if (!channelNames.isEmpty() && referenceResolver != null) {
+                    channelResolver = channelName -> referenceResolver.resolve(channelName, MessageChannel.class);
+                }
             }
 
             return new PurgeMessageChannelAction(this);

--- a/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/springintegration/xml/ObjectFactory.java
+++ b/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/springintegration/xml/ObjectFactory.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.springintegration.xml;
+
+import jakarta.xml.bind.annotation.XmlRegistry;
+
+/**
+ * This object contains factory methods for each
+ * Java content interface and Java element interface
+ * generated in the org.citrusframework.ftp.model package.
+ * <p>An ObjectFactory allows you to programatically
+ * construct new instances of the Java representation
+ * for XML content. The Java representation of XML
+ * content can consist of schema derived interfaces
+ * and classes representing the binding of schema
+ * type definitions, element declarations and model
+ * groups.  Factory methods for each of these are
+ * provided in this class.
+ *
+ */
+@XmlRegistry
+public class ObjectFactory {
+
+    /**
+     * Create a new ObjectFactory that can be used to create new instances of schema derived classes for package: org.citrusframework.xml.actions
+     *
+     */
+    public ObjectFactory() {
+    }
+
+    /**
+     * Create an instance of {@link PurgeChannels }
+     *
+     */
+    public PurgeChannels createPurgeChannels() {
+        return new PurgeChannels();
+    }
+
+}

--- a/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/springintegration/xml/package-info.java
+++ b/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/springintegration/xml/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@jakarta.xml.bind.annotation.XmlSchema(namespace = "http://citrusframework.org/schema/xml/testcase", elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
+package org.citrusframework.springintegration.xml;

--- a/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/springintegration/yaml/PurgeChannels.java
+++ b/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/springintegration/yaml/PurgeChannels.java
@@ -1,0 +1,107 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.springintegration.yaml;
+
+import java.util.List;
+
+import org.citrusframework.TestAction;
+import org.citrusframework.TestActionBuilder;
+import org.citrusframework.TestActor;
+import org.citrusframework.actions.PurgeMessageChannelAction;
+import org.citrusframework.context.SpringBeanReferenceResolver;
+import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.spi.ReferenceResolverAware;
+import org.springframework.integration.core.MessageSelector;
+import org.springframework.messaging.core.DestinationResolver;
+
+public class PurgeChannels implements TestActionBuilder<TestAction>, ReferenceResolverAware {
+
+    private final PurgeMessageChannelAction.Builder builder = new PurgeMessageChannelAction.Builder();
+
+    private String description;
+    private String actor;
+
+    private String channelResolver;
+    private String messageSelector;
+
+    private ReferenceResolver referenceResolver;
+
+    public void setDescription(String value) {
+        this.description = value;
+    }
+
+    public void setActor(String actor) {
+        this.actor = actor;
+    }
+
+    public void setChannel(String channel) {
+        builder.channel(channel);
+    }
+
+    public void setChannels(List<String> channels) {
+        builder.channelNames(channels);
+    }
+
+    public void setChannelResolver(String channelResolver) {
+        this.channelResolver = channelResolver;
+    }
+
+    public void setMessageSelector(String messageSelector) {
+        this.messageSelector = messageSelector;
+    }
+
+    public void setSelector(String messageSelector) {
+        this.messageSelector = messageSelector;
+    }
+
+    @Override
+    public TestAction build() {
+        builder.setReferenceResolver(referenceResolver);
+        builder.description(description);
+
+        if (referenceResolver != null) {
+            if (referenceResolver instanceof SpringBeanReferenceResolver) {
+                builder.beanFactory(((SpringBeanReferenceResolver) referenceResolver).getApplicationContext());
+                builder.withApplicationContext(((SpringBeanReferenceResolver) referenceResolver).getApplicationContext());
+            }
+
+            if (actor != null) {
+                builder.actor(referenceResolver.resolve(actor, TestActor.class));
+            }
+
+            if (channelResolver != null) {
+                builder.channelResolver(referenceResolver.resolve(channelResolver, DestinationResolver.class));
+            } else {
+                builder.channelResolver(referenceResolver);
+            }
+
+            if (messageSelector != null) {
+                builder.selector(referenceResolver.resolve(messageSelector, MessageSelector.class));
+            }
+        }
+
+        return builder.build();
+    }
+
+    @Override
+    public void setReferenceResolver(ReferenceResolver referenceResolver) {
+        this.referenceResolver = referenceResolver;
+    }
+}

--- a/endpoints/citrus-spring-integration/src/main/resources/META-INF/citrus/xml/builder/purge-channels
+++ b/endpoints/citrus-spring-integration/src/main/resources/META-INF/citrus/xml/builder/purge-channels
@@ -1,0 +1,2 @@
+type=org.citrusframework.springintegration.xml.PurgeChannels
+ns=http://citrusframework.org/schema/xml/testcase

--- a/endpoints/citrus-spring-integration/src/main/resources/META-INF/citrus/xml/builder/purgeChannels
+++ b/endpoints/citrus-spring-integration/src/main/resources/META-INF/citrus/xml/builder/purgeChannels
@@ -1,0 +1,2 @@
+type=org.citrusframework.springintegration.xml.PurgeChannels
+ns=http://citrusframework.org/schema/xml/testcase

--- a/endpoints/citrus-spring-integration/src/main/resources/META-INF/citrus/yaml/builder/purgeChannels
+++ b/endpoints/citrus-spring-integration/src/main/resources/META-INF/citrus/yaml/builder/purgeChannels
@@ -1,0 +1,1 @@
+type=org.citrusframework.springintegration.yaml.PurgeChannels

--- a/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/springintegration/groovy/AbstractGroovyActionDslTest.java
+++ b/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/springintegration/groovy/AbstractGroovyActionDslTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.springintegration.groovy;
+
+import org.citrusframework.Citrus;
+import org.citrusframework.CitrusContext;
+import org.citrusframework.CitrusInstanceManager;
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.annotations.CitrusAnnotations;
+import org.citrusframework.context.StaticTestContextFactory;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.citrusframework.testng.AbstractTestNGUnitTest;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeClass;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class AbstractGroovyActionDslTest extends AbstractTestNGUnitTest {
+
+    protected Citrus citrus;
+
+    @Mock
+    protected CitrusContext citrusContext;
+
+    @BeforeClass
+    public void setupMocks() {
+        MockitoAnnotations.openMocks(this);
+        citrus = CitrusInstanceManager.newInstance(() -> citrusContext);
+    }
+
+    @Override
+    protected TestContext createTestContext() {
+        TestContext context = super.createTestContext();
+        doAnswer(invocation -> {
+            context.getReferenceResolver().bind(invocation.getArgument(0, String.class), invocation.getArgument(1));
+            return null;
+        }).when(citrusContext).bind(any(String.class), any());
+
+        when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
+        when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
+        when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        CitrusAnnotations.injectAll(this, citrus, context);
+        return context;
+    }
+
+    protected GroovyTestLoader createTestLoader(String sourcePath) {
+        GroovyTestLoader testLoader = new GroovyTestLoader().source(sourcePath);
+        CitrusAnnotations.injectAll(testLoader, citrus, context);
+        CitrusAnnotations.injectTestRunner(testLoader, new DefaultTestCaseRunner(context));
+
+        return testLoader;
+    }
+}

--- a/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/springintegration/groovy/PurgeChannelsTest.java
+++ b/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/springintegration/groovy/PurgeChannelsTest.java
@@ -1,0 +1,68 @@
+package org.citrusframework.springintegration.groovy;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.actions.PurgeMessageChannelAction;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.mockito.Mock;
+import org.springframework.integration.core.MessageSelector;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.core.DestinationResolver;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class PurgeChannelsTest extends AbstractGroovyActionDslTest {
+
+    @Mock
+    private DestinationResolver<MessageChannel> channelResolver;
+    @Mock
+    private MessageChannel messageChannel;
+
+    @Mock
+    private MessageSelector messageSelector;
+
+    @Test
+    public void shouldLoadActions() throws Exception {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/springintegration/groovy/purge-channels.test.groovy");
+
+        context.getReferenceResolver().bind("channelResolver", channelResolver);
+        context.getReferenceResolver().bind("testChannel", messageChannel);
+        context.getReferenceResolver().bind("testChannel1", messageChannel);
+        context.getReferenceResolver().bind("testChannel2", messageChannel);
+        context.getReferenceResolver().bind("testChannel3", messageChannel);
+        context.getReferenceResolver().bind("messageSelector", messageSelector);
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "PurgeChannelsTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 3L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), PurgeMessageChannelAction.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "purge-channel");
+
+        int actionIndex = 0;
+
+        PurgeMessageChannelAction action = (PurgeMessageChannelAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getMessageSelector());
+        Assert.assertNull(action.getChannelResolver());
+        Assert.assertEquals(action.getChannels().size(), 1);
+        Assert.assertEquals(action.getChannels().get(0), messageChannel);
+        Assert.assertEquals(action.getChannelNames().size(), 0);
+
+        action = (PurgeMessageChannelAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getMessageSelector());
+        Assert.assertEquals(action.getChannelResolver(), context.getReferenceResolver().resolve("channelResolver"));
+        Assert.assertEquals(action.getChannels().size(), 0);
+        Assert.assertEquals(action.getChannelNames().size(), 2);
+        Assert.assertEquals(action.getChannelNames().get(0), "testChannel1");
+        Assert.assertEquals(action.getChannelNames().get(1), "testChannel2");
+
+        action = (PurgeMessageChannelAction) result.getTestAction(actionIndex);
+        Assert.assertEquals(action.getMessageSelector(), context.getReferenceResolver().resolve("messageSelector"));
+        Assert.assertEquals(action.getChannels().size(), 0);
+        Assert.assertEquals(action.getChannelNames().size(), 1);
+        Assert.assertEquals(action.getChannelNames().get(0), "testChannel3");
+    }
+}

--- a/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/springintegration/xml/AbstractXmlActionTest.java
+++ b/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/springintegration/xml/AbstractXmlActionTest.java
@@ -1,0 +1,71 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.springintegration.xml;
+
+import org.citrusframework.Citrus;
+import org.citrusframework.CitrusContext;
+import org.citrusframework.CitrusInstanceManager;
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.annotations.CitrusAnnotations;
+import org.citrusframework.context.StaticTestContextFactory;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.testng.AbstractTestNGUnitTest;
+import org.citrusframework.xml.XmlTestLoader;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeClass;
+
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class AbstractXmlActionTest extends AbstractTestNGUnitTest {
+
+    protected Citrus citrus;
+
+    @Mock
+    protected CitrusContext citrusContext;
+
+    @BeforeClass
+    public void setupMocks() {
+        MockitoAnnotations.openMocks(this);
+        citrus = CitrusInstanceManager.newInstance(() -> citrusContext);
+    }
+
+    @Override
+    protected TestContext createTestContext() {
+        TestContext context = super.createTestContext();
+        when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
+        when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
+        when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        CitrusAnnotations.injectAll(this, citrus, context);
+        return context;
+    }
+
+    protected XmlTestLoader createTestLoader(String sourcePath) {
+        XmlTestLoader testLoader = new XmlTestLoader(this.getClass(), "Test", this.getClass().getPackageName());
+        CitrusAnnotations.injectAll(testLoader, citrus, context);
+        CitrusAnnotations.injectTestRunner(testLoader, new DefaultTestCaseRunner(context));
+        testLoader.setSource(sourcePath);
+
+        return testLoader;
+    }
+}

--- a/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/springintegration/xml/PurgeChannelsTest.java
+++ b/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/springintegration/xml/PurgeChannelsTest.java
@@ -1,0 +1,77 @@
+package org.citrusframework.springintegration.xml;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.actions.PurgeMessageChannelAction;
+import org.citrusframework.xml.XmlTestLoader;
+import org.citrusframework.xml.actions.XmlTestActionBuilder;
+import org.mockito.Mock;
+import org.springframework.integration.core.MessageSelector;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.core.DestinationResolver;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class PurgeChannelsTest extends AbstractXmlActionTest {
+
+    @Mock
+    private DestinationResolver<MessageChannel> channelResolver;
+    @Mock
+    private MessageChannel messageChannel;
+
+    @Mock
+    private MessageSelector messageSelector;
+
+    @Test
+    public void shouldLoadActions() throws Exception {
+        XmlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/springintegration/xml/purge-channels-test.xml");
+
+        context.getReferenceResolver().bind("channelResolver", channelResolver);
+        context.getReferenceResolver().bind("testChannel", messageChannel);
+        context.getReferenceResolver().bind("testChannel1", messageChannel);
+        context.getReferenceResolver().bind("testChannel2", messageChannel);
+        context.getReferenceResolver().bind("testChannel3", messageChannel);
+        context.getReferenceResolver().bind("messageSelector", messageSelector);
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "PurgeChannelsTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 3L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), PurgeMessageChannelAction.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "purge-channel");
+
+        int actionIndex = 0;
+
+        PurgeMessageChannelAction action = (PurgeMessageChannelAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getMessageSelector());
+        Assert.assertNotNull(action.getChannelResolver());
+        Assert.assertEquals(action.getChannels().size(), 1);
+        Assert.assertEquals(action.getChannelNames().size(), 1);
+        Assert.assertEquals(action.getChannelNames().get(0), "testChannel1");
+
+        action = (PurgeMessageChannelAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getMessageSelector());
+        Assert.assertEquals(action.getChannelResolver(), context.getReferenceResolver().resolve("channelResolver"));
+        Assert.assertEquals(action.getChannels().size(), 0);
+        Assert.assertEquals(action.getChannelNames().size(), 2);
+        Assert.assertEquals(action.getChannelNames().get(0), "testChannel1");
+        Assert.assertEquals(action.getChannelNames().get(1), "testChannel2");
+
+        action = (PurgeMessageChannelAction) result.getTestAction(actionIndex);
+        Assert.assertEquals(action.getMessageSelector(), context.getReferenceResolver().resolve("messageSelector"));
+        Assert.assertEquals(action.getChannels().size(), 0);
+        Assert.assertEquals(action.getChannelNames().size(), 1);
+        Assert.assertEquals(action.getChannelNames().get(0), "testChannel3");
+    }
+
+    @Test
+    public void shouldLookupTestActionBuilder() {
+        Assert.assertTrue(XmlTestActionBuilder.lookup("purge-channels").isPresent());
+        Assert.assertEquals(XmlTestActionBuilder.lookup("purge-channels").get().getClass(), PurgeChannels.class);
+        Assert.assertTrue(XmlTestActionBuilder.lookup("purgeChannels").isPresent());
+        Assert.assertEquals(XmlTestActionBuilder.lookup("purgeChannels").get().getClass(), PurgeChannels.class);
+    }
+}

--- a/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/springintegration/yaml/AbstractYamlActionTest.java
+++ b/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/springintegration/yaml/AbstractYamlActionTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.springintegration.yaml;
+
+import org.citrusframework.Citrus;
+import org.citrusframework.CitrusContext;
+import org.citrusframework.CitrusInstanceManager;
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.annotations.CitrusAnnotations;
+import org.citrusframework.context.StaticTestContextFactory;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.testng.AbstractTestNGUnitTest;
+import org.citrusframework.yaml.YamlTestLoader;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeClass;
+
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class AbstractYamlActionTest extends AbstractTestNGUnitTest {
+
+    protected Citrus citrus;
+
+    @Mock
+    protected CitrusContext citrusContext;
+
+    @BeforeClass
+    public void setupMocks() {
+        MockitoAnnotations.openMocks(this);
+        citrus = CitrusInstanceManager.newInstance(() -> citrusContext);
+    }
+
+    @Override
+    protected TestContext createTestContext() {
+        TestContext context = super.createTestContext();
+        when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
+        when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
+        when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        CitrusAnnotations.injectAll(this, citrus, context);
+        return context;
+    }
+
+    protected YamlTestLoader createTestLoader(String sourcePath) {
+        YamlTestLoader testLoader = new YamlTestLoader(this.getClass(), "Test", this.getClass().getPackageName());
+        CitrusAnnotations.injectAll(testLoader, citrus, context);
+        CitrusAnnotations.injectTestRunner(testLoader, new DefaultTestCaseRunner(context));
+        testLoader.setSource(sourcePath);
+
+        return testLoader;
+    }
+}

--- a/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/springintegration/yaml/PurgeChannelsTest.java
+++ b/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/springintegration/yaml/PurgeChannelsTest.java
@@ -1,0 +1,76 @@
+package org.citrusframework.springintegration.yaml;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.actions.PurgeMessageChannelAction;
+import org.citrusframework.yaml.YamlTestLoader;
+import org.citrusframework.yaml.actions.YamlTestActionBuilder;
+import org.mockito.Mock;
+import org.springframework.integration.core.MessageSelector;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.core.DestinationResolver;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class PurgeChannelsTest extends AbstractYamlActionTest {
+
+    @Mock
+    private DestinationResolver<MessageChannel> channelResolver;
+    @Mock
+    private MessageChannel messageChannel;
+
+    @Mock
+    private MessageSelector messageSelector;
+
+    @Test
+    public void shouldLoadActions() throws Exception {
+        YamlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/springintegration/yaml/purge-channels-test.yaml");
+
+        context.getReferenceResolver().bind("channelResolver", channelResolver);
+        context.getReferenceResolver().bind("testChannel", messageChannel);
+        context.getReferenceResolver().bind("testChannel1", messageChannel);
+        context.getReferenceResolver().bind("testChannel2", messageChannel);
+        context.getReferenceResolver().bind("testChannel3", messageChannel);
+        context.getReferenceResolver().bind("messageSelector", messageSelector);
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "PurgeChannelsTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 3L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), PurgeMessageChannelAction.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "purge-channel");
+
+        int actionIndex = 0;
+
+        PurgeMessageChannelAction action = (PurgeMessageChannelAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getMessageSelector());
+        Assert.assertNotNull(action.getChannelResolver());
+        Assert.assertEquals(action.getChannels().size(), 0);
+        Assert.assertEquals(action.getChannelNames().size(), 1);
+        Assert.assertEquals(action.getChannelNames().get(0), "testChannel");
+
+        action = (PurgeMessageChannelAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getMessageSelector());
+        Assert.assertEquals(action.getChannelResolver(), context.getReferenceResolver().resolve("channelResolver"));
+        Assert.assertEquals(action.getChannels().size(), 0);
+        Assert.assertEquals(action.getChannelNames().size(), 2);
+        Assert.assertEquals(action.getChannelNames().get(0), "testChannel1");
+        Assert.assertEquals(action.getChannelNames().get(1), "testChannel2");
+
+        action = (PurgeMessageChannelAction) result.getTestAction(actionIndex);
+        Assert.assertEquals(action.getMessageSelector(), context.getReferenceResolver().resolve("messageSelector"));
+        Assert.assertEquals(action.getChannels().size(), 0);
+        Assert.assertEquals(action.getChannelNames().size(), 1);
+        Assert.assertEquals(action.getChannelNames().get(0), "testChannel3");
+    }
+
+    @Test
+    public void shouldLookupTestActionBuilder() {
+        Assert.assertTrue(YamlTestActionBuilder.lookup().containsKey("purgeChannels"));
+        Assert.assertTrue(YamlTestActionBuilder.lookup("purgeChannels").isPresent());
+        Assert.assertEquals(YamlTestActionBuilder.lookup("purgeChannels").get().getClass(), PurgeChannels.class);
+    }
+}

--- a/endpoints/citrus-spring-integration/src/test/resources/org/citrusframework/springintegration/groovy/purge-channels.test.groovy
+++ b/endpoints/citrus-spring-integration/src/test/resources/org/citrusframework/springintegration/groovy/purge-channels.test.groovy
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.springintegration.groovy
+
+import static org.citrusframework.actions.PurgeMessageChannelAction.Builder.purgeChannels
+
+name "PurgeChannelsTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+actions {
+    $(purgeChannels()
+        .channel(testChannel))
+
+    $(purgeChannels()
+        .channelResolver(channelResolver)
+        .channel("testChannel1")
+        .channel("testChannel2"))
+
+    $(purgeChannels()
+        .selector(messageSelector)
+        .channel("testChannel3"))
+}

--- a/endpoints/citrus-spring-integration/src/test/resources/org/citrusframework/springintegration/xml/purge-channels-test.xml
+++ b/endpoints/citrus-spring-integration/src/test/resources/org/citrusframework/springintegration/xml/purge-channels-test.xml
@@ -1,0 +1,39 @@
+<!--
+  ~ Copyright 2021 the original author or authors.
+  ~
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements. See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License. You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<test name="PurgeChannelsTest" author="Christoph" status="FINAL" xmlns="http://citrusframework.org/schema/xml/testcase"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://citrusframework.org/schema/xml/testcase http://citrusframework.org/schema/xml/testcase/citrus-testcase.xsd">
+  <description>Sample test in XML</description>
+  <actions>
+    <purge-channels>
+      <channel ref="testChannel"/>
+      <channel name="testChannel1"/>
+    </purge-channels>
+
+    <purge-channels channel-resolver="channelResolver">
+      <channel name="testChannel1"/>
+      <channel name="testChannel2"/>
+    </purge-channels>
+
+    <purge-channels message-selector="messageSelector">
+      <channel name="testChannel3"/>
+    </purge-channels>
+  </actions>
+</test>

--- a/endpoints/citrus-spring-integration/src/test/resources/org/citrusframework/springintegration/yaml/purge-channels-test.yaml
+++ b/endpoints/citrus-spring-integration/src/test/resources/org/citrusframework/springintegration/yaml/purge-channels-test.yaml
@@ -1,0 +1,16 @@
+name: "PurgeChannelsTest"
+author: "Christoph"
+status: "FINAL"
+actions:
+  - purgeChannels:
+      channel: "testChannel"
+
+  - purgeChannels:
+      channelResolver: "channelResolver"
+      channels:
+        - "testChannel1"
+        - "testChannel2"
+
+  - purgeChannels:
+      messageSelector: "messageSelector"
+      channel: "testChannel3"

--- a/endpoints/citrus-ws/pom.xml
+++ b/endpoints/citrus-ws/pom.xml
@@ -84,6 +84,12 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.citrusframework</groupId>
+      <artifactId>citrus-yaml</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
 
     <dependency>
       <groupId>com.sun.xml.messaging.saaj</groupId>

--- a/endpoints/citrus-ws/pom.xml
+++ b/endpoints/citrus-ws/pom.xml
@@ -90,6 +90,12 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.citrusframework</groupId>
+      <artifactId>citrus-xml</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
 
     <dependency>
       <groupId>com.sun.xml.messaging.saaj</groupId>

--- a/endpoints/citrus-ws/pom.xml
+++ b/endpoints/citrus-ws/pom.xml
@@ -203,5 +203,11 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.citrusframework</groupId>
+      <artifactId>citrus-groovy</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/actions/AssertSoapFault.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/actions/AssertSoapFault.java
@@ -452,6 +452,10 @@ public class AssertSoapFault extends AbstractActionContainer {
         public AssertSoapFault doBuild() {
             if (validationContext == null) {
                 this.validationContext = new SoapFaultValidationContext.Builder();
+
+                if (!faultDetailResourcePaths.isEmpty() || !faultDetails.isEmpty()) {
+                    this.validationContext.detail(new SoapFaultDetailValidationContext.Builder().build());
+                }
             }
 
             if (referenceResolver != null) {

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/actions/ReceiveSoapMessageAction.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/actions/ReceiveSoapMessageAction.java
@@ -106,6 +106,7 @@ public class ReceiveSoapMessageAction extends ReceiveMessageAction implements Te
 
         private final List<SoapAttachment> attachments = new ArrayList<>();
         private SoapAttachmentValidator attachmentValidator = new SimpleSoapAttachmentValidator();
+        private String attachmentValidatorName;
 
         public Builder() {
             message(new StaticMessageBuilder(soapMessage))
@@ -122,6 +123,14 @@ public class ReceiveSoapMessageAction extends ReceiveMessageAction implements Te
 
         @Override
         public ReceiveSoapMessageAction doBuild() {
+            if (referenceResolver != null) {
+                if (attachmentValidatorName != null) {
+                    attachmentValidator = referenceResolver.resolve(attachmentValidatorName, SoapAttachmentValidator.class);
+                } else if (referenceResolver.isResolvable(SoapAttachmentValidator.class)) {
+                    attachmentValidator = referenceResolver.resolve(SoapAttachmentValidator.class);
+                }
+            }
+
             return new ReceiveSoapMessageAction(this);
         }
     }
@@ -241,6 +250,16 @@ public class ReceiveSoapMessageAction extends ReceiveMessageAction implements Te
         }
 
         /**
+         * Set explicit SOAP attachment validator name.
+         * @param validator
+         * @return
+         */
+        public SoapMessageBuilderSupport attachmentValidatorName(String validator) {
+            delegate.attachmentValidatorName = validator;
+            return this;
+        }
+
+        /**
          * Set explicit SOAP attachment validator.
          * @param validator
          * @return
@@ -256,7 +275,7 @@ public class ReceiveSoapMessageAction extends ReceiveMessageAction implements Te
          * @return
          */
         public SoapMessageBuilderSupport contentType(String contentType) {
-            soapMessage.header(SoapMessageHeaders.HTTP_CONTENT_TYPE, contentType);
+            soapMessage.contentType(contentType);
             return this;
         }
 
@@ -266,7 +285,17 @@ public class ReceiveSoapMessageAction extends ReceiveMessageAction implements Te
          * @return
          */
         public SoapMessageBuilderSupport accept(String accept) {
-            soapMessage.header(SoapMessageHeaders.HTTP_ACCEPT, accept);
+            soapMessage.accept(accept);
+            return this;
+        }
+
+        /**
+         * Sets the response status reason phrase.
+         * @param reasonPhrase
+         * @return
+         */
+        public SoapMessageBuilderSupport reasonPhrase(String reasonPhrase) {
+            soapMessage.reasonPhrase(reasonPhrase);
             return this;
         }
 
@@ -276,7 +305,7 @@ public class ReceiveSoapMessageAction extends ReceiveMessageAction implements Te
          * @return
          */
         public SoapMessageBuilderSupport status(HttpStatus status) {
-            soapMessage.header(SoapMessageHeaders.HTTP_STATUS_CODE, status.value());
+            soapMessage.status(status);
             return this;
         }
 
@@ -286,7 +315,7 @@ public class ReceiveSoapMessageAction extends ReceiveMessageAction implements Te
          * @return
          */
         public SoapMessageBuilderSupport statusCode(Integer statusCode) {
-            soapMessage.header(SoapMessageHeaders.HTTP_STATUS_CODE, statusCode);
+            soapMessage.statusCode(statusCode);
             return this;
         }
 

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/actions/SendSoapFaultAction.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/actions/SendSoapFaultAction.java
@@ -30,7 +30,6 @@ import org.citrusframework.validation.builder.StaticMessageBuilder;
 import org.citrusframework.ws.message.SoapAttachment;
 import org.citrusframework.ws.message.SoapFault;
 import org.citrusframework.ws.message.SoapMessage;
-import org.citrusframework.ws.message.SoapMessageHeaders;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
 import org.springframework.util.StringUtils;
@@ -288,7 +287,7 @@ public class SendSoapFaultAction extends SendSoapMessageAction {
              * @return
              */
             public SoapFaultMessageBuilderSupport status(HttpStatus status) {
-                soapMessage.header(SoapMessageHeaders.HTTP_STATUS_CODE, status.value());
+                soapMessage.status(status);
                 return this;
             }
 
@@ -299,7 +298,17 @@ public class SendSoapFaultAction extends SendSoapMessageAction {
              * @return
              */
             public SoapFaultMessageBuilderSupport statusCode(Integer statusCode) {
-                soapMessage.header(SoapMessageHeaders.HTTP_STATUS_CODE, statusCode);
+                soapMessage.statusCode(statusCode);
+                return this;
+            }
+
+            /**
+             * Sets the response status reason phrase.
+             * @param reasonPhrase
+             * @return
+             */
+            public SoapFaultMessageBuilderSupport reasonPhrase(String reasonPhrase) {
+                soapMessage.reasonPhrase(reasonPhrase);
                 return this;
             }
         }

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/actions/SendSoapMessageAction.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/actions/SendSoapMessageAction.java
@@ -130,6 +130,14 @@ public class SendSoapMessageAction extends SendMessageAction implements TestActi
     }
 
     /**
+     * Gets mtom enabled.
+     * @return
+     */
+    public boolean isMtomEnabled() {
+        return mtomEnabled;
+    }
+
+    /**
      * Action builder.
      */
     public static final class Builder extends SendSoapMessageBuilder<SendSoapMessageAction, Builder.SendSoapMessageBuilderSupport, Builder> {
@@ -268,7 +276,7 @@ public class SendSoapMessageAction extends SendMessageAction implements TestActi
         }
 
         /**
-         * Sets the charset name for this send action builder's attachment.
+         * Sets the charset name for this send action builder's most recent attachment.
          * @param charsetName
          * @return
          */
@@ -307,7 +315,7 @@ public class SendSoapMessageAction extends SendMessageAction implements TestActi
          * @return
          */
         public M contentType(String contentType) {
-            soapMessage.header(SoapMessageHeaders.HTTP_CONTENT_TYPE, contentType);
+            soapMessage.contentType(contentType);
             return self;
         }
 
@@ -317,7 +325,7 @@ public class SendSoapMessageAction extends SendMessageAction implements TestActi
          * @return
          */
         public M accept(String accept) {
-            soapMessage.header(SoapMessageHeaders.HTTP_ACCEPT, accept);
+            soapMessage.accept(accept);
             return self;
         }
 

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/actions/SoapClientActionBuilder.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/actions/SoapClientActionBuilder.java
@@ -66,6 +66,7 @@ public class SoapClientActionBuilder implements TestActionBuilder.DelegatingTest
             builder.endpoint(soapClientUri);
         }
 
+        builder.name("soap:receive-response");
         builder.withReferenceResolver(referenceResolver);
         this.delegate = builder;
         return builder;
@@ -83,6 +84,7 @@ public class SoapClientActionBuilder implements TestActionBuilder.DelegatingTest
             builder.endpoint(soapClientUri);
         }
 
+        builder.name("soap:assert-fault");
         builder.withReferenceResolver(referenceResolver);
         this.delegate = builder;
         return builder;
@@ -100,6 +102,7 @@ public class SoapClientActionBuilder implements TestActionBuilder.DelegatingTest
             builder.endpoint(soapClientUri);
         }
 
+        builder.name("soap:send-request");
         builder.withReferenceResolver(referenceResolver);
         this.delegate = builder;
         return builder;

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/actions/SoapClientActionBuilder.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/actions/SoapClientActionBuilder.java
@@ -71,6 +71,23 @@ public class SoapClientActionBuilder implements TestActionBuilder.DelegatingTest
         return builder;
     }
 
+        /**
+     * Generic response builder for expecting response messages on client.
+     * @return
+     */
+    public AssertSoapFault.Builder assertFault() {
+        AssertSoapFault.Builder builder = new AssertSoapFault.Builder();
+        if (soapClient != null) {
+            builder.endpoint(soapClient);
+        } else {
+            builder.endpoint(soapClientUri);
+        }
+
+        builder.withReferenceResolver(referenceResolver);
+        this.delegate = builder;
+        return builder;
+    }
+
     /**
      * Generic request builder with request method and path.
      * @return

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/actions/SoapServerActionBuilder.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/actions/SoapServerActionBuilder.java
@@ -66,6 +66,7 @@ public class SoapServerActionBuilder implements TestActionBuilder.DelegatingTest
             builder.endpoint(soapServerUri);
         }
 
+        builder.name("soap:receive-request");
         builder.withReferenceResolver(referenceResolver);
         this.delegate = builder;
         return builder;
@@ -83,6 +84,7 @@ public class SoapServerActionBuilder implements TestActionBuilder.DelegatingTest
             builder.endpoint(soapServerUri);
         }
 
+        builder.name("soap:send-response");
         builder.withReferenceResolver(referenceResolver);
         this.delegate = builder;
         return builder;
@@ -100,6 +102,7 @@ public class SoapServerActionBuilder implements TestActionBuilder.DelegatingTest
             builder.endpoint(soapServerUri);
         }
 
+        builder.name("soap:send-fault");
         builder.withReferenceResolver(referenceResolver);
         this.delegate = builder;
         return builder;

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/message/SoapMessage.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/message/SoapMessage.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 
 import org.citrusframework.message.DefaultMessage;
 import org.citrusframework.message.Message;
+import org.springframework.http.HttpStatus;
 
 /**
  * SOAP message representation holding additional elements like SOAP action, header fragment data and
@@ -38,7 +39,7 @@ public class SoapMessage extends DefaultMessage {
     private static final long serialVersionUID = 3289201140229458069L;
 
     /** Optional list of SOAP attachments */
-    private List<SoapAttachment> attachments = new ArrayList<SoapAttachment>();
+    private final List<SoapAttachment> attachments = new ArrayList<>();
 
     /** enable/disable mtom attachments */
     private boolean mtomEnabled = false;
@@ -64,7 +65,7 @@ public class SoapMessage extends DefaultMessage {
      * @param payload
      */
     public SoapMessage(Object payload) {
-        this(payload, new LinkedHashMap<String, Object>());
+        this(payload, new LinkedHashMap<>());
     }
 
     /**
@@ -95,6 +96,64 @@ public class SoapMessage extends DefaultMessage {
     @Override
     public SoapMessage addHeaderData(String headerData) {
         return (SoapMessage) super.addHeaderData(headerData);
+    }
+
+    /**
+     * Sets the Http request content type header.
+     *
+     * @param contentType The content type header value to use
+     * @return The altered HttpMessage
+     */
+    public SoapMessage contentType(final String contentType) {
+        setHeader(SoapMessageHeaders.HTTP_CONTENT_TYPE, contentType);
+        return this;
+    }
+
+    /**
+     * Sets the Http accepted content type header for response.
+     *
+     * @param accept The accept header value to set
+     * @return The altered HttpMessage
+     */
+    public SoapMessage accept(final String accept) {
+        setHeader(SoapMessageHeaders.HTTP_ACCEPT, accept);
+        return this;
+    }
+
+
+
+    /**
+     * Sets the Http response status code.
+     *
+     * @param statusCode The status code header to respond with
+     * @return The altered HttpMessage
+     */
+    public SoapMessage status(final HttpStatus statusCode) {
+        statusCode(statusCode.value());
+        reasonPhrase(statusCode.name());
+        return this;
+    }
+
+    /**
+     * Sets the Http response status code header.
+     *
+     * @param statusCode The status code header value to respond with
+     * @return The altered HttpMessage
+     */
+    public SoapMessage statusCode(final Integer statusCode) {
+        setHeader(SoapMessageHeaders.HTTP_STATUS_CODE, statusCode);
+        return this;
+    }
+
+    /**
+     * Sets the Http response reason phrase header.
+     *
+     * @param reasonPhrase The reason phrase header value to use
+     * @return The altered HttpMessage
+     */
+    public SoapMessage reasonPhrase(final String reasonPhrase) {
+        setHeader(SoapMessageHeaders.HTTP_REASON_PHRASE, reasonPhrase);
+        return this;
     }
 
     /**

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/message/SoapMessageHeaders.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/message/SoapMessageHeaders.java
@@ -22,21 +22,24 @@ import org.citrusframework.message.MessageHeaders;
  * @author Christoph Deppisch
  */
 public abstract class SoapMessageHeaders {
-    
+
     /**
      * Prevent instantiation.
      */
     private SoapMessageHeaders() {
     }
-    
+
     /** Citrus ws specific header prefix */
     public static final String SOAP_PREFIX = MessageHeaders.PREFIX + "soap_";
 
     /** Special header prefix for http transport headers in SOAP message sender */
     public static final String HTTP_PREFIX = MessageHeaders.PREFIX + "http_";
-    
+
     /** Special status code header */
     public static final String HTTP_STATUS_CODE = HTTP_PREFIX + "status_code";
+
+    /** Special status reason phrase header */
+    public static final String HTTP_REASON_PHRASE = HTTP_PREFIX + "reason_phrase";
 
     /** Server context path */
     public static final String HTTP_CONTEXT_PATH = HTTP_PREFIX + "context_path";

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/validation/SoapFaultValidationContext.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/validation/SoapFaultValidationContext.java
@@ -38,7 +38,7 @@ public class SoapFaultValidationContext extends DefaultValidationContext {
      */
     public static final class Builder implements ValidationContext.Builder<SoapFaultValidationContext, Builder> {
 
-        private List<SoapFaultDetailValidationContext> validationContexts = new ArrayList<>();
+        private final List<SoapFaultDetailValidationContext> validationContexts = new ArrayList<>();
 
         /**
          * Static entry method for fluent builder API.
@@ -86,7 +86,7 @@ public class SoapFaultValidationContext extends DefaultValidationContext {
 
     /**
      * Gets the validationContexts.
-     * @return the validationContexts the validationContexts to get.
+     * @return the validationContexts.
      */
     public List<SoapFaultDetailValidationContext> getValidationContexts() {
         return validationContexts;

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/xml/ObjectFactory.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/xml/ObjectFactory.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.ws.xml;
+
+import jakarta.xml.bind.annotation.XmlRegistry;
+
+/**
+ * This object contains factory methods for each
+ * Java content interface and Java element interface
+ * generated in the org.citrusframework.ftp.model package.
+ * <p>An ObjectFactory allows you to programatically
+ * construct new instances of the Java representation
+ * for XML content. The Java representation of XML
+ * content can consist of schema derived interfaces
+ * and classes representing the binding of schema
+ * type definitions, element declarations and model
+ * groups.  Factory methods for each of these are
+ * provided in this class.
+ *
+ */
+@XmlRegistry
+public class ObjectFactory {
+
+    /**
+     * Create a new ObjectFactory that can be used to create new instances of schema derived classes for package: org.citrusframework.xml.actions
+     *
+     */
+    public ObjectFactory() {
+    }
+
+    /**
+     * Create an instance of {@link Soap }
+     *
+     */
+    public Soap createSoap() {
+        return new Soap();
+    }
+
+}

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/xml/Soap.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/xml/Soap.java
@@ -47,7 +47,6 @@ import org.citrusframework.ws.actions.SoapClientActionBuilder;
 import org.citrusframework.ws.actions.SoapServerActionBuilder;
 import org.citrusframework.ws.message.SoapAttachment;
 import org.citrusframework.ws.message.SoapMessageHeaders;
-import org.citrusframework.ws.validation.SoapFaultDetailValidationContext;
 import org.citrusframework.xml.TestActions;
 import org.citrusframework.xml.actions.Message;
 import org.citrusframework.xml.actions.Receive;
@@ -454,8 +453,6 @@ public class Soap implements TestActionBuilder<TestAction>, ReferenceResolverAwa
             if (faultDetail.getResource() != null) {
                 assertFault.faultDetailResource(faultDetail.getResource().getFile());
             }
-
-            assertFault.validateDetail(new SoapFaultDetailValidationContext.Builder());
         }
 
         if (soapFault.validator != null) {

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/xml/Soap.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/xml/Soap.java
@@ -1,0 +1,1238 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.ws.xml;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
+import org.citrusframework.TestAction;
+import org.citrusframework.TestActionBuilder;
+import org.citrusframework.TestActionContainerBuilder;
+import org.citrusframework.actions.ReceiveMessageAction;
+import org.citrusframework.actions.SendMessageAction;
+import org.citrusframework.endpoint.resolver.EndpointUriResolver;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.spi.ReferenceResolverAware;
+import org.citrusframework.ws.actions.AssertSoapFault;
+import org.citrusframework.ws.actions.ReceiveSoapMessageAction;
+import org.citrusframework.ws.actions.SendSoapFaultAction;
+import org.citrusframework.ws.actions.SendSoapMessageAction;
+import org.citrusframework.ws.actions.SoapActionBuilder;
+import org.citrusframework.ws.actions.SoapClientActionBuilder;
+import org.citrusframework.ws.actions.SoapServerActionBuilder;
+import org.citrusframework.ws.message.SoapAttachment;
+import org.citrusframework.ws.message.SoapMessageHeaders;
+import org.citrusframework.ws.validation.SoapFaultDetailValidationContext;
+import org.citrusframework.xml.TestActions;
+import org.citrusframework.xml.actions.Message;
+import org.citrusframework.xml.actions.Receive;
+import org.citrusframework.xml.actions.Send;
+
+/**
+ * @author Christoph Deppisch
+ */
+@XmlRootElement(name = "soap")
+public class Soap implements TestActionBuilder<TestAction>, ReferenceResolverAware {
+
+    private TestActionBuilder<?> builder;
+
+    private Receive receive;
+    private Send send;
+
+    private String description;
+    private String actor;
+
+    private ReferenceResolver referenceResolver;
+
+    @XmlElement
+    public Soap setDescription(String value) {
+        this.description = value;
+        return this;
+    }
+
+    @XmlAttribute(name = "actor")
+    public Soap setActor(String actor) {
+        this.actor = actor;
+        return this;
+    }
+
+    @XmlAttribute(name = "client")
+    public Soap setSoapClient(String soapClient) {
+        builder = new SoapActionBuilder().client(soapClient);
+        return this;
+    }
+
+    @XmlAttribute(name = "server")
+    public Soap setSoapServer(String soapServer) {
+        builder = new SoapActionBuilder().server(soapServer);
+        return this;
+    }
+
+    @XmlElement(name = "send-request")
+    public Soap setSendRequest(ClientRequest request) {
+        SendSoapMessageAction.Builder requestBuilder = asClientBuilder().send();
+        requestBuilder.name("soap:send-request");
+        requestBuilder.description(description);
+
+        send = new Send(requestBuilder) {
+            @Override
+            protected SendMessageAction doBuild() {
+                // do not build inside delegate. the actual build is called directly on the builder.
+                return null;
+            }
+        };
+
+        if (request.fork != null) {
+            send.setFork(request.fork);
+        }
+
+        if (request.extract != null) {
+            send.setExtract(request.extract);
+        }
+
+        if (request.uri != null) {
+            requestBuilder.message().header(EndpointUriResolver.ENDPOINT_URI_HEADER_NAME, request.uri);
+        }
+
+        if (request.getMessage() != null) {
+            send.setMessage(request.getMessage());
+
+            if (request.getMessage().contentType != null) {
+                requestBuilder.message().contentType(request.getMessage().contentType);
+            }
+
+            if (request.getMessage().accept != null) {
+                requestBuilder.message().accept(request.getMessage().accept);
+            }
+
+            if (request.getMessage().soapAction != null) {
+                requestBuilder.message().soapAction(request.getMessage().soapAction);
+            }
+
+            if (request.getMessage().mtomEnabled != null) {
+                requestBuilder.message().mtomEnabled(request.getMessage().mtomEnabled);
+            }
+
+            for (SoapMessage.Attachment attachment : request.getMessage().getAttachments()) {
+                SoapAttachment soapAttachment = new SoapAttachment();
+                soapAttachment.setContentId(attachment.getContentId());
+                soapAttachment.setContentType(attachment.getContentType());
+                if (attachment.getResource() != null) {
+                    soapAttachment.setContentResourcePath(attachment.getResource().getFile());
+                }
+                if (attachment.getCharset() != null) {
+                    soapAttachment.setCharsetName(attachment.getCharset());
+                }
+                soapAttachment.setContent(attachment.getContent());
+                requestBuilder.message().attachment(soapAttachment);
+            }
+        }
+
+        builder = requestBuilder;
+        return this;
+    }
+
+    @XmlElement(name = "receive-response")
+    public Soap setReceiveResponse(ClientResponse response) {
+        ReceiveSoapMessageAction.Builder responseBuilder = asClientBuilder().receive();
+
+        responseBuilder.name("soap:receive-response");
+        responseBuilder.description(description);
+
+        receive = new Receive(responseBuilder) {
+            @Override
+            protected ReceiveMessageAction doBuild() {
+                // do not build inside delegate. the actual build is called directly on the builder.
+                return null;
+            }
+        };
+
+        if (response.getMessage() != null) {
+            if (response.getMessage().status != null) {
+                responseBuilder.message().statusCode(Integer.parseInt(response.getMessage().status));
+            }
+
+            if (response.getMessage().reasonPhrase != null) {
+                responseBuilder.message().reasonPhrase(response.getMessage().reasonPhrase);
+            }
+
+            if (response.getMessage().contentType != null) {
+                responseBuilder.message().contentType(response.getMessage().contentType);
+            }
+
+            for (SoapMessage.Attachment attachment : response.getMessage().getAttachments()) {
+                SoapAttachment soapAttachment = new SoapAttachment();
+                soapAttachment.setContentId(attachment.getContentId());
+                soapAttachment.setContentType(attachment.getContentType());
+                if (attachment.getResource() != null) {
+                    soapAttachment.setContentResourcePath(attachment.getResource().getFile());
+                }
+                if (attachment.getCharset() != null) {
+                    soapAttachment.setCharsetName(attachment.getCharset());
+                }
+                soapAttachment.setContent(attachment.getContent());
+                responseBuilder.message().attachment(soapAttachment);
+            }
+
+            receive.setMessage(response.getMessage());
+        }
+
+        if (response.attachmentValidator != null) {
+            responseBuilder.message().attachmentValidatorName(response.attachmentValidator);
+        }
+
+        if (response.timeout != null) {
+            receive.setTimeout(response.timeout);
+        }
+
+        receive.setSelect(response.select);
+        receive.setValidator(response.validator);
+        receive.setValidators(response.validators);
+        receive.setHeaderValidator(response.headerValidator);
+        receive.setHeaderValidators(response.headerValidators);
+
+        if (response.selector != null) {
+            receive.setSelector(response.selector);
+        }
+
+        receive.setSelect(response.select);
+
+        response.getValidates().forEach(receive.getValidates()::add);
+
+        if (response.extract != null) {
+            receive.setExtract(response.extract);
+        }
+
+        builder = responseBuilder;
+        return this;
+    }
+
+    @XmlElement(name = "receive-request")
+    public Soap setReceiveRequest(ServerRequest request) {
+        ReceiveSoapMessageAction.Builder requestBuilder = asServerBuilder().receive();
+
+        requestBuilder.name("soap:receive-request");
+        requestBuilder.description(description);
+
+        receive = new Receive(requestBuilder) {
+            @Override
+            protected ReceiveMessageAction doBuild() {
+                // do not build inside delegate. the actual build is called directly on the builder.
+                return null;
+            }
+        };
+
+        if (request.getMessage() != null) {
+            receive.setMessage(request.getMessage());
+
+            if (request.getMessage().contentType != null) {
+                requestBuilder.message().contentType(request.getMessage().contentType);
+            }
+
+            if (request.getMessage().accept != null) {
+                requestBuilder.message().accept(request.getMessage().accept);
+            }
+
+            if (request.getMessage().soapAction != null) {
+                requestBuilder.message().soapAction(request.getMessage().soapAction);
+            }
+
+            for (SoapMessage.Attachment attachment : request.getMessage().getAttachments()) {
+                SoapAttachment soapAttachment = new SoapAttachment();
+                soapAttachment.setContentId(attachment.getContentId());
+                soapAttachment.setContentType(attachment.getContentType());
+                if (attachment.getResource() != null) {
+                    soapAttachment.setContentResourcePath(attachment.getResource().getFile());
+                }
+                if (attachment.getCharset() != null) {
+                    soapAttachment.setCharsetName(attachment.getCharset());
+                }
+                soapAttachment.setContent(attachment.getContent());
+                requestBuilder.message().attachment(soapAttachment);
+            }
+        }
+
+        if (request.attachmentValidator != null) {
+            requestBuilder.message().attachmentValidatorName(request.attachmentValidator);
+        }
+
+        if (request.selector != null) {
+            receive.setSelector(request.selector);
+        }
+
+        receive.setSelect(request.select);
+        receive.setValidator(request.validator);
+        receive.setValidators(request.validators);
+        receive.setHeaderValidator(request.headerValidator);
+        receive.setHeaderValidators(request.headerValidators);
+
+        if (request.timeout != null) {
+            receive.setTimeout(request.timeout);
+        }
+
+        request.getValidates().forEach(receive.getValidates()::add);
+
+        if (request.extract != null) {
+            receive.setExtract(request.extract);
+        }
+
+        builder = requestBuilder;
+        return this;
+    }
+
+    @XmlElement(name = "send-response")
+    public Soap setSendResponse(ServerResponse response) {
+        SendSoapMessageAction.Builder responseBuilder = asServerBuilder().send();
+
+        responseBuilder.name("soap:send-response");
+        responseBuilder.description(description);
+
+        send = new Send(responseBuilder) {
+            @Override
+            protected SendMessageAction doBuild() {
+                // do not build inside delegate. the actual build is called directly on the builder.
+                return null;
+            }
+        };
+
+        if (response.getMessage() != null) {
+            send.setMessage(response.getMessage());
+
+            if (response.extract != null) {
+                send.setExtract(response.extract);
+            }
+
+            if (response.getMessage().status != null) {
+                responseBuilder.message().header(SoapMessageHeaders.HTTP_STATUS_CODE, response.getMessage().status);
+            }
+
+            if (response.getMessage().reasonPhrase != null) {
+                responseBuilder.message().header(SoapMessageHeaders.HTTP_REASON_PHRASE, response.getMessage().reasonPhrase);
+            }
+
+            if (response.getMessage().contentType != null) {
+                responseBuilder.message().contentType(response.getMessage().contentType);
+            }
+
+            for (SoapMessage.Attachment attachment : response.getMessage().getAttachments()) {
+                SoapAttachment soapAttachment = new SoapAttachment();
+                soapAttachment.setContentId(attachment.getContentId());
+                soapAttachment.setContentType(attachment.getContentType());
+                if (attachment.getResource() != null) {
+                    soapAttachment.setContentResourcePath(attachment.getResource().getFile());
+                }
+                if (attachment.getCharset() != null) {
+                    soapAttachment.setCharsetName(attachment.getCharset());
+                }
+                soapAttachment.setContent(attachment.getContent());
+                responseBuilder.message().attachment(soapAttachment);
+            }
+        }
+
+        builder = responseBuilder;
+        return this;
+    }
+
+    @XmlElement(name = "send-fault")
+    public void setSendFault(ServerFaultResponse response) {
+        SendSoapFaultAction.Builder responseBuilder = asServerBuilder().sendFault();
+        responseBuilder.name("soap:send-fault");
+        responseBuilder.description(description);
+
+        send = new Send(responseBuilder) {
+            @Override
+            protected SendMessageAction doBuild() {
+                // do not build inside delegate. the actual build is called directly on the builder.
+                return null;
+            }
+        };
+
+        if (response.getMessage() != null) {
+            send.setMessage(response.getMessage());
+
+            if (response.extract != null) {
+                send.setExtract(response.extract);
+            }
+
+            if (response.getMessage().status != null) {
+                responseBuilder.message().statusCode(Integer.parseInt(response.getMessage().status));
+            }
+
+            if (response.getMessage().reasonPhrase != null) {
+                responseBuilder.message().reasonPhrase(response.getMessage().reasonPhrase);
+            }
+
+            if (response.getMessage().faultCode != null) {
+                responseBuilder.message().faultCode(response.getMessage().faultCode);
+            }
+
+            if (response.getMessage().faultString != null) {
+                responseBuilder.message().faultString(response.getMessage().faultString);
+            }
+
+            if (response.getMessage().faultActor != null) {
+                responseBuilder.message().faultActor(response.getMessage().faultActor);
+            }
+
+            for (SoapFault.SoapFaultDetail faultDetail : response.getMessage().getFaultDetails()) {
+                if (faultDetail.content != null) {
+                    responseBuilder.message().faultDetail(faultDetail.getContent().trim());
+                }
+
+                if (faultDetail.getResource() != null) {
+                    responseBuilder.message().faultDetailResource(faultDetail.getResource().getFile());
+                }
+            }
+
+            for (SoapMessage.Attachment attachment : response.getMessage().getAttachments()) {
+                SoapAttachment soapAttachment = new SoapAttachment();
+                soapAttachment.setContentId(attachment.getContentId());
+                soapAttachment.setContentType(attachment.getContentType());
+                if (attachment.getResource() != null) {
+                    soapAttachment.setContentResourcePath(attachment.getResource().getFile());
+                }
+                if (attachment.getCharset() != null) {
+                    soapAttachment.setCharsetName(attachment.getCharset());
+                }
+                soapAttachment.setContent(attachment.getContent());
+                responseBuilder.message().attachment(soapAttachment);
+            }
+        }
+
+        builder = responseBuilder;
+    }
+
+    @XmlElement(name = "assert-fault")
+    public void setAssertFault(ClientAssertFault soapFault) {
+        AssertSoapFault.Builder assertFault = asClientBuilder().assertFault();
+
+        assertFault.name("soap:assert-fault");
+        assertFault.description(description);
+
+        if (soapFault.faultCode != null) {
+            assertFault.faultCode(soapFault.faultCode);
+        }
+
+        if (soapFault.faultString != null) {
+            assertFault.faultString(soapFault.faultString);
+        }
+
+        if (soapFault.faultActor != null) {
+            assertFault.faultActor(soapFault.faultActor);
+        }
+
+        for (SoapFault.SoapFaultDetail faultDetail : soapFault.getFaultDetails()) {
+            if (faultDetail.content != null) {
+                assertFault.faultDetail(faultDetail.getContent().trim());
+            }
+
+            if (faultDetail.getResource() != null) {
+                assertFault.faultDetailResource(faultDetail.getResource().getFile());
+            }
+
+            assertFault.validateDetail(new SoapFaultDetailValidationContext.Builder());
+        }
+
+        if (soapFault.validator != null) {
+            assertFault.validator(soapFault.validator);
+        }
+
+        if (soapFault.getActions() != null) {
+            assertFault.actions(soapFault.getActions().getActionBuilders().toArray(TestActionBuilder<?>[]::new));
+        }
+
+        builder = assertFault;
+    }
+
+    @Override
+    public TestAction build() {
+        if (builder == null) {
+            throw new CitrusRuntimeException("Missing client or server Soap action - please provide proper action details");
+        }
+
+        if (send != null) {
+            send.setReferenceResolver(referenceResolver);
+            send.setActor(actor);
+            send.build();
+        }
+
+        if (receive != null) {
+            receive.setReferenceResolver(referenceResolver);
+            receive.setActor(actor);
+            receive.build();
+        }
+
+        if (builder instanceof TestActionContainerBuilder<?,?>) {
+            ((TestActionContainerBuilder<?,?>) builder).getActions().stream()
+                    .filter(action -> action instanceof ReferenceResolverAware)
+                    .forEach(action -> ((ReferenceResolverAware) action).setReferenceResolver(referenceResolver));
+        }
+
+        if (builder instanceof ReferenceResolverAware) {
+            ((ReferenceResolverAware) builder).setReferenceResolver(referenceResolver);
+        }
+
+        return builder.build();
+    }
+
+    @Override
+    public void setReferenceResolver(ReferenceResolver referenceResolver) {
+        this.referenceResolver = referenceResolver;
+    }
+
+    /**
+     * Converts current builder to client builder.
+     * @return
+     */
+    private SoapClientActionBuilder asClientBuilder() {
+        if (builder instanceof SoapClientActionBuilder) {
+            return (SoapClientActionBuilder) builder;
+        }
+
+        throw new CitrusRuntimeException(String.format("Failed to convert '%s' to soap client action builder",
+                Optional.ofNullable(builder).map(Object::getClass).map(Class::getName).orElse("null")));
+    }
+
+    /**
+     * Converts current builder to client builder.
+     * @return
+     */
+    private SoapServerActionBuilder asServerBuilder() {
+        if (builder instanceof SoapServerActionBuilder) {
+            return (SoapServerActionBuilder) builder;
+        }
+
+        throw new CitrusRuntimeException(String.format("Failed to convert '%s' to soap client action builder",
+                Optional.ofNullable(builder).map(Object::getClass).map(Class::getName).orElse("null")));
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(name = "", propOrder = {
+            "message",
+            "extract"
+    })
+    public static class ClientRequest {
+        @XmlAttribute(name = "uri")
+        protected String uri;
+        @XmlAttribute(name = "fork")
+        protected Boolean fork;
+
+        @XmlElement(name = "message")
+        protected SoapRequest message;
+
+        @XmlElement
+        protected Message.Extract extract;
+
+        public SoapRequest getMessage() {
+            return message;
+        }
+
+        public void setMessage(SoapRequest message) {
+            this.message = message;
+        }
+
+        public String getUri() {
+            return uri;
+        }
+
+        public void setUri(String uri) {
+            this.uri = uri;
+        }
+
+        public Boolean getFork() {
+            return fork;
+        }
+
+        public void setFork(Boolean fork) {
+            this.fork = fork;
+        }
+
+        public Message.Extract getExtract() {
+            return extract;
+        }
+
+        public void setExtract(Message.Extract extract) {
+            this.extract = extract;
+        }
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(name = "", propOrder = {
+            "selector",
+            "message",
+            "validates",
+            "extract"
+    })
+    public static class ServerRequest {
+        @XmlAttribute
+        protected Integer timeout;
+
+        @XmlAttribute
+        protected String select;
+
+        @XmlAttribute
+        protected String validator;
+
+        @XmlAttribute
+        protected String validators;
+
+        @XmlAttribute(name = "header-validator")
+        protected String headerValidator;
+
+        @XmlAttribute(name = "header-validators")
+        protected String headerValidators;
+
+        @XmlAttribute(name= "attachment-validator")
+        protected String attachmentValidator;
+
+        @XmlElement
+        protected SoapRequest message;
+
+        @XmlElement
+        protected Receive.Selector selector;
+
+        @XmlElement(name = "validate")
+        protected List<Receive.Validate> validates;
+
+        @XmlElement
+        protected Message.Extract extract;
+
+        public SoapRequest getMessage() {
+            return message;
+        }
+
+        public void setMessage(SoapRequest message) {
+            this.message = message;
+        }
+
+        public String getAttachmentValidator() {
+            return attachmentValidator;
+        }
+
+        public void setAttachmentValidator(String attachmentValidator) {
+            this.attachmentValidator = attachmentValidator;
+        }
+
+        public Integer getTimeout() {
+            return timeout;
+        }
+
+        public void setTimeout(Integer timeout) {
+            this.timeout = timeout;
+        }
+
+        public String getSelect() {
+            return select;
+        }
+
+        public void setSelect(String select) {
+            this.select = select;
+        }
+
+        public String getValidator() {
+            return validator;
+        }
+
+        public void setValidator(String validator) {
+            this.validator = validator;
+        }
+
+        public String getValidators() {
+            return validators;
+        }
+
+        public void setValidators(String validators) {
+            this.validators = validators;
+        }
+
+        public String getHeaderValidator() {
+            return headerValidator;
+        }
+
+        public void setHeaderValidator(String headerValidator) {
+            this.headerValidator = headerValidator;
+        }
+
+        public String getHeaderValidators() {
+            return headerValidators;
+        }
+
+        public void setHeaderValidators(String headerValidators) {
+            this.headerValidators = headerValidators;
+        }
+
+        public Receive.Selector getSelector() {
+            return selector;
+        }
+
+        public void setSelector(Receive.Selector selector) {
+            this.selector = selector;
+        }
+
+        public List<Receive.Validate> getValidates() {
+            if (validates == null) {
+                validates = new ArrayList<>();
+            }
+
+            return validates;
+        }
+
+        public Message.Extract getExtract() {
+            return extract;
+        }
+
+        public void setExtract(Message.Extract extract) {
+            this.extract = extract;
+        }
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(name = "", propOrder = {
+            "message",
+            "extract"
+    })
+    public static class ServerResponse {
+        @XmlElement
+        protected SoapResponse message;
+
+        @XmlElement
+        protected Message.Extract extract;
+
+        public SoapResponse getMessage() {
+            return message;
+        }
+
+        public void setMessage(SoapResponse message) {
+            this.message = message;
+        }
+
+        public Message.Extract getExtract() {
+            return extract;
+        }
+
+        public void setExtract(Message.Extract extract) {
+            this.extract = extract;
+        }
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(name = "", propOrder = {
+            "selector",
+            "message",
+            "validates",
+            "extract"
+    })
+    public static class ClientResponse {
+        @XmlAttribute
+        protected Integer timeout;
+
+        @XmlAttribute
+        protected String select;
+
+        @XmlAttribute
+        protected String validator;
+
+        @XmlAttribute
+        protected String validators;
+
+        @XmlAttribute(name = "header-validator")
+        protected String headerValidator;
+
+        @XmlAttribute(name = "header-validators")
+        protected String headerValidators;
+
+        @XmlElement
+        protected Receive.Selector selector;
+
+        @XmlElement
+        protected SoapResponse message;
+
+        @XmlAttribute(name = "attachment-validator")
+        protected String attachmentValidator;
+
+        @XmlElement(name = "validate")
+        protected List<Receive.Validate> validates;
+
+        @XmlElement
+        protected Message.Extract extract;
+
+        public SoapResponse getMessage() {
+            return message;
+        }
+
+        public void setMessage(SoapResponse message) {
+            this.message = message;
+        }
+
+        public String getAttachmentValidator() {
+            return attachmentValidator;
+        }
+
+        public void setAttachmentValidator(String attachmentValidator) {
+            this.attachmentValidator = attachmentValidator;
+        }
+
+        public Integer getTimeout() {
+            return timeout;
+        }
+
+        public void setTimeout(Integer timeout) {
+            this.timeout = timeout;
+        }
+
+        public String getSelect() {
+            return select;
+        }
+
+        public void setSelect(String select) {
+            this.select = select;
+        }
+
+        public Receive.Selector getSelector() {
+            return selector;
+        }
+
+        public void setSelector(Receive.Selector selector) {
+            this.selector = selector;
+        }
+
+        public String getValidator() {
+            return validator;
+        }
+
+        public void setValidator(String validator) {
+            this.validator = validator;
+        }
+
+        public String getValidators() {
+            return validators;
+        }
+
+        public void setValidators(String validators) {
+            this.validators = validators;
+        }
+
+        public String getHeaderValidator() {
+            return headerValidator;
+        }
+
+        public void setHeaderValidator(String headerValidator) {
+            this.headerValidator = headerValidator;
+        }
+
+        public String getHeaderValidators() {
+            return headerValidators;
+        }
+
+        public void setHeaderValidators(String headerValidators) {
+            this.headerValidators = headerValidators;
+        }
+
+        public List<Receive.Validate> getValidates() {
+            if (validates == null) {
+                validates = new ArrayList<>();
+            }
+
+            return validates;
+        }
+
+        public void setValidates(List<Receive.Validate> validates) {
+            this.validates = validates;
+        }
+
+        public Message.Extract getExtract() {
+            return extract;
+        }
+
+        public void setExtract(Message.Extract extract) {
+            this.extract = extract;
+        }
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(name = "", propOrder = {})
+    public static class ClientAssertFault extends SoapFault {
+        @XmlAttribute
+        protected String validator;
+
+        @XmlElement(name = "when")
+        protected TestActions actions;
+
+        public String getValidator() {
+            return validator;
+        }
+
+        public void setValidator(String validator) {
+            this.validator = validator;
+        }
+
+        public void setWhen(TestActions actions) {
+            this.actions = actions;
+        }
+
+        public void setActions(TestActions actions) {
+            this.actions = actions;
+        }
+
+        public TestActions getActions() {
+            return actions;
+        }
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(name = "", propOrder = {
+            "message",
+            "extract"
+    })
+    public static class ServerFaultResponse {
+        @XmlElement
+        protected Message.Extract extract;
+
+        @XmlElement
+        protected SoapFault message;
+
+        public SoapFault getMessage() {
+            return message;
+        }
+
+        public void setMessage(SoapFault message) {
+            this.message = message;
+        }
+
+        public Message.Extract getExtract() {
+            return extract;
+        }
+
+        public void setExtract(Message.Extract extract) {
+            this.extract = extract;
+        }
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(name = "", propOrder = {
+            "attachments",
+    })
+    public static class SoapMessage extends Message {
+
+        @XmlElement(name = "attachment")
+        private List<SoapMessage.Attachment> attachments;
+
+        public List<SoapMessage.Attachment> getAttachments() {
+            if (attachments == null) {
+                attachments = new ArrayList<>();
+            }
+
+            return attachments;
+        }
+
+        public void setAttachments(List<SoapMessage.Attachment> attachments) {
+            this.attachments = attachments;
+        }
+
+        @XmlAccessorType(XmlAccessType.FIELD)
+        @XmlType(name = "", propOrder = {
+                "content",
+                "resource"
+        })
+        public static class Attachment {
+            @XmlAttribute(name = "content-id")
+            private String contentId;
+            @XmlAttribute(name = "content-type")
+            private String contentType;
+            @XmlAttribute(name = "charset")
+            private String charset;
+            @XmlElement
+            private String content;
+            @XmlElement
+            private Resource resource;
+
+            public String getContentId() {
+                return contentId;
+            }
+
+            public void setContentId(String contentId) {
+                this.contentId = contentId;
+            }
+
+            public String getContentType() {
+                return contentType;
+            }
+
+            public void setContentType(String contentType) {
+                this.contentType = contentType;
+            }
+
+            public String getContent() {
+                return content;
+            }
+
+            public void setContent(String content) {
+                this.content = content;
+            }
+
+            public String getCharset() {
+                return charset;
+            }
+
+            public void setCharset(String charset) {
+                this.charset = charset;
+            }
+
+            public Resource getResource() {
+                return resource;
+            }
+
+            public void setResource(Resource resource) {
+                this.resource = resource;
+            }
+
+            @XmlAccessorType(XmlAccessType.FIELD)
+            @XmlType(name = "")
+            public static class Resource {
+                @XmlAttribute(name = "file")
+                protected String file;
+
+                public String getFile() {
+                    return file;
+                }
+
+                public void setFile(String file) {
+                    this.file = file;
+                }
+            }
+        }
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(name = "")
+    public static class SoapRequest extends SoapMessage {
+        @XmlAttribute
+        protected String path;
+        @XmlAttribute(name = "content-type")
+        protected String contentType;
+        @XmlAttribute(name = "accept")
+        protected String accept;
+        @XmlAttribute(name = "version")
+        protected String version;
+
+        @XmlAttribute(name = "soap-action")
+        protected String soapAction;
+
+        @XmlAttribute(name = "mtom-enabled")
+        protected Boolean mtomEnabled;
+
+        public String getPath() {
+            return path;
+        }
+
+        public void setPath(String path) {
+            this.path = path;
+        }
+
+        public String getContentType() {
+            return contentType;
+        }
+
+        public void setContentType(String contentType) {
+            this.contentType = contentType;
+        }
+
+        public String getAccept() {
+            return accept;
+        }
+
+        public void setAccept(String accept) {
+            this.accept = accept;
+        }
+
+        public String getVersion() {
+            return version;
+        }
+
+        public void setVersion(String version) {
+            this.version = version;
+        }
+
+        public String getSoapAction() {
+            return soapAction;
+        }
+
+        public void setSoapAction(String soapAction) {
+            this.soapAction = soapAction;
+        }
+
+        public Boolean getMtomEnabled() {
+            return mtomEnabled;
+        }
+
+        public void setMtomEnabled(Boolean mtomEnabled) {
+            this.mtomEnabled = mtomEnabled;
+        }
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(name = "")
+    public static class SoapResponse extends SoapMessage {
+        @XmlAttribute(name = "status")
+        protected String status;
+        @XmlAttribute(name = "reason-phrase")
+        protected String reasonPhrase;
+        @XmlAttribute(name = "version")
+        protected String version;
+        @XmlAttribute(name = "content-type")
+        protected String contentType;
+
+        public String getStatus() {
+            return status;
+        }
+
+        public void setStatus(String status) {
+            this.status = status;
+        }
+
+        public String getReasonPhrase() {
+            return reasonPhrase;
+        }
+
+        public void setReasonPhrase(String reasonPhrase) {
+            this.reasonPhrase = reasonPhrase;
+        }
+
+        public String getVersion() {
+            return version;
+        }
+
+        public void setVersion(String version) {
+            this.version = version;
+        }
+
+        public String getContentType() {
+            return contentType;
+        }
+
+        public void setContentType(String contentType) {
+            this.contentType = contentType;
+        }
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(name = "", propOrder = {
+            "faultDetails"
+    })
+    public static class SoapFault extends SoapResponse {
+        @XmlAttribute(name = "fault-code")
+        protected String faultCode;
+        @XmlAttribute(name = "fault-string")
+        protected String faultString;
+        @XmlAttribute(name = "fault-actor")
+        protected String faultActor;
+
+        @XmlElement(name = "fault-detail")
+        protected List<SoapFault.SoapFaultDetail> faultDetails;
+
+        public void setFaultCode(String faultCode) {
+            this.faultCode = faultCode;
+        }
+
+        public String getFaultCode() {
+            return faultCode;
+        }
+
+        public void setFaultString(String faultString) {
+            this.faultString = faultString;
+        }
+
+        public String getFaultString() {
+            return faultString;
+        }
+
+        public void setFaultActor(String faultActor) {
+            this.faultActor = faultActor;
+        }
+
+        public String getFaultActor() {
+            return faultActor;
+        }
+
+        public void setFaultDetails(List<SoapFault.SoapFaultDetail> faultDetails) {
+            this.faultDetails = faultDetails;
+        }
+
+        public List<SoapFault.SoapFaultDetail> getFaultDetails() {
+            if (faultDetails == null) {
+                faultDetails = new ArrayList<>();
+            }
+
+            return faultDetails;
+        }
+
+        @XmlAccessorType(XmlAccessType.FIELD)
+        @XmlType(name = "", propOrder = {
+                "content",
+                "resource"
+        })
+        public static class SoapFaultDetail {
+            @XmlElement
+            protected String content;
+            @XmlElement
+            protected Resource resource;
+
+            public void setContent(String content) {
+                this.content = content;
+            }
+
+            public String getContent() {
+                return content;
+            }
+
+            public void setResource(Resource resource) {
+                this.resource = resource;
+            }
+
+            public Resource getResource() {
+                return resource;
+            }
+
+            @XmlAccessorType(XmlAccessType.FIELD)
+            @XmlType(name = "")
+            public static class Resource {
+                @XmlAttribute(name = "file", required = true)
+                protected String file;
+
+                public String getFile() {
+                    return file;
+                }
+
+                public void setFile(String file) {
+                    this.file = file;
+                }
+            }
+        }
+    }
+
+}

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/xml/package-info.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/xml/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@jakarta.xml.bind.annotation.XmlSchema(namespace = "http://citrusframework.org/schema/xml/testcase", elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
+package org.citrusframework.ws.xml;

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/yaml/Soap.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/yaml/Soap.java
@@ -1,0 +1,1059 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.ws.yaml;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.citrusframework.TestAction;
+import org.citrusframework.TestActionBuilder;
+import org.citrusframework.TestActionContainerBuilder;
+import org.citrusframework.actions.ReceiveMessageAction;
+import org.citrusframework.actions.SendMessageAction;
+import org.citrusframework.endpoint.resolver.EndpointUriResolver;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.spi.ReferenceResolverAware;
+import org.citrusframework.ws.actions.AssertSoapFault;
+import org.citrusframework.ws.actions.ReceiveSoapMessageAction;
+import org.citrusframework.ws.actions.SendSoapFaultAction;
+import org.citrusframework.ws.actions.SendSoapMessageAction;
+import org.citrusframework.ws.actions.SoapActionBuilder;
+import org.citrusframework.ws.actions.SoapClientActionBuilder;
+import org.citrusframework.ws.actions.SoapServerActionBuilder;
+import org.citrusframework.ws.message.SoapAttachment;
+import org.citrusframework.ws.message.SoapMessageHeaders;
+import org.citrusframework.ws.validation.SoapFaultDetailValidationContext;
+import org.citrusframework.yaml.TestActions;
+import org.citrusframework.yaml.actions.Message;
+import org.citrusframework.yaml.actions.Receive;
+import org.citrusframework.yaml.actions.Send;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class Soap implements TestActionBuilder<TestAction>, ReferenceResolverAware {
+
+    private TestActionBuilder<?> builder;
+
+    private Receive receive;
+    private Send send;
+
+    private String description;
+    private String actor;
+
+    private ReferenceResolver referenceResolver;
+
+    public void setDescription(String value) {
+        this.description = value;
+    }
+
+    public void setActor(String actor) {
+        this.actor = actor;
+    }
+
+    public void setClient(String soapClient) {
+        builder = new SoapActionBuilder().client(soapClient);
+    }
+
+    public void setServer(String soapServer) {
+        builder = new SoapActionBuilder().server(soapServer);
+    }
+
+    public void setSendRequest(ClientRequest request) {
+        SendSoapMessageAction.Builder requestBuilder = asClientBuilder().send();
+        requestBuilder.name("soap:send-request");
+        requestBuilder.description(description);
+
+        send = new Send(requestBuilder) {
+            @Override
+            protected SendMessageAction doBuild() {
+                // do not build inside delegate. the actual build is called directly on the builder.
+                return null;
+            }
+        };
+
+        if (request.fork != null) {
+            send.setFork(request.fork);
+        }
+
+        if (request.extract != null) {
+            send.setExtract(request.extract);
+        }
+
+        if (request.uri != null) {
+            requestBuilder.message().header(EndpointUriResolver.ENDPOINT_URI_HEADER_NAME, request.uri);
+        }
+
+        if (request.getMessage() != null) {
+            send.setMessage(request.getMessage());
+
+            if (request.getMessage().contentType != null) {
+                requestBuilder.message().contentType(request.getMessage().contentType);
+            }
+
+            if (request.getMessage().accept != null) {
+                requestBuilder.message().accept(request.getMessage().accept);
+            }
+
+            if (request.getMessage().soapAction != null) {
+                requestBuilder.message().soapAction(request.getMessage().soapAction);
+            }
+
+            if (request.getMessage().mtomEnabled != null) {
+                requestBuilder.message().mtomEnabled(request.getMessage().mtomEnabled);
+            }
+
+            for (SoapMessage.Attachment attachment : request.getMessage().getAttachments()) {
+                SoapAttachment soapAttachment = new SoapAttachment();
+                soapAttachment.setContentId(attachment.getContentId());
+                soapAttachment.setContentType(attachment.getContentType());
+                soapAttachment.setContentResourcePath(attachment.getResource());
+                if (attachment.getCharset() != null) {
+                    soapAttachment.setCharsetName(attachment.getCharset());
+                }
+                soapAttachment.setContent(attachment.getContent());
+                requestBuilder.message().attachment(soapAttachment);
+            }
+        }
+
+        builder = requestBuilder;
+    }
+
+    public void setReceiveResponse(ClientResponse response) {
+        ReceiveSoapMessageAction.Builder responseBuilder = asClientBuilder().receive();
+
+        responseBuilder.name("soap:receive-response");
+        responseBuilder.description(description);
+
+        receive = new Receive(responseBuilder) {
+            @Override
+            protected ReceiveMessageAction doBuild() {
+                // do not build inside delegate. the actual build is called directly on the builder.
+                return null;
+            }
+        };
+
+        if (response.getMessage() != null) {
+            if (response.getMessage().status != null) {
+                responseBuilder.message().statusCode(Integer.parseInt(response.getMessage().status));
+            }
+
+            if (response.getMessage().reasonPhrase != null) {
+                responseBuilder.message().reasonPhrase(response.getMessage().reasonPhrase);
+            }
+
+            if (response.getMessage().contentType != null) {
+                responseBuilder.message().contentType(response.getMessage().contentType);
+            }
+
+            for (SoapMessage.Attachment attachment : response.getMessage().getAttachments()) {
+                SoapAttachment soapAttachment = new SoapAttachment();
+                soapAttachment.setContentId(attachment.getContentId());
+                soapAttachment.setContentType(attachment.getContentType());
+                soapAttachment.setContentResourcePath(attachment.getResource());
+                if (attachment.getCharset() != null) {
+                    soapAttachment.setCharsetName(attachment.getCharset());
+                }
+                soapAttachment.setContent(attachment.getContent());
+                responseBuilder.message().attachment(soapAttachment);
+            }
+
+            receive.setMessage(response.getMessage());
+        }
+
+        if (response.attachmentValidator != null) {
+            responseBuilder.message().attachmentValidatorName(response.attachmentValidator);
+        }
+
+        if (response.timeout != null) {
+            receive.setTimeout(response.timeout);
+        }
+
+        receive.setSelect(response.select);
+        receive.setValidator(response.validator);
+        receive.setValidators(response.validators);
+        receive.setHeaderValidator(response.headerValidator);
+        receive.setHeaderValidators(response.headerValidators);
+
+        if (response.selector != null) {
+            receive.setSelector(response.selector);
+        }
+
+        receive.setSelect(response.select);
+
+        response.getValidate().forEach(receive.getValidate()::add);
+
+        if (response.extract != null) {
+            receive.setExtract(response.extract);
+        }
+
+        builder = responseBuilder;
+    }
+
+    public void setReceiveRequest(ServerRequest request) {
+        ReceiveSoapMessageAction.Builder requestBuilder = asServerBuilder().receive();
+
+        requestBuilder.name("soap:receive-request");
+        requestBuilder.description(description);
+
+        receive = new Receive(requestBuilder) {
+            @Override
+            protected ReceiveMessageAction doBuild() {
+                // do not build inside delegate. the actual build is called directly on the builder.
+                return null;
+            }
+        };
+
+        if (request.getMessage() != null) {
+            receive.setMessage(request.getMessage());
+
+            if (request.getMessage().contentType != null) {
+                requestBuilder.message().contentType(request.getMessage().contentType);
+            }
+
+            if (request.getMessage().accept != null) {
+                requestBuilder.message().accept(request.getMessage().accept);
+            }
+
+            if (request.getMessage().soapAction != null) {
+                requestBuilder.message().soapAction(request.getMessage().soapAction);
+            }
+
+            for (SoapMessage.Attachment attachment : request.getMessage().getAttachments()) {
+                SoapAttachment soapAttachment = new SoapAttachment();
+                soapAttachment.setContentId(attachment.getContentId());
+                soapAttachment.setContentType(attachment.getContentType());
+                soapAttachment.setContentResourcePath(attachment.getResource());
+                if (attachment.getCharset() != null) {
+                    soapAttachment.setCharsetName(attachment.getCharset());
+                }
+                soapAttachment.setContent(attachment.getContent());
+                requestBuilder.message().attachment(soapAttachment);
+            }
+        }
+
+        if (request.attachmentValidator != null) {
+            requestBuilder.message().attachmentValidatorName(request.attachmentValidator);
+        }
+
+        if (request.selector != null) {
+            receive.setSelector(request.selector);
+        }
+
+        receive.setSelect(request.select);
+        receive.setValidator(request.validator);
+        receive.setValidators(request.validators);
+        receive.setHeaderValidator(request.headerValidator);
+        receive.setHeaderValidators(request.headerValidators);
+
+        if (request.timeout != null) {
+            receive.setTimeout(request.timeout);
+        }
+
+        request.getValidates().forEach(receive.getValidate()::add);
+
+        if (request.extract != null) {
+            receive.setExtract(request.extract);
+        }
+
+        builder = requestBuilder;
+    }
+
+    public void setSendResponse(ServerResponse response) {
+        SendSoapMessageAction.Builder responseBuilder = asServerBuilder().send();
+
+        responseBuilder.name("soap:send-response");
+        responseBuilder.description(description);
+
+        send = new Send(responseBuilder) {
+            @Override
+            protected SendMessageAction doBuild() {
+                // do not build inside delegate. the actual build is called directly on the builder.
+                return null;
+            }
+        };
+
+        if (response.getMessage() != null) {
+            send.setMessage(response.getMessage());
+
+            if (response.extract != null) {
+                send.setExtract(response.extract);
+            }
+
+            if (response.getMessage().status != null) {
+                responseBuilder.message().header(SoapMessageHeaders.HTTP_STATUS_CODE, response.getMessage().status);
+            }
+
+            if (response.getMessage().reasonPhrase != null) {
+                responseBuilder.message().header(SoapMessageHeaders.HTTP_REASON_PHRASE, response.getMessage().reasonPhrase);
+            }
+
+            if (response.getMessage().contentType != null) {
+                responseBuilder.message().contentType(response.getMessage().contentType);
+            }
+
+            for (SoapMessage.Attachment attachment : response.getMessage().getAttachments()) {
+                SoapAttachment soapAttachment = new SoapAttachment();
+                soapAttachment.setContentId(attachment.getContentId());
+                soapAttachment.setContentType(attachment.getContentType());
+                soapAttachment.setContentResourcePath(attachment.getResource());
+                if (attachment.getCharset() != null) {
+                    soapAttachment.setCharsetName(attachment.getCharset());
+                }
+                soapAttachment.setContent(attachment.getContent());
+                responseBuilder.message().attachment(soapAttachment);
+            }
+        }
+
+        builder = responseBuilder;
+    }
+
+    public void setSendFault(ServerFaultResponse response) {
+        SendSoapFaultAction.Builder responseBuilder = asServerBuilder().sendFault();
+        responseBuilder.name("soap:send-fault");
+        responseBuilder.description(description);
+
+        send = new Send(responseBuilder) {
+            @Override
+            protected SendMessageAction doBuild() {
+                // do not build inside delegate. the actual build is called directly on the builder.
+                return null;
+            }
+        };
+
+        if (response.getMessage() != null) {
+            send.setMessage(response.getMessage());
+
+            if (response.extract != null) {
+                send.setExtract(response.extract);
+            }
+
+            if (response.getMessage().status != null) {
+                responseBuilder.message().statusCode(Integer.parseInt(response.getMessage().status));
+            }
+
+            if (response.getMessage().reasonPhrase != null) {
+                responseBuilder.message().reasonPhrase(response.getMessage().reasonPhrase);
+            }
+
+            if (response.getMessage().faultCode != null) {
+                responseBuilder.message().faultCode(response.getMessage().faultCode);
+            }
+
+            if (response.getMessage().faultString != null) {
+                responseBuilder.message().faultString(response.getMessage().faultString);
+            }
+
+            if (response.getMessage().faultActor != null) {
+                responseBuilder.message().faultActor(response.getMessage().faultActor);
+            }
+
+            for (SoapFault.SoapFaultDetail faultDetail : response.getMessage().getFaultDetails()) {
+                if (faultDetail.content != null) {
+                    responseBuilder.message().faultDetail(faultDetail.content);
+                }
+
+                if (faultDetail.resource != null) {
+                    responseBuilder.message().faultDetailResource(faultDetail.resource);
+                }
+            }
+
+            for (SoapMessage.Attachment attachment : response.getMessage().getAttachments()) {
+                SoapAttachment soapAttachment = new SoapAttachment();
+                soapAttachment.setContentId(attachment.getContentId());
+                soapAttachment.setContentType(attachment.getContentType());
+                soapAttachment.setContentResourcePath(attachment.getResource());
+                if (attachment.getCharset() != null) {
+                    soapAttachment.setCharsetName(attachment.getCharset());
+                }
+                soapAttachment.setContent(attachment.getContent());
+                responseBuilder.message().attachment(soapAttachment);
+            }
+        }
+
+        builder = responseBuilder;
+    }
+
+    public void setAssertFault(ClientAssertFault soapFault) {
+        AssertSoapFault.Builder assertFault = asClientBuilder().assertFault();
+
+        assertFault.name("soap:assert-fault");
+        assertFault.description(description);
+
+        if (soapFault.faultCode != null) {
+            assertFault.faultCode(soapFault.faultCode);
+        }
+
+        if (soapFault.faultString != null) {
+            assertFault.faultString(soapFault.faultString);
+        }
+
+        if (soapFault.faultActor != null) {
+            assertFault.faultActor(soapFault.faultActor);
+        }
+
+        for (SoapFault.SoapFaultDetail faultDetail : soapFault.getFaultDetails()) {
+            if (faultDetail.content != null) {
+                assertFault.faultDetail(faultDetail.content);
+            }
+
+            if (faultDetail.resource != null) {
+                assertFault.faultDetailResource(faultDetail.resource);
+            }
+
+            assertFault.validateDetail(new SoapFaultDetailValidationContext.Builder());
+        }
+
+        if (soapFault.validator != null) {
+            assertFault.validator(soapFault.validator);
+        }
+
+        if (!soapFault.getActions().isEmpty()) {
+            assertFault.actions(soapFault.getActions().toArray(TestActionBuilder<?>[]::new));
+        }
+
+        builder = assertFault;
+    }
+
+    @Override
+    public TestAction build() {
+        if (builder == null) {
+            throw new CitrusRuntimeException("Missing client or server Soap action - please provide proper action details");
+        }
+
+        if (send != null) {
+            send.setReferenceResolver(referenceResolver);
+            send.setActor(actor);
+            send.build();
+        }
+
+        if (receive != null) {
+            receive.setReferenceResolver(referenceResolver);
+            receive.setActor(actor);
+            receive.build();
+        }
+
+        if (builder instanceof TestActionContainerBuilder<?,?>) {
+            ((TestActionContainerBuilder<?,?>) builder).getActions().stream()
+                    .filter(action -> action instanceof ReferenceResolverAware)
+                    .forEach(action -> ((ReferenceResolverAware) action).setReferenceResolver(referenceResolver));
+        }
+
+        if (builder instanceof ReferenceResolverAware) {
+            ((ReferenceResolverAware) builder).setReferenceResolver(referenceResolver);
+        }
+
+        return builder.build();
+    }
+
+    @Override
+    public void setReferenceResolver(ReferenceResolver referenceResolver) {
+        this.referenceResolver = referenceResolver;
+    }
+
+    /**
+     * Converts current builder to client builder.
+     * @return
+     */
+    private SoapClientActionBuilder asClientBuilder() {
+        if (builder instanceof SoapClientActionBuilder) {
+            return (SoapClientActionBuilder) builder;
+        }
+
+        throw new CitrusRuntimeException(String.format("Failed to convert '%s' to soap client action builder",
+                Optional.ofNullable(builder).map(Object::getClass).map(Class::getName).orElse("null")));
+    }
+
+    /**
+     * Converts current builder to client builder.
+     * @return
+     */
+    private SoapServerActionBuilder asServerBuilder() {
+        if (builder instanceof SoapServerActionBuilder) {
+            return (SoapServerActionBuilder) builder;
+        }
+
+        throw new CitrusRuntimeException(String.format("Failed to convert '%s' to soap client action builder",
+                Optional.ofNullable(builder).map(Object::getClass).map(Class::getName).orElse("null")));
+    }
+
+    public static class ClientRequest {
+        protected String uri;
+        protected Boolean fork;
+
+        protected SoapRequest message;
+
+        protected Message.Extract extract;
+
+        public String getUri() {
+            return uri;
+        }
+
+        public void setUri(String uri) {
+            this.uri = uri;
+        }
+
+        public Boolean getFork() {
+            return fork;
+        }
+
+        public void setFork(Boolean fork) {
+            this.fork = fork;
+        }
+
+        public SoapRequest getMessage() {
+            return message;
+        }
+
+        public void setMessage(SoapRequest message) {
+            this.message = message;
+        }
+
+        public Message.Extract getExtract() {
+            return extract;
+        }
+
+        public void setExtract(Message.Extract extract) {
+            this.extract = extract;
+        }
+    }
+
+    public static class ServerRequest {
+        protected Integer timeout;
+        protected String select;
+        protected String validator;
+        protected String validators;
+        protected String headerValidator;
+        protected String headerValidators;
+
+        protected Receive.Selector selector;
+
+        protected String attachmentValidator;
+        protected SoapRequest message;
+
+        public SoapRequest getMessage() {
+            return message;
+        }
+
+        public void setMessage(SoapRequest message) {
+            this.message = message;
+        }
+
+
+        public String getAttachmentValidator() {
+            return attachmentValidator;
+        }
+
+        public void setAttachmentValidator(String attachmentValidator) {
+            this.attachmentValidator = attachmentValidator;
+        }
+
+        protected List<Receive.Validate> validates;
+
+        protected Message.Extract extract;
+
+        public Integer getTimeout() {
+            return timeout;
+        }
+
+        public void setTimeout(Integer timeout) {
+            this.timeout = timeout;
+        }
+
+        public String getSelect() {
+            return select;
+        }
+
+        public void setSelect(String select) {
+            this.select = select;
+        }
+
+        public String getValidator() {
+            return validator;
+        }
+
+        public void setValidator(String validator) {
+            this.validator = validator;
+        }
+
+        public String getValidators() {
+            return validators;
+        }
+
+        public void setValidators(String validators) {
+            this.validators = validators;
+        }
+
+        public String getHeaderValidator() {
+            return headerValidator;
+        }
+
+        public void setHeaderValidator(String headerValidator) {
+            this.headerValidator = headerValidator;
+        }
+
+        public String getHeaderValidators() {
+            return headerValidators;
+        }
+
+        public void setHeaderValidators(String headerValidators) {
+            this.headerValidators = headerValidators;
+        }
+
+        public Receive.Selector getSelector() {
+            return selector;
+        }
+
+        public void setSelector(Receive.Selector selector) {
+            this.selector = selector;
+        }
+
+        public List<Receive.Validate> getValidates() {
+            if (validates == null) {
+                validates = new ArrayList<>();
+            }
+
+            return validates;
+        }
+
+        public Message.Extract getExtract() {
+            return extract;
+        }
+
+        public void setExtract(Message.Extract extract) {
+            this.extract = extract;
+        }
+    }
+
+    public static class ServerResponse {
+        protected Message.Extract extract;
+
+        protected SoapResponse message;
+
+        public SoapResponse getMessage() {
+            return message;
+        }
+
+        public void setMessage(SoapResponse message) {
+            this.message = message;
+        }
+
+        public Message.Extract getExtract() {
+            return extract;
+        }
+
+        public void setExtract(Message.Extract extract) {
+            this.extract = extract;
+        }
+    }
+
+    public static class ClientResponse {
+        protected Integer timeout;
+        protected String select;
+        protected String validator;
+        protected String validators;
+
+        protected String attachmentValidator;
+        protected SoapResponse message;
+
+        public SoapResponse getMessage() {
+            return message;
+        }
+
+        public void setMessage(SoapResponse message) {
+            this.message = message;
+        }
+
+
+        public String getAttachmentValidator() {
+            return attachmentValidator;
+        }
+
+        public void setAttachmentValidator(String attachmentValidator) {
+            this.attachmentValidator = attachmentValidator;
+        }
+
+        protected String headerValidator;
+        protected String headerValidators;
+
+        protected Receive.Selector selector;
+
+        protected List<Receive.Validate> validate;
+
+        protected Message.Extract extract;
+
+        public Integer getTimeout() {
+            return timeout;
+        }
+
+        public void setTimeout(Integer timeout) {
+            this.timeout = timeout;
+        }
+
+        public String getSelect() {
+            return select;
+        }
+
+        public void setSelect(String select) {
+            this.select = select;
+        }
+
+        public Receive.Selector getSelector() {
+            return selector;
+        }
+
+        public void setSelector(Receive.Selector selector) {
+            this.selector = selector;
+        }
+
+        public String getValidator() {
+            return validator;
+        }
+
+        public void setValidator(String validator) {
+            this.validator = validator;
+        }
+
+        public String getValidators() {
+            return validators;
+        }
+
+        public void setValidators(String validators) {
+            this.validators = validators;
+        }
+
+        public String getHeaderValidator() {
+            return headerValidator;
+        }
+
+        public void setHeaderValidator(String headerValidator) {
+            this.headerValidator = headerValidator;
+        }
+
+        public String getHeaderValidators() {
+            return headerValidators;
+        }
+
+        public void setHeaderValidators(String headerValidators) {
+            this.headerValidators = headerValidators;
+        }
+
+        public List<Receive.Validate> getValidate() {
+            if (validate == null) {
+                validate = new ArrayList<>();
+            }
+
+            return validate;
+        }
+
+        public void setValidate(List<Receive.Validate> validate) {
+            this.validate = validate;
+        }
+
+        public Message.Extract getExtract() {
+            return extract;
+        }
+
+        public void setExtract(Message.Extract extract) {
+            this.extract = extract;
+        }
+    }
+
+    public static class ClientAssertFault extends SoapFault {
+        protected String validator;
+
+        protected List<TestActionBuilder<?>> actions;
+
+        public String getValidator() {
+            return validator;
+        }
+
+        public void setValidator(String validator) {
+            this.validator = validator;
+        }
+
+        public void setWhen(List<TestActions> actions) {
+            getActions().addAll(actions.stream().map(TestActions::get).toList());
+        }
+
+        public void setActions(List<TestActions> actions) {
+            getActions().addAll(actions.stream().map(TestActions::get).toList());
+        }
+
+        public List<TestActionBuilder<?>> getActions() {
+            if (actions == null) {
+                actions = new ArrayList<>();
+            }
+
+            return actions;
+        }
+    }
+
+    public static class ServerFaultResponse {
+        protected Message.Extract extract;
+
+        protected SoapFault message;
+
+        public SoapFault getMessage() {
+            return message;
+        }
+
+        public void setMessage(SoapFault message) {
+            this.message = message;
+        }
+
+        public Message.Extract getExtract() {
+            return extract;
+        }
+
+        public void setExtract(Message.Extract extract) {
+            this.extract = extract;
+        }
+    }
+
+    public static class SoapMessage extends Message {
+
+        private List<Attachment> attachments;
+
+        public List<Attachment> getAttachments() {
+            if (attachments == null) {
+                attachments = new ArrayList<>();
+            }
+
+            return attachments;
+        }
+
+        public void setAttachments(List<Attachment> attachments) {
+            this.attachments = attachments;
+        }
+
+        public static class Attachment {
+            private String contentId;
+            private String contentType;
+            private String content;
+            private String resource;
+            private String charset;
+
+            public String getContentId() {
+                return contentId;
+            }
+
+            public void setContentId(String contentId) {
+                this.contentId = contentId;
+            }
+
+            public String getContentType() {
+                return contentType;
+            }
+
+            public void setContentType(String contentType) {
+                this.contentType = contentType;
+            }
+
+            public String getContent() {
+                return content;
+            }
+
+            public void setContent(String content) {
+                this.content = content;
+            }
+
+            public String getCharset() {
+                return charset;
+            }
+
+            public void setCharset(String charset) {
+                this.charset = charset;
+            }
+
+            public String getResource() {
+                return resource;
+            }
+
+            public void setResource(String resource) {
+                this.resource = resource;
+            }
+        }
+    }
+
+    public static class SoapRequest extends SoapMessage {
+        protected String path;
+        protected String contentType;
+        protected String accept;
+        protected String version;
+
+        protected String soapAction;
+        protected Boolean mtomEnabled;
+
+        public String getPath() {
+            return path;
+        }
+
+        public void setPath(String path) {
+            this.path = path;
+        }
+
+        public String getContentType() {
+            return contentType;
+        }
+
+        public void setContentType(String contentType) {
+            this.contentType = contentType;
+        }
+
+        public String getAccept() {
+            return accept;
+        }
+
+        public void setAccept(String accept) {
+            this.accept = accept;
+        }
+
+        public String getVersion() {
+            return version;
+        }
+
+        public void setVersion(String version) {
+            this.version = version;
+        }
+
+        public String getSoapAction() {
+            return soapAction;
+        }
+
+        public void setSoapAction(String soapAction) {
+            this.soapAction = soapAction;
+        }
+
+        public Boolean getMtomEnabled() {
+            return mtomEnabled;
+        }
+
+        public void setMtomEnabled(Boolean mtomEnabled) {
+            this.mtomEnabled = mtomEnabled;
+        }
+    }
+
+    public static class SoapResponse extends SoapMessage {
+        protected String status;
+        protected String reasonPhrase;
+        protected String version;
+        protected String contentType;
+
+        public String getStatus() {
+            return status;
+        }
+
+        public void setStatus(String status) {
+            this.status = status;
+        }
+
+        public String getReasonPhrase() {
+            return reasonPhrase;
+        }
+
+        public void setReasonPhrase(String reasonPhrase) {
+            this.reasonPhrase = reasonPhrase;
+        }
+
+        public String getVersion() {
+            return version;
+        }
+
+        public void setVersion(String version) {
+            this.version = version;
+        }
+
+        public String getContentType() {
+            return contentType;
+        }
+
+        public void setContentType(String contentType) {
+                this.contentType = contentType;
+            }
+    }
+
+    public static class SoapFault extends SoapResponse {
+        protected String faultCode;
+        protected String faultString;
+        protected String faultActor;
+
+        protected List<SoapFaultDetail> faultDetails;
+
+        public void setFaultCode(String faultCode) {
+            this.faultCode = faultCode;
+        }
+
+        public String getFaultCode() {
+            return faultCode;
+        }
+
+        public void setFaultString(String faultString) {
+            this.faultString = faultString;
+        }
+
+        public String getFaultString() {
+            return faultString;
+        }
+
+        public void setFaultActor(String faultActor) {
+            this.faultActor = faultActor;
+        }
+
+        public String getFaultActor() {
+            return faultActor;
+        }
+
+        public void setFaultDetails(List<SoapFaultDetail> faultDetails) {
+            this.faultDetails = faultDetails;
+        }
+
+        public List<SoapFaultDetail> getFaultDetails() {
+            if (faultDetails == null) {
+                faultDetails = new ArrayList<>();
+            }
+
+            return faultDetails;
+        }
+
+        public static class SoapFaultDetail {
+            protected String content;
+            protected String resource;
+
+            public void setContent(String content) {
+                this.content = content;
+            }
+
+            public String getContent() {
+                return content;
+            }
+
+            public void setResource(String resource) {
+                this.resource = resource;
+            }
+
+            public String getResource() {
+                return resource;
+            }
+        }
+    }
+}

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/yaml/Soap.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/yaml/Soap.java
@@ -41,7 +41,6 @@ import org.citrusframework.ws.actions.SoapClientActionBuilder;
 import org.citrusframework.ws.actions.SoapServerActionBuilder;
 import org.citrusframework.ws.message.SoapAttachment;
 import org.citrusframework.ws.message.SoapMessageHeaders;
-import org.citrusframework.ws.validation.SoapFaultDetailValidationContext;
 import org.citrusframework.yaml.TestActions;
 import org.citrusframework.yaml.actions.Message;
 import org.citrusframework.yaml.actions.Receive;
@@ -419,8 +418,6 @@ public class Soap implements TestActionBuilder<TestAction>, ReferenceResolverAwa
             if (faultDetail.resource != null) {
                 assertFault.faultDetailResource(faultDetail.resource);
             }
-
-            assertFault.validateDetail(new SoapFaultDetailValidationContext.Builder());
         }
 
         if (soapFault.validator != null) {

--- a/endpoints/citrus-ws/src/main/resources/META-INF/citrus/xml/builder/soap
+++ b/endpoints/citrus-ws/src/main/resources/META-INF/citrus/xml/builder/soap
@@ -1,0 +1,2 @@
+type=org.citrusframework.ws.xml.Soap
+ns=http://citrusframework.org/schema/xml/testcase

--- a/endpoints/citrus-ws/src/main/resources/META-INF/citrus/yaml/builder/soap
+++ b/endpoints/citrus-ws/src/main/resources/META-INF/citrus/yaml/builder/soap
@@ -1,0 +1,1 @@
+type=org.citrusframework.ws.yaml.Soap

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/actions/dsl/AssertSoapFaultBuilderTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/actions/dsl/AssertSoapFaultBuilderTest.java
@@ -100,7 +100,7 @@ public class AssertSoapFaultBuilderTest extends UnitTestSupport {
         TestCase test = runner.getTestCase();
         Assert.assertEquals(test.getActionCount(), 1);
         Assert.assertEquals(test.getActions().get(0).getClass(), AssertSoapFault.class);
-        Assert.assertEquals(test.getActions().get(0).getName(), "soap-fault");
+        Assert.assertEquals(test.getActions().get(0).getName(), "soap:assert-fault");
 
         AssertSoapFault container = (AssertSoapFault)(test.getTestAction(0));
 
@@ -143,7 +143,7 @@ public class AssertSoapFaultBuilderTest extends UnitTestSupport {
         TestCase test = runner.getTestCase();
         Assert.assertEquals(test.getActionCount(), 1);
         Assert.assertEquals(test.getActions().get(0).getClass(), AssertSoapFault.class);
-        Assert.assertEquals(test.getActions().get(0).getName(), "soap-fault");
+        Assert.assertEquals(test.getActions().get(0).getName(), "soap:assert-fault");
 
         AssertSoapFault container = (AssertSoapFault)(test.getTestAction(0));
 
@@ -190,7 +190,7 @@ public class AssertSoapFaultBuilderTest extends UnitTestSupport {
         TestCase test = runner.getTestCase();
         Assert.assertEquals(test.getActionCount(), 1);
         Assert.assertEquals(test.getActions().get(0).getClass(), AssertSoapFault.class);
-        Assert.assertEquals(test.getActions().get(0).getName(), "soap-fault");
+        Assert.assertEquals(test.getActions().get(0).getName(), "soap:assert-fault");
 
         AssertSoapFault container = (AssertSoapFault)(test.getTestAction(0));
 
@@ -236,7 +236,7 @@ public class AssertSoapFaultBuilderTest extends UnitTestSupport {
         TestCase test = runner.getTestCase();
         Assert.assertEquals(test.getActionCount(), 1);
         Assert.assertEquals(test.getActions().get(0).getClass(), AssertSoapFault.class);
-        Assert.assertEquals(test.getActions().get(0).getName(), "soap-fault");
+        Assert.assertEquals(test.getActions().get(0).getName(), "soap:assert-fault");
 
         AssertSoapFault container = (AssertSoapFault)(test.getTestAction(0));
 
@@ -285,7 +285,7 @@ public class AssertSoapFaultBuilderTest extends UnitTestSupport {
         TestCase test = runner.getTestCase();
         Assert.assertEquals(test.getActionCount(), 1);
         Assert.assertEquals(test.getActions().get(0).getClass(), AssertSoapFault.class);
-        Assert.assertEquals(test.getActions().get(0).getName(), "soap-fault");
+        Assert.assertEquals(test.getActions().get(0).getName(), "soap:assert-fault");
 
         AssertSoapFault container = (AssertSoapFault)(test.getTestAction(0));
 
@@ -336,7 +336,7 @@ public class AssertSoapFaultBuilderTest extends UnitTestSupport {
         TestCase test = runner.getTestCase();
         Assert.assertEquals(test.getActionCount(), 1);
         Assert.assertEquals(test.getActions().get(0).getClass(), AssertSoapFault.class);
-        Assert.assertEquals(test.getActions().get(0).getName(), "soap-fault");
+        Assert.assertEquals(test.getActions().get(0).getName(), "soap:assert-fault");
 
         AssertSoapFault container = (AssertSoapFault)(test.getTestAction(0));
 
@@ -387,7 +387,7 @@ public class AssertSoapFaultBuilderTest extends UnitTestSupport {
         TestCase test = runner.getTestCase();
         Assert.assertEquals(test.getActionCount(), 1);
         Assert.assertEquals(test.getActions().get(0).getClass(), AssertSoapFault.class);
-        Assert.assertEquals(test.getActions().get(0).getName(), "soap-fault");
+        Assert.assertEquals(test.getActions().get(0).getName(), "soap:assert-fault");
 
         AssertSoapFault container = (AssertSoapFault)(test.getTestAction(0));
 
@@ -436,7 +436,7 @@ public class AssertSoapFaultBuilderTest extends UnitTestSupport {
         TestCase test = runner.getTestCase();
         Assert.assertEquals(test.getActionCount(), 1);
         Assert.assertEquals(test.getActions().get(0).getClass(), AssertSoapFault.class);
-        Assert.assertEquals(test.getActions().get(0).getName(), "soap-fault");
+        Assert.assertEquals(test.getActions().get(0).getName(), "soap:assert-fault");
 
         AssertSoapFault container = (AssertSoapFault)(test.getTestAction(0));
 
@@ -489,7 +489,7 @@ public class AssertSoapFaultBuilderTest extends UnitTestSupport {
         TestCase test = runner.getTestCase();
         Assert.assertEquals(test.getActionCount(), 1);
         Assert.assertEquals(test.getActions().get(0).getClass(), AssertSoapFault.class);
-        Assert.assertEquals(test.getActions().get(0).getName(), "soap-fault");
+        Assert.assertEquals(test.getActions().get(0).getName(), "soap:assert-fault");
 
         AssertSoapFault container = (AssertSoapFault)(test.getTestAction(0));
 
@@ -537,7 +537,7 @@ public class AssertSoapFaultBuilderTest extends UnitTestSupport {
         TestCase test = runner.getTestCase();
         Assert.assertEquals(test.getActionCount(), 1);
         Assert.assertEquals(test.getActions().get(0).getClass(), AssertSoapFault.class);
-        Assert.assertEquals(test.getActions().get(0).getName(), "soap-fault");
+        Assert.assertEquals(test.getActions().get(0).getName(), "soap:assert-fault");
 
         AssertSoapFault container = (AssertSoapFault)(test.getTestAction(0));
 
@@ -584,7 +584,7 @@ public class AssertSoapFaultBuilderTest extends UnitTestSupport {
         TestCase test = runner.getTestCase();
         Assert.assertEquals(test.getActionCount(), 1);
         Assert.assertEquals(test.getActions().get(0).getClass(), AssertSoapFault.class);
-        Assert.assertEquals(test.getActions().get(0).getName(), "soap-fault");
+        Assert.assertEquals(test.getActions().get(0).getName(), "soap:assert-fault");
 
         AssertSoapFault container = (AssertSoapFault)(test.getTestAction(0));
 

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/actions/dsl/AssertSoapFaultBuilderTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/actions/dsl/AssertSoapFaultBuilderTest.java
@@ -47,7 +47,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import static org.citrusframework.DefaultTestActionBuilder.action;
-import static org.citrusframework.ws.actions.AssertSoapFault.Builder.assertSoapFault;
+import static org.citrusframework.ws.actions.SoapActionBuilder.soap;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
@@ -58,15 +58,15 @@ public class AssertSoapFaultBuilderTest extends UnitTestSupport {
     public static final String INTERNAL_SERVER_ERROR = "Internal server error";
     public static final String SOAP_FAULT_VALIDATOR = "soapFaultValidator";
 
-    private Resource resource = Mockito.mock(Resource.class);
-    private SoapFaultValidator soapFaultValidator = Mockito.mock(SoapFaultValidator.class);
-    private ReferenceResolver referenceResolver = Mockito.mock(ReferenceResolver.class);
+    private final Resource resource = Mockito.mock(Resource.class);
+    private final SoapFaultValidator soapFaultValidator = Mockito.mock(SoapFaultValidator.class);
+    private final ReferenceResolver referenceResolver = Mockito.mock(ReferenceResolver.class);
 
-    private SoapMessage soapMessage = Mockito.mock(SoapMessage.class);
-    private SoapBody soapBody = Mockito.mock(SoapBody.class);
-    private SoapFault soapFault = Mockito.mock(SoapFault.class);
-    private SoapFaultDetail soapFaultDetail = Mockito.mock(SoapFaultDetail.class);
-    private SoapFaultDetailElement soapFaultDetailElement = Mockito.mock(SoapFaultDetailElement.class);
+    private final SoapMessage soapMessage = Mockito.mock(SoapMessage.class);
+    private final SoapBody soapBody = Mockito.mock(SoapBody.class);
+    private final SoapFault soapFault = Mockito.mock(SoapFault.class);
+    private final SoapFaultDetail soapFaultDetail = Mockito.mock(SoapFaultDetail.class);
+    private final SoapFaultDetailElement soapFaultDetailElement = Mockito.mock(SoapFaultDetailElement.class);
 
     @Test
     public void testAssertSoapFaultBuilder() {
@@ -89,7 +89,9 @@ public class AssertSoapFaultBuilderTest extends UnitTestSupport {
 
         context.setReferenceResolver(referenceResolver);
         DefaultTestCaseRunner runner = new DefaultTestCaseRunner(context);
-        runner.run(assertSoapFault().faultCode(SoapFaultDefinition.SERVER.getLocalPart())
+        runner.run(soap().client("soapClient")
+                        .assertFault()
+                            .faultCode(SoapFaultDefinition.SERVER.getLocalPart())
                             .faultString(INTERNAL_SERVER_ERROR)
                         .when(action(context -> {
                             throw new SoapFaultClientException(soapMessage);
@@ -129,12 +131,14 @@ public class AssertSoapFaultBuilderTest extends UnitTestSupport {
 
         context.setReferenceResolver(referenceResolver);
         DefaultTestCaseRunner runner = new DefaultTestCaseRunner(context);
-        runner.run(assertSoapFault().faultCode(SoapFaultDefinition.SERVER.getLocalPart())
-                .faultString(INTERNAL_SERVER_ERROR)
-                .validator(soapFaultValidator)
-                .when(action(context -> {
-                    throw new SoapFaultClientException(soapMessage);
-                })));
+        runner.run(soap().client("soapClient")
+                    .assertFault()
+                        .faultCode(SoapFaultDefinition.SERVER.getLocalPart())
+                        .faultString(INTERNAL_SERVER_ERROR)
+                        .validator(soapFaultValidator)
+                    .when(action(context -> {
+                        throw new SoapFaultClientException(soapMessage);
+                    })));
 
         TestCase test = runner.getTestCase();
         Assert.assertEquals(test.getActionCount(), 1);
@@ -174,7 +178,9 @@ public class AssertSoapFaultBuilderTest extends UnitTestSupport {
 
         context.setReferenceResolver(referenceResolver);
         DefaultTestCaseRunner runner = new DefaultTestCaseRunner(context);
-        runner.run(assertSoapFault().faultCode(SoapFaultDefinition.SERVER.getLocalPart())
+        runner.run(soap().client("soapClient")
+                        .assertFault()
+                                .faultCode(SoapFaultDefinition.SERVER.getLocalPart())
                                 .faultString(INTERNAL_SERVER_ERROR)
                                 .validator(SOAP_FAULT_VALIDATOR)
                         .when(action(context -> {
@@ -219,7 +225,9 @@ public class AssertSoapFaultBuilderTest extends UnitTestSupport {
 
         context.setReferenceResolver(referenceResolver);
         DefaultTestCaseRunner runner = new DefaultTestCaseRunner(context);
-        runner.run(assertSoapFault().faultCode(SoapFaultDefinition.SERVER.getLocalPart())
+        runner.run(soap().client("soapClient")
+                        .assertFault()
+                                .faultCode(SoapFaultDefinition.SERVER.getLocalPart())
                                 .faultString(INTERNAL_SERVER_ERROR)
                         .when(action(context -> {
                             throw new SoapFaultClientException(soapMessage);
@@ -265,7 +273,9 @@ public class AssertSoapFaultBuilderTest extends UnitTestSupport {
 
         context.setReferenceResolver(referenceResolver);
         DefaultTestCaseRunner runner = new DefaultTestCaseRunner(context);
-        runner.run(assertSoapFault().faultCode(SoapFaultDefinition.SERVER.getLocalPart())
+        runner.run(soap().client("soapClient")
+                        .assertFault()
+                                .faultCode(SoapFaultDefinition.SERVER.getLocalPart())
                                 .faultString(INTERNAL_SERVER_ERROR)
                                 .faultDetail("<ErrorDetail><message>Something went wrong</message></ErrorDetail>")
                         .when(action(context -> {
@@ -313,7 +323,9 @@ public class AssertSoapFaultBuilderTest extends UnitTestSupport {
 
         context.setReferenceResolver(referenceResolver);
         DefaultTestCaseRunner runner = new DefaultTestCaseRunner(context);
-        runner.run(assertSoapFault().faultCode(SoapFaultDefinition.SERVER.getLocalPart())
+        runner.run(soap().client("soapClient")
+                        .assertFault()
+                                .faultCode(SoapFaultDefinition.SERVER.getLocalPart())
                                 .faultString(INTERNAL_SERVER_ERROR)
                                 .faultDetail("<ErrorDetail><code>1001</code></ErrorDetail>")
                                 .faultDetail("<MessageDetail><message>Something went wrong</message></MessageDetail>")
@@ -363,7 +375,9 @@ public class AssertSoapFaultBuilderTest extends UnitTestSupport {
 
         context.setReferenceResolver(referenceResolver);
         DefaultTestCaseRunner runner = new DefaultTestCaseRunner(context);
-        runner.run(assertSoapFault().faultCode(SoapFaultDefinition.SERVER.getLocalPart())
+        runner.run(soap().client("soapClient")
+                        .assertFault()
+                                .faultCode(SoapFaultDefinition.SERVER.getLocalPart())
                                 .faultString(INTERNAL_SERVER_ERROR)
                                 .faultDetailResource(resource)
                         .when(action(context -> {
@@ -410,7 +424,9 @@ public class AssertSoapFaultBuilderTest extends UnitTestSupport {
 
         context.setReferenceResolver(referenceResolver);
         DefaultTestCaseRunner runner = new DefaultTestCaseRunner(context);
-        runner.run(assertSoapFault().faultCode(SoapFaultDefinition.SERVER.getLocalPart())
+        runner.run(soap().client("soapClient")
+                        .assertFault()
+                                .faultCode(SoapFaultDefinition.SERVER.getLocalPart())
                                 .faultString(INTERNAL_SERVER_ERROR)
                                 .faultDetailResource("classpath:org/citrusframework/ws/actions/dsl/soap-fault-detail.xml")
                         .when(action(context -> {
@@ -460,7 +476,9 @@ public class AssertSoapFaultBuilderTest extends UnitTestSupport {
 
         context.setReferenceResolver(referenceResolver);
         DefaultTestCaseRunner runner = new DefaultTestCaseRunner(context);
-        runner.run(assertSoapFault().faultCode(SoapFaultDefinition.SERVER.getLocalPart())
+        runner.run(soap().client("soapClient")
+                        .assertFault()
+                                .faultCode(SoapFaultDefinition.SERVER.getLocalPart())
                                 .faultString(INTERNAL_SERVER_ERROR)
                                 .faultDetail("<ErrorDetail><code>1001</code></ErrorDetail>")
                                 .faultDetailResource(resource)
@@ -507,7 +525,9 @@ public class AssertSoapFaultBuilderTest extends UnitTestSupport {
 
         context.setReferenceResolver(referenceResolver);
         DefaultTestCaseRunner runner = new DefaultTestCaseRunner(context);
-        runner.run(assertSoapFault().faultCode(SoapFaultDefinition.SERVER.getLocalPart())
+        runner.run(soap().client("soapClient")
+                        .assertFault()
+                                .faultCode(SoapFaultDefinition.SERVER.getLocalPart())
                                 .faultString(INTERNAL_SERVER_ERROR)
                                 .validator(soapFaultValidator)
                         .when(action(context -> {
@@ -552,7 +572,9 @@ public class AssertSoapFaultBuilderTest extends UnitTestSupport {
 
         context.setReferenceResolver(referenceResolver);
         DefaultTestCaseRunner runner = new DefaultTestCaseRunner(context);
-        runner.run(assertSoapFault().faultCode(SoapFaultDefinition.SERVER.getLocalPart())
+        runner.run(soap().client("soapClient")
+                        .assertFault()
+                                .faultCode(SoapFaultDefinition.SERVER.getLocalPart())
                                 .faultString(INTERNAL_SERVER_ERROR)
                                 .faultActor("MyActor")
                         .when(action(context -> {

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/actions/dsl/ReceiveSoapMessageTestActionBuilderTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/actions/dsl/ReceiveSoapMessageTestActionBuilderTest.java
@@ -99,7 +99,7 @@ public class ReceiveSoapMessageTestActionBuilderTest extends UnitTestSupport {
         Assert.assertEquals(test.getActions().get(0).getClass(), ReceiveSoapMessageAction.class);
 
         ReceiveSoapMessageAction action = ((ReceiveSoapMessageAction)test.getActions().get(0));
-        Assert.assertEquals(action.getName(), "receive");
+        Assert.assertEquals(action.getName(), "soap:receive-request");
 
         Assert.assertEquals(action.getMessageType(), MessageType.PLAINTEXT.name());
         Assert.assertEquals(action.getEndpoint(), server);
@@ -141,7 +141,7 @@ public class ReceiveSoapMessageTestActionBuilderTest extends UnitTestSupport {
         Assert.assertEquals(test.getActions().get(0).getClass(), ReceiveSoapMessageAction.class);
 
         ReceiveSoapMessageAction action = ((ReceiveSoapMessageAction)test.getActions().get(0));
-        Assert.assertEquals(action.getName(), "receive");
+        Assert.assertEquals(action.getName(), "soap:receive-request");
 
         Assert.assertEquals(action.getMessageType(), MessageType.XML.name());
         Assert.assertEquals(action.getEndpoint(), server);
@@ -184,7 +184,7 @@ public class ReceiveSoapMessageTestActionBuilderTest extends UnitTestSupport {
         Assert.assertEquals(test.getActions().get(0).getClass(), ReceiveSoapMessageAction.class);
 
         ReceiveSoapMessageAction action = ((ReceiveSoapMessageAction)test.getActions().get(0));
-        Assert.assertEquals(action.getName(), "receive");
+        Assert.assertEquals(action.getName(), "soap:receive-request");
 
         Assert.assertEquals(action.getMessageType(), MessageType.XML.name());
         Assert.assertEquals(action.getEndpoint(), server);
@@ -232,7 +232,7 @@ public class ReceiveSoapMessageTestActionBuilderTest extends UnitTestSupport {
         Assert.assertEquals(test.getActions().get(0).getClass(), ReceiveSoapMessageAction.class);
 
         ReceiveSoapMessageAction action = ((ReceiveSoapMessageAction)test.getActions().get(0));
-        Assert.assertEquals(action.getName(), "receive");
+        Assert.assertEquals(action.getName(), "soap:receive-request");
 
         Assert.assertEquals(action.getMessageType(), MessageType.XML.name());
         Assert.assertEquals(action.getEndpoint(), server);
@@ -286,7 +286,7 @@ public class ReceiveSoapMessageTestActionBuilderTest extends UnitTestSupport {
         Assert.assertEquals(test.getActions().get(0).getClass(), ReceiveSoapMessageAction.class);
 
         ReceiveSoapMessageAction action = ((ReceiveSoapMessageAction)test.getActions().get(0));
-        Assert.assertEquals(action.getName(), "receive");
+        Assert.assertEquals(action.getName(), "soap:receive-request");
 
         Assert.assertEquals(action.getMessageType(), MessageType.XML.name());
         Assert.assertEquals(action.getEndpoint(), server);
@@ -347,12 +347,12 @@ public class ReceiveSoapMessageTestActionBuilderTest extends UnitTestSupport {
         Assert.assertEquals(test.getActions().get(1).getClass(), ReceiveSoapMessageAction.class);
 
         ReceiveSoapMessageAction action = ((ReceiveSoapMessageAction)test.getActions().get(0));
-        Assert.assertEquals(action.getName(), "receive");
+        Assert.assertEquals(action.getName(), "soap:receive-request");
         Assert.assertEquals(action.getEndpointUri(), "replyMessageEndpoint");
         Assert.assertEquals(action.getMessageType(), MessageType.XML.name());
 
         action = ((ReceiveSoapMessageAction)test.getActions().get(1));
-        Assert.assertEquals(action.getName(), "receive");
+        Assert.assertEquals(action.getName(), "soap:receive-request");
         Assert.assertEquals(action.getEndpointUri(), "fooMessageEndpoint");
         Assert.assertEquals(action.getMessageType(), MessageType.XML.name());
     }

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/actions/dsl/SendSoapFaultTestActionBuilderTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/actions/dsl/SendSoapFaultTestActionBuilderTest.java
@@ -85,7 +85,7 @@ public class SendSoapFaultTestActionBuilderTest extends UnitTestSupport {
         Assert.assertEquals(test.getActions().get(0).getClass(), SendSoapFaultAction.class);
 
         SendSoapFaultAction action = (SendSoapFaultAction)test.getActions().get(0);
-        Assert.assertEquals(action.getName(), "send");
+        Assert.assertEquals(action.getName(), "soap:send-fault");
 
         Assert.assertEquals(action.getEndpoint(), soapServer);
         Assert.assertEquals(action.getMessageBuilder().getClass(), StaticMessageBuilder.class);
@@ -129,7 +129,7 @@ public class SendSoapFaultTestActionBuilderTest extends UnitTestSupport {
         Assert.assertEquals(test.getActions().get(0).getClass(), SendSoapFaultAction.class);
 
         SendSoapFaultAction action = (SendSoapFaultAction)test.getActions().get(0);
-        Assert.assertEquals(action.getName(), "send");
+        Assert.assertEquals(action.getName(), "soap:send-fault");
 
         Assert.assertEquals(action.getEndpointUri(), "soapServer");
         Assert.assertEquals(action.getMessageBuilder().getClass(), StaticMessageBuilder.class);
@@ -171,7 +171,7 @@ public class SendSoapFaultTestActionBuilderTest extends UnitTestSupport {
         Assert.assertEquals(test.getActions().get(0).getClass(), SendSoapFaultAction.class);
 
         SendSoapFaultAction action = (SendSoapFaultAction)test.getActions().get(0);
-        Assert.assertEquals(action.getName(), "send");
+        Assert.assertEquals(action.getName(), "soap:send-fault");
 
         Assert.assertEquals(action.getEndpoint(), soapServer);
         Assert.assertEquals(action.getMessageBuilder().getClass(), StaticMessageBuilder.class);
@@ -211,7 +211,7 @@ public class SendSoapFaultTestActionBuilderTest extends UnitTestSupport {
         Assert.assertEquals(test.getActions().get(0).getClass(), SendSoapFaultAction.class);
 
         SendSoapFaultAction action = (SendSoapFaultAction)test.getActions().get(0);
-        Assert.assertEquals(action.getName(), "send");
+        Assert.assertEquals(action.getName(), "soap:send-fault");
 
         Assert.assertEquals(action.getEndpoint(), soapServer);
         Assert.assertEquals(action.getMessageBuilder().getClass(), StaticMessageBuilder.class);
@@ -251,7 +251,7 @@ public class SendSoapFaultTestActionBuilderTest extends UnitTestSupport {
         Assert.assertEquals(test.getActions().get(0).getClass(), SendSoapFaultAction.class);
 
         SendSoapFaultAction action = (SendSoapFaultAction)test.getActions().get(0);
-        Assert.assertEquals(action.getName(), "send");
+        Assert.assertEquals(action.getName(), "soap:send-fault");
 
         Assert.assertEquals(action.getEndpoint(), soapServer);
         Assert.assertEquals(action.getMessageBuilder().getClass(), StaticMessageBuilder.class);
@@ -294,7 +294,7 @@ public class SendSoapFaultTestActionBuilderTest extends UnitTestSupport {
         Assert.assertEquals(test.getActions().get(0).getClass(), SendSoapFaultAction.class);
 
         SendSoapFaultAction action = (SendSoapFaultAction)test.getActions().get(0);
-        Assert.assertEquals(action.getName(), "send");
+        Assert.assertEquals(action.getName(), "soap:send-fault");
 
         Assert.assertEquals(action.getEndpoint(), soapServer);
         Assert.assertEquals(action.getMessageBuilder().getClass(), StaticMessageBuilder.class);

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/actions/dsl/SendSoapMessageTestActionBuilderTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/actions/dsl/SendSoapMessageTestActionBuilderTest.java
@@ -103,7 +103,7 @@ public class SendSoapMessageTestActionBuilderTest extends UnitTestSupport {
         Assert.assertEquals(test.getActions().get(1).getClass(), SendSoapMessageAction.class);
 
         SendSoapMessageAction action = ((SendSoapMessageAction)test.getActions().get(0));
-        Assert.assertEquals(action.getName(), "send");
+        Assert.assertEquals(action.getName(), "soap:send-request");
 
         Assert.assertEquals(action.getEndpoint(), soapClient);
         Assert.assertEquals(action.getMessageBuilder().getClass(), StaticMessageBuilder.class);
@@ -119,7 +119,7 @@ public class SendSoapMessageTestActionBuilderTest extends UnitTestSupport {
         Assert.assertFalse(action.isForkMode());
 
         action = ((SendSoapMessageAction)test.getActions().get(1));
-        Assert.assertEquals(action.getName(), "send");
+        Assert.assertEquals(action.getName(), "soap:send-request");
 
         Assert.assertEquals(action.getEndpoint(), soapClient);
         Assert.assertEquals(action.getMessageBuilder().getClass(), StaticMessageBuilder.class);
@@ -150,7 +150,7 @@ public class SendSoapMessageTestActionBuilderTest extends UnitTestSupport {
         Assert.assertEquals(test.getActions().get(0).getClass(), SendSoapMessageAction.class);
 
         SendSoapMessageAction action = ((SendSoapMessageAction)test.getActions().get(0));
-        Assert.assertEquals(action.getName(), "send");
+        Assert.assertEquals(action.getName(), "soap:send-request");
 
         Assert.assertEquals(action.getEndpoint(), soapClient);
         Assert.assertEquals(action.getMessageBuilder().getClass(), StaticMessageBuilder.class);
@@ -186,7 +186,7 @@ public class SendSoapMessageTestActionBuilderTest extends UnitTestSupport {
         Assert.assertEquals(test.getActions().get(0).getClass(), SendSoapMessageAction.class);
 
         SendSoapMessageAction action = ((SendSoapMessageAction)test.getActions().get(0));
-        Assert.assertEquals(action.getName(), "send");
+        Assert.assertEquals(action.getName(), "soap:send-request");
 
         Assert.assertEquals(action.getEndpoint(), soapClient);
         Assert.assertEquals(action.getMessageBuilder().getClass(), StaticMessageBuilder.class);
@@ -227,7 +227,7 @@ public class SendSoapMessageTestActionBuilderTest extends UnitTestSupport {
         Assert.assertEquals(test.getActions().get(0).getClass(), SendSoapMessageAction.class);
 
         SendSoapMessageAction action = ((SendSoapMessageAction)test.getActions().get(0));
-        Assert.assertEquals(action.getName(), "send");
+        Assert.assertEquals(action.getName(), "soap:send-request");
 
         Assert.assertEquals(action.getEndpoint(), soapClient);
         Assert.assertEquals(action.getMessageBuilder().getClass(), StaticMessageBuilder.class);
@@ -269,7 +269,7 @@ public class SendSoapMessageTestActionBuilderTest extends UnitTestSupport {
         Assert.assertEquals(test.getActions().get(0).getClass(), SendSoapMessageAction.class);
 
         SendSoapMessageAction action = ((SendSoapMessageAction)test.getActions().get(0));
-        Assert.assertEquals(action.getName(), "send");
+        Assert.assertEquals(action.getName(), "soap:send-request");
 
         Assert.assertEquals(action.getEndpoint(), soapClient);
         Assert.assertEquals(action.getMessageBuilder().getClass(), StaticMessageBuilder.class);
@@ -314,7 +314,7 @@ public class SendSoapMessageTestActionBuilderTest extends UnitTestSupport {
         Assert.assertEquals(test.getActions().get(0).getClass(), SendSoapMessageAction.class);
 
         SendSoapMessageAction action = ((SendSoapMessageAction)test.getActions().get(0));
-        Assert.assertEquals(action.getName(), "send");
+        Assert.assertEquals(action.getName(), "soap:send-request");
 
         Assert.assertEquals(action.getEndpoint(), soapClient);
         Assert.assertEquals(action.getMessageBuilder().getClass(), StaticMessageBuilder.class);
@@ -362,7 +362,7 @@ public class SendSoapMessageTestActionBuilderTest extends UnitTestSupport {
         Assert.assertEquals(test.getActions().get(0).getClass(), SendSoapMessageAction.class);
 
         SendSoapMessageAction action = ((SendSoapMessageAction)test.getActions().get(0));
-        Assert.assertEquals(action.getName(), "send");
+        Assert.assertEquals(action.getName(), "soap:send-request");
 
         Assert.assertEquals(action.getEndpoint(), soapClient);
         Assert.assertEquals(action.getMessageBuilder().getClass(), StaticMessageBuilder.class);
@@ -423,7 +423,7 @@ public class SendSoapMessageTestActionBuilderTest extends UnitTestSupport {
         Assert.assertEquals(test.getActions().get(1).getClass(), SendSoapMessageAction.class);
 
         SendMessageAction action = ((SendSoapMessageAction)test.getActions().get(0));
-        Assert.assertEquals(action.getName(), "send");
+        Assert.assertEquals(action.getName(), "soap:send-request");
         Assert.assertEquals(action.getEndpointUri(), "soapClient");
 
         StaticMessageBuilder messageBuilder = (StaticMessageBuilder) action.getMessageBuilder();
@@ -432,7 +432,7 @@ public class SendSoapMessageTestActionBuilderTest extends UnitTestSupport {
         Assert.assertTrue(messageBuilder.buildMessageHeaders(context).containsKey("operation"));
 
         action = ((SendSoapMessageAction)test.getActions().get(1));
-        Assert.assertEquals(action.getName(), "send");
+        Assert.assertEquals(action.getName(), "soap:send-request");
         Assert.assertEquals(action.getEndpointUri(), "otherClient");
     }
 }

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/config/xml/AssertSoapFaultParserTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/config/xml/AssertSoapFaultParserTest.java
@@ -76,7 +76,7 @@ public class AssertSoapFaultParserTest extends AbstractActionParserTest<AssertSo
         action = getNextTestActionFromTest();
         Assert.assertNotNull(action.getAction());
         Assert.assertEquals(action.getValidator(), beanDefinitionContext.getBean("soapFaultValidator"));
-        Assert.assertEquals(action.getFaultCode(), "{http://citrusframework.org/faults}FAULT-1003");
+        Assert.assertEquals(action.getFaultCode(), "{http://citrusframework.org/faults}FAULT-1005");
         Assert.assertEquals(action.getFaultString(), "FaultString");
         Assert.assertEquals(action.getFaultActor(), "FaultActor");
         Assert.assertEquals(action.getFaultDetails().size(), 1L);
@@ -93,7 +93,7 @@ public class AssertSoapFaultParserTest extends AbstractActionParserTest<AssertSo
         action = getNextTestActionFromTest();
         Assert.assertNotNull(action.getAction());
         Assert.assertEquals(action.getValidator(), beanDefinitionContext.getBean("soapFaultValidator"));
-        Assert.assertEquals(action.getFaultCode(), "{http://citrusframework.org/faults}FAULT-1003");
+        Assert.assertEquals(action.getFaultCode(), "{http://citrusframework.org/faults}FAULT-1006");
         Assert.assertEquals(action.getFaultString(), "FaultString");
         Assert.assertEquals(action.getFaultActor(), "FaultActor");
         Assert.assertEquals(action.getFaultDetails().size(), 1L);
@@ -109,7 +109,7 @@ public class AssertSoapFaultParserTest extends AbstractActionParserTest<AssertSo
         action = getNextTestActionFromTest();
         Assert.assertNotNull(action.getAction());
         Assert.assertEquals(action.getValidator(), beanDefinitionContext.getBean("soapFaultValidator"));
-        Assert.assertEquals(action.getFaultCode(), "{http://citrusframework.org/faults}FAULT-1003");
+        Assert.assertEquals(action.getFaultCode(), "{http://citrusframework.org/faults}FAULT-1007");
         Assert.assertEquals(action.getFaultString(), "FaultString");
         Assert.assertEquals(action.getFaultActor(), "FaultActor");
         Assert.assertEquals(action.getFaultDetails().size(), 1L);

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/config/xml/SendSoapMessageActionParserTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/config/xml/SendSoapMessageActionParserTest.java
@@ -31,10 +31,11 @@ public class SendSoapMessageActionParserTest extends AbstractActionParserTest<Se
     public void testSendMessageActionParser() {
         assertActionCount(5);
         assertActionClassAndName(SendSoapMessageAction.class, "send");
-        
+
         // 1st action
         SendSoapMessageAction action = getNextTestActionFromTest();
         Assert.assertFalse(action.isForkMode());
+        Assert.assertFalse(action.isMtomEnabled());
         Assert.assertEquals(action.getAttachments().size(), 1L);
         Assert.assertEquals(action.getAttachments().get(0).getContent().trim(), "This is an attachment!");
         Assert.assertNull(action.getAttachments().get(0).getContentResourcePath());

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/groovy/AbstractGroovyActionDslTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/groovy/AbstractGroovyActionDslTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.ws.groovy;
+
+import org.citrusframework.Citrus;
+import org.citrusframework.CitrusContext;
+import org.citrusframework.CitrusInstanceManager;
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.annotations.CitrusAnnotations;
+import org.citrusframework.context.StaticTestContextFactory;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.citrusframework.testng.AbstractTestNGUnitTest;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeClass;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class AbstractGroovyActionDslTest extends AbstractTestNGUnitTest {
+
+    protected Citrus citrus;
+
+    @Mock
+    protected CitrusContext citrusContext;
+
+    @BeforeClass
+    public void setupMocks() {
+        MockitoAnnotations.openMocks(this);
+        citrus = CitrusInstanceManager.newInstance(() -> citrusContext);
+    }
+
+    @Override
+    protected TestContext createTestContext() {
+        TestContext context = super.createTestContext();
+        doAnswer(invocation -> {
+            context.getReferenceResolver().bind(invocation.getArgument(0, String.class), invocation.getArgument(1));
+            return null;
+        }).when(citrusContext).bind(any(String.class), any());
+
+        when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
+        when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
+        when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        CitrusAnnotations.injectAll(this, citrus, context);
+        return context;
+    }
+
+    protected GroovyTestLoader createTestLoader(String sourcePath) {
+        GroovyTestLoader testLoader = new GroovyTestLoader().source(sourcePath);
+        CitrusAnnotations.injectAll(testLoader, citrus, context);
+        CitrusAnnotations.injectTestRunner(testLoader, new DefaultTestCaseRunner(context));
+
+        return testLoader;
+    }
+}

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/groovy/AssertSoapFaultTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/groovy/AssertSoapFaultTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.ws.groovy;
+
+import java.io.IOException;
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.endpoint.EndpointAdapter;
+import org.citrusframework.endpoint.direct.DirectEndpointAdapter;
+import org.citrusframework.endpoint.direct.DirectSyncEndpointConfiguration;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.citrusframework.message.Message;
+import org.citrusframework.util.FileUtils;
+import org.citrusframework.util.SocketUtils;
+import org.citrusframework.validation.DefaultMessageHeaderValidator;
+import org.citrusframework.ws.TextEqualsMessageValidator;
+import org.citrusframework.ws.actions.AssertSoapFault;
+import org.citrusframework.ws.client.WebServiceClient;
+import org.citrusframework.ws.message.SoapFault;
+import org.citrusframework.ws.message.SoapMessage;
+import org.citrusframework.ws.server.WebServiceServer;
+import org.citrusframework.ws.validation.SimpleSoapFaultValidator;
+import org.citrusframework.ws.validation.SoapFaultValidator;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.ws.endpoint.builder.WebServiceEndpoints.soap;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class AssertSoapFaultTest extends AbstractGroovyActionDslTest {
+
+    private final int port = SocketUtils.findAvailableTcpPort(8080);
+    private final String uri = "http://localhost:" + port + "/test";
+
+    private WebServiceServer soapServer;
+    private WebServiceClient soapClient;
+
+    private final Queue<SoapMessage> responses = new ArrayBlockingQueue<>(4);
+
+    @BeforeClass
+    public void setupEndpoints() {
+        EndpointAdapter endpointAdapter = new DirectEndpointAdapter(new DirectSyncEndpointConfiguration()) {
+            @Override
+            public Message handleMessageInternal(Message request) {
+                return responses.isEmpty() ? new SoapMessage() : responses.remove();
+            }
+        };
+
+        soapServer = soap().server()
+                .port(port)
+                .timeout(500L)
+                .endpointAdapter(endpointAdapter)
+                .autoStart(true)
+                .name("soapServer")
+                .build();
+        soapServer.initialize();
+
+        soapClient = soap().client()
+                .defaultUri(uri)
+                .name("soapClient")
+                .build();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void cleanupEndpoints() {
+        if (soapServer != null) {
+            soapServer.stop();
+        }
+    }
+
+    @Test
+    public void shouldLoadSoapClientActions() throws IOException {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/ws/groovy/assert-soap-fault.test.groovy");
+
+        context.setVariable("port", port);
+
+        context.getReferenceResolver().bind("soapClient", soapClient);
+        context.getReferenceResolver().bind("soapServer", soapServer);
+
+        context.getReferenceResolver().bind("headerValidator", new DefaultMessageHeaderValidator());
+        context.getMessageValidatorRegistry().addMessageValidator("validator", new TextEqualsMessageValidator());
+        context.getReferenceResolver().bind("soapFaultValidator", new SimpleSoapFaultValidator());
+        context.getReferenceResolver().bind("customSoapFaultValidator", new SimpleSoapFaultValidator());
+
+        responses.add(createSoapFault("FAULT-1001"));
+        responses.add(createSoapFault("FAULT-1002"));
+        responses.add(createSoapFault("FAULT-1003").addFaultDetail("<ns0:FaultDetail xmlns:ns0=\"http://citrusframework.org/schemas/samples/HelloService.xsd\">" +
+                    "<ns0:DetailId>1000</ns0:DetailId>" +
+                "</ns0:FaultDetail>"));
+        responses.add(createSoapFault("FAULT-1004").addFaultDetail(FileUtils.readToString(
+                FileUtils.getFileResource("classpath:org/citrusframework/ws/actions/test-fault-detail.xml"))));
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "AssertSoapFaultTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 4L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), AssertSoapFault.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "soap:assert-fault");
+
+        int actionIndex = 0;
+
+        AssertSoapFault action = (AssertSoapFault) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getAction());
+        Assert.assertEquals(action.getValidator(), context.getReferenceResolver().resolve("soapFaultValidator", SoapFaultValidator.class));
+        Assert.assertEquals(action.getFaultCode(), "{http://citrusframework.org/faults}FAULT-1001");
+        Assert.assertNull(action.getFaultString());
+        Assert.assertEquals(action.getFaultDetails().size(), 0L);
+        Assert.assertNotNull(action.getValidationContext());
+
+        action = (AssertSoapFault) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getAction());
+        Assert.assertEquals(action.getValidator(), context.getReferenceResolver().resolve("soapFaultValidator", SoapFaultValidator.class));
+        Assert.assertEquals(action.getFaultCode(), "{http://citrusframework.org/faults}FAULT-1002");
+        Assert.assertEquals(action.getFaultString(), "FaultString");
+        Assert.assertEquals(action.getFaultDetails().size(), 0L);
+        Assert.assertNotNull(action.getValidationContext());
+
+        action = (AssertSoapFault) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getAction());
+        Assert.assertEquals(action.getValidator(), context.getReferenceResolver().resolve("soapFaultValidator", SoapFaultValidator.class));
+        Assert.assertEquals(action.getFaultCode(), "{http://citrusframework.org/faults}FAULT-1003");
+        Assert.assertEquals(action.getFaultString(), "FaultString");
+        Assert.assertEquals(action.getFaultActor(), "FaultActor");
+        Assert.assertEquals(action.getFaultDetails().size(), 1L);
+        Assert.assertEquals(action.getFaultDetails().get(0), "<ns0:FaultDetail xmlns:ns0=\"http://citrusframework.org/schemas/samples/HelloService.xsd\">" +
+                    "<ns0:DetailId>1000</ns0:DetailId>" +
+                "</ns0:FaultDetail>");
+        Assert.assertEquals(action.getValidationContext().getValidationContexts().size(), 1L);
+
+        action = (AssertSoapFault) result.getTestAction(actionIndex);
+        Assert.assertNotNull(action.getAction());
+        Assert.assertEquals(action.getValidator(), context.getReferenceResolver().resolve("customSoapFaultValidator", SoapFaultValidator.class));
+        Assert.assertEquals(action.getFaultCode(), "{http://citrusframework.org/faults}FAULT-1004");
+        Assert.assertEquals(action.getFaultString(), "FaultString");
+        Assert.assertEquals(action.getFaultDetails().size(), 0L);
+        Assert.assertEquals(action.getFaultDetailResourcePaths().size(), 1L);
+        Assert.assertEquals(action.getFaultDetailResourcePaths().get(0), "classpath:org/citrusframework/ws/actions/test-fault-detail.xml");
+        Assert.assertEquals(action.getValidationContext().getValidationContexts().size(), 1L);
+    }
+
+    private SoapFault createSoapFault(String faultCode) {
+        SoapFault fault = new SoapFault("<TestResponse>Hello User</TestResponse>");
+
+        fault.faultCode(String.format("{http://citrusframework.org/faults}%s", faultCode));
+        fault.faultString("FaultString");
+        fault.faultActor("FaultActor");
+
+        return fault;
+    }
+}

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/groovy/SendSoapFaultTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/groovy/SendSoapFaultTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.ws.groovy;
+
+import java.io.IOException;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.endpoint.AbstractEndpointAdapter;
+import org.citrusframework.endpoint.EndpointAdapter;
+import org.citrusframework.endpoint.direct.DirectEndpointAdapter;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.citrusframework.message.DefaultMessageQueue;
+import org.citrusframework.message.MessageQueue;
+import org.citrusframework.message.MessageType;
+import org.citrusframework.validation.DefaultMessageHeaderValidator;
+import org.citrusframework.validation.builder.StaticMessageBuilder;
+import org.citrusframework.ws.TextEqualsMessageValidator;
+import org.citrusframework.ws.actions.ReceiveSoapMessageAction;
+import org.citrusframework.ws.actions.SendSoapFaultAction;
+import org.citrusframework.ws.message.SoapMessage;
+import org.citrusframework.ws.server.WebServiceServer;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.endpoint.direct.DirectEndpoints.direct;
+import static org.citrusframework.ws.endpoint.builder.WebServiceEndpoints.soap;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class SendSoapFaultTest extends AbstractGroovyActionDslTest {
+
+    private WebServiceServer soapServer;
+
+    private final MessageQueue inboundQueue = new DefaultMessageQueue("inboundQueue");
+    private final EndpointAdapter endpointAdapter = new DirectEndpointAdapter(direct()
+            .synchronous()
+            .timeout(100L)
+            .queue(inboundQueue)
+            .build());
+
+    @BeforeClass
+    public void setupEndpoints() {
+        soapServer = soap().server()
+                .timeout(100L)
+                .endpointAdapter(endpointAdapter)
+                .autoStart(true)
+                .name("soapServer")
+                .build();
+    }
+
+    @BeforeMethod
+    @Override
+    public void prepareTest() {
+        super.prepareTest();
+        ((AbstractEndpointAdapter) endpointAdapter).setTestContextFactory(testContextFactory);
+    }
+
+    @Test
+    public void shouldLoadSoapServerActions() throws IOException {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/ws/groovy/send-soap-fault.test.groovy");
+
+        context.getReferenceResolver().bind("soapServer", soapServer);
+        context.getReferenceResolver().bind("headerValidator", new DefaultMessageHeaderValidator());
+        context.getMessageValidatorRegistry().addMessageValidator("validator", new TextEqualsMessageValidator());
+
+        endpointAdapter.handleMessage(new SoapMessage("<TestMessage>Hello Citrus</TestMessage>").contentType("application/xml"));
+        endpointAdapter.handleMessage(new SoapMessage("<TestMessage>Hello Citrus</TestMessage>").contentType("application/xml"));
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "SendSoapFaultTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 4L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), ReceiveSoapMessageAction.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "soap:receive-request");
+
+        Assert.assertEquals(result.getTestAction(1).getClass(), SendSoapFaultAction.class);
+        Assert.assertEquals(result.getTestAction(1).getName(), "soap:send-fault");
+
+        int actionIndex = 0;
+
+        ReceiveSoapMessageAction action = (ReceiveSoapMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getMessageBuilder().build(context, MessageType.XML.name()).getPayload(), "<TestMessage>Hello Citrus</TestMessage>");
+
+        SendSoapFaultAction send = (SendSoapFaultAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(send.getEndpointUri(), "soapServer");
+        Assert.assertNotNull(send.getMessageBuilder());
+        Assert.assertEquals(send.getMessageBuilder().getClass(), StaticMessageBuilder.class);
+
+        StaticMessageBuilder messageBuilder = (StaticMessageBuilder)send.getMessageBuilder();
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 1L);
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get("operation"), "sendFault");
+        Assert.assertEquals(send.getFaultCode(), "{http://citrusframework.org/faults}citrus-ns:FAULT-1000");
+        Assert.assertEquals(send.getFaultString(), "FaultString");
+        Assert.assertEquals(send.getFaultDetails().size(), 1);
+        Assert.assertTrue(send.getFaultDetails().get(0).startsWith("<ns0:FaultDetail xmlns:ns0=\"http://citrusframework.org/schemas/samples/HelloService.xsd\">"));
+        Assert.assertNull(send.getFaultActor());
+
+        action = (ReceiveSoapMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getMessageBuilder().build(context, MessageType.XML.name()).getPayload(), "<TestMessage>Hello Citrus</TestMessage>");
+
+        send = (SendSoapFaultAction) result.getTestAction(actionIndex);
+        Assert.assertEquals(send.getEndpointUri(), "soapServer");
+        Assert.assertNotNull(send.getMessageBuilder());
+        Assert.assertEquals(send.getMessageBuilder().getClass(), StaticMessageBuilder.class);
+
+        messageBuilder = (StaticMessageBuilder)send.getMessageBuilder();
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 1);
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get("operation"), "sendFault");
+        Assert.assertEquals(send.getFaultCode(), "{http://citrusframework.org/faults}citrus-ns:FAULT-1001");
+        Assert.assertEquals(send.getFaultString(), "FaultString");
+        Assert.assertEquals(send.getFaultDetails().size(), 0);
+        Assert.assertEquals(send.getFaultDetailResourcePaths().size(), 1);
+        Assert.assertEquals(send.getFaultDetailResourcePaths().get(0), "classpath:org/citrusframework/ws/actions/test-fault-detail.xml");
+        Assert.assertEquals(send.getFaultActor(), "FaultActor");
+    }
+}

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/groovy/SoapClientTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/groovy/SoapClientTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.ws.groovy;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.endpoint.EndpointAdapter;
+import org.citrusframework.endpoint.direct.DirectEndpointAdapter;
+import org.citrusframework.endpoint.direct.DirectSyncEndpointConfiguration;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.citrusframework.message.Message;
+import org.citrusframework.util.FileUtils;
+import org.citrusframework.util.SocketUtils;
+import org.citrusframework.validation.DefaultMessageHeaderValidator;
+import org.citrusframework.ws.TextEqualsMessageValidator;
+import org.citrusframework.ws.actions.ReceiveSoapMessageAction;
+import org.citrusframework.ws.actions.SendSoapMessageAction;
+import org.citrusframework.ws.client.WebServiceClient;
+import org.citrusframework.ws.message.SoapAttachment;
+import org.citrusframework.ws.message.SoapMessage;
+import org.citrusframework.ws.server.WebServiceServer;
+import org.citrusframework.ws.validation.SimpleSoapAttachmentValidator;
+import org.citrusframework.ws.validation.SoapAttachmentValidator;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.ws.endpoint.builder.WebServiceEndpoints.soap;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class SoapClientTest extends AbstractGroovyActionDslTest {
+
+    private final int port = SocketUtils.findAvailableTcpPort(8080);
+    private final String uri = "http://localhost:" + port + "/test";
+
+    private WebServiceServer soapServer;
+    private WebServiceClient soapClient;
+
+    private final Queue<SoapMessage> responses = new ArrayBlockingQueue<>(4);
+
+    @BeforeClass
+    public void setupEndpoints() {
+        EndpointAdapter endpointAdapter = new DirectEndpointAdapter(new DirectSyncEndpointConfiguration()) {
+            @Override
+            public Message handleMessageInternal(Message request) {
+                return responses.isEmpty() ? new SoapMessage() : responses.remove();
+            }
+        };
+
+        soapServer = soap().server()
+                .port(port)
+                .timeout(500L)
+                .endpointAdapter(endpointAdapter)
+                .autoStart(true)
+                .name("soapServer")
+                .build();
+        soapServer.initialize();
+
+        soapClient = soap().client()
+                .defaultUri(uri)
+                .name("soapClient")
+                .build();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void cleanupEndpoints() {
+        if (soapServer != null) {
+            soapServer.stop();
+        }
+    }
+
+    @Test
+    public void shouldLoadSoapClientActions() throws IOException {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/ws/groovy/soap-client.test.groovy");
+
+        context.setVariable("port", port);
+
+        context.getReferenceResolver().bind("soapClient", soapClient);
+        context.getReferenceResolver().bind("soapServer", soapServer);
+
+        context.getReferenceResolver().bind("headerValidator", new DefaultMessageHeaderValidator());
+        context.getMessageValidatorRegistry().addMessageValidator("validator", new TextEqualsMessageValidator());
+        context.getReferenceResolver().bind("soapAttachmentValidator", new SimpleSoapAttachmentValidator());
+        context.getReferenceResolver().bind("mySoapAttachmentValidator", new SimpleSoapAttachmentValidator());
+
+        responses.add(createSoapMessage(new SoapAttachment("MySoapAttachment", "text/plain", "This is an attachment!")));
+
+        responses.add(createSoapMessage(new SoapAttachment("MySoapAttachment", "application/xml",
+                FileUtils.readToString(FileUtils.getFileResource("classpath:org/citrusframework/ws/actions/test-attachment.xml")), "UTF-8")));
+
+        responses.add(createSoapMessage(new SoapAttachment("FirstSoapAttachment", "text/plain", "This is an attachment!"),
+                new SoapAttachment("SecondSoapAttachment", "application/xml", FileUtils.readToString(FileUtils.getFileResource("classpath:org/citrusframework/ws/actions/test-attachment.xml")), "UTF-8")));
+
+        responses.add(createSoapMessage());
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "SoapClientTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 8L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), SendSoapMessageAction.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "soap:send-request");
+
+        Assert.assertEquals(result.getTestAction(1).getClass(), ReceiveSoapMessageAction.class);
+        Assert.assertEquals(result.getTestAction(1).getName(), "soap:receive-response");
+
+        int actionIndex = 0;
+
+        SendSoapMessageAction send = (SendSoapMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertFalse(send.isForkMode());
+        Assert.assertEquals(send.getAttachments().size(), 1L);
+        Assert.assertEquals(send.getAttachments().get(0).getContent().trim(), "This is an attachment!");
+        Assert.assertNull(send.getAttachments().get(0).getContentResourcePath());
+        Assert.assertEquals(send.getAttachments().get(0).getContentId(), "MySoapAttachment");
+        Assert.assertEquals(send.getAttachments().get(0).getContentType(), "text/plain");
+
+        ReceiveSoapMessageAction receive = (ReceiveSoapMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(receive.getAttachmentValidator(), context.getReferenceResolver().resolve("soapAttachmentValidator", SoapAttachmentValidator.class));
+        Assert.assertEquals(receive.getAttachments().size(), 1L);
+        Assert.assertEquals(receive.getAttachments().get(0).getContent().trim(), "This is an attachment!");
+        Assert.assertNull(receive.getAttachments().get(0).getContentResourcePath());
+        Assert.assertEquals(receive.getAttachments().get(0).getContentId(), "MySoapAttachment");
+        Assert.assertEquals(receive.getAttachments().get(0).getContentType(), "text/plain");
+
+        send = (SendSoapMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertFalse(send.isForkMode());
+        Assert.assertEquals(send.getAttachments().size(), 1L);
+        Assert.assertEquals(send.getAttachments().get(0).getContent(), FileUtils.readToString(FileUtils.getFileResource("classpath:org/citrusframework/ws/actions/test-attachment.xml")));
+        Assert.assertEquals(send.getAttachments().get(0).getContentId(), "MySoapAttachment");
+        Assert.assertEquals(send.getAttachments().get(0).getContentType(), "application/xml");
+        Assert.assertEquals(send.getAttachments().get(0).getCharsetName(), "UTF-8");
+
+        receive = (ReceiveSoapMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(receive.getAttachmentValidator(), context.getReferenceResolver().resolve("mySoapAttachmentValidator", SoapAttachmentValidator.class));
+        Assert.assertEquals(receive.getAttachments().size(), 1L);
+        Assert.assertEquals(receive.getAttachments().get(0).getContent(), FileUtils.readToString(FileUtils.getFileResource("classpath:org/citrusframework/ws/actions/test-attachment.xml")));
+        Assert.assertEquals(receive.getAttachments().get(0).getContentId(), "MySoapAttachment");
+        Assert.assertEquals(receive.getAttachments().get(0).getContentType(), "application/xml");
+        Assert.assertEquals(receive.getAttachments().get(0).getCharsetName(), "UTF-8");
+
+        send = (SendSoapMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertFalse(send.isForkMode());
+        Assert.assertEquals(send.getAttachments().size(), 2L);
+        Assert.assertEquals(send.getAttachments().get(0).getContent().trim(), "This is an attachment!");
+        Assert.assertNull(send.getAttachments().get(0).getContentResourcePath());
+        Assert.assertEquals(send.getAttachments().get(0).getContentId(), "FirstSoapAttachment");
+        Assert.assertEquals(send.getAttachments().get(0).getContentType(), "text/plain");
+        Assert.assertNull(send.getAttachments().get(1).getContentResourcePath());
+        Assert.assertNotNull(send.getAttachments().get(1).getContent());
+        Assert.assertEquals(send.getAttachments().get(1).getContentId(), "SecondSoapAttachment");
+        Assert.assertEquals(send.getAttachments().get(1).getContentType(), "application/xml");
+        Assert.assertEquals(send.getAttachments().get(1).getCharsetName(), "UTF-8");
+
+        receive = (ReceiveSoapMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(receive.getAttachmentValidator(), context.getReferenceResolver().resolve("soapAttachmentValidator"));
+        Assert.assertEquals(receive.getAttachments().size(), 2L);
+        Assert.assertEquals(receive.getAttachments().get(0).getContent().trim(), "This is an attachment!");
+        Assert.assertNull(receive.getAttachments().get(0).getContentResourcePath());
+        Assert.assertEquals(receive.getAttachments().get(0).getContentId(), "FirstSoapAttachment");
+        Assert.assertEquals(receive.getAttachments().get(0).getContentType(), "text/plain");
+        Assert.assertNull(receive.getAttachments().get(1).getContentResourcePath());
+        Assert.assertNotNull(receive.getAttachments().get(1).getContent());
+        Assert.assertEquals(receive.getAttachments().get(1).getContentId(), "SecondSoapAttachment");
+        Assert.assertEquals(receive.getAttachments().get(1).getContentType(), "application/xml");
+        Assert.assertEquals(receive.getAttachments().get(1).getCharsetName(), "UTF-8");
+
+        send = (SendSoapMessageAction) result.getTestAction(actionIndex);
+        Assert.assertTrue(send.isMtomEnabled());
+        Assert.assertEquals(send.getAttachments().size(), 0L);
+    }
+
+    private SoapMessage createSoapMessage(SoapAttachment... attachments) {
+        SoapMessage message = new SoapMessage("<TestResponse>Hello User</TestResponse>")
+                .contentType("application/xml");
+
+        Arrays.stream(attachments).forEach(message::addAttachment);
+
+        return message;
+    }
+}

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/groovy/SoapServerTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/groovy/SoapServerTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.ws.groovy;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.endpoint.AbstractEndpointAdapter;
+import org.citrusframework.endpoint.EndpointAdapter;
+import org.citrusframework.endpoint.direct.DirectEndpointAdapter;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.citrusframework.message.DefaultMessageQueue;
+import org.citrusframework.message.MessageQueue;
+import org.citrusframework.message.MessageType;
+import org.citrusframework.util.FileUtils;
+import org.citrusframework.validation.DefaultMessageHeaderValidator;
+import org.citrusframework.ws.TextEqualsMessageValidator;
+import org.citrusframework.ws.actions.ReceiveSoapMessageAction;
+import org.citrusframework.ws.actions.SendSoapMessageAction;
+import org.citrusframework.ws.message.SoapAttachment;
+import org.citrusframework.ws.message.SoapMessage;
+import org.citrusframework.ws.server.WebServiceServer;
+import org.citrusframework.ws.validation.SimpleSoapAttachmentValidator;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.endpoint.direct.DirectEndpoints.direct;
+import static org.citrusframework.ws.endpoint.builder.WebServiceEndpoints.soap;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class SoapServerTest extends AbstractGroovyActionDslTest {
+
+    private WebServiceServer soapServer;
+
+    private final MessageQueue inboundQueue = new DefaultMessageQueue("inboundQueue");
+    private final EndpointAdapter endpointAdapter = new DirectEndpointAdapter(direct()
+            .synchronous()
+            .timeout(100L)
+            .queue(inboundQueue)
+            .build());
+
+    @BeforeClass
+    public void setupEndpoints() {
+        soapServer = soap().server()
+                .timeout(100L)
+                .endpointAdapter(endpointAdapter)
+                .autoStart(true)
+                .name("soapServer")
+                .build();
+    }
+
+    @BeforeMethod
+    @Override
+    public void prepareTest() {
+        super.prepareTest();
+        ((AbstractEndpointAdapter) endpointAdapter).setTestContextFactory(testContextFactory);
+    }
+
+    @Test
+    public void shouldLoadSoapServerActions() throws IOException {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/ws/groovy/soap-server.test.groovy");
+
+        context.getReferenceResolver().bind("soapServer", soapServer);
+        context.getReferenceResolver().bind("headerValidator", new DefaultMessageHeaderValidator());
+        context.getMessageValidatorRegistry().addMessageValidator("validator", new TextEqualsMessageValidator());
+        context.getReferenceResolver().bind("soapAttachmentValidator", new SimpleSoapAttachmentValidator());
+        context.getReferenceResolver().bind("mySoapAttachmentValidator", new SimpleSoapAttachmentValidator());
+
+        endpointAdapter.handleMessage(createSoapMessage(new SoapAttachment("MySoapAttachment", "text/plain", "This is an attachment!")));
+        endpointAdapter.handleMessage(createSoapMessage(new SoapAttachment("MySoapAttachment", "application/xml",
+                FileUtils.readToString(FileUtils.getFileResource("classpath:org/citrusframework/ws/actions/test-attachment.xml")), "UTF-8")));
+        endpointAdapter.handleMessage(createSoapMessage(new SoapAttachment("FirstSoapAttachment", "text/plain", "This is an attachment!"),
+                new SoapAttachment("SecondSoapAttachment", "application/xml", FileUtils.readToString(FileUtils.getFileResource("classpath:org/citrusframework/ws/actions/test-attachment.xml")), "UTF-8")));
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "SoapServerTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 6L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), ReceiveSoapMessageAction.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "soap:receive-request");
+
+        Assert.assertEquals(result.getTestAction(1).getClass(), SendSoapMessageAction.class);
+        Assert.assertEquals(result.getTestAction(1).getName(), "soap:send-response");
+
+        int actionIndex = 0;
+
+        ReceiveSoapMessageAction action = (ReceiveSoapMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getMessageBuilder().build(context, MessageType.XML.name()).getPayload(), "<TestMessage>Hello Citrus</TestMessage>");
+        Assert.assertEquals(action.getAttachmentValidator(), context.getReferenceResolver().resolve("soapAttachmentValidator"));
+        Assert.assertEquals(action.getAttachments().size(), 1L);
+        Assert.assertEquals(action.getAttachments().get(0).getContent().trim(), "This is an attachment!");
+        Assert.assertNull(action.getAttachments().get(0).getContentResourcePath());
+        Assert.assertEquals(action.getAttachments().get(0).getContentId(), "MySoapAttachment");
+        Assert.assertEquals(action.getAttachments().get(0).getContentType(), "text/plain");
+
+        SendSoapMessageAction send = (SendSoapMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertFalse(send.isForkMode());
+        Assert.assertEquals(send.getAttachments().size(), 1L);
+        Assert.assertEquals(send.getAttachments().get(0).getContent().trim(), "This is an attachment!");
+        Assert.assertNull(send.getAttachments().get(0).getContentResourcePath());
+        Assert.assertEquals(send.getAttachments().get(0).getContentId(), "MySoapAttachment");
+        Assert.assertEquals(send.getAttachments().get(0).getContentType(), "text/plain");
+
+        action = (ReceiveSoapMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getAttachmentValidator(), context.getReferenceResolver().resolve("mySoapAttachmentValidator"));
+        Assert.assertEquals(action.getAttachments().size(), 1L);
+        Assert.assertNull(action.getAttachments().get(0).getContentResourcePath());
+        Assert.assertNotNull(action.getAttachments().get(0).getContent());
+        Assert.assertEquals(action.getAttachments().get(0).getContentId(), "MySoapAttachment");
+        Assert.assertEquals(action.getAttachments().get(0).getContentType(), "application/xml");
+        Assert.assertEquals(action.getAttachments().get(0).getCharsetName(), "UTF-8");
+
+        send = (SendSoapMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertFalse(send.isForkMode());
+        Assert.assertEquals(send.getAttachments().size(), 1L);
+        Assert.assertEquals(send.getAttachments().get(0).getContent(), FileUtils.readToString(FileUtils.getFileResource("classpath:org/citrusframework/ws/actions/test-attachment.xml")));
+        Assert.assertEquals(send.getAttachments().get(0).getContentId(), "MySoapAttachment");
+        Assert.assertEquals(send.getAttachments().get(0).getContentType(), "application/xml");
+        Assert.assertEquals(send.getAttachments().get(0).getCharsetName(), "UTF-8");
+
+        action = (ReceiveSoapMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getAttachmentValidator(), context.getReferenceResolver().resolve("soapAttachmentValidator"));
+        Assert.assertEquals(action.getAttachments().size(), 2L);
+        Assert.assertEquals(action.getAttachments().get(0).getContent().trim(), "This is an attachment!");
+        Assert.assertNull(action.getAttachments().get(0).getContentResourcePath());
+        Assert.assertEquals(action.getAttachments().get(0).getContentId(), "FirstSoapAttachment");
+        Assert.assertEquals(action.getAttachments().get(0).getContentType(), "text/plain");
+        Assert.assertNull(action.getAttachments().get(1).getContentResourcePath());
+        Assert.assertNotNull(action.getAttachments().get(1).getContent());
+        Assert.assertEquals(action.getAttachments().get(1).getContentId(), "SecondSoapAttachment");
+        Assert.assertEquals(action.getAttachments().get(1).getContentType(), "application/xml");
+        Assert.assertEquals(action.getAttachments().get(1).getCharsetName(), "UTF-8");
+
+        send = (SendSoapMessageAction) result.getTestAction(actionIndex);
+        Assert.assertFalse(send.isForkMode());
+        Assert.assertEquals(send.getAttachments().size(), 2L);
+        Assert.assertEquals(send.getAttachments().get(0).getContent().trim(), "This is an attachment!");
+        Assert.assertNull(send.getAttachments().get(0).getContentResourcePath());
+        Assert.assertEquals(send.getAttachments().get(0).getContentId(), "FirstSoapAttachment");
+        Assert.assertEquals(send.getAttachments().get(0).getContentType(), "text/plain");
+        Assert.assertNull(send.getAttachments().get(1).getContentResourcePath());
+        Assert.assertNotNull(send.getAttachments().get(1).getContent());
+        Assert.assertEquals(send.getAttachments().get(1).getContentId(), "SecondSoapAttachment");
+        Assert.assertEquals(send.getAttachments().get(1).getContentType(), "application/xml");
+        Assert.assertEquals(send.getAttachments().get(1).getCharsetName(), "UTF-8");
+    }
+
+    private SoapMessage createSoapMessage(SoapAttachment... attachments) {
+        SoapMessage message = new SoapMessage("<TestMessage>Hello Citrus</TestMessage>")
+                .contentType("application/xml");
+
+        Arrays.stream(attachments).forEach(message::addAttachment);
+
+        return message;
+    }
+}

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/xml/AbstractXmlActionTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/xml/AbstractXmlActionTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.ws.xml;
+
+import org.citrusframework.Citrus;
+import org.citrusframework.CitrusContext;
+import org.citrusframework.CitrusInstanceManager;
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.annotations.CitrusAnnotations;
+import org.citrusframework.context.StaticTestContextFactory;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.testng.AbstractTestNGUnitTest;
+import org.citrusframework.xml.XmlTestLoader;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeClass;
+
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class AbstractXmlActionTest extends AbstractTestNGUnitTest {
+
+    protected Citrus citrus;
+
+    @Mock
+    protected CitrusContext citrusContext;
+
+    @BeforeClass
+    public void setupMocks() {
+        MockitoAnnotations.openMocks(this);
+        citrus = CitrusInstanceManager.newInstance(() -> citrusContext);
+    }
+
+    @Override
+    protected TestContext createTestContext() {
+        TestContext context = super.createTestContext();
+        when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
+        when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
+        when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        CitrusAnnotations.injectAll(this, citrus, context);
+        return context;
+    }
+
+    protected XmlTestLoader createTestLoader(String sourcePath) {
+        XmlTestLoader testLoader = new XmlTestLoader(this.getClass(), "Test", this.getClass().getPackageName());
+        CitrusAnnotations.injectAll(testLoader, citrus, context);
+        CitrusAnnotations.injectTestRunner(testLoader, new DefaultTestCaseRunner(context));
+        testLoader.setSource(sourcePath);
+
+        return testLoader;
+    }
+}

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/xml/AssertSoapFaultTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/xml/AssertSoapFaultTest.java
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-package org.citrusframework.ws.yaml;
+package org.citrusframework.ws.xml;
 
 import java.io.IOException;
 import java.util.Queue;
@@ -40,7 +40,7 @@ import org.citrusframework.ws.message.SoapMessage;
 import org.citrusframework.ws.server.WebServiceServer;
 import org.citrusframework.ws.validation.SimpleSoapFaultValidator;
 import org.citrusframework.ws.validation.SoapFaultValidator;
-import org.citrusframework.yaml.YamlTestLoader;
+import org.citrusframework.xml.XmlTestLoader;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -51,7 +51,7 @@ import static org.citrusframework.ws.endpoint.builder.WebServiceEndpoints.soap;
 /**
  * @author Christoph Deppisch
  */
-public class AssertSoapFaultTest extends AbstractYamlActionTest {
+public class AssertSoapFaultTest extends AbstractXmlActionTest {
 
     private final int port = SocketUtils.findAvailableTcpPort(8080);
     private final String uri = "http://localhost:" + port + "/test";
@@ -94,7 +94,7 @@ public class AssertSoapFaultTest extends AbstractYamlActionTest {
 
     @Test
     public void shouldLoadSoapClientActions() throws IOException {
-        YamlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/ws/yaml/assert-soap-fault-test.yaml");
+        XmlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/ws/xml/assert-soap-fault-test.xml");
 
         context.setVariable("port", port);
 

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/xml/SendSoapFaultTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/xml/SendSoapFaultTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.ws.xml;
+
+import java.io.IOException;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.endpoint.AbstractEndpointAdapter;
+import org.citrusframework.endpoint.EndpointAdapter;
+import org.citrusframework.endpoint.direct.DirectEndpointAdapter;
+import org.citrusframework.message.DefaultMessageQueue;
+import org.citrusframework.message.MessageQueue;
+import org.citrusframework.message.MessageType;
+import org.citrusframework.validation.DefaultMessageHeaderValidator;
+import org.citrusframework.validation.builder.StaticMessageBuilder;
+import org.citrusframework.ws.TextEqualsMessageValidator;
+import org.citrusframework.ws.actions.ReceiveSoapMessageAction;
+import org.citrusframework.ws.actions.SendSoapFaultAction;
+import org.citrusframework.ws.message.SoapMessage;
+import org.citrusframework.ws.server.WebServiceServer;
+import org.citrusframework.xml.XmlTestLoader;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.endpoint.direct.DirectEndpoints.direct;
+import static org.citrusframework.ws.endpoint.builder.WebServiceEndpoints.soap;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class SendSoapFaultTest extends AbstractXmlActionTest {
+
+    private WebServiceServer soapServer;
+
+    private final MessageQueue inboundQueue = new DefaultMessageQueue("inboundQueue");
+    private final EndpointAdapter endpointAdapter = new DirectEndpointAdapter(direct()
+            .synchronous()
+            .timeout(100L)
+            .queue(inboundQueue)
+            .build());
+
+    @BeforeClass
+    public void setupEndpoints() {
+        soapServer = soap().server()
+                .timeout(100L)
+                .endpointAdapter(endpointAdapter)
+                .autoStart(true)
+                .name("soapServer")
+                .build();
+    }
+
+    @BeforeMethod
+    @Override
+    public void prepareTest() {
+        super.prepareTest();
+        ((AbstractEndpointAdapter) endpointAdapter).setTestContextFactory(testContextFactory);
+    }
+
+    @Test
+    public void shouldLoadSoapServerActions() throws IOException {
+        XmlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/ws/xml/send-soap-fault-test.xml");
+
+        context.getReferenceResolver().bind("soapServer", soapServer);
+        context.getReferenceResolver().bind("headerValidator", new DefaultMessageHeaderValidator());
+        context.getMessageValidatorRegistry().addMessageValidator("validator", new TextEqualsMessageValidator());
+
+        endpointAdapter.handleMessage(new SoapMessage("<TestMessage>Hello Citrus</TestMessage>").contentType("application/xml"));
+        endpointAdapter.handleMessage(new SoapMessage("<TestMessage>Hello Citrus</TestMessage>").contentType("application/xml"));
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "SendSoapFaultTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 4L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), ReceiveSoapMessageAction.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "soap:receive-request");
+
+        Assert.assertEquals(result.getTestAction(1).getClass(), SendSoapFaultAction.class);
+        Assert.assertEquals(result.getTestAction(1).getName(), "soap:send-fault");
+
+        int actionIndex = 0;
+
+        ReceiveSoapMessageAction action = (ReceiveSoapMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getMessageBuilder().build(context, MessageType.XML.name()).getPayload(), "<TestMessage>Hello Citrus</TestMessage>");
+
+        SendSoapFaultAction send = (SendSoapFaultAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(send.getEndpointUri(), "soapServer");
+        Assert.assertNotNull(send.getMessageBuilder());
+        Assert.assertEquals(send.getMessageBuilder().getClass(), StaticMessageBuilder.class);
+
+        StaticMessageBuilder messageBuilder = (StaticMessageBuilder)send.getMessageBuilder();
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 1L);
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get("operation"), "sendFault");
+        Assert.assertEquals(send.getFaultCode(), "{http://citrusframework.org/faults}citrus-ns:FAULT-1000");
+        Assert.assertEquals(send.getFaultString(), "FaultString");
+        Assert.assertEquals(send.getFaultDetails().size(), 1);
+        Assert.assertTrue(send.getFaultDetails().get(0).startsWith("<ns0:FaultDetail xmlns:ns0=\"http://citrusframework.org/schemas/samples/HelloService.xsd\">"));
+        Assert.assertNull(send.getFaultActor());
+
+        action = (ReceiveSoapMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getMessageBuilder().build(context, MessageType.XML.name()).getPayload(), "<TestMessage>Hello Citrus</TestMessage>");
+
+        send = (SendSoapFaultAction) result.getTestAction(actionIndex);
+        Assert.assertEquals(send.getEndpointUri(), "soapServer");
+        Assert.assertNotNull(send.getMessageBuilder());
+        Assert.assertEquals(send.getMessageBuilder().getClass(), StaticMessageBuilder.class);
+
+        messageBuilder = (StaticMessageBuilder)send.getMessageBuilder();
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 1);
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get("operation"), "sendFault");
+        Assert.assertEquals(send.getFaultCode(), "{http://citrusframework.org/faults}citrus-ns:FAULT-1001");
+        Assert.assertEquals(send.getFaultString(), "FaultString");
+        Assert.assertEquals(send.getFaultDetails().size(), 0);
+        Assert.assertEquals(send.getFaultDetailResourcePaths().size(), 1);
+        Assert.assertEquals(send.getFaultDetailResourcePaths().get(0), "classpath:org/citrusframework/ws/actions/test-fault-detail.xml");
+        Assert.assertEquals(send.getFaultActor(), "FaultActor");
+    }
+}

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/xml/SoapClientTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/xml/SoapClientTest.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.ws.xml;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.endpoint.EndpointAdapter;
+import org.citrusframework.endpoint.direct.DirectEndpointAdapter;
+import org.citrusframework.endpoint.direct.DirectSyncEndpointConfiguration;
+import org.citrusframework.message.Message;
+import org.citrusframework.message.MessageType;
+import org.citrusframework.util.FileUtils;
+import org.citrusframework.util.SocketUtils;
+import org.citrusframework.validation.DefaultMessageHeaderValidator;
+import org.citrusframework.ws.TextEqualsMessageValidator;
+import org.citrusframework.ws.actions.ReceiveSoapMessageAction;
+import org.citrusframework.ws.actions.SendSoapMessageAction;
+import org.citrusframework.ws.client.WebServiceClient;
+import org.citrusframework.ws.message.SoapAttachment;
+import org.citrusframework.ws.message.SoapMessage;
+import org.citrusframework.ws.message.SoapMessageHeaders;
+import org.citrusframework.ws.server.WebServiceServer;
+import org.citrusframework.ws.validation.SimpleSoapAttachmentValidator;
+import org.citrusframework.ws.validation.SoapAttachmentValidator;
+import org.citrusframework.xml.XmlTestLoader;
+import org.citrusframework.xml.actions.XmlTestActionBuilder;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.ws.endpoint.builder.WebServiceEndpoints.soap;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class SoapClientTest extends AbstractXmlActionTest {
+
+    private final int port = SocketUtils.findAvailableTcpPort(8080);
+    private final String uri = "http://localhost:" + port + "/test";
+
+    private WebServiceServer soapServer;
+    private WebServiceClient soapClient;
+
+    private final Queue<SoapMessage> responses = new ArrayBlockingQueue<>(4);
+
+    @BeforeClass
+    public void setupEndpoints() {
+        EndpointAdapter endpointAdapter = new DirectEndpointAdapter(new DirectSyncEndpointConfiguration()) {
+            @Override
+            public Message handleMessageInternal(Message request) {
+                return responses.isEmpty() ? new SoapMessage() : responses.remove();
+            }
+        };
+
+        soapServer = soap().server()
+                .port(port)
+                .timeout(500L)
+                .endpointAdapter(endpointAdapter)
+                .autoStart(true)
+                .name("soapServer")
+                .build();
+        soapServer.initialize();
+
+        soapClient = soap().client()
+                .defaultUri(uri)
+                .name("soapClient")
+                .build();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void cleanupEndpoints() {
+        if (soapServer != null) {
+            soapServer.stop();
+        }
+    }
+
+    @Test
+    public void shouldLoadSoapClientActions() throws IOException {
+        XmlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/ws/xml/soap-client-test.xml");
+
+        context.setVariable("port", port);
+
+        context.getReferenceResolver().bind("soapClient", soapClient);
+        context.getReferenceResolver().bind("soapServer", soapServer);
+
+        context.getReferenceResolver().bind("headerValidator", new DefaultMessageHeaderValidator());
+        context.getMessageValidatorRegistry().addMessageValidator("validator", new TextEqualsMessageValidator());
+        context.getReferenceResolver().bind("soapAttachmentValidator", new SimpleSoapAttachmentValidator());
+        context.getReferenceResolver().bind("mySoapAttachmentValidator", new SimpleSoapAttachmentValidator());
+
+        responses.add(createSoapMessage(new SoapAttachment("MySoapAttachment", "text/plain", "This is an attachment!")));
+
+        responses.add(createSoapMessage(new SoapAttachment("MySoapAttachment", "application/xml",
+                FileUtils.readToString(FileUtils.getFileResource("classpath:org/citrusframework/ws/actions/test-attachment.xml")), "UTF-8")));
+
+        responses.add(createSoapMessage(new SoapAttachment("FirstSoapAttachment", "text/plain", "This is an attachment!"),
+                new SoapAttachment("SecondSoapAttachment", "application/xml", FileUtils.readToString(FileUtils.getFileResource("classpath:org/citrusframework/ws/actions/test-attachment.xml")), "UTF-8")));
+
+        responses.add(createSoapMessage());
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "SoapClientTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 8L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), SendSoapMessageAction.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "soap:send-request");
+
+        Assert.assertEquals(result.getTestAction(1).getClass(), ReceiveSoapMessageAction.class);
+        Assert.assertEquals(result.getTestAction(1).getName(), "soap:receive-response");
+
+        int actionIndex = 0;
+
+        SendSoapMessageAction send = (SendSoapMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertFalse(send.isForkMode());
+        Assert.assertEquals(send.getMessageBuilder().build(context, MessageType.XML.name()).getHeader(SoapMessageHeaders.SOAP_ACTION), "myAction");
+        Assert.assertEquals(send.getAttachments().size(), 1L);
+        Assert.assertEquals(send.getAttachments().get(0).getContent().trim(), "This is an attachment!");
+        Assert.assertNull(send.getAttachments().get(0).getContentResourcePath());
+        Assert.assertEquals(send.getAttachments().get(0).getContentId(), "MySoapAttachment");
+        Assert.assertEquals(send.getAttachments().get(0).getContentType(), "text/plain");
+
+        ReceiveSoapMessageAction receive = (ReceiveSoapMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(receive.getMessageBuilder().build(context, MessageType.XML.name()).getPayload(), "<?xml version=\"1.0\" encoding=\"UTF-8\"?><TestResponse>Hello User</TestResponse>");
+        Assert.assertEquals(receive.getAttachmentValidator(), context.getReferenceResolver().resolve("soapAttachmentValidator", SoapAttachmentValidator.class));
+        Assert.assertEquals(receive.getAttachments().size(), 1L);
+        Assert.assertEquals(receive.getAttachments().get(0).getContent().trim(), "This is an attachment!");
+        Assert.assertNull(receive.getAttachments().get(0).getContentResourcePath());
+        Assert.assertEquals(receive.getAttachments().get(0).getContentId(), "MySoapAttachment");
+        Assert.assertEquals(receive.getAttachments().get(0).getContentType(), "text/plain");
+
+        send = (SendSoapMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertFalse(send.isForkMode());
+        Assert.assertEquals(send.getAttachments().size(), 1L);
+        Assert.assertEquals(send.getAttachments().get(0).getContentResourcePath(), "classpath:org/citrusframework/ws/actions/test-attachment.xml");
+        Assert.assertEquals(send.getAttachments().get(0).getContentId(), "MySoapAttachment");
+        Assert.assertEquals(send.getAttachments().get(0).getContentType(), "application/xml");
+        Assert.assertEquals(send.getAttachments().get(0).getCharsetName(), "UTF-8");
+
+        receive = (ReceiveSoapMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(receive.getAttachmentValidator(), context.getReferenceResolver().resolve("mySoapAttachmentValidator", SoapAttachmentValidator.class));
+        Assert.assertEquals(receive.getAttachments().size(), 1L);
+        Assert.assertEquals(receive.getAttachments().get(0).getContentResourcePath(), "classpath:org/citrusframework/ws/actions/test-attachment.xml");
+        Assert.assertEquals(receive.getAttachments().get(0).getContentId(), "MySoapAttachment");
+        Assert.assertEquals(receive.getAttachments().get(0).getContentType(), "application/xml");
+        Assert.assertEquals(receive.getAttachments().get(0).getCharsetName(), "UTF-8");
+
+        send = (SendSoapMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertFalse(send.isForkMode());
+        Assert.assertEquals(send.getAttachments().size(), 2L);
+        Assert.assertEquals(send.getAttachments().get(0).getContent().trim(), "This is an attachment!");
+        Assert.assertNull(send.getAttachments().get(0).getContentResourcePath());
+        Assert.assertEquals(send.getAttachments().get(0).getContentId(), "FirstSoapAttachment");
+        Assert.assertEquals(send.getAttachments().get(0).getContentType(), "text/plain");
+        Assert.assertNotNull(send.getAttachments().get(1).getContentResourcePath());
+        Assert.assertEquals(send.getAttachments().get(1).getContentId(), "SecondSoapAttachment");
+        Assert.assertEquals(send.getAttachments().get(1).getContentType(), "application/xml");
+        Assert.assertEquals(send.getAttachments().get(1).getCharsetName(), "UTF-8");
+
+        receive = (ReceiveSoapMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(receive.getAttachmentValidator(), context.getReferenceResolver().resolve("soapAttachmentValidator"));
+        Assert.assertEquals(receive.getAttachments().size(), 2L);
+        Assert.assertEquals(receive.getAttachments().get(0).getContent().trim(), "This is an attachment!");
+        Assert.assertNull(receive.getAttachments().get(0).getContentResourcePath());
+        Assert.assertEquals(receive.getAttachments().get(0).getContentId(), "FirstSoapAttachment");
+        Assert.assertEquals(receive.getAttachments().get(0).getContentType(), "text/plain");
+        Assert.assertNotNull(receive.getAttachments().get(1).getContentResourcePath());
+        Assert.assertEquals(receive.getAttachments().get(1).getContentId(), "SecondSoapAttachment");
+        Assert.assertEquals(receive.getAttachments().get(1).getContentType(), "application/xml");
+        Assert.assertEquals(receive.getAttachments().get(1).getCharsetName(), "UTF-8");
+
+        send = (SendSoapMessageAction) result.getTestAction(actionIndex);
+        Assert.assertTrue(send.isMtomEnabled());
+        Assert.assertEquals(send.getAttachments().size(), 0L);
+    }
+
+    @Test
+    public void shouldLookupTestActionBuilder() {
+        Assert.assertTrue(XmlTestActionBuilder.lookup("soap").isPresent());
+        Assert.assertEquals(XmlTestActionBuilder.lookup("soap").get().getClass(), Soap.class);
+    }
+
+    private SoapMessage createSoapMessage(SoapAttachment... attachments) {
+        SoapMessage message = new SoapMessage("<TestResponse>Hello User</TestResponse>")
+                .contentType("application/xml");
+
+        Arrays.stream(attachments).forEach(message::addAttachment);
+
+        return message;
+    }
+}

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/xml/SoapServerTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/xml/SoapServerTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.ws.xml;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.endpoint.AbstractEndpointAdapter;
+import org.citrusframework.endpoint.EndpointAdapter;
+import org.citrusframework.endpoint.direct.DirectEndpointAdapter;
+import org.citrusframework.message.DefaultMessageQueue;
+import org.citrusframework.message.MessageQueue;
+import org.citrusframework.message.MessageType;
+import org.citrusframework.util.FileUtils;
+import org.citrusframework.validation.DefaultMessageHeaderValidator;
+import org.citrusframework.ws.TextEqualsMessageValidator;
+import org.citrusframework.ws.actions.ReceiveSoapMessageAction;
+import org.citrusframework.ws.actions.SendSoapMessageAction;
+import org.citrusframework.ws.message.SoapAttachment;
+import org.citrusframework.ws.message.SoapMessage;
+import org.citrusframework.ws.server.WebServiceServer;
+import org.citrusframework.ws.validation.SimpleSoapAttachmentValidator;
+import org.citrusframework.xml.XmlTestLoader;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.endpoint.direct.DirectEndpoints.direct;
+import static org.citrusframework.ws.endpoint.builder.WebServiceEndpoints.soap;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class SoapServerTest extends AbstractXmlActionTest {
+
+    private WebServiceServer soapServer;
+
+    private final MessageQueue inboundQueue = new DefaultMessageQueue("inboundQueue");
+    private final EndpointAdapter endpointAdapter = new DirectEndpointAdapter(direct()
+            .synchronous()
+            .timeout(100L)
+            .queue(inboundQueue)
+            .build());
+
+    @BeforeClass
+    public void setupEndpoints() {
+        soapServer = soap().server()
+                .timeout(100L)
+                .endpointAdapter(endpointAdapter)
+                .autoStart(true)
+                .name("soapServer")
+                .build();
+    }
+
+    @BeforeMethod
+    @Override
+    public void prepareTest() {
+        super.prepareTest();
+        ((AbstractEndpointAdapter) endpointAdapter).setTestContextFactory(testContextFactory);
+    }
+
+    @Test
+    public void shouldLoadSoapServerActions() throws IOException {
+        XmlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/ws/xml/soap-server-test.xml");
+
+        context.getReferenceResolver().bind("soapServer", soapServer);
+        context.getReferenceResolver().bind("headerValidator", new DefaultMessageHeaderValidator());
+        context.getMessageValidatorRegistry().addMessageValidator("validator", new TextEqualsMessageValidator());
+        context.getReferenceResolver().bind("soapAttachmentValidator", new SimpleSoapAttachmentValidator());
+        context.getReferenceResolver().bind("mySoapAttachmentValidator", new SimpleSoapAttachmentValidator());
+
+        endpointAdapter.handleMessage(createSoapMessage(new SoapAttachment("MySoapAttachment", "text/plain", "This is an attachment!")));
+        endpointAdapter.handleMessage(createSoapMessage(new SoapAttachment("MySoapAttachment", "application/xml",
+                FileUtils.readToString(FileUtils.getFileResource("classpath:org/citrusframework/ws/actions/test-attachment.xml")), "UTF-8")));
+        endpointAdapter.handleMessage(createSoapMessage(new SoapAttachment("FirstSoapAttachment", "text/plain", "This is an attachment!"),
+                new SoapAttachment("SecondSoapAttachment", "application/xml", FileUtils.readToString(FileUtils.getFileResource("classpath:org/citrusframework/ws/actions/test-attachment.xml")), "UTF-8")));
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "SoapServerTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 6L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), ReceiveSoapMessageAction.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "soap:receive-request");
+
+        Assert.assertEquals(result.getTestAction(1).getClass(), SendSoapMessageAction.class);
+        Assert.assertEquals(result.getTestAction(1).getName(), "soap:send-response");
+
+        int actionIndex = 0;
+
+        ReceiveSoapMessageAction action = (ReceiveSoapMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getMessageBuilder().build(context, MessageType.XML.name()).getPayload(), "<TestMessage>Hello Citrus</TestMessage>");
+        Assert.assertEquals(action.getAttachmentValidator(), context.getReferenceResolver().resolve("soapAttachmentValidator"));
+        Assert.assertEquals(action.getAttachments().size(), 1L);
+        Assert.assertEquals(action.getAttachments().get(0).getContent().trim(), "This is an attachment!");
+        Assert.assertNull(action.getAttachments().get(0).getContentResourcePath());
+        Assert.assertEquals(action.getAttachments().get(0).getContentId(), "MySoapAttachment");
+        Assert.assertEquals(action.getAttachments().get(0).getContentType(), "text/plain");
+
+        SendSoapMessageAction send = (SendSoapMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertFalse(send.isForkMode());
+        Assert.assertEquals(send.getAttachments().size(), 1L);
+        Assert.assertEquals(send.getAttachments().get(0).getContent().trim(), "This is an attachment!");
+        Assert.assertNull(send.getAttachments().get(0).getContentResourcePath());
+        Assert.assertEquals(send.getAttachments().get(0).getContentId(), "MySoapAttachment");
+        Assert.assertEquals(send.getAttachments().get(0).getContentType(), "text/plain");
+
+        action = (ReceiveSoapMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getAttachmentValidator(), context.getReferenceResolver().resolve("mySoapAttachmentValidator"));
+        Assert.assertEquals(action.getAttachments().size(), 1L);
+        Assert.assertNotNull(action.getAttachments().get(0).getContentResourcePath());
+        Assert.assertEquals(action.getAttachments().get(0).getContentId(), "MySoapAttachment");
+        Assert.assertEquals(action.getAttachments().get(0).getContentType(), "application/xml");
+        Assert.assertEquals(action.getAttachments().get(0).getCharsetName(), "UTF-8");
+
+        send = (SendSoapMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertFalse(send.isForkMode());
+        Assert.assertEquals(send.getAttachments().size(), 1L);
+        Assert.assertEquals(send.getAttachments().get(0).getContentResourcePath(), "classpath:org/citrusframework/ws/actions/test-attachment.xml");
+        Assert.assertEquals(send.getAttachments().get(0).getContentId(), "MySoapAttachment");
+        Assert.assertEquals(send.getAttachments().get(0).getContentType(), "application/xml");
+        Assert.assertEquals(send.getAttachments().get(0).getCharsetName(), "UTF-8");
+
+        action = (ReceiveSoapMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getAttachmentValidator(), context.getReferenceResolver().resolve("soapAttachmentValidator"));
+        Assert.assertEquals(action.getAttachments().size(), 2L);
+        Assert.assertEquals(action.getAttachments().get(0).getContent().trim(), "This is an attachment!");
+        Assert.assertNull(action.getAttachments().get(0).getContentResourcePath());
+        Assert.assertEquals(action.getAttachments().get(0).getContentId(), "FirstSoapAttachment");
+        Assert.assertEquals(action.getAttachments().get(0).getContentType(), "text/plain");
+        Assert.assertNotNull(action.getAttachments().get(1).getContentResourcePath());
+        Assert.assertEquals(action.getAttachments().get(1).getContentId(), "SecondSoapAttachment");
+        Assert.assertEquals(action.getAttachments().get(1).getContentType(), "application/xml");
+        Assert.assertEquals(action.getAttachments().get(1).getCharsetName(), "UTF-8");
+
+        send = (SendSoapMessageAction) result.getTestAction(actionIndex);
+        Assert.assertFalse(send.isForkMode());
+        Assert.assertEquals(send.getAttachments().size(), 2L);
+        Assert.assertEquals(send.getAttachments().get(0).getContent().trim(), "This is an attachment!");
+        Assert.assertNull(send.getAttachments().get(0).getContentResourcePath());
+        Assert.assertEquals(send.getAttachments().get(0).getContentId(), "FirstSoapAttachment");
+        Assert.assertEquals(send.getAttachments().get(0).getContentType(), "text/plain");
+        Assert.assertNotNull(send.getAttachments().get(1).getContentResourcePath());
+        Assert.assertEquals(send.getAttachments().get(1).getContentId(), "SecondSoapAttachment");
+        Assert.assertEquals(send.getAttachments().get(1).getContentType(), "application/xml");
+        Assert.assertEquals(send.getAttachments().get(1).getCharsetName(), "UTF-8");
+    }
+
+    private SoapMessage createSoapMessage(SoapAttachment... attachments) {
+        SoapMessage message = new SoapMessage("<TestMessage>Hello Citrus</TestMessage>")
+                .contentType("application/xml");
+
+        Arrays.stream(attachments).forEach(message::addAttachment);
+
+        return message;
+    }
+}

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/yaml/AbstractYamlActionTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/yaml/AbstractYamlActionTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.ws.yaml;
+
+import org.citrusframework.Citrus;
+import org.citrusframework.CitrusContext;
+import org.citrusframework.CitrusInstanceManager;
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.annotations.CitrusAnnotations;
+import org.citrusframework.context.StaticTestContextFactory;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.testng.AbstractTestNGUnitTest;
+import org.citrusframework.yaml.YamlTestLoader;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeClass;
+
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class AbstractYamlActionTest extends AbstractTestNGUnitTest {
+
+    protected Citrus citrus;
+
+    @Mock
+    protected CitrusContext citrusContext;
+
+    @BeforeClass
+    public void setupMocks() {
+        MockitoAnnotations.openMocks(this);
+        citrus = CitrusInstanceManager.newInstance(() -> citrusContext);
+    }
+
+    @Override
+    protected TestContext createTestContext() {
+        TestContext context = super.createTestContext();
+        when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
+        when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
+        when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        CitrusAnnotations.injectAll(this, citrus, context);
+        return context;
+    }
+
+    protected YamlTestLoader createTestLoader(String sourcePath) {
+        YamlTestLoader testLoader = new YamlTestLoader(this.getClass(), "Test", this.getClass().getPackageName());
+        CitrusAnnotations.injectAll(testLoader, citrus, context);
+        CitrusAnnotations.injectTestRunner(testLoader, new DefaultTestCaseRunner(context));
+        testLoader.setSource(sourcePath);
+
+        return testLoader;
+    }
+}

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/yaml/AssertSoapFaultTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/yaml/AssertSoapFaultTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.ws.yaml;
+
+import java.io.IOException;
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.endpoint.EndpointAdapter;
+import org.citrusframework.endpoint.direct.DirectEndpointAdapter;
+import org.citrusframework.endpoint.direct.DirectSyncEndpointConfiguration;
+import org.citrusframework.message.Message;
+import org.citrusframework.util.FileUtils;
+import org.citrusframework.util.SocketUtils;
+import org.citrusframework.validation.DefaultMessageHeaderValidator;
+import org.citrusframework.ws.TextEqualsMessageValidator;
+import org.citrusframework.ws.actions.AssertSoapFault;
+import org.citrusframework.ws.client.WebServiceClient;
+import org.citrusframework.ws.message.SoapFault;
+import org.citrusframework.ws.message.SoapMessage;
+import org.citrusframework.ws.server.WebServiceServer;
+import org.citrusframework.ws.validation.SimpleSoapFaultValidator;
+import org.citrusframework.ws.validation.SoapFaultValidator;
+import org.citrusframework.yaml.YamlTestLoader;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.ws.endpoint.builder.WebServiceEndpoints.soap;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class AssertSoapFaultTest extends AbstractYamlActionTest {
+
+    private final int port = SocketUtils.findAvailableTcpPort(8080);
+    private final String uri = "http://localhost:" + port + "/test";
+
+    private WebServiceServer soapServer;
+    private WebServiceClient soapClient;
+
+    private final Queue<SoapMessage> responses = new ArrayBlockingQueue<>(4);
+
+    @BeforeClass
+    public void setupEndpoints() {
+        EndpointAdapter endpointAdapter = new DirectEndpointAdapter(new DirectSyncEndpointConfiguration()) {
+            @Override
+            public Message handleMessageInternal(Message request) {
+                return responses.isEmpty() ? new SoapMessage() : responses.remove();
+            }
+        };
+
+        soapServer = soap().server()
+                .port(port)
+                .timeout(500L)
+                .endpointAdapter(endpointAdapter)
+                .autoStart(true)
+                .name("soapServer")
+                .build();
+        soapServer.initialize();
+
+        soapClient = soap().client()
+                .defaultUri(uri)
+                .name("soapClient")
+                .build();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void cleanupEndpoints() {
+        if (soapServer != null) {
+            soapServer.stop();
+        }
+    }
+
+    @Test
+    public void shouldLoadSoapClientActions() throws IOException {
+        YamlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/ws/yaml/assert-soap-fault-test.yaml");
+
+        context.setVariable("port", port);
+
+        context.getReferenceResolver().bind("soapClient", soapClient);
+        context.getReferenceResolver().bind("soapServer", soapServer);
+
+        context.getReferenceResolver().bind("headerValidator", new DefaultMessageHeaderValidator());
+        context.getMessageValidatorRegistry().addMessageValidator("validator", new TextEqualsMessageValidator());
+        context.getReferenceResolver().bind("soapFaultValidator", new SimpleSoapFaultValidator());
+        context.getReferenceResolver().bind("customSoapFaultValidator", new SimpleSoapFaultValidator());
+
+        responses.add(createSoapFault("FAULT-1001"));
+        responses.add(createSoapFault("FAULT-1002"));
+        responses.add(createSoapFault("FAULT-1003").addFaultDetail("<ns0:FaultDetail xmlns:ns0=\"http://citrusframework.org/schemas/samples/HelloService.xsd\">" +
+                    "<ns0:DetailId>1000</ns0:DetailId>" +
+                "</ns0:FaultDetail>"));
+        responses.add(createSoapFault("FAULT-1004").addFaultDetail(FileUtils.readToString(
+                FileUtils.getFileResource("classpath:org/citrusframework/ws/actions/test-fault-detail.xml"))));
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "AssertSoapFaultTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 4L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), AssertSoapFault.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "soap:assert-fault");
+
+        int actionIndex = 0;
+
+        AssertSoapFault action = (AssertSoapFault) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getAction());
+        Assert.assertEquals(action.getValidator(), context.getReferenceResolver().resolve("soapFaultValidator", SoapFaultValidator.class));
+        Assert.assertEquals(action.getFaultCode(), "{http://citrusframework.org/faults}FAULT-1001");
+        Assert.assertNull(action.getFaultString());
+        Assert.assertEquals(action.getFaultDetails().size(), 0L);
+        Assert.assertNotNull(action.getValidationContext());
+
+        action = (AssertSoapFault) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getAction());
+        Assert.assertEquals(action.getValidator(), context.getReferenceResolver().resolve("soapFaultValidator", SoapFaultValidator.class));
+        Assert.assertEquals(action.getFaultCode(), "{http://citrusframework.org/faults}FAULT-1002");
+        Assert.assertEquals(action.getFaultString(), "FaultString");
+        Assert.assertEquals(action.getFaultDetails().size(), 0L);
+        Assert.assertNotNull(action.getValidationContext());
+
+        action = (AssertSoapFault) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getAction());
+        Assert.assertEquals(action.getValidator(), context.getReferenceResolver().resolve("soapFaultValidator", SoapFaultValidator.class));
+        Assert.assertEquals(action.getFaultCode(), "{http://citrusframework.org/faults}FAULT-1003");
+        Assert.assertEquals(action.getFaultString(), "FaultString");
+        Assert.assertEquals(action.getFaultActor(), "FaultActor");
+        Assert.assertEquals(action.getFaultDetails().size(), 1L);
+        Assert.assertEquals(action.getFaultDetails().get(0), "<ns0:FaultDetail xmlns:ns0=\"http://citrusframework.org/schemas/samples/HelloService.xsd\">" +
+                    "<ns0:DetailId>1000</ns0:DetailId>" +
+                "</ns0:FaultDetail>");
+        Assert.assertEquals(action.getValidationContext().getValidationContexts().size(), 1L);
+
+        action = (AssertSoapFault) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getAction());
+        Assert.assertEquals(action.getValidator(), context.getReferenceResolver().resolve("customSoapFaultValidator", SoapFaultValidator.class));
+        Assert.assertEquals(action.getFaultCode(), "{http://citrusframework.org/faults}FAULT-1004");
+        Assert.assertEquals(action.getFaultString(), "FaultString");
+        Assert.assertEquals(action.getFaultDetails().size(), 0L);
+        Assert.assertEquals(action.getFaultDetailResourcePaths().size(), 1L);
+        Assert.assertEquals(action.getFaultDetailResourcePaths().get(0), "classpath:org/citrusframework/ws/actions/test-fault-detail.xml");
+        Assert.assertEquals(action.getValidationContext().getValidationContexts().size(), 1L);
+    }
+
+    private SoapFault createSoapFault(String faultCode) {
+        SoapFault fault = new SoapFault("<TestResponse>Hello User</TestResponse>");
+
+        fault.faultCode(String.format("{http://citrusframework.org/faults}%s", faultCode));
+        fault.faultString("FaultString");
+        fault.faultActor("FaultActor");
+
+        return fault;
+    }
+}

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/yaml/SendSoapFaultTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/yaml/SendSoapFaultTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.ws.yaml;
+
+import java.io.IOException;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.endpoint.AbstractEndpointAdapter;
+import org.citrusframework.endpoint.EndpointAdapter;
+import org.citrusframework.endpoint.direct.DirectEndpointAdapter;
+import org.citrusframework.message.DefaultMessageQueue;
+import org.citrusframework.message.MessageQueue;
+import org.citrusframework.message.MessageType;
+import org.citrusframework.validation.DefaultMessageHeaderValidator;
+import org.citrusframework.validation.builder.StaticMessageBuilder;
+import org.citrusframework.ws.TextEqualsMessageValidator;
+import org.citrusframework.ws.actions.ReceiveSoapMessageAction;
+import org.citrusframework.ws.actions.SendSoapFaultAction;
+import org.citrusframework.ws.message.SoapMessage;
+import org.citrusframework.ws.server.WebServiceServer;
+import org.citrusframework.yaml.YamlTestLoader;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.endpoint.direct.DirectEndpoints.direct;
+import static org.citrusframework.ws.endpoint.builder.WebServiceEndpoints.soap;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class SendSoapFaultTest extends AbstractYamlActionTest {
+
+    private WebServiceServer soapServer;
+
+    private final MessageQueue inboundQueue = new DefaultMessageQueue("inboundQueue");
+    private final EndpointAdapter endpointAdapter = new DirectEndpointAdapter(direct()
+            .synchronous()
+            .timeout(100L)
+            .queue(inboundQueue)
+            .build());
+
+    @BeforeClass
+    public void setupEndpoints() {
+        soapServer = soap().server()
+                .timeout(100L)
+                .endpointAdapter(endpointAdapter)
+                .autoStart(true)
+                .name("soapServer")
+                .build();
+    }
+
+    @BeforeMethod
+    @Override
+    public void prepareTest() {
+        super.prepareTest();
+        ((AbstractEndpointAdapter) endpointAdapter).setTestContextFactory(testContextFactory);
+    }
+
+    @Test
+    public void shouldLoadSoapServerActions() throws IOException {
+        YamlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/ws/yaml/send-soap-fault-test.yaml");
+
+        context.getReferenceResolver().bind("soapServer", soapServer);
+        context.getReferenceResolver().bind("headerValidator", new DefaultMessageHeaderValidator());
+        context.getMessageValidatorRegistry().addMessageValidator("validator", new TextEqualsMessageValidator());
+
+        endpointAdapter.handleMessage(new SoapMessage("<TestMessage>Hello Citrus</TestMessage>").contentType("application/xml"));
+        endpointAdapter.handleMessage(new SoapMessage("<TestMessage>Hello Citrus</TestMessage>").contentType("application/xml"));
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "SendSoapFaultTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 4L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), ReceiveSoapMessageAction.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "soap:receive-request");
+
+        Assert.assertEquals(result.getTestAction(1).getClass(), SendSoapFaultAction.class);
+        Assert.assertEquals(result.getTestAction(1).getName(), "soap:send-fault");
+
+        int actionIndex = 0;
+
+        ReceiveSoapMessageAction action = (ReceiveSoapMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getMessageBuilder().build(context, MessageType.XML.name()).getPayload(), "<TestMessage>Hello Citrus</TestMessage>");
+
+        SendSoapFaultAction send = (SendSoapFaultAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(send.getEndpointUri(), "soapServer");
+        Assert.assertNotNull(send.getMessageBuilder());
+        Assert.assertEquals(send.getMessageBuilder().getClass(), StaticMessageBuilder.class);
+
+        StaticMessageBuilder messageBuilder = (StaticMessageBuilder)send.getMessageBuilder();
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 1L);
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get("operation"), "sendFault");
+        Assert.assertEquals(send.getFaultCode(), "{http://citrusframework.org/faults}citrus-ns:FAULT-1000");
+        Assert.assertEquals(send.getFaultString(), "FaultString");
+        Assert.assertEquals(send.getFaultDetails().size(), 1);
+        Assert.assertTrue(send.getFaultDetails().get(0).startsWith("<ns0:FaultDetail xmlns:ns0=\"http://citrusframework.org/schemas/samples/HelloService.xsd\">"));
+        Assert.assertNull(send.getFaultActor());
+
+        action = (ReceiveSoapMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getMessageBuilder().build(context, MessageType.XML.name()).getPayload(), "<TestMessage>Hello Citrus</TestMessage>");
+
+        send = (SendSoapFaultAction) result.getTestAction(actionIndex);
+        Assert.assertEquals(send.getEndpointUri(), "soapServer");
+        Assert.assertNotNull(send.getMessageBuilder());
+        Assert.assertEquals(send.getMessageBuilder().getClass(), StaticMessageBuilder.class);
+
+        messageBuilder = (StaticMessageBuilder)send.getMessageBuilder();
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 1);
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get("operation"), "sendFault");
+        Assert.assertEquals(send.getFaultCode(), "{http://citrusframework.org/faults}citrus-ns:FAULT-1001");
+        Assert.assertEquals(send.getFaultString(), "FaultString");
+        Assert.assertEquals(send.getFaultDetails().size(), 0);
+        Assert.assertEquals(send.getFaultDetailResourcePaths().size(), 1);
+        Assert.assertEquals(send.getFaultDetailResourcePaths().get(0), "classpath:org/citrusframework/ws/actions/test-fault-detail.xml");
+        Assert.assertEquals(send.getFaultActor(), "FaultActor");
+    }
+}

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/yaml/SoapClientTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/yaml/SoapClientTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.ws.yaml;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.endpoint.EndpointAdapter;
+import org.citrusframework.endpoint.direct.DirectEndpointAdapter;
+import org.citrusframework.endpoint.direct.DirectSyncEndpointConfiguration;
+import org.citrusframework.message.Message;
+import org.citrusframework.util.FileUtils;
+import org.citrusframework.util.SocketUtils;
+import org.citrusframework.validation.DefaultMessageHeaderValidator;
+import org.citrusframework.ws.TextEqualsMessageValidator;
+import org.citrusframework.ws.actions.ReceiveSoapMessageAction;
+import org.citrusframework.ws.actions.SendSoapMessageAction;
+import org.citrusframework.ws.client.WebServiceClient;
+import org.citrusframework.ws.message.SoapAttachment;
+import org.citrusframework.ws.message.SoapMessage;
+import org.citrusframework.ws.server.WebServiceServer;
+import org.citrusframework.ws.validation.SimpleSoapAttachmentValidator;
+import org.citrusframework.ws.validation.SoapAttachmentValidator;
+import org.citrusframework.yaml.YamlTestLoader;
+import org.citrusframework.yaml.actions.YamlTestActionBuilder;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.ws.endpoint.builder.WebServiceEndpoints.soap;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class SoapClientTest extends AbstractYamlActionTest {
+
+    private final int port = SocketUtils.findAvailableTcpPort(8080);
+    private final String uri = "http://localhost:" + port + "/test";
+
+    private WebServiceServer soapServer;
+    private WebServiceClient soapClient;
+
+    private final Queue<SoapMessage> responses = new ArrayBlockingQueue<>(4);
+
+    @BeforeClass
+    public void setupEndpoints() {
+        EndpointAdapter endpointAdapter = new DirectEndpointAdapter(new DirectSyncEndpointConfiguration()) {
+            @Override
+            public Message handleMessageInternal(Message request) {
+                return responses.isEmpty() ? new SoapMessage() : responses.remove();
+            }
+        };
+
+        soapServer = soap().server()
+                .port(port)
+                .timeout(500L)
+                .endpointAdapter(endpointAdapter)
+                .autoStart(true)
+                .name("soapServer")
+                .build();
+        soapServer.initialize();
+
+        soapClient = soap().client()
+                .defaultUri(uri)
+                .name("soapClient")
+                .build();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void cleanupEndpoints() {
+        if (soapServer != null) {
+            soapServer.stop();
+        }
+    }
+
+    @Test
+    public void shouldLoadSoapClientActions() throws IOException {
+        YamlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/ws/yaml/soap-client-test.yaml");
+
+        context.setVariable("port", port);
+
+        context.getReferenceResolver().bind("soapClient", soapClient);
+        context.getReferenceResolver().bind("soapServer", soapServer);
+
+        context.getReferenceResolver().bind("headerValidator", new DefaultMessageHeaderValidator());
+        context.getMessageValidatorRegistry().addMessageValidator("validator", new TextEqualsMessageValidator());
+        context.getReferenceResolver().bind("soapAttachmentValidator", new SimpleSoapAttachmentValidator());
+        context.getReferenceResolver().bind("mySoapAttachmentValidator", new SimpleSoapAttachmentValidator());
+
+        responses.add(createSoapMessage(new SoapAttachment("MySoapAttachment", "text/plain", "This is an attachment!")));
+
+        responses.add(createSoapMessage(new SoapAttachment("MySoapAttachment", "application/xml",
+                FileUtils.readToString(FileUtils.getFileResource("classpath:org/citrusframework/ws/actions/test-attachment.xml")), "UTF-8")));
+
+        responses.add(createSoapMessage(new SoapAttachment("FirstSoapAttachment", "text/plain", "This is an attachment!"),
+                new SoapAttachment("SecondSoapAttachment", "application/xml", FileUtils.readToString(FileUtils.getFileResource("classpath:org/citrusframework/ws/actions/test-attachment.xml")), "UTF-8")));
+
+        responses.add(createSoapMessage());
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "SoapClientTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 8L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), SendSoapMessageAction.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "soap:send-request");
+
+        Assert.assertEquals(result.getTestAction(1).getClass(), ReceiveSoapMessageAction.class);
+        Assert.assertEquals(result.getTestAction(1).getName(), "soap:receive-response");
+
+        int actionIndex = 0;
+
+        SendSoapMessageAction send = (SendSoapMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertFalse(send.isForkMode());
+        Assert.assertEquals(send.getAttachments().size(), 1L);
+        Assert.assertEquals(send.getAttachments().get(0).getContent().trim(), "This is an attachment!");
+        Assert.assertNull(send.getAttachments().get(0).getContentResourcePath());
+        Assert.assertEquals(send.getAttachments().get(0).getContentId(), "MySoapAttachment");
+        Assert.assertEquals(send.getAttachments().get(0).getContentType(), "text/plain");
+
+        ReceiveSoapMessageAction receive = (ReceiveSoapMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(receive.getAttachmentValidator(), context.getReferenceResolver().resolve("soapAttachmentValidator", SoapAttachmentValidator.class));
+        Assert.assertEquals(receive.getAttachments().size(), 1L);
+        Assert.assertEquals(receive.getAttachments().get(0).getContent().trim(), "This is an attachment!");
+        Assert.assertNull(receive.getAttachments().get(0).getContentResourcePath());
+        Assert.assertEquals(receive.getAttachments().get(0).getContentId(), "MySoapAttachment");
+        Assert.assertEquals(receive.getAttachments().get(0).getContentType(), "text/plain");
+
+        send = (SendSoapMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertFalse(send.isForkMode());
+        Assert.assertEquals(send.getAttachments().size(), 1L);
+        Assert.assertEquals(send.getAttachments().get(0).getContentResourcePath(), "classpath:org/citrusframework/ws/actions/test-attachment.xml");
+        Assert.assertEquals(send.getAttachments().get(0).getContentId(), "MySoapAttachment");
+        Assert.assertEquals(send.getAttachments().get(0).getContentType(), "application/xml");
+        Assert.assertEquals(send.getAttachments().get(0).getCharsetName(), "UTF-8");
+
+        receive = (ReceiveSoapMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(receive.getAttachmentValidator(), context.getReferenceResolver().resolve("mySoapAttachmentValidator", SoapAttachmentValidator.class));
+        Assert.assertEquals(receive.getAttachments().size(), 1L);
+        Assert.assertEquals(receive.getAttachments().get(0).getContentResourcePath(), "classpath:org/citrusframework/ws/actions/test-attachment.xml");
+        Assert.assertEquals(receive.getAttachments().get(0).getContentId(), "MySoapAttachment");
+        Assert.assertEquals(receive.getAttachments().get(0).getContentType(), "application/xml");
+        Assert.assertEquals(receive.getAttachments().get(0).getCharsetName(), "UTF-8");
+
+        send = (SendSoapMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertFalse(send.isForkMode());
+        Assert.assertEquals(send.getAttachments().size(), 2L);
+        Assert.assertEquals(send.getAttachments().get(0).getContent().trim(), "This is an attachment!");
+        Assert.assertNull(send.getAttachments().get(0).getContentResourcePath());
+        Assert.assertEquals(send.getAttachments().get(0).getContentId(), "FirstSoapAttachment");
+        Assert.assertEquals(send.getAttachments().get(0).getContentType(), "text/plain");
+        Assert.assertNotNull(send.getAttachments().get(1).getContentResourcePath());
+        Assert.assertEquals(send.getAttachments().get(1).getContentId(), "SecondSoapAttachment");
+        Assert.assertEquals(send.getAttachments().get(1).getContentType(), "application/xml");
+        Assert.assertEquals(send.getAttachments().get(1).getCharsetName(), "UTF-8");
+
+        receive = (ReceiveSoapMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(receive.getAttachmentValidator(), context.getReferenceResolver().resolve("soapAttachmentValidator"));
+        Assert.assertEquals(receive.getAttachments().size(), 2L);
+        Assert.assertEquals(receive.getAttachments().get(0).getContent().trim(), "This is an attachment!");
+        Assert.assertNull(receive.getAttachments().get(0).getContentResourcePath());
+        Assert.assertEquals(receive.getAttachments().get(0).getContentId(), "FirstSoapAttachment");
+        Assert.assertEquals(receive.getAttachments().get(0).getContentType(), "text/plain");
+        Assert.assertNotNull(receive.getAttachments().get(1).getContentResourcePath());
+        Assert.assertEquals(receive.getAttachments().get(1).getContentId(), "SecondSoapAttachment");
+        Assert.assertEquals(receive.getAttachments().get(1).getContentType(), "application/xml");
+        Assert.assertEquals(receive.getAttachments().get(1).getCharsetName(), "UTF-8");
+
+        send = (SendSoapMessageAction) result.getTestAction(actionIndex);
+        Assert.assertTrue(send.isMtomEnabled());
+        Assert.assertEquals(send.getAttachments().size(), 0L);
+    }
+
+    @Test
+    public void shouldLookupTestActionBuilder() {
+        Assert.assertTrue(YamlTestActionBuilder.lookup().containsKey("soap"));
+        Assert.assertTrue(YamlTestActionBuilder.lookup("soap").isPresent());
+        Assert.assertEquals(YamlTestActionBuilder.lookup("soap").get().getClass(), Soap.class);
+    }
+
+    private SoapMessage createSoapMessage(SoapAttachment... attachments) {
+        SoapMessage message = new SoapMessage("<TestResponse>Hello User</TestResponse>")
+                .contentType("application/xml");
+
+        Arrays.stream(attachments).forEach(message::addAttachment);
+
+        return message;
+    }
+}

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/yaml/SoapServerTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/yaml/SoapServerTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.ws.yaml;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.endpoint.AbstractEndpointAdapter;
+import org.citrusframework.endpoint.EndpointAdapter;
+import org.citrusframework.endpoint.direct.DirectEndpointAdapter;
+import org.citrusframework.message.DefaultMessageQueue;
+import org.citrusframework.message.MessageQueue;
+import org.citrusframework.message.MessageType;
+import org.citrusframework.util.FileUtils;
+import org.citrusframework.validation.DefaultMessageHeaderValidator;
+import org.citrusframework.ws.TextEqualsMessageValidator;
+import org.citrusframework.ws.actions.ReceiveSoapMessageAction;
+import org.citrusframework.ws.actions.SendSoapMessageAction;
+import org.citrusframework.ws.message.SoapAttachment;
+import org.citrusframework.ws.message.SoapMessage;
+import org.citrusframework.ws.server.WebServiceServer;
+import org.citrusframework.ws.validation.SimpleSoapAttachmentValidator;
+import org.citrusframework.yaml.YamlTestLoader;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.endpoint.direct.DirectEndpoints.direct;
+import static org.citrusframework.ws.endpoint.builder.WebServiceEndpoints.soap;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class SoapServerTest extends AbstractYamlActionTest {
+
+    private WebServiceServer soapServer;
+
+    private final MessageQueue inboundQueue = new DefaultMessageQueue("inboundQueue");
+    private final EndpointAdapter endpointAdapter = new DirectEndpointAdapter(direct()
+            .synchronous()
+            .timeout(100L)
+            .queue(inboundQueue)
+            .build());
+
+    @BeforeClass
+    public void setupEndpoints() {
+        soapServer = soap().server()
+                .timeout(100L)
+                .endpointAdapter(endpointAdapter)
+                .autoStart(true)
+                .name("soapServer")
+                .build();
+    }
+
+    @BeforeMethod
+    @Override
+    public void prepareTest() {
+        super.prepareTest();
+        ((AbstractEndpointAdapter) endpointAdapter).setTestContextFactory(testContextFactory);
+    }
+
+    @Test
+    public void shouldLoadSoapServerActions() throws IOException {
+        YamlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/ws/yaml/soap-server-test.yaml");
+
+        context.getReferenceResolver().bind("soapServer", soapServer);
+        context.getReferenceResolver().bind("headerValidator", new DefaultMessageHeaderValidator());
+        context.getMessageValidatorRegistry().addMessageValidator("validator", new TextEqualsMessageValidator());
+        context.getReferenceResolver().bind("soapAttachmentValidator", new SimpleSoapAttachmentValidator());
+        context.getReferenceResolver().bind("mySoapAttachmentValidator", new SimpleSoapAttachmentValidator());
+
+        endpointAdapter.handleMessage(createSoapMessage(new SoapAttachment("MySoapAttachment", "text/plain", "This is an attachment!")));
+        endpointAdapter.handleMessage(createSoapMessage(new SoapAttachment("MySoapAttachment", "application/xml",
+                FileUtils.readToString(FileUtils.getFileResource("classpath:org/citrusframework/ws/actions/test-attachment.xml")), "UTF-8")));
+        endpointAdapter.handleMessage(createSoapMessage(new SoapAttachment("FirstSoapAttachment", "text/plain", "This is an attachment!"),
+                new SoapAttachment("SecondSoapAttachment", "application/xml", FileUtils.readToString(FileUtils.getFileResource("classpath:org/citrusframework/ws/actions/test-attachment.xml")), "UTF-8")));
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "SoapServerTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 6L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), ReceiveSoapMessageAction.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "soap:receive-request");
+
+        Assert.assertEquals(result.getTestAction(1).getClass(), SendSoapMessageAction.class);
+        Assert.assertEquals(result.getTestAction(1).getName(), "soap:send-response");
+
+        int actionIndex = 0;
+
+        ReceiveSoapMessageAction action = (ReceiveSoapMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getMessageBuilder().build(context, MessageType.XML.name()).getPayload(), "<TestMessage>Hello Citrus</TestMessage>");
+        Assert.assertEquals(action.getAttachmentValidator(), context.getReferenceResolver().resolve("soapAttachmentValidator"));
+        Assert.assertEquals(action.getAttachments().size(), 1L);
+        Assert.assertEquals(action.getAttachments().get(0).getContent().trim(), "This is an attachment!");
+        Assert.assertNull(action.getAttachments().get(0).getContentResourcePath());
+        Assert.assertEquals(action.getAttachments().get(0).getContentId(), "MySoapAttachment");
+        Assert.assertEquals(action.getAttachments().get(0).getContentType(), "text/plain");
+
+        SendSoapMessageAction send = (SendSoapMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertFalse(send.isForkMode());
+        Assert.assertEquals(send.getAttachments().size(), 1L);
+        Assert.assertEquals(send.getAttachments().get(0).getContent().trim(), "This is an attachment!");
+        Assert.assertNull(send.getAttachments().get(0).getContentResourcePath());
+        Assert.assertEquals(send.getAttachments().get(0).getContentId(), "MySoapAttachment");
+        Assert.assertEquals(send.getAttachments().get(0).getContentType(), "text/plain");
+
+        action = (ReceiveSoapMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getAttachmentValidator(), context.getReferenceResolver().resolve("mySoapAttachmentValidator"));
+        Assert.assertEquals(action.getAttachments().size(), 1L);
+        Assert.assertNotNull(action.getAttachments().get(0).getContentResourcePath());
+        Assert.assertEquals(action.getAttachments().get(0).getContentId(), "MySoapAttachment");
+        Assert.assertEquals(action.getAttachments().get(0).getContentType(), "application/xml");
+        Assert.assertEquals(action.getAttachments().get(0).getCharsetName(), "UTF-8");
+
+        send = (SendSoapMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertFalse(send.isForkMode());
+        Assert.assertEquals(send.getAttachments().size(), 1L);
+        Assert.assertEquals(send.getAttachments().get(0).getContentResourcePath(), "classpath:org/citrusframework/ws/actions/test-attachment.xml");
+        Assert.assertEquals(send.getAttachments().get(0).getContentId(), "MySoapAttachment");
+        Assert.assertEquals(send.getAttachments().get(0).getContentType(), "application/xml");
+        Assert.assertEquals(send.getAttachments().get(0).getCharsetName(), "UTF-8");
+
+        action = (ReceiveSoapMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getAttachmentValidator(), context.getReferenceResolver().resolve("soapAttachmentValidator"));
+        Assert.assertEquals(action.getAttachments().size(), 2L);
+        Assert.assertEquals(action.getAttachments().get(0).getContent().trim(), "This is an attachment!");
+        Assert.assertNull(action.getAttachments().get(0).getContentResourcePath());
+        Assert.assertEquals(action.getAttachments().get(0).getContentId(), "FirstSoapAttachment");
+        Assert.assertEquals(action.getAttachments().get(0).getContentType(), "text/plain");
+        Assert.assertNotNull(action.getAttachments().get(1).getContentResourcePath());
+        Assert.assertEquals(action.getAttachments().get(1).getContentId(), "SecondSoapAttachment");
+        Assert.assertEquals(action.getAttachments().get(1).getContentType(), "application/xml");
+        Assert.assertEquals(action.getAttachments().get(1).getCharsetName(), "UTF-8");
+
+        send = (SendSoapMessageAction) result.getTestAction(actionIndex);
+        Assert.assertFalse(send.isForkMode());
+        Assert.assertEquals(send.getAttachments().size(), 2L);
+        Assert.assertEquals(send.getAttachments().get(0).getContent().trim(), "This is an attachment!");
+        Assert.assertNull(send.getAttachments().get(0).getContentResourcePath());
+        Assert.assertEquals(send.getAttachments().get(0).getContentId(), "FirstSoapAttachment");
+        Assert.assertEquals(send.getAttachments().get(0).getContentType(), "text/plain");
+        Assert.assertNotNull(send.getAttachments().get(1).getContentResourcePath());
+        Assert.assertEquals(send.getAttachments().get(1).getContentId(), "SecondSoapAttachment");
+        Assert.assertEquals(send.getAttachments().get(1).getContentType(), "application/xml");
+        Assert.assertEquals(send.getAttachments().get(1).getCharsetName(), "UTF-8");
+    }
+
+    private SoapMessage createSoapMessage(SoapAttachment... attachments) {
+        SoapMessage message = new SoapMessage("<TestMessage>Hello Citrus</TestMessage>")
+                .contentType("application/xml");
+
+        Arrays.stream(attachments).forEach(message::addAttachment);
+
+        return message;
+    }
+}

--- a/endpoints/citrus-ws/src/test/resources/org/citrusframework/ws/config/xml/AssertSoapFaultParserTest-context.xml
+++ b/endpoints/citrus-ws/src/test/resources/org/citrusframework/ws/config/xml/AssertSoapFaultParserTest-context.xml
@@ -49,7 +49,7 @@
                 </ws:when>
             </ws:assert-fault>
 
-            <ws:assert-fault fault-code="{http://citrusframework.org/faults}FAULT-1003"
+            <ws:assert-fault fault-code="{http://citrusframework.org/faults}FAULT-1005"
                        fault-string="FaultString"
                        fault-actor="FaultActor">
                 <ws:fault-detail schema-repository="fooSchemaRepository">
@@ -62,7 +62,7 @@
                 </ws:when>
             </ws:assert-fault>
 
-            <ws:assert-fault fault-code="{http://citrusframework.org/faults}FAULT-1003"
+            <ws:assert-fault fault-code="{http://citrusframework.org/faults}FAULT-1006"
                        fault-string="FaultString"
                        fault-actor="FaultActor">
                 <ws:fault-detail schema="fooSchema">
@@ -75,7 +75,7 @@
                 </ws:when>
             </ws:assert-fault>
 
-            <ws:assert-fault fault-code="{http://citrusframework.org/faults}FAULT-1003"
+            <ws:assert-fault fault-code="{http://citrusframework.org/faults}FAULT-1007"
                        fault-string="FaultString"
                        fault-actor="FaultActor">
                 <ws:fault-detail schema-validation="false">

--- a/endpoints/citrus-ws/src/test/resources/org/citrusframework/ws/config/xml/ReceiveSoapMessageActionParserTest-context.xml
+++ b/endpoints/citrus-ws/src/test/resources/org/citrusframework/ws/config/xml/ReceiveSoapMessageActionParserTest-context.xml
@@ -8,7 +8,7 @@
                                   http://www.citrusframework.org/schema/ws/testcase http://www.citrusframework.org/schema/ws/testcase/citrus-ws-testcase.xsd">
     <testcase name="ReceiveSoapMessageActionParserTest">
         <actions>
-            <ws:receive endpoint="mySoapServer">
+            <ws:receive endpoint="mySoapServer" soap-action="myAction">
                 <message>
                     <data>
                         <![CDATA[

--- a/endpoints/citrus-ws/src/test/resources/org/citrusframework/ws/config/xml/ReceiveSoapMessageActionParserTest-context.xml
+++ b/endpoints/citrus-ws/src/test/resources/org/citrusframework/ws/config/xml/ReceiveSoapMessageActionParserTest-context.xml
@@ -33,7 +33,7 @@
                 </message>
                 <ws:attachment content-id="MySoapAttachment" content-type="application/xml"
                                charset-name="UTF-8" validator="mySoapAttachmentValidator">
-                    <ws:resource file="classpath:org/citrusframework/ws/actions/test-attachment.txt"/>
+                    <ws:resource file="classpath:org/citrusframework/ws/actions/test-attachment.xml"/>
                 </ws:attachment>
             </ws:receive>
 
@@ -52,7 +52,7 @@
                 </ws:attachment>
                 <ws:attachment content-id="SecondSoapAttachment" content-type="application/xml"
                                charset-name="UTF-8">
-                    <ws:resource file="classpath:org/citrusframework/ws/actions/test-attachment.txt"/>
+                    <ws:resource file="classpath:org/citrusframework/ws/actions/test-attachment.xml"/>
                 </ws:attachment>
             </ws:receive>
         </actions>

--- a/endpoints/citrus-ws/src/test/resources/org/citrusframework/ws/config/xml/SendSoapMessageActionParserTest-context.xml
+++ b/endpoints/citrus-ws/src/test/resources/org/citrusframework/ws/config/xml/SendSoapMessageActionParserTest-context.xml
@@ -32,7 +32,7 @@
                     </data>
                 </message>
                 <ws:attachment content-id="MySoapAttachment" content-type="application/xml" charset-name="UTF-8">
-                    <ws:resource file="classpath:org/citrusframework/ws/actions/test-attachment.txt"/>
+                    <ws:resource file="classpath:org/citrusframework/ws/actions/test-attachment.xml"/>
                 </ws:attachment>
             </ws:send>
 
@@ -45,31 +45,31 @@
                     </data>
                 </message>
                 <ws:attachment content-id="FirstSoapAttachment" content-type="text/plain">
-                  <ws:data>
-                    <![CDATA[This is an attachment!]]>
-                  </ws:data>
+                    <ws:data>
+                        <![CDATA[This is an attachment!]]>
+                    </ws:data>
                 </ws:attachment>
                 <ws:attachment content-id="SecondSoapAttachment" content-type="application/xml" charset-name="UTF-8">
-                  <ws:resource file="classpath:org/citrusframework/ws/actions/test-attachment.txt"/>
+                    <ws:resource file="classpath:org/citrusframework/ws/actions/test-attachment.xml"/>
                 </ws:attachment>
             </ws:send>
 
             <ws:send endpoint="mySoapClient" fork="true">
-              <message>
-                <data>
-                  <![CDATA[
-                      <TestMessage>Hello Citrus</TestMessage>
-                  ]]>
-                </data>
-              </message>
+                <message>
+                    <data>
+                        <![CDATA[
+                            <TestMessage>Hello Citrus</TestMessage>
+                        ]]>
+                    </data>
+                </message>
             </ws:send>
 
             <ws:send endpoint="mySoapClient" fork="true">
                 <message schema-validation="true" schema="fooSchema" schema-repository="fooRepository">
                     <data>
                         <![CDATA[
-                      <TestMessage>Hello Citrus</TestMessage>
-                  ]]>
+                            <TestMessage>Hello Citrus</TestMessage>
+                        ]]>
                     </data>
                 </message>
             </ws:send>

--- a/endpoints/citrus-ws/src/test/resources/org/citrusframework/ws/config/xml/SendSoapMessageActionParserTest-context.xml
+++ b/endpoints/citrus-ws/src/test/resources/org/citrusframework/ws/config/xml/SendSoapMessageActionParserTest-context.xml
@@ -8,7 +8,7 @@
                                   http://www.citrusframework.org/schema/ws/testcase http://www.citrusframework.org/schema/ws/testcase/citrus-ws-testcase.xsd">
     <testcase name="SendSoapMessageActionParserTest">
         <actions>
-            <ws:send endpoint="mySoapClient">
+            <ws:send endpoint="mySoapClient" soap-action="myAction">
                 <message>
                     <data>
                         <![CDATA[

--- a/endpoints/citrus-ws/src/test/resources/org/citrusframework/ws/groovy/assert-soap-fault.test.groovy
+++ b/endpoints/citrus-ws/src/test/resources/org/citrusframework/ws/groovy/assert-soap-fault.test.groovy
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.ws.groovy
+
+
+import static org.citrusframework.ws.actions.SoapActionBuilder.soap
+
+name "AssertSoapFaultTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+actions {
+    $(soap()
+        .client("soapClient")
+        .assertFault()
+            .faultCode("{http://citrusframework.org/faults}FAULT-1001")
+            .when(
+                soap()
+                    .client("soapClient")
+                    .send()
+                    .message()
+                        .body("<TestMessage>Hello Citrus</TestMessage>")
+            )
+    )
+
+    $(soap()
+        .client("soapClient")
+        .assertFault()
+            .faultCode("{http://citrusframework.org/faults}FAULT-1002")
+            .faultString("FaultString")
+            .when(
+                soap()
+                    .client("soapClient")
+                    .send()
+                    .message()
+                        .body("<TestMessage>Hello Citrus</TestMessage>")
+            )
+    )
+
+    $(soap()
+        .client("soapClient")
+        .assertFault()
+            .faultCode("{http://citrusframework.org/faults}FAULT-1003")
+            .faultString("FaultString")
+            .faultActor("FaultActor")
+            .faultDetail('<ns0:FaultDetail xmlns:ns0="http://citrusframework.org/schemas/samples/HelloService.xsd"><ns0:DetailId>1000</ns0:DetailId></ns0:FaultDetail>')
+            .when(
+                soap()
+                    .client("soapClient")
+                    .send()
+                    .message()
+                        .body("<TestMessage>Hello Citrus</TestMessage>")
+            )
+    )
+
+    $(soap()
+        .client("soapClient")
+        .assertFault()
+            .validator("customSoapFaultValidator")
+            .faultCode("{http://citrusframework.org/faults}FAULT-1004")
+            .faultString("FaultString")
+            .faultDetailResource("classpath:org/citrusframework/ws/actions/test-fault-detail.xml")
+            .when(
+                soap()
+                    .client("soapClient")
+                    .send()
+                    .message()
+                        .body("<TestMessage>Hello Citrus</TestMessage>")
+            )
+    )
+
+
+}

--- a/endpoints/citrus-ws/src/test/resources/org/citrusframework/ws/groovy/send-soap-fault.test.groovy
+++ b/endpoints/citrus-ws/src/test/resources/org/citrusframework/ws/groovy/send-soap-fault.test.groovy
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.ws.groovy
+
+
+import static org.citrusframework.ws.actions.SoapActionBuilder.soap
+
+name "SendSoapFaultTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+actions {
+    $(soap()
+        .server("soapServer")
+        .receive()
+        .message()
+            .body("<TestMessage>Hello Citrus</TestMessage>")
+    )
+
+    $(soap()
+        .server("soapServer")
+        .sendFault()
+        .message()
+            .faultCode("{http://citrusframework.org/faults}citrus-ns:FAULT-1000")
+            .faultString("FaultString")
+            .faultDetail("""<ns0:FaultDetail xmlns:ns0="http://citrusframework.org/schemas/samples/HelloService.xsd">
+                            <ns0:DetailId>1000</ns0:DetailId>
+                        </ns0:FaultDetail>""")
+            .header("operation", "sendFault")
+    )
+
+    $(soap()
+        .server("soapServer")
+        .receive()
+        .message()
+            .body("<TestMessage>Hello Citrus</TestMessage>")
+    )
+
+    $(soap()
+        .server("soapServer")
+        .sendFault()
+        .message()
+            .faultCode("{http://citrusframework.org/faults}citrus-ns:FAULT-1001")
+            .faultString("FaultString")
+            .faultActor("FaultActor")
+            .faultDetailResource("classpath:org/citrusframework/ws/actions/test-fault-detail.xml")
+            .header("operation", "sendFault")
+    )
+}

--- a/endpoints/citrus-ws/src/test/resources/org/citrusframework/ws/groovy/soap-client.test.groovy
+++ b/endpoints/citrus-ws/src/test/resources/org/citrusframework/ws/groovy/soap-client.test.groovy
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.ws.groovy
+
+import org.citrusframework.util.FileUtils
+
+import java.nio.charset.StandardCharsets
+
+import static org.citrusframework.ws.actions.SoapActionBuilder.soap
+
+name "SoapClientTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+actions {
+    $(soap()
+        .client("soapClient")
+        .send()
+        .message()
+            .soapAction("myAction")
+            .body("<TestMessage>Hello Citrus</TestMessage>")
+            .attachment("MySoapAttachment", "text/plain", "This is an attachment!")
+    )
+
+    $(soap()
+        .client("soapClient")
+        .receive()
+        .message()
+            .body('<?xml version="1.0" encoding="UTF-8"?><TestResponse>Hello User</TestResponse>')
+            .attachment("MySoapAttachment", "text/plain", "This is an attachment!")
+    )
+
+    $(soap()
+        .client("soapClient")
+        .send()
+        .message()
+            .body("<TestMessage>Hello Citrus</TestMessage>")
+            .attachment("MySoapAttachment", "application/xml",
+                    FileUtils.getFileResource("classpath:org/citrusframework/ws/actions/test-attachment.xml"), StandardCharsets.UTF_8)
+    )
+
+    $(soap()
+        .client("soapClient")
+        .receive()
+        .message()
+            .attachmentValidatorName("mySoapAttachmentValidator")
+            .body('<?xml version="1.0" encoding="UTF-8"?><TestResponse>Hello User</TestResponse>')
+            .attachment("MySoapAttachment", "application/xml",
+                    FileUtils.getFileResource("classpath:org/citrusframework/ws/actions/test-attachment.xml"), StandardCharsets.UTF_8)
+    )
+
+    $(soap()
+        .client("soapClient")
+        .send()
+        .message()
+            .body("<TestMessage>Hello Citrus</TestMessage>")
+            .attachment("FirstSoapAttachment", "text/plain", "This is an attachment!")
+            .attachment("SecondSoapAttachment", "application/xml",
+                    FileUtils.getFileResource("classpath:org/citrusframework/ws/actions/test-attachment.xml"), StandardCharsets.UTF_8)
+    )
+
+    $(soap()
+        .client("soapClient")
+        .receive()
+        .message()
+            .body('<?xml version="1.0" encoding="UTF-8"?><TestResponse>Hello User</TestResponse>')
+            .attachment("FirstSoapAttachment", "text/plain", "This is an attachment!")
+            .attachment("SecondSoapAttachment", "application/xml",
+                    FileUtils.getFileResource("classpath:org/citrusframework/ws/actions/test-attachment.xml"), StandardCharsets.UTF_8)
+    )
+
+    $(soap()
+        .client("soapClient")
+        .send()
+        .message()
+            .body("<TestMessage>Hello Citrus</TestMessage>")
+            .mtomEnabled(true)
+    )
+
+    $(soap()
+        .client("soapClient")
+        .receive()
+        .message()
+            .body('<?xml version="1.0" encoding="UTF-8"?><TestResponse>Hello User</TestResponse>')
+    )
+}

--- a/endpoints/citrus-ws/src/test/resources/org/citrusframework/ws/groovy/soap-server.test.groovy
+++ b/endpoints/citrus-ws/src/test/resources/org/citrusframework/ws/groovy/soap-server.test.groovy
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.ws.groovy
+
+import org.citrusframework.util.FileUtils
+
+import java.nio.charset.StandardCharsets
+
+import static org.citrusframework.ws.actions.SoapActionBuilder.soap
+
+name "SoapServerTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+actions {
+    $(soap()
+        .server("soapServer")
+        .receive()
+        .message()
+            .soapAction("myAction")
+            .body("<TestMessage>Hello Citrus</TestMessage>")
+            .attachment("MySoapAttachment", "text/plain", "This is an attachment!")
+    )
+
+    $(soap()
+        .server("soapServer")
+        .send()
+        .message()
+            .body('<?xml version="1.0" encoding="UTF-8"?><TestResponse>Hello User</TestResponse>')
+            .attachment("MySoapAttachment", "text/plain", "This is an attachment!")
+    )
+
+    $(soap()
+        .server("soapServer")
+        .receive()
+        .message()
+            .attachmentValidatorName("mySoapAttachmentValidator")
+            .body("<TestMessage>Hello Citrus</TestMessage>")
+            .attachment("MySoapAttachment", "application/xml",
+                    FileUtils.getFileResource("classpath:org/citrusframework/ws/actions/test-attachment.xml"), StandardCharsets.UTF_8)
+    )
+
+    $(soap()
+        .server("soapServer")
+        .send()
+        .message()
+            .body('<?xml version="1.0" encoding="UTF-8"?><TestResponse>Hello User</TestResponse>')
+            .attachment("MySoapAttachment", "application/xml",
+                    FileUtils.getFileResource("classpath:org/citrusframework/ws/actions/test-attachment.xml"), StandardCharsets.UTF_8)
+    )
+
+    $(soap()
+        .server("soapServer")
+        .receive()
+        .message()
+            .body("<TestMessage>Hello Citrus</TestMessage>")
+            .attachment("FirstSoapAttachment", "text/plain", "This is an attachment!")
+            .attachment("SecondSoapAttachment", "application/xml",
+                    FileUtils.getFileResource("classpath:org/citrusframework/ws/actions/test-attachment.xml"), StandardCharsets.UTF_8)
+    )
+
+    $(soap()
+        .server("soapServer")
+        .send()
+        .message()
+            .body('<?xml version="1.0" encoding="UTF-8"?><TestResponse>Hello User</TestResponse>')
+            .attachment("FirstSoapAttachment", "text/plain", "This is an attachment!")
+            .attachment("SecondSoapAttachment", "application/xml",
+                    FileUtils.getFileResource("classpath:org/citrusframework/ws/actions/test-attachment.xml"), StandardCharsets.UTF_8)
+    )
+}

--- a/endpoints/citrus-ws/src/test/resources/org/citrusframework/ws/xml/assert-soap-fault-test.xml
+++ b/endpoints/citrus-ws/src/test/resources/org/citrusframework/ws/xml/assert-soap-fault-test.xml
@@ -1,0 +1,111 @@
+<!--
+  ~ Copyright 2021 the original author or authors.
+  ~
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements. See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License. You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<test name="AssertSoapFaultTest" author="Christoph" status="FINAL" xmlns="http://citrusframework.org/schema/xml/testcase"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://citrusframework.org/schema/xml/testcase http://citrusframework.org/schema/xml/testcase/citrus-testcase.xsd">
+  <actions>
+    <soap client="soapClient">
+      <assert-fault fault-code="{http://citrusframework.org/faults}FAULT-1001">
+        <when>
+          <soap client="soapClient">
+            <send-request>
+              <message>
+                <body>
+                  <data>
+                    <![CDATA[
+                        <TestMessage>Hello Citrus</TestMessage>
+                    ]]>
+                  </data>
+                </body>
+              </message>
+            </send-request>
+          </soap>
+        </when>
+      </assert-fault>
+    </soap>
+
+    <soap client="soapClient">
+      <assert-fault fault-code="{http://citrusframework.org/faults}FAULT-1002" fault-string="FaultString">
+        <when>
+          <soap client="soapClient">
+            <send-request>
+              <message>
+                <body>
+                  <data>
+                    <![CDATA[
+                        <TestMessage>Hello Citrus</TestMessage>
+                    ]]>
+                  </data>
+                </body>
+              </message>
+            </send-request>
+          </soap>
+        </when>
+      </assert-fault>
+    </soap>
+
+    <soap client="soapClient">
+      <assert-fault fault-code="{http://citrusframework.org/faults}FAULT-1003" fault-string="FaultString" fault-actor="FaultActor">
+        <fault-detail>
+          <content><![CDATA[<ns0:FaultDetail xmlns:ns0="http://citrusframework.org/schemas/samples/HelloService.xsd"><ns0:DetailId>1000</ns0:DetailId></ns0:FaultDetail>]]></content>
+        </fault-detail>
+        <when>
+          <soap client="soapClient">
+            <send-request>
+              <message>
+                <body>
+                  <data>
+                    <![CDATA[
+                        <TestMessage>Hello Citrus</TestMessage>
+                    ]]>
+                  </data>
+                </body>
+              </message>
+            </send-request>
+          </soap>
+        </when>
+      </assert-fault>
+    </soap>
+
+    <soap client="soapClient">
+      <assert-fault fault-code="{http://citrusframework.org/faults}FAULT-1004" fault-string="FaultString" validator="customSoapFaultValidator">
+        <fault-detail>
+          <resource file="classpath:org/citrusframework/ws/actions/test-fault-detail.xml"/>
+        </fault-detail>
+        <when>
+          <soap client="soapClient">
+            <send-request>
+              <message>
+                <body>
+                  <data>
+                    <![CDATA[
+                        <TestMessage>Hello Citrus</TestMessage>
+                    ]]>
+                  </data>
+                </body>
+              </message>
+            </send-request>
+          </soap>
+        </when>
+      </assert-fault>
+    </soap>
+
+  </actions>
+</test>

--- a/endpoints/citrus-ws/src/test/resources/org/citrusframework/ws/xml/send-soap-fault-test.xml
+++ b/endpoints/citrus-ws/src/test/resources/org/citrusframework/ws/xml/send-soap-fault-test.xml
@@ -1,0 +1,85 @@
+<!--
+  ~ Copyright 2021 the original author or authors.
+  ~
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements. See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License. You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<test name="SendSoapFaultTest" author="Christoph" status="FINAL" xmlns="http://citrusframework.org/schema/xml/testcase"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://citrusframework.org/schema/xml/testcase http://citrusframework.org/schema/xml/testcase/citrus-testcase.xsd">
+  <actions>
+    <soap server="soapServer">
+      <receive-request>
+        <message>
+          <body>
+            <data>
+              <![CDATA[
+                  <TestMessage>Hello Citrus</TestMessage>
+              ]]>
+            </data>
+          </body>
+        </message>
+      </receive-request>
+    </soap>
+
+    <soap server="soapServer">
+      <send-fault>
+        <message fault-code="{http://citrusframework.org/faults}citrus-ns:FAULT-1000" fault-string="FaultString">
+          <headers>
+            <header name="operation" value="sendFault"/>
+          </headers>
+          <fault-detail>
+            <content>
+              <![CDATA[
+              <ns0:FaultDetail xmlns:ns0="http://citrusframework.org/schemas/samples/HelloService.xsd">
+                  <ns0:DetailId>1000</ns0:DetailId>
+              </ns0:FaultDetail>
+              ]]>
+            </content>
+          </fault-detail>
+        </message>
+      </send-fault>
+    </soap>
+
+    <soap server="soapServer">
+      <receive-request>
+        <message>
+          <body>
+            <data>
+              <![CDATA[
+                  <TestMessage>Hello Citrus</TestMessage>
+              ]]>
+            </data>
+          </body>
+        </message>
+      </receive-request>
+    </soap>
+
+    <soap server="soapServer">
+      <send-fault>
+        <message fault-code="{http://citrusframework.org/faults}citrus-ns:FAULT-1001" fault-string="FaultString" fault-actor="FaultActor">
+          <headers>
+            <header name="operation" value="sendFault"/>
+          </headers>
+          <fault-detail>
+            <resource file="classpath:org/citrusframework/ws/actions/test-fault-detail.xml"/>
+          </fault-detail>
+        </message>
+      </send-fault>
+    </soap>
+
+  </actions>
+</test>

--- a/endpoints/citrus-ws/src/test/resources/org/citrusframework/ws/xml/soap-client-test.xml
+++ b/endpoints/citrus-ws/src/test/resources/org/citrusframework/ws/xml/soap-client-test.xml
@@ -1,0 +1,168 @@
+<!--
+  ~ Copyright 2021 the original author or authors.
+  ~
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements. See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License. You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<test name="SoapClientTest" author="Christoph" status="FINAL" xmlns="http://citrusframework.org/schema/xml/testcase"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://citrusframework.org/schema/xml/testcase http://citrusframework.org/schema/xml/testcase/citrus-testcase.xsd">
+  <actions>
+    <soap client="soapClient">
+      <send-request>
+        <message soap-action="myAction">
+          <body>
+            <data>
+              <![CDATA[
+                  <TestMessage>Hello Citrus</TestMessage>
+              ]]>
+            </data>
+          </body>
+          <attachment content-id="MySoapAttachment" content-type="text/plain">
+            <content>
+              <![CDATA[This is an attachment!]]>
+            </content>
+          </attachment>
+        </message>
+      </send-request>
+    </soap>
+
+    <soap client="soapClient">
+      <receive-response>
+        <message>
+          <body>
+            <data>
+              <![CDATA[
+                  <?xml version="1.0" encoding="UTF-8"?><TestResponse>Hello User</TestResponse>
+              ]]>
+            </data>
+          </body>
+          <attachment content-id="MySoapAttachment" content-type="text/plain">
+            <content>
+              <![CDATA[This is an attachment!]]>
+            </content>
+          </attachment>
+        </message>
+      </receive-response>
+    </soap>
+
+    <soap client="soapClient">
+      <send-request>
+        <message>
+          <body>
+            <data>
+              <![CDATA[
+                  <TestMessage>Hello Citrus</TestMessage>
+              ]]>
+            </data>
+          </body>
+          <attachment content-id="MySoapAttachment" content-type="application/xml" charset="UTF-8">
+            <resource file="classpath:org/citrusframework/ws/actions/test-attachment.xml"/>
+          </attachment>
+        </message>
+      </send-request>
+    </soap>
+
+    <soap client="soapClient">
+      <receive-response attachment-validator="mySoapAttachmentValidator">
+        <message>
+          <body>
+            <data>
+              <![CDATA[
+                  <?xml version="1.0" encoding="UTF-8"?><TestResponse>Hello User</TestResponse>
+              ]]>
+            </data>
+          </body>
+          <attachment content-id="MySoapAttachment" content-type="application/xml" charset="UTF-8">
+            <resource file="classpath:org/citrusframework/ws/actions/test-attachment.xml"/>
+          </attachment>
+        </message>
+      </receive-response>
+    </soap>
+
+    <soap client="soapClient">
+      <send-request>
+        <message>
+          <body>
+            <data>
+              <![CDATA[
+                  <TestMessage>Hello Citrus</TestMessage>
+              ]]>
+            </data>
+          </body>
+          <attachment content-id="FirstSoapAttachment" content-type="text/plain">
+            <content>
+              <![CDATA[This is an attachment!]]>
+            </content>
+          </attachment>
+          <attachment content-id="SecondSoapAttachment" content-type="application/xml" charset="UTF-8">
+            <resource file="classpath:org/citrusframework/ws/actions/test-attachment.xml"/>
+          </attachment>
+        </message>
+      </send-request>
+    </soap>
+
+    <soap client="soapClient">
+      <receive-response>
+        <message>
+          <body>
+            <data>
+              <![CDATA[
+                  <?xml version="1.0" encoding="UTF-8"?><TestResponse>Hello User</TestResponse>
+              ]]>
+            </data>
+          </body>
+          <attachment content-id="FirstSoapAttachment" content-type="text/plain">
+            <content>
+              <![CDATA[This is an attachment!]]>
+            </content>
+          </attachment>
+          <attachment content-id="SecondSoapAttachment" content-type="application/xml" charset="UTF-8">
+            <resource file="classpath:org/citrusframework/ws/actions/test-attachment.xml"/>
+          </attachment>
+        </message>
+      </receive-response>
+    </soap>
+
+    <soap client="soapClient">
+      <send-request>
+        <message mtom-enabled="true">
+          <body>
+            <data>
+              <![CDATA[
+                  <TestMessage>Hello Citrus</TestMessage>
+              ]]>
+            </data>
+          </body>
+        </message>
+      </send-request>
+    </soap>
+
+    <soap client="soapClient">
+      <receive-response>
+        <message>
+          <body>
+            <data>
+              <![CDATA[
+                  <?xml version="1.0" encoding="UTF-8"?><TestResponse>Hello User</TestResponse>
+              ]]>
+            </data>
+          </body>
+        </message>
+      </receive-response>
+    </soap>
+  </actions>
+</test>

--- a/endpoints/citrus-ws/src/test/resources/org/citrusframework/ws/xml/soap-server-test.xml
+++ b/endpoints/citrus-ws/src/test/resources/org/citrusframework/ws/xml/soap-server-test.xml
@@ -1,0 +1,140 @@
+<!--
+  ~ Copyright 2021 the original author or authors.
+  ~
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements. See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License. You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<test name="SoapServerTest" author="Christoph" status="FINAL" xmlns="http://citrusframework.org/schema/xml/testcase"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://citrusframework.org/schema/xml/testcase http://citrusframework.org/schema/xml/testcase/citrus-testcase.xsd">
+  <actions>
+    <soap server="soapServer">
+      <receive-request>
+        <message soap-action="myAction">
+          <body>
+            <data>
+              <![CDATA[
+                  <TestMessage>Hello Citrus</TestMessage>
+              ]]>
+            </data>
+          </body>
+          <attachment content-id="MySoapAttachment" content-type="text/plain">
+            <content>
+              <![CDATA[This is an attachment!]]>
+            </content>
+          </attachment>
+        </message>
+      </receive-request>
+    </soap>
+
+    <soap server="soapServer">
+      <send-response>
+        <message>
+          <body>
+            <data>
+              <![CDATA[
+                  <TestResponse>Hello User</TestResponse>
+              ]]>
+            </data>
+          </body>
+          <attachment content-id="MySoapAttachment" content-type="text/plain">
+            <content>
+              <![CDATA[This is an attachment!]]>
+            </content>
+          </attachment>
+        </message>
+      </send-response>
+    </soap>
+
+    <soap server="soapServer">
+      <receive-request attachment-validator="mySoapAttachmentValidator">
+        <message>
+          <body>
+            <data>
+              <![CDATA[
+                  <TestMessage>Hello Citrus</TestMessage>
+              ]]>
+            </data>
+          </body>
+          <attachment content-id="MySoapAttachment" content-type="application/xml" charset="UTF-8">
+            <resource file="classpath:org/citrusframework/ws/actions/test-attachment.xml"/>
+          </attachment>
+        </message>
+      </receive-request>
+    </soap>
+
+    <soap server="soapServer">
+      <send-response>
+        <message>
+          <body>
+            <data>
+              <![CDATA[
+                  <TestResponse>Hello User</TestResponse>
+              ]]>
+            </data>
+          </body>
+          <attachment content-id="MySoapAttachment" content-type="application/xml" charset="UTF-8">
+            <resource file="classpath:org/citrusframework/ws/actions/test-attachment.xml"/>
+          </attachment>
+        </message>
+      </send-response>
+    </soap>
+
+    <soap server="soapServer">
+      <receive-request>
+        <message>
+          <body>
+            <data>
+              <![CDATA[
+                  <TestMessage>Hello Citrus</TestMessage>
+              ]]>
+            </data>
+          </body>
+          <attachment content-id="FirstSoapAttachment" content-type="text/plain">
+            <content>
+              <![CDATA[This is an attachment!]]>
+            </content>
+          </attachment>
+          <attachment content-id="SecondSoapAttachment" content-type="application/xml" charset="UTF-8">
+            <resource file="classpath:org/citrusframework/ws/actions/test-attachment.xml"/>
+          </attachment>
+        </message>
+      </receive-request>
+    </soap>
+
+    <soap server="soapServer">
+      <send-response>
+        <message>
+          <body>
+            <data>
+              <![CDATA[
+                  <TestResponse>Hello User</TestResponse>
+              ]]>
+            </data>
+          </body>
+          <attachment content-id="FirstSoapAttachment" content-type="text/plain">
+            <content>
+              <![CDATA[This is an attachment!]]>
+            </content>
+          </attachment>
+          <attachment content-id="SecondSoapAttachment" content-type="application/xml" charset="UTF-8">
+            <resource file="classpath:org/citrusframework/ws/actions/test-attachment.xml"/>
+          </attachment>
+        </message>
+      </send-response>
+    </soap>
+  </actions>
+</test>

--- a/endpoints/citrus-ws/src/test/resources/org/citrusframework/ws/yaml/assert-soap-fault-test.yaml
+++ b/endpoints/citrus-ws/src/test/resources/org/citrusframework/ws/yaml/assert-soap-fault-test.yaml
@@ -1,0 +1,60 @@
+name: "AssertSoapFaultTest"
+author: "Christoph"
+status: "FINAL"
+actions:
+  - soap:
+      client: "soapClient"
+      assertFault:
+        faultCode: "{http://citrusframework.org/faults}FAULT-1001"
+        when:
+          - soap:
+              client: "soapClient"
+              sendRequest:
+                message:
+                  body:
+                    data: <TestMessage>Hello Citrus</TestMessage>
+
+  - soap:
+      client: "soapClient"
+      assertFault:
+        faultCode: "{http://citrusframework.org/faults}FAULT-1002"
+        faultString: "FaultString"
+        when:
+          - soap:
+              client: "soapClient"
+              sendRequest:
+                message:
+                  body:
+                    data: <TestMessage>Hello Citrus</TestMessage>
+
+  - soap:
+      client: "soapClient"
+      assertFault:
+        faultCode: "{http://citrusframework.org/faults}FAULT-1003"
+        faultString: "FaultString"
+        faultActor: "FaultActor"
+        faultDetails:
+          - content: <ns0:FaultDetail xmlns:ns0="http://citrusframework.org/schemas/samples/HelloService.xsd"><ns0:DetailId>1000</ns0:DetailId></ns0:FaultDetail>
+        when:
+          - soap:
+              client: "soapClient"
+              sendRequest:
+                message:
+                  body:
+                    data: <TestMessage>Hello Citrus</TestMessage>
+
+  - soap:
+      client: "soapClient"
+      assertFault:
+        validator: customSoapFaultValidator
+        faultCode: "{http://citrusframework.org/faults}FAULT-1004"
+        faultString: "FaultString"
+        faultDetails:
+          - resource: "classpath:org/citrusframework/ws/actions/test-fault-detail.xml"
+        when:
+          - soap:
+              client: "soapClient"
+              sendRequest:
+                message:
+                  body:
+                    data: <TestMessage>Hello Citrus</TestMessage>

--- a/endpoints/citrus-ws/src/test/resources/org/citrusframework/ws/yaml/send-soap-fault-test.yaml
+++ b/endpoints/citrus-ws/src/test/resources/org/citrusframework/ws/yaml/send-soap-fault-test.yaml
@@ -1,0 +1,43 @@
+name: "SendSoapFaultTest"
+author: "Christoph"
+status: "FINAL"
+actions:
+  - soap:
+      server: "soapServer"
+      receiveRequest:
+        message:
+          body:
+            data: <TestMessage>Hello Citrus</TestMessage>
+  - soap:
+      server: "soapServer"
+      sendFault:
+        message:
+          faultCode: "{http://citrusframework.org/faults}citrus-ns:FAULT-1000"
+          faultString: "FaultString"
+          faultDetails:
+            - content: |
+                <ns0:FaultDetail xmlns:ns0="http://citrusframework.org/schemas/samples/HelloService.xsd">
+                    <ns0:DetailId>1000</ns0:DetailId>
+                </ns0:FaultDetail>
+          headers:
+            - name: operation
+              value: sendFault
+
+  - soap:
+      server: "soapServer"
+      receiveRequest:
+        message:
+          body:
+            data: <TestMessage>Hello Citrus</TestMessage>
+  - soap:
+      server: "soapServer"
+      sendFault:
+        message:
+          faultCode: "{http://citrusframework.org/faults}citrus-ns:FAULT-1001"
+          faultString: "FaultString"
+          faultActor: "FaultActor"
+          faultDetails:
+            - resource: "classpath:org/citrusframework/ws/actions/test-fault-detail.xml"
+          headers:
+            - name: operation
+              value: sendFault

--- a/endpoints/citrus-ws/src/test/resources/org/citrusframework/ws/yaml/soap-client-test.yaml
+++ b/endpoints/citrus-ws/src/test/resources/org/citrusframework/ws/yaml/soap-client-test.yaml
@@ -1,0 +1,97 @@
+name: "SoapClientTest"
+author: "Christoph"
+status: "FINAL"
+actions:
+  - soap:
+      client: "soapClient"
+      sendRequest:
+        message:
+          soapAction: "myAction"
+          body:
+            data: <TestMessage>Hello Citrus</TestMessage>
+          attachments:
+            - contentId: "MySoapAttachment"
+              contentType: "text/plain"
+              content: |
+                This is an attachment!
+  - soap:
+      client: "soapClient"
+      receiveResponse:
+        message:
+          body:
+            data: '<?xml version="1.0" encoding="UTF-8"?><TestResponse>Hello User</TestResponse>'
+          attachments:
+            - contentId: "MySoapAttachment"
+              contentType: "text/plain"
+              content: |
+                This is an attachment!
+
+  - soap:
+      client: "soapClient"
+      sendRequest:
+        message:
+          body:
+            data: <TestMessage>Hello Citrus</TestMessage>
+          attachments:
+            - contentId: "MySoapAttachment"
+              contentType: "application/xml"
+              charset: "UTF-8"
+              resource: "classpath:org/citrusframework/ws/actions/test-attachment.xml"
+  - soap:
+      client: "soapClient"
+      receiveResponse:
+        attachmentValidator: "mySoapAttachmentValidator"
+        message:
+          body:
+            data: '<?xml version="1.0" encoding="UTF-8"?><TestResponse>Hello User</TestResponse>'
+          attachments:
+            - contentId: "MySoapAttachment"
+              contentType: "application/xml"
+              charset: "UTF-8"
+              resource: "classpath:org/citrusframework/ws/actions/test-attachment.xml"
+
+  - soap:
+      client: "soapClient"
+      sendRequest:
+        message:
+          body:
+            data: <TestMessage>Hello Citrus</TestMessage>
+          attachments:
+            - contentId: "FirstSoapAttachment"
+              contentType: "text/plain"
+              content: |
+                This is an attachment!
+            - contentId: "SecondSoapAttachment"
+              contentType: "application/xml"
+              charset: "UTF-8"
+              resource: "classpath:org/citrusframework/ws/actions/test-attachment.xml"
+  - soap:
+      client: "soapClient"
+      receiveResponse:
+        message:
+          body:
+            data: '<?xml version="1.0" encoding="UTF-8"?><TestResponse>Hello User</TestResponse>'
+          attachments:
+            - contentId: "FirstSoapAttachment"
+              contentType: "text/plain"
+              content: |
+                This is an attachment!
+            - contentId: "SecondSoapAttachment"
+              contentType: "application/xml"
+              charset: "UTF-8"
+              resource: "classpath:org/citrusframework/ws/actions/test-attachment.xml"
+
+  - soap:
+      client: "soapClient"
+      sendRequest:
+        message:
+          body:
+            data: <TestMessage>Hello Citrus</TestMessage>
+          mtomEnabled: true
+
+  - soap:
+      client: "soapClient"
+      receiveResponse:
+        message:
+          body:
+            data: '<?xml version="1.0" encoding="UTF-8"?><TestResponse>Hello User</TestResponse>'

--- a/endpoints/citrus-ws/src/test/resources/org/citrusframework/ws/yaml/soap-server-test.yaml
+++ b/endpoints/citrus-ws/src/test/resources/org/citrusframework/ws/yaml/soap-server-test.yaml
@@ -1,0 +1,82 @@
+name: "SoapServerTest"
+author: "Christoph"
+status: "FINAL"
+actions:
+  - soap:
+      server: "soapServer"
+      receiveRequest:
+        message:
+          soapAction: "myAction"
+          body:
+            data: <TestMessage>Hello Citrus</TestMessage>
+          attachments:
+            - contentId: "MySoapAttachment"
+              contentType: "text/plain"
+              content: |
+                This is an attachment!
+  - soap:
+      server: "soapServer"
+      sendResponse:
+        message:
+          body:
+            data: <TestResponse>Hello User</TestResponse>
+          attachments:
+            - contentId: "MySoapAttachment"
+              contentType: "text/plain"
+              content: |
+                This is an attachment!
+
+  - soap:
+      server: "soapServer"
+      receiveRequest:
+        attachmentValidator: "mySoapAttachmentValidator"
+        message:
+          body:
+            data: <TestMessage>Hello Citrus</TestMessage>
+          attachments:
+            - contentId: "MySoapAttachment"
+              contentType: "application/xml"
+              charset: "UTF-8"
+              resource: "classpath:org/citrusframework/ws/actions/test-attachment.xml"
+  - soap:
+      server: "soapServer"
+      sendResponse:
+        message:
+          body:
+            data: <TestResponse>Hello User</TestResponse>
+          attachments:
+            - contentId: "MySoapAttachment"
+              contentType: "application/xml"
+              charset: "UTF-8"
+              resource: "classpath:org/citrusframework/ws/actions/test-attachment.xml"
+
+  - soap:
+      server: "soapServer"
+      receiveRequest:
+        message:
+          body:
+            data: <TestMessage>Hello Citrus</TestMessage>
+          attachments:
+            - contentId: "FirstSoapAttachment"
+              contentType: "text/plain"
+              content: |
+                This is an attachment!
+            - contentId: "SecondSoapAttachment"
+              contentType: "application/xml"
+              charset: "UTF-8"
+              resource: "classpath:org/citrusframework/ws/actions/test-attachment.xml"
+  - soap:
+      server: "soapServer"
+      sendResponse:
+        message:
+          body:
+            data: <TestResponse>Hello User</TestResponse>
+          attachments:
+            - contentId: "FirstSoapAttachment"
+              contentType: "text/plain"
+              content: |
+                This is an attachment!
+            - contentId: "SecondSoapAttachment"
+              contentType: "application/xml"
+              charset: "UTF-8"
+              resource: "classpath:org/citrusframework/ws/actions/test-attachment.xml"

--- a/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/GroovyTemplateLoader.java
+++ b/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/GroovyTemplateLoader.java
@@ -1,0 +1,51 @@
+package org.citrusframework.groovy;
+
+import java.io.IOException;
+
+import org.citrusframework.container.Template;
+import org.citrusframework.container.TemplateLoader;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.groovy.dsl.GroovyShellUtils;
+import org.citrusframework.groovy.dsl.actions.ActionsScript;
+import org.citrusframework.groovy.dsl.actions.TemplateConfiguration;
+import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.spi.ReferenceResolverAware;
+import org.citrusframework.util.FileUtils;
+import org.codehaus.groovy.control.customizers.ImportCustomizer;
+import org.springframework.core.io.Resource;
+
+public class GroovyTemplateLoader implements TemplateLoader, ReferenceResolverAware {
+
+    private ReferenceResolver referenceResolver;
+
+    @Override
+    public Template load(String filePath) {
+        try {
+            Resource script = FileUtils.getFileResource(filePath);
+            ImportCustomizer ic = new ImportCustomizer();
+            Template.Builder builder = new Template.Builder();
+            builder.setReferenceResolver(referenceResolver);
+            GroovyShellUtils.run(ic, new TemplateConfiguration(builder),
+                    ActionsScript.normalize(FileUtils.readToString(script)), null, null);
+
+            return new Template(builder);
+        } catch (IOException e) {
+            throw new CitrusRuntimeException("Failed to load XML template for source '" + filePath + "'", e);
+        }
+    }
+
+    @Override
+    public void setReferenceResolver(ReferenceResolver referenceResolver) {
+        this.referenceResolver = referenceResolver;
+    }
+
+    /**
+     * Adds reference resolver in builder pattern style.
+     * @param referenceResolver
+     * @return
+     */
+    public GroovyTemplateLoader withReferenceResolver(ReferenceResolver referenceResolver) {
+        setReferenceResolver(referenceResolver);
+        return this;
+    }
+}

--- a/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/GroovyTestLoader.java
+++ b/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/GroovyTestLoader.java
@@ -49,11 +49,14 @@ public class GroovyTestLoader extends DefaultTestLoader implements TestSourceAwa
                 basePath = FileUtils.getBasePath(((ClassPathResource) scriptSource).getPath());
             }
 
+            String source = FileUtils.readToString(scriptSource);
+            GroovyShellUtils.autoAddImports(source, ic);
+
             testCase = runner.getTestCase();
             configurer.forEach(it -> it.accept(testCase));
             runner.start();
 
-            GroovyShellUtils.run(ic, new TestCaseScript(citrus, runner, context, basePath), FileUtils.readToString(scriptSource), citrus, context);
+            GroovyShellUtils.run(ic, new TestCaseScript(citrus, runner, context, basePath), source, citrus, context);
 
             handler.forEach(it -> it.accept(testCase));
         } catch (IOException e) {

--- a/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/GroovyShellUtils.java
+++ b/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/GroovyShellUtils.java
@@ -23,6 +23,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.citrusframework.Citrus;
+import org.citrusframework.TestActionBuilder;
 import org.citrusframework.context.TestContext;
 import groovy.lang.Binding;
 import groovy.lang.GroovyShell;
@@ -109,5 +110,21 @@ public class GroovyShellUtils {
         } else {
             return script.trim();
         }
+    }
+
+    /**
+     * Automatically adds static imports for TestAction builders used in given script.
+     * @param source the script source code.
+     * @param ic the import customizer.
+     */
+    public static void autoAddImports(String source, ImportCustomizer ic) {
+        TestActionBuilder.lookup()
+                .entrySet()
+                .stream()
+                .filter(entry -> !entry.getKey().equals("send") && !entry.getKey().equals("receive") )
+                .filter(entry -> !source.contains("import static " + String.format("%s.%s", entry.getValue().getClass().getCanonicalName(), entry.getKey())))
+                .filter(entry -> source.contains(String.format("$(%s(", entry.getKey())) || source.contains(String.format("%s()", entry.getKey())))
+                .peek(entry -> System.out.println(entry.getKey()))
+                .forEach(entry -> ic.addStaticImport(entry.getValue().getClass().getCanonicalName(), entry.getKey()));
     }
 }

--- a/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/actions/Action.java
+++ b/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/actions/Action.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl.actions;
+
+import org.citrusframework.TestAction;
+import org.citrusframework.TestActionBuilder;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.spi.ReferenceResolverAware;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class Action implements TestActionBuilder<TestAction>, ReferenceResolverAware {
+
+    private String reference;
+    private ReferenceResolver referenceResolver;
+
+    public static Action action() {
+        return new Action();
+    }
+
+    public Action reference(String reference) {
+        this.reference = reference;
+        return this;
+    }
+
+    public Action ref(String reference) {
+        this.reference = reference;
+        return this;
+    }
+
+    @Override
+    public TestAction build() {
+        if (referenceResolver != null) {
+            if (referenceResolver.isResolvable(reference, TestActionBuilder.class)) {
+                return referenceResolver.resolve(reference, TestActionBuilder.class).build();
+            }
+
+            if (referenceResolver.isResolvable(reference, TestAction.class)) {
+                return referenceResolver.resolve(reference, TestAction.class);
+            }
+        }
+
+        throw new CitrusRuntimeException(String.format("Unable to resolve test action with reference '%s'", reference));
+    }
+
+    @Override
+    public void setReferenceResolver(ReferenceResolver referenceResolver) {
+        this.referenceResolver = referenceResolver;
+    }
+}

--- a/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/actions/ActionsBuilder.java
+++ b/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/actions/ActionsBuilder.java
@@ -174,7 +174,7 @@ public interface ActionsBuilder {
      * @return test action builder instance.
      */
     private TestActionBuilder<?> findTestActionBuilder(String id, Object[] args) {
-        TestActionBuilder<?> builder = TestActionBuilder.lookup(id).orElseThrow(() -> new MissingMethodException(id, TestCaseScript.class, args));
+        TestActionBuilder<?> builder = TestActionBuilder.lookup(id).orElseThrow(() -> new MissingMethodException(id, this.getClass(), args));
 
         if (args == null || args.length == 0) {
             return builder;

--- a/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/actions/ActionsBuilder.java
+++ b/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/actions/ActionsBuilder.java
@@ -19,24 +19,15 @@
 
 package org.citrusframework.groovy.dsl.actions;
 
-import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
-import java.util.Optional;
 
 import groovy.lang.Closure;
-import groovy.lang.GroovyObjectSupport;
 import groovy.lang.GroovyRuntimeException;
 import groovy.lang.MissingMethodException;
 import org.citrusframework.TestAction;
 import org.citrusframework.TestActionBuilder;
-import org.citrusframework.actions.CreateVariablesAction;
-import org.citrusframework.actions.EchoAction;
-import org.citrusframework.actions.ReceiveMessageAction;
-import org.citrusframework.actions.SendMessageAction;
-import org.citrusframework.actions.SleepAction;
-import org.citrusframework.container.Wait;
 import org.citrusframework.groovy.dsl.test.TestCaseScript;
 import org.springframework.util.ReflectionUtils;
 
@@ -89,66 +80,19 @@ public interface ActionsBuilder {
     }
 
     /**
-     * Workaround method selection errors because Object classes do also use sleep method
-     * signatures and Groovy may not know which one of them to invoke.
-     * @return
-     */
-    default GroovyTestActionWrapper<SleepAction> delay() {
-        return new GroovyTestActionWrapper<>(this, new SleepAction.Builder());
-    }
-
-    /**
-     * Workaround method selection errors because Object classes do also use wait method
-     * signatures and Groovy may not know which one of them to invoke.
-     * @return
-     */
-    default GroovyTestActionWrapper<Wait> waitFor() {
-        return new GroovyTestActionWrapper<>(this, new Wait.Builder());
-    }
-
-    /**
-     * Alias for create variables action.
-     * @return
-     */
-    default GroovyTestActionWrapper<CreateVariablesAction> createVariable(String name, String value) {
-        CreateVariablesAction.Builder builder = new CreateVariablesAction.Builder();
-        builder.variable(name, value);
-        return new GroovyTestActionWrapper<>(this, builder);
-    }
-
-    /**
      * Special send message action wrapper adding Groovy closure support when specifying the message to send.
      * @return
      */
-    default GroovyTestActionWrapper<SendMessageAction> send() {
-        return new GroovyTestActionWrapper<>(this, new SendActionBuilderWrapper());
+    default SendActionBuilderWrapper send() {
+        return new SendActionBuilderWrapper();
     }
 
     /**
      * Special receive message action wrapper adding Groovy closure support when specifying the message to receive.
      * @return
      */
-    default GroovyTestActionWrapper<ReceiveMessageAction> receive() {
-        return new GroovyTestActionWrapper<>(this, new ReceiveActionBuilderWrapper());
-    }
-
-    /**
-     * Workaround method selection errors because Groovy also defines print method
-     * signatures and Groovy may not know which one of them to invoke.
-     * @param text
-     * @return
-     */
-    default GroovyTestActionWrapper<EchoAction> log(String text) {
-        return new GroovyTestActionWrapper<>(this, new EchoAction.Builder().message(text));
-    }
-
-    /**
-     * Workaround method selection errors because Groovy also defines print method
-     * signatures and Groovy may not know which one of them to invoke.
-     * @return
-     */
-    default GroovyTestActionWrapper<EchoAction> log() {
-        return new GroovyTestActionWrapper<>(this, new EchoAction.Builder());
+    default ReceiveActionBuilderWrapper receive() {
+        return new ReceiveActionBuilderWrapper();
     }
 
     default Object methodMissing(String name, Object argLine) {
@@ -162,7 +106,7 @@ public interface ActionsBuilder {
             throw new MissingMethodException(name, TestCaseScript.class, args);
         }
 
-        return new GroovyTestActionWrapper<>(this, actionBuilder);
+        return actionBuilder;
     }
 
     /**
@@ -202,145 +146,6 @@ public interface ActionsBuilder {
             return (TestActionBuilder<?>) initializer.invoke(null, args);
         } catch (IllegalAccessException | InvocationTargetException e) {
             throw new GroovyRuntimeException("Failed to get action builder", e);
-        }
-    }
-
-    class GroovyTestActionWrapper<T extends TestAction> extends GroovyObjectSupport implements TestActionBuilder<T> {
-        private final ActionsBuilder builder;
-        private TestActionBuilder<T> delegate;
-
-        public GroovyTestActionWrapper(ActionsBuilder builder, TestActionBuilder<T> delegate) {
-            this.builder = builder;
-            this.delegate = delegate;
-        }
-
-        /**
-         * Helper method overloading the -- operator to finish the action building. Allows to use the operator as bulletin point style
-         * list of actions.
-         * @return
-         */
-        public Object negative() {
-            return builder.$(delegate);
-        }
-
-        public Object methodMissing(String name, Object argLine) {
-            Object[] args = Optional.ofNullable(argLine).map(Object[].class::cast).orElse(new Object[]{});
-
-            try {
-                Method m;
-                if (args.length > 0) {
-                    Class<?>[] paramTypes = Arrays.stream(args).map(Object::getClass).toArray(Class[]::new);
-                    m = findMethodWithArguments(name, delegate.getClass(), paramTypes);
-                } else {
-                    m = ReflectionUtils.findMethod(delegate.getClass(), name);
-                }
-
-                if (m != null) {
-                    Object result = m.invoke(delegate, normalizeMethodArgs(m, args));
-
-                    if (result instanceof TestActionBuilder) {
-                        delegate = (TestActionBuilder<T>) result;
-                    } else if (result instanceof SendActionBuilderWrapper.SendMessageActionBuilderSupport.GroovyMessageBuilderSupport) {
-                        return result;
-                    } else if (result instanceof ReceiveActionBuilderWrapper.ReceiveMessageActionBuilderSupport.GroovyMessageBuilderSupport) {
-                        return result;
-                    }
-
-                    return this;
-                }
-            } catch (IllegalAccessException | InvocationTargetException e) {
-                throw new MissingMethodException(name, delegate.getClass(), args);
-            }
-
-            throw new MissingMethodException(name, delegate.getClass(), args);
-        }
-
-        /**
-         * Normalize arguments for given method. Converts arguments to array if applicable.
-         * @param method
-         * @param args
-         * @return
-         */
-        private static Object[] normalizeMethodArgs(Method method, Object[] args) {
-            if (args.length == 0) {
-                return args;
-            }
-
-            if (Arrays.stream(args).allMatch(p -> p.getClass().equals(args[0].getClass()))) {
-                if (method.getParameterTypes().length == 1 && method.getParameterTypes()[0].isArray()) {
-                    Object array = Array.newInstance(args[0].getClass(), args.length);
-                    for (int i = 0; i < args.length; i++) {
-                        Array.set(array, i, args[i]);
-                    }
-                    return new Object[] { array };
-                }
-            }
-
-            return args;
-        }
-
-        /**
-         * Try to find proper method with given argument types. Supports varArgs methods and Array arguments.
-         * @param name
-         * @param type
-         * @param paramTypes
-         * @return
-         */
-        private static Method findMethodWithArguments(String name, Class<?> type, Class<?>[] paramTypes) {
-            Method m = ReflectionUtils.findMethod(type, name, paramTypes);
-            if (m != null) {
-                return m;
-            }
-
-            Optional<Method> method = Arrays.stream(ReflectionUtils.getAllDeclaredMethods(type))
-                    .filter(candidate -> candidate.getName().equals(name))
-                    .filter(candidate -> candidate.getParameterTypes().length == paramTypes.length)
-                    .filter(candidate -> {
-                        boolean fullParamMatch = true;
-                        for (int i = 0; i < candidate.getParameterTypes().length && fullParamMatch; i++) {
-                            fullParamMatch = candidate.getParameterTypes()[i].isAssignableFrom(paramTypes[i]) ||
-                                    (candidate.getParameterTypes()[i].isPrimitive() && candidate.getParameterTypes()[i].getSimpleName().equalsIgnoreCase(paramTypes[i].getSimpleName()));
-                        }
-                        return fullParamMatch;
-                    })
-                    .findFirst();
-
-            if (method.isPresent()) {
-                return method.get();
-            }
-
-            if (Arrays.stream(paramTypes).allMatch(p -> p.equals(paramTypes[0]))) {
-                method = Arrays.stream(ReflectionUtils.getAllDeclaredMethods(type))
-                            .filter(candidate -> candidate.getName().equals(name))
-                            .filter(Method::isVarArgs)
-                            .filter(candidate -> candidate.getParameterTypes().length == 1 &&
-                                    candidate.getParameterTypes()[0].getComponentType().isAssignableFrom(paramTypes[0]))
-                            .findFirst();
-
-                if (method.isPresent()) {
-                    return method.get();
-                }
-
-                method = Arrays.stream(ReflectionUtils.getAllDeclaredMethods(type))
-                        .filter(candidate -> candidate.getName().equals(name))
-                        .filter(candidate -> candidate.getParameterTypes().length == 1 &&
-                                candidate.getParameterTypes()[0].isArray() &&
-                                candidate.getParameterTypes()[0].getComponentType().isAssignableFrom(paramTypes[0]))
-                        .findFirst();
-
-
-
-                if (method.isPresent()) {
-                    return method.get();
-                }
-            }
-
-            return null;
-        }
-
-        @Override
-        public T build() {
-            return delegate.build();
         }
     }
 }

--- a/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/actions/ActionsScript.java
+++ b/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/actions/ActionsScript.java
@@ -57,6 +57,11 @@ public class ActionsScript {
     }
 
     public static boolean isActionScript(String script) {
+        if ((script.startsWith("package ") || script.startsWith("import "))
+                && (script.contains("actions {") || script.contains("actions{"))) {
+            return true;
+        }
+
         return script.startsWith("actions {") || script.startsWith("actions{") ||
                 script.startsWith("$actions {") || script.startsWith("$actions{") ||
                 script.startsWith("$finally {") || script.startsWith("$finally{") ||

--- a/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/actions/ActionsScript.java
+++ b/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/actions/ActionsScript.java
@@ -42,7 +42,7 @@ public class ActionsScript {
         GroovyShellUtils.run(ic, new ActionsConfiguration(runner, context), normalize(script), citrus, context);
     }
 
-    private String normalize(String script) {
+    public static String normalize(String script) {
         String normalized = GroovyShellUtils.removeComments(script);
 
         if (isActionScript(normalized)) {

--- a/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/actions/ActionsScript.java
+++ b/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/actions/ActionsScript.java
@@ -39,6 +39,8 @@ public class ActionsScript {
 
     public void execute(TestActionRunner runner, TestContext context) {
         ImportCustomizer ic = new ImportCustomizer();
+        GroovyShellUtils.autoAddImports(script, ic);
+
         GroovyShellUtils.run(ic, new ActionsConfiguration(runner, context), normalize(script), citrus, context);
     }
 

--- a/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/actions/FinallyActionsBuilder.java
+++ b/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/actions/FinallyActionsBuilder.java
@@ -21,13 +21,10 @@ package org.citrusframework.groovy.dsl.actions;
 
 import java.util.function.Supplier;
 
+import groovy.lang.GroovyObjectSupport;
 import org.citrusframework.TestAction;
 import org.citrusframework.TestActionBuilder;
-import org.citrusframework.actions.CreateVariablesAction;
-import org.citrusframework.actions.SleepAction;
 import org.citrusframework.container.FinallySequence;
-import org.citrusframework.container.Wait;
-import groovy.lang.GroovyObjectSupport;
 
 /**
  * @author Christoph Deppisch
@@ -35,27 +32,6 @@ import groovy.lang.GroovyObjectSupport;
 public class FinallyActionsBuilder extends GroovyObjectSupport implements ActionsBuilder, Supplier<FinallySequence.Builder> {
 
     private final FinallySequence.Builder builder = new FinallySequence.Builder();
-
-    @Override
-    public GroovyTestActionWrapper<Wait> waitFor() {
-        GroovyTestActionWrapper<Wait> waitFor = ActionsBuilder.super.waitFor();
-        builder.actions(waitFor);
-        return waitFor;
-    }
-
-    @Override
-    public GroovyTestActionWrapper<SleepAction> delay() {
-        GroovyTestActionWrapper<SleepAction> delay = ActionsBuilder.super.delay();
-        builder.actions(delay);
-        return delay;
-    }
-
-    @Override
-    public GroovyTestActionWrapper<CreateVariablesAction> createVariable(String name, String value) {
-        GroovyTestActionWrapper<CreateVariablesAction> createVariable = ActionsBuilder.super.createVariable(name, value);
-        builder.actions(createVariable);
-        return createVariable;
-    }
 
     @Override
     public <T extends TestAction> T $(TestActionBuilder<T> nested) {

--- a/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/actions/ReceiveActionBuilderWrapper.java
+++ b/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/actions/ReceiveActionBuilderWrapper.java
@@ -19,6 +19,7 @@
 
 package org.citrusframework.groovy.dsl.actions;
 
+import groovy.lang.Closure;
 import org.citrusframework.actions.ReceiveMessageAction;
 import org.citrusframework.groovy.dsl.actions.model.BodySpec;
 import org.citrusframework.groovy.dsl.actions.model.HeaderSpec;
@@ -26,7 +27,7 @@ import org.citrusframework.groovy.dsl.actions.model.JsonBodySpec;
 import org.citrusframework.groovy.dsl.actions.model.XmlBodySpec;
 import org.citrusframework.message.builder.DefaultPayloadBuilder;
 import org.citrusframework.message.builder.ReceiveMessageBuilderSupport;
-import groovy.lang.Closure;
+import org.citrusframework.util.FileUtils;
 
 /**
  * @author Christoph Deppisch
@@ -68,6 +69,11 @@ public class ReceiveActionBuilderWrapper extends ReceiveMessageAction.ReceiveMes
             return this.body(new DefaultPayloadBuilder(bodySpec.get(code.call())));
         }
 
+        @Override
+        public ReceiveMessageActionBuilderSupport body(String payload) {
+            return super.body(payload.trim());
+        }
+
         public GroovyMessageBuilderSupport body() {
             return new GroovyMessageBuilderSupport();
         }
@@ -82,6 +88,10 @@ public class ReceiveActionBuilderWrapper extends ReceiveMessageAction.ReceiveMes
         }
 
         public class GroovyMessageBuilderSupport {
+
+            public ReceiveMessageActionBuilderSupport resource(String filePath) {
+                return ReceiveMessageActionBuilderSupport.this.body(FileUtils.getFileResource(filePath));
+            }
 
             public ReceiveMessageActionBuilderSupport json(Closure<?> callable) {
                 JsonBodySpec bodySpec = new JsonBodySpec();

--- a/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/actions/SendActionBuilderWrapper.java
+++ b/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/actions/SendActionBuilderWrapper.java
@@ -22,9 +22,12 @@ package org.citrusframework.groovy.dsl.actions;
 import org.citrusframework.actions.SendMessageAction;
 import org.citrusframework.groovy.dsl.actions.model.BodySpec;
 import org.citrusframework.groovy.dsl.actions.model.HeaderSpec;
+import org.citrusframework.groovy.dsl.actions.model.JsonBodySpec;
+import org.citrusframework.groovy.dsl.actions.model.XmlBodySpec;
 import org.citrusframework.message.builder.DefaultPayloadBuilder;
 import org.citrusframework.message.builder.SendMessageBuilderSupport;
 import groovy.lang.Closure;
+import org.citrusframework.util.FileUtils;
 
 /**
  * @author Christoph Deppisch
@@ -66,6 +69,15 @@ public class SendActionBuilderWrapper extends SendMessageAction.SendMessageActio
             return this.body(new DefaultPayloadBuilder(bodySpec.get(code.call())));
         }
 
+        @Override
+        public SendMessageActionBuilderSupport body(String payload) {
+            return super.body(payload.trim());
+        }
+
+        public GroovyMessageBuilderSupport body() {
+            return new GroovyMessageBuilderSupport();
+        }
+
         public SendMessageActionBuilderSupport headers(Closure<?> callable) {
             HeaderSpec headerSpec = new HeaderSpec();
             Closure<?> code = callable.rehydrate(headerSpec, this, this);
@@ -75,6 +87,28 @@ public class SendActionBuilderWrapper extends SendMessageAction.SendMessageActio
             return this.headers(headerSpec.get());
         }
 
+        public class GroovyMessageBuilderSupport {
+
+            public SendMessageActionBuilderSupport resource(String filePath) {
+                return SendMessageActionBuilderSupport.this.body(FileUtils.getFileResource(filePath));
+            }
+
+            public SendMessageActionBuilderSupport json(Closure<?> callable) {
+                JsonBodySpec bodySpec = new JsonBodySpec();
+                Closure<?> code = callable.rehydrate(bodySpec, this, this);
+                code.setResolveStrategy(Closure.DELEGATE_ONLY);
+
+                return SendMessageActionBuilderSupport.this.body(new DefaultPayloadBuilder(bodySpec.get(code.call())));
+            }
+
+            public SendMessageActionBuilderSupport xml(Closure<?> callable) {
+                XmlBodySpec bodySpec = new XmlBodySpec();
+                Closure<?> code = callable.rehydrate(bodySpec, this, this);
+                code.setResolveStrategy(Closure.DELEGATE_ONLY);
+
+                return SendMessageActionBuilderSupport.this.body(new DefaultPayloadBuilder(bodySpec.get(code.call())));
+            }
+        }
     }
 
 }

--- a/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/actions/TemplateConfiguration.java
+++ b/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/actions/TemplateConfiguration.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl.actions;
+
+import java.util.Optional;
+
+import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
+import groovy.lang.GroovyObjectSupport;
+import org.citrusframework.TestAction;
+import org.citrusframework.TestActionBuilder;
+import org.citrusframework.container.Template;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class TemplateConfiguration implements ActionsBuilder {
+
+    private final Template.Builder target;
+
+    public TemplateConfiguration(Template.Builder builder) {
+        this.target = builder;
+    }
+
+    public void actions(@DelegatesTo(TemplateConfiguration.class) Closure<?> callable) {
+        callable.setResolveStrategy(Closure.DELEGATE_FIRST);
+        callable.setDelegate(this);
+        callable.call();
+    }
+
+    public void name(String templateName) {
+        target.templateName(templateName);
+    }
+
+    public void description(String description) {
+        target.description(description);
+    }
+
+    public void globalContext(boolean global) {
+        target.globalContext(global);
+    }
+
+    public void $actions(@DelegatesTo(TemplateConfiguration.class) Closure<?> callable) {
+        this.actions(callable);
+    }
+
+    public void parameters(@DelegatesTo(ParameterConfiguration.class) Closure<?> callable) {
+        callable.setResolveStrategy(Closure.DELEGATE_FIRST);
+        callable.setDelegate(new ParameterConfiguration(target));
+        callable.call();
+    }
+
+    @Override
+    public <T extends TestAction> T $(TestActionBuilder<T> builder) {
+        T action = builder.build();
+        target.actions(action);
+        return action;
+    }
+
+    private static class ParameterConfiguration extends GroovyObjectSupport {
+
+        private final Template.Builder target;
+        public ParameterConfiguration(Template.Builder builder) {
+            this.target = builder;
+        }
+
+        public void propertyMissing(String name, Object value) {
+            target.parameter(name, Optional.ofNullable(value).map(Object::toString).orElse("").trim());
+        }
+    }
+}

--- a/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/configuration/ContextConfiguration.java
+++ b/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/configuration/ContextConfiguration.java
@@ -102,6 +102,10 @@ public class ContextConfiguration {
                 ((InitializingPhase) endpoint).initialize();
             }
             citrus.getCitrusContext().bind(endpoint.getName(), endpoint);
+
+            if (context != null && !context.getReferenceResolver().equals(citrus.getCitrusContext().getReferenceResolver())) {
+                context.getReferenceResolver().bind(endpoint.getName(), endpoint);
+            }
         });
     }
 }

--- a/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/test/TestCaseScript.java
+++ b/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/test/TestCaseScript.java
@@ -22,6 +22,7 @@ package org.citrusframework.groovy.dsl.test;
 import org.citrusframework.Citrus;
 import org.citrusframework.TestAction;
 import org.citrusframework.TestActionBuilder;
+import org.citrusframework.TestCaseMetaInfo;
 import org.citrusframework.TestCaseRunner;
 import org.citrusframework.container.FinallySequence;
 import org.citrusframework.context.TestContext;
@@ -52,6 +53,22 @@ public class TestCaseScript extends GroovyObjectSupport implements ActionsBuilde
 
     public ContextConfiguration configuration() {
         return new ContextConfiguration(citrus, context, basePath);
+    }
+
+    public void name(String name) {
+        runner.name(name);
+    }
+
+    public void author(String author) {
+        runner.author(author);
+    }
+
+    public void description(String description) {
+        runner.description(description);
+    }
+
+    public void status(String status) {
+        runner.status(TestCaseMetaInfo.Status.valueOf(status));
     }
 
     public void configuration(@DelegatesTo(ContextConfiguration.class) Closure<?> callable) {

--- a/runtime/citrus-groovy/src/main/resources/META-INF/citrus/template/loader/groovy
+++ b/runtime/citrus-groovy/src/main/resources/META-INF/citrus/template/loader/groovy
@@ -1,0 +1,1 @@
+type=org.citrusframework.groovy.GroovyTemplateLoader

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/GroovyTemplateLoaderTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/GroovyTemplateLoaderTest.java
@@ -17,24 +17,23 @@
  * limitations under the License.
  */
 
-package org.citrusframework.yaml.container;
+package org.citrusframework.groovy;
 
+import org.citrusframework.UnitTestSupport;
 import org.citrusframework.container.Template;
-import org.citrusframework.yaml.YamlTemplateLoader;
-import org.citrusframework.yaml.actions.AbstractYamlActionTest;
-import org.testng.annotations.Test;
 import org.testng.Assert;
+import org.testng.annotations.Test;
 
 /**
  * @author Christoph Deppisch
  */
-public class TemplateTest extends AbstractYamlActionTest {
+public class GroovyTemplateLoaderTest extends UnitTestSupport {
 
     @Test
     public void shouldLoadTemplate() {
-        Template template = new YamlTemplateLoader()
+        Template template = new GroovyTemplateLoader()
                 .withReferenceResolver(context.getReferenceResolver())
-                .load("classpath:org/citrusframework/yaml/container/template-test.yaml");
+                .load("classpath:org/citrusframework/groovy/template.groovy");
 
         Assert.assertEquals(template.getTemplateName(), "myTemplate");
         Assert.assertEquals(template.getName(), "template:myTemplate");
@@ -42,15 +41,17 @@ public class TemplateTest extends AbstractYamlActionTest {
         Assert.assertEquals(template.getActions().size(), 1);
         Assert.assertTrue(template.isGlobalContext());
 
-        template = new YamlTemplateLoader()
+        template = new GroovyTemplateLoader()
                 .withReferenceResolver(context.getReferenceResolver())
-                .load("classpath:org/citrusframework/yaml/container/template-parameters-test.yaml");
+                .load("classpath:org/citrusframework/groovy/template-parameters.groovy");
         Assert.assertEquals(template.getTemplateName(), "myTemplate");
         Assert.assertEquals(template.getName(), "template:myTemplate");
         Assert.assertEquals(template.getParameter().size(), 3);
         Assert.assertEquals(template.getParameter().get("foo"), "");
         Assert.assertEquals(template.getParameter().get("bar"), "barValue");
-        Assert.assertEquals(template.getParameter().get("baz"), "foo" + System.lineSeparator() + "bar" + System.lineSeparator() + "baz");
+        Assert.assertEquals(template.getParameter().get("baz"), "foo" + System.lineSeparator() +
+                "        bar" + System.lineSeparator() +
+                "        baz");
         Assert.assertEquals(template.getActions().size(), 2);
         Assert.assertFalse(template.isGlobalContext());
     }

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/NoopMessageProcessor.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/NoopMessageProcessor.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy;
+
+import org.citrusframework.context.TestContext;
+import org.citrusframework.message.Message;
+import org.citrusframework.message.MessageProcessor;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class NoopMessageProcessor implements MessageProcessor {
+
+    @Override
+    public void process(Message message, TestContext context) {
+    }
+
+    public static class Builder implements MessageProcessor.Builder<NoopMessageProcessor, Builder> {
+        @Override
+        public NoopMessageProcessor build() {
+            return new NoopMessageProcessor();
+        }
+    }
+}

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/NoopVariableExtractor.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/NoopVariableExtractor.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy;
+
+import java.util.Map;
+
+import org.citrusframework.context.TestContext;
+import org.citrusframework.message.Message;
+import org.citrusframework.variable.VariableExtractor;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class NoopVariableExtractor implements VariableExtractor {
+    @Override
+    public void extractVariables(Message message, TestContext context) {
+    }
+
+    public static class Builder implements VariableExtractor.Builder<NoopVariableExtractor, Builder> {
+
+        @Override
+        public Builder expressions(Map<String, Object> expressions) {
+            return this;
+        }
+
+        @Override
+        public Builder expression(String expression, Object value) {
+            return this;
+        }
+
+        @Override
+        public NoopVariableExtractor build() {
+            return new NoopVariableExtractor();
+        }
+    }
+}

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/AbstractGroovyActionDslTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/AbstractGroovyActionDslTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl;
+
+import org.citrusframework.Citrus;
+import org.citrusframework.CitrusContext;
+import org.citrusframework.CitrusInstanceManager;
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.annotations.CitrusAnnotations;
+import org.citrusframework.context.StaticTestContextFactory;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.citrusframework.testng.AbstractTestNGUnitTest;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeClass;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class AbstractGroovyActionDslTest extends AbstractTestNGUnitTest {
+
+    protected Citrus citrus;
+
+    @Mock
+    protected CitrusContext citrusContext;
+
+    @BeforeClass
+    public void setupMocks() {
+        MockitoAnnotations.openMocks(this);
+        citrus = CitrusInstanceManager.newInstance(() -> citrusContext);
+    }
+
+    @Override
+    protected TestContext createTestContext() {
+        TestContext context = super.createTestContext();
+        doAnswer(invocation -> {
+            context.getReferenceResolver().bind(invocation.getArgument(0, String.class), invocation.getArgument(1));
+            return null;
+        }).when(citrusContext).bind(any(String.class), any());
+
+        when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
+        when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
+        when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        CitrusAnnotations.injectAll(this, citrus, context);
+        return context;
+    }
+
+    protected GroovyTestLoader createTestLoader(String sourcePath) {
+        GroovyTestLoader testLoader = new GroovyTestLoader().source(sourcePath);
+        CitrusAnnotations.injectAll(testLoader, citrus, context);
+        CitrusAnnotations.injectTestRunner(testLoader, new DefaultTestCaseRunner(context));
+
+        return testLoader;
+    }
+}

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/ActionTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/ActionTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.actions.EchoAction;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.EchoAction.Builder.echo;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class ActionTest extends AbstractGroovyActionDslTest {
+
+    @Test
+    public void shouldLoadAction() {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/groovy/dsl/action.test.groovy");
+
+        EchoAction action = echo().build();
+
+        context.getReferenceResolver().bind("echoBuilder", echo().message("Citrus rocks!"));
+        context.getReferenceResolver().bind("echo", action);
+
+        testLoader.load();
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "ActionTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 2L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), EchoAction.class);
+        Assert.assertEquals(((EchoAction) result.getTestAction(0)).getMessage(), "Citrus rocks!");
+
+        Assert.assertEquals(result.getTestAction(1).getClass(), EchoAction.class);
+        Assert.assertEquals(result.getTestAction(1), action);
+    }
+}

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/ApplyTemplateTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/ApplyTemplateTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.container.Template;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.actions.EchoAction.Builder.echo;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class ApplyTemplateTest extends AbstractGroovyActionDslTest {
+
+    @Test
+    public void shouldLoadApplyTemplate() {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/groovy/dsl/apply-template.test.groovy");
+
+        context.getReferenceResolver().bind("myTemplate", new Template.Builder()
+                .actions(echo().message("Hello from Citrus!"))
+                .build());
+
+        Template printTemplate = new Template.Builder()
+                .parameter("text", "Should be overwritten")
+                .actions(echo().message("${text}"), echo().message("${message}"))
+                .build();
+        context.getReferenceResolver().bind("print", printTemplate);
+
+        testLoader.load();
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "ApplyTemplateTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 3L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), Template.class);
+
+        Template action = (Template) result.getTestAction(0);
+        Assert.assertEquals(action.getName(), "template:myTemplate");
+        Assert.assertEquals(action.getTemplateName(), "myTemplate");
+
+        action = (Template) result.getTestAction(1);
+        Assert.assertEquals(action.getName(), "template:print");
+        Assert.assertEquals(action.getTemplateName(), "print");
+        Assert.assertEquals(action.getParameter().size(), 2);
+        Assert.assertEquals(action.getParameter().get("text"), "Hello from Citrus!");
+        Assert.assertTrue(action.getParameter().get("message").contains("<Text>Hello from Citrus!</Text>"));
+
+        Assert.assertEquals(printTemplate.getParameter().size(), 1L);
+        Assert.assertEquals(printTemplate.getParameter().get("text"), "Should be overwritten");
+
+        action = (Template) result.getTestAction(2);
+        Assert.assertEquals(action.getName(), "template:echo");
+        Assert.assertEquals(action.getTemplateName(), "echo");
+
+        Assert.assertFalse(context.getReferenceResolver().isResolvable("echo", Template.class));
+        Assert.assertFalse(context.getReferenceResolver().isResolvable("echo", Template.Builder.class));
+    }
+}

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/CreateVariablesTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/CreateVariablesTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.actions.CreateVariablesAction;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class CreateVariablesTest extends AbstractGroovyActionDslTest {
+
+    @Test
+    public void shouldLoadCreateVariables() {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/groovy/dsl/create-variables.test.groovy");
+
+        testLoader.load();
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "CreateVariablesTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActions().get(0).getClass(), CreateVariablesAction.class);
+        Assert.assertEquals(result.getActions().get(1).getClass(), CreateVariablesAction.class);
+        Assert.assertEquals(result.getActions().get(2).getClass(), CreateVariablesAction.class);
+
+        CreateVariablesAction action = (CreateVariablesAction)result.getActions().get(0);
+        Assert.assertEquals(action.getName(), "create-variables");
+        Assert.assertEquals(action.getVariables().toString(), "{foo=bar}");
+
+        action = (CreateVariablesAction)result.getActions().get(1);
+        Assert.assertEquals(action.getName(), "create-variables");
+        Assert.assertEquals(action.getVariables().toString(), "{text=Hello Citrus!}");
+
+        action = (CreateVariablesAction)result.getActions().get(2);
+        Assert.assertEquals(action.getName(), "create-variables");
+        Assert.assertEquals(action.getVariables().toString(), "{foobar=bars}");
+    }
+}

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/EchoTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/EchoTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.actions.EchoAction;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class EchoTest extends AbstractGroovyActionDslTest {
+
+    @Test
+    public void shouldLoadEcho() {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/groovy/dsl/echo.test.groovy");
+
+        testLoader.load();
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "EchoTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 1L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), EchoAction.class);
+        Assert.assertEquals(((EchoAction) result.getTestAction(0)).getMessage(), "Hello from Citrus!");
+    }
+
+    @Test
+    public void shouldLoadPrint() {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/groovy/dsl/print.test.groovy");
+
+        testLoader.load();
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "PrintTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 2L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), EchoAction.class);
+        Assert.assertEquals(((EchoAction) result.getTestAction(0)).getMessage(), "Hello from Citrus!");
+        Assert.assertEquals(result.getTestAction(1).getClass(), EchoAction.class);
+        Assert.assertEquals(((EchoAction) result.getTestAction(1)).getMessage(), "Hello");
+    }
+}

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/ExpectTimeoutTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/ExpectTimeoutTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2006-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.actions.ReceiveTimeoutAction;
+import org.citrusframework.endpoint.direct.DirectEndpoint;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ * @since 2.3
+ */
+public class ExpectTimeoutTest extends AbstractGroovyActionDslTest {
+
+    @Test
+    public void testReceiveTimeoutBuilder() {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/groovy/dsl/expect-timeout.test.groovy");
+
+        testLoader.load();
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "ExpectTimeoutTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 4L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), ReceiveTimeoutAction.class);
+
+        int actionIndex = 0;
+
+        ReceiveTimeoutAction action = (ReceiveTimeoutAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getTimeout(), 1000L);
+        Assert.assertNull(action.getEndpointUri());
+        Assert.assertEquals(action.getEndpoint(), context.getReferenceResolver().resolve("helloEndpoint", DirectEndpoint.class));
+        Assert.assertNull(action.getMessageSelector());
+
+        action = (ReceiveTimeoutAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getEndpointUri(), "direct:helloQueue");
+
+        action = (ReceiveTimeoutAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getTimeout(), 500L);
+        Assert.assertEquals(action.getEndpointUri(), "helloEndpoint");
+        Assert.assertEquals(action.getMessageSelector(), "operation='Test'");
+        Assert.assertEquals(action.getMessageSelectorMap().size(), 0L);
+
+        action = (ReceiveTimeoutAction) result.getTestAction(actionIndex);
+        Assert.assertEquals(action.getTimeout(), 500L);
+        Assert.assertEquals(action.getEndpointUri(), "helloEndpoint");
+        Assert.assertNull(action.getMessageSelector());
+        Assert.assertEquals(action.getMessageSelectorMap().size(), 1L);
+        Assert.assertEquals(action.getMessageSelectorMap().get("operation"), "Test");
+    }
+}

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/FailTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/FailTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.actions.FailAction;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class FailTest extends AbstractGroovyActionDslTest {
+
+    @Test
+    public void shouldLoadFail() {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/groovy/dsl/fail.test.groovy");
+
+        testLoader.load();
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "FailTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 2L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), org.citrusframework.container.Assert.class);
+        Assert.assertEquals(((org.citrusframework.container.Assert) result.getTestAction(0)).getException(), CitrusRuntimeException.class);
+        Assert.assertEquals(((org.citrusframework.container.Assert) result.getTestAction(0)).getMessage(), "Something went wrong");
+        Assert.assertEquals(((org.citrusframework.container.Assert) result.getTestAction(0)).getActionCount(), 1L);
+        Assert.assertEquals(((org.citrusframework.container.Assert) result.getTestAction(0)).getAction().getClass(), FailAction.class);
+
+        Assert.assertEquals(result.getTestAction(1).getClass(), org.citrusframework.container.Assert.class);
+        Assert.assertEquals(((org.citrusframework.container.Assert) result.getTestAction(1)).getException(), CitrusRuntimeException.class);
+        Assert.assertEquals(((org.citrusframework.container.Assert) result.getTestAction(1)).getMessage(), "Something went wrong");
+        Assert.assertEquals(((org.citrusframework.container.Assert) result.getTestAction(1)).getActionCount(), 1L);
+        Assert.assertEquals(((org.citrusframework.container.Assert) result.getTestAction(1)).getAction().getClass(), FailAction.class);
+    }
+}

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/LoadPropertiesTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/LoadPropertiesTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.actions.LoadPropertiesAction;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class LoadPropertiesTest extends AbstractGroovyActionDslTest {
+
+    @Test
+    public void shouldLoadProperties() {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/groovy/dsl/load-properties.test.groovy");
+
+        testLoader.load();
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "LoadPropertiesTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 1L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), LoadPropertiesAction.class);
+
+        LoadPropertiesAction action = (LoadPropertiesAction) result.getTestAction(0);
+        Assert.assertEquals(action.getFilePath(), "classpath:org/citrusframework/groovy/load.properties");
+    }
+}

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/PurgeEndpointTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/PurgeEndpointTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.actions.PurgeEndpointAction;
+import org.citrusframework.endpoint.Endpoint;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.citrusframework.message.DefaultMessageQueue;
+import org.citrusframework.message.MessageQueue;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.endpoint.direct.DirectEndpoints.direct;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class PurgeEndpointTest extends AbstractGroovyActionDslTest {
+
+    @Test
+    public void shouldLoadPurgeEndpoint() {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/groovy/dsl/purge-endpoints.test.groovy");
+
+        MessageQueue testQueue = new DefaultMessageQueue("testQueue");
+        context.getReferenceResolver().bind("testQueue", testQueue);
+        context.getReferenceResolver().bind("testEndpoint", direct().asynchronous().queue(testQueue).build());
+        context.getReferenceResolver().bind("testEndpoint1", direct().asynchronous().queue(testQueue).build());
+        context.getReferenceResolver().bind("testEndpoint2", direct().asynchronous().queue(testQueue).build());
+        context.getReferenceResolver().bind("testEndpoint3", direct().asynchronous().queue(testQueue).build());
+
+        testLoader.load();
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "PurgeEndpointTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 5L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), PurgeEndpointAction.class);
+
+        int actionIndex = 0;
+
+        PurgeEndpointAction action = (PurgeEndpointAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getReceiveTimeout(), 100L);
+        Assert.assertEquals(action.getSleepTime(), 350L);
+        Assert.assertNull(action.getMessageSelector());
+        Assert.assertNotNull(action.getMessageSelectorMap());
+        Assert.assertEquals(action.getMessageSelectorMap().size(), 0);
+        Assert.assertEquals(action.getEndpoints().size(), 0);
+        Assert.assertEquals(action.getEndpointNames().size(), 3);
+        Assert.assertEquals(action.getEndpointNames().get(0), "testEndpoint1");
+        Assert.assertEquals(action.getEndpointNames().get(1), "testEndpoint2");
+        Assert.assertEquals(action.getEndpointNames().get(2), "testEndpoint3");
+
+        action = (PurgeEndpointAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(action.getMessageSelector());
+        Assert.assertNotNull(action.getMessageSelectorMap());
+        Assert.assertEquals(action.getMessageSelectorMap().size(), 0);
+        Assert.assertEquals(action.getEndpoints().size(), 3);
+        Assert.assertEquals(action.getEndpoints().get(0), context.getReferenceResolver().resolve("testEndpoint1", Endpoint.class));
+        Assert.assertEquals(action.getEndpoints().get(1), context.getReferenceResolver().resolve("testEndpoint2", Endpoint.class));
+        Assert.assertEquals(action.getEndpoints().get(2), context.getReferenceResolver().resolve("testEndpoint3", Endpoint.class));
+        Assert.assertEquals(action.getEndpointNames().size(), 0);
+
+        action = (PurgeEndpointAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getReceiveTimeout(), 500L);
+        Assert.assertEquals(action.getSleepTime(), 100L);
+        Assert.assertEquals(action.getMessageSelector(), "operation = 'sayHello'");
+        Assert.assertEquals(action.getMessageSelectorMap().size(), 0);
+        Assert.assertEquals(action.getEndpoints().size(), 0);
+        Assert.assertEquals(action.getEndpointNames().size(), 1);
+        Assert.assertEquals(action.getEndpointNames().get(0), "testEndpoint");
+
+        action = (PurgeEndpointAction) result.getTestAction(actionIndex++);
+        Assert.assertNull(action.getMessageSelector());
+        Assert.assertEquals(action.getMessageSelectorMap().size(), 1);
+        Assert.assertEquals(action.getMessageSelectorMap().get("operation"), "sayHello");
+        Assert.assertEquals(action.getEndpoints().size(), 0);
+        Assert.assertEquals(action.getEndpointNames().size(), 1);
+        Assert.assertEquals(action.getEndpointNames().get(0), "testEndpoint");
+
+        action = (PurgeEndpointAction) result.getTestAction(actionIndex);
+        Assert.assertNull(action.getMessageSelector());
+        Assert.assertEquals(action.getMessageSelectorMap().size(), 2);
+        Assert.assertEquals(action.getMessageSelectorMap().get("operation"), "sayHello");
+        Assert.assertEquals(action.getMessageSelectorMap().get("id"), 12345);
+        Assert.assertEquals(action.getEndpoints().size(), 0);
+        Assert.assertEquals(action.getEndpointNames().size(), 1);
+        Assert.assertEquals(action.getEndpointNames().get(0), "testEndpoint");
+    }
+
+}

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/ReceiveTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/ReceiveTest.java
@@ -1,0 +1,382 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl;
+
+import java.io.IOException;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.actions.ReceiveMessageAction;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.citrusframework.groovy.NoopMessageProcessor;
+import org.citrusframework.groovy.NoopVariableExtractor;
+import org.citrusframework.message.DefaultMessage;
+import org.citrusframework.message.DefaultMessageQueue;
+import org.citrusframework.message.DelegatingPathExpressionProcessor;
+import org.citrusframework.message.MessageQueue;
+import org.citrusframework.message.MessageType;
+import org.citrusframework.spi.BindToRegistry;
+import org.citrusframework.util.FileUtils;
+import org.citrusframework.validation.DefaultHeaderValidator;
+import org.citrusframework.validation.DelegatingPayloadVariableExtractor;
+import org.citrusframework.validation.HeaderValidator;
+import org.citrusframework.validation.MessageValidator;
+import org.citrusframework.validation.TextEqualsMessageValidator;
+import org.citrusframework.validation.builder.DefaultMessageBuilder;
+import org.citrusframework.validation.context.HeaderValidationContext;
+import org.citrusframework.validation.json.JsonMessageValidationContext;
+import org.citrusframework.validation.json.JsonPathMessageValidationContext;
+import org.citrusframework.validation.script.ScriptValidationContext;
+import org.citrusframework.validation.xml.XmlMessageValidationContext;
+import org.citrusframework.validation.xml.XpathMessageValidationContext;
+import org.citrusframework.variable.MessageHeaderVariableExtractor;
+import org.citrusframework.variable.dictionary.DataDictionary;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.endpoint.direct.DirectEndpoints.direct;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class ReceiveTest extends AbstractGroovyActionDslTest {
+
+    @BindToRegistry
+    final DataDictionary<?> myDataDictionary = Mockito.mock(DataDictionary.class);
+
+    @BindToRegistry
+    final MessageValidator<?> myValidator = Mockito.mock(MessageValidator.class);
+
+    @BindToRegistry
+    final MessageValidator<?> defaultMessageValidator = Mockito.mock(MessageValidator.class);
+
+    @Test
+    public void shouldLoadReceive() throws IOException {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/groovy/dsl/receive.test.groovy");
+
+        MessageQueue helloQueue = new DefaultMessageQueue("helloQueue");
+        context.getMessageValidatorRegistry().addMessageValidator("textEqualsMessageValidator", new TextEqualsMessageValidator().enableTrim());
+        context.getReferenceResolver().bind("defaultHeaderValidator", new DefaultHeaderValidator());
+        context.getReferenceResolver().bind("myHeaderValidator", new DefaultHeaderValidator());
+        context.getReferenceResolver().bind("helloQueue", helloQueue);
+        context.getReferenceResolver().bind("helloEndpoint", direct().asynchronous().queue(helloQueue).build());
+
+        context.getReferenceResolver().bind("jsonPathVariableExtractorBuilder", new NoopVariableExtractor.Builder());
+        context.getReferenceResolver().bind("xpathVariableExtractorBuilder", new NoopVariableExtractor.Builder());
+
+        context.getReferenceResolver().bind("jsonPathMessageProcessorBuilder", new NoopMessageProcessor.Builder());
+        context.getReferenceResolver().bind("xpathMessageProcessorBuilder", new NoopMessageProcessor.Builder());
+
+        helloQueue.send(new DefaultMessage("Hello from Citrus!").setHeader("operation", "sayHello"));
+        helloQueue.send(new DefaultMessage("<TestMessage>Hello Citrus</TestMessage>").setHeader("operation", "sayHello"));
+        helloQueue.send(new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" + System.lineSeparator() +
+                "                <TestMessage xmlns=\"http://citrusframework.org/test\">Hello Citrus</TestMessage>")
+                                .addHeaderData("<Header xmlns=\"http://citrusframework.org/test\"><operation>hello</operation></Header>")
+                                .setHeader("operation", "sayHello"));
+        helloQueue.send(new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + System.lineSeparator() +
+                "<TestRequest>" + System.lineSeparator() +
+                "    <Message>Hello World!</Message>" + System.lineSeparator() +
+                "</TestRequest>").setHeader("operation", "sayHello"));
+        helloQueue.send(new DefaultMessage("<TestMessage>Hello Citrus</TestMessage>").setHeader("operation", "sayHello"));
+        helloQueue.send(new DefaultMessage("<TestMessage>Hello Citrus</TestMessage>").setHeader("operation", "sayHello"));
+        helloQueue.send(new DefaultMessage("<ns:TestMessage xmlns:ns=\"http://citrusframework.org\">Hello Citrus</ns:TestMessage>").setHeader("operation", "sayHello"));
+        helloQueue.send(new DefaultMessage("<TestMessage>Hello Citrus</TestMessage>").setHeader("operation", "sayHello"));
+        helloQueue.send(new DefaultMessage("<TestMessage>Hello Citrus</TestMessage>").setHeader("operation", "sayHello"));
+        helloQueue.send(new DefaultMessage("<TestMessage>Hello Citrus</TestMessage>").setHeader("operation", "sayHello"));
+        helloQueue.send(new DefaultMessage("<TestMessage>Hello Citrus</TestMessage>").setHeader("operation", "sayHello"));
+        helloQueue.send(new DefaultMessage("<TestMessage>Hello Citrus</TestMessage>").setHeader("operation", "sayHello"));
+        helloQueue.send(new DefaultMessage("<TestMessage>Hello Citrus</TestMessage>").setHeader("operation", "sayHello"));
+        helloQueue.send(new DefaultMessage("{ \"FooMessage\": { \"foo\": \"Hello World!\" }, { \"bar\": \"@ignore@\" }}").setHeader("operation", "sayHello"));
+        helloQueue.send(new DefaultMessage("{ \"message\": { \"text\": \"Hello World!\" }, { \"bar\": \"@ignore@\" }}").setHeader("operation", "sayHello"));
+        helloQueue.send(new DefaultMessage("<TestMessage>Hello Citrus</TestMessage>").setHeader("operation", "sayHello"));
+        helloQueue.send(new DefaultMessage("<TestMessage>Hello Citrus</TestMessage>").setHeader("operation", "sayHello"));
+
+        testLoader.load();
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "ReceiveTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 17L);
+
+        int actionIndex = 0;
+
+        ReceiveMessageAction action = (ReceiveMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getClass(), ReceiveMessageAction.class);
+        Assert.assertEquals(action.getReceiveTimeout(), 10000L);
+        Assert.assertEquals(action.getMessageBuilder().build(context, MessageType.PLAINTEXT.name()).getPayload(String.class), "Hello from Citrus!");
+
+        action = (ReceiveMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertTrue(action.getMessageSelectorMap().isEmpty());
+        Assert.assertNull(action.getMessageSelector());
+        Assert.assertEquals(action.getEndpointUri(), "helloEndpoint");
+
+        Assert.assertEquals(action.getValidationContexts().size(), 3);
+        Assert.assertTrue(action.getValidationContexts().get(0) instanceof HeaderValidationContext);
+        Assert.assertTrue(action.getValidationContexts().get(1) instanceof XmlMessageValidationContext);
+        Assert.assertTrue(action.getValidationContexts().get(2) instanceof JsonMessageValidationContext);
+
+        Assert.assertTrue(action.getMessageBuilder() instanceof DefaultMessageBuilder);
+        DefaultMessageBuilder messageBuilder = (DefaultMessageBuilder)action.getMessageBuilder();
+
+        Assert.assertEquals(messageBuilder.buildMessagePayload(context, action.getMessageType()), "<TestMessage>Hello Citrus</TestMessage>");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 1);
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get("operation"), "sayHello");
+        Assert.assertEquals(action.getMessageProcessors().size(), 0);
+        Assert.assertEquals(action.getControlMessageProcessors().size(), 0);
+
+        Assert.assertNull(action.getDataDictionary());
+        Assert.assertEquals(action.getMessageProcessors().size(), 0);
+        Assert.assertEquals(action.getControlMessageProcessors().size(), 0);
+
+        action = (ReceiveMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertTrue(action.getMessageSelectorMap().isEmpty());
+        Assert.assertNull(action.getMessageSelector());
+        Assert.assertEquals(action.getEndpointUri(), "helloEndpoint");
+
+        Assert.assertEquals(action.getValidationContexts().size(), 3);
+        Assert.assertTrue(action.getValidationContexts().get(0) instanceof HeaderValidationContext);
+        Assert.assertTrue(action.getValidationContexts().get(1) instanceof XmlMessageValidationContext);
+        Assert.assertTrue(action.getValidationContexts().get(2) instanceof JsonMessageValidationContext);
+
+        Assert.assertTrue(action.getMessageBuilder() instanceof DefaultMessageBuilder);
+        messageBuilder = (DefaultMessageBuilder)action.getMessageBuilder();
+
+        Assert.assertEquals(messageBuilder.buildMessagePayload(context, action.getMessageType()), "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>"+System.getProperty("line.separator")+
+                "                <TestMessage xmlns=\"http://citrusframework.org/test\">Hello Citrus</TestMessage>");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 1);
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get("operation"), "sayHello");
+        Assert.assertEquals(messageBuilder.buildMessageHeaderData(context).size(), 1);
+        Assert.assertEquals(messageBuilder.buildMessageHeaderData(context).get(0).trim(), "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>"+System.getProperty("line.separator")+
+                "                <Header xmlns=\"http://citrusframework.org/test\"><operation>hello</operation></Header>");
+        Assert.assertEquals(action.getMessageProcessors().size(), 0);
+        Assert.assertEquals(action.getControlMessageProcessors().size(), 0);
+
+        Assert.assertNull(action.getDataDictionary());
+        Assert.assertEquals(action.getMessageProcessors().size(), 0);
+        Assert.assertEquals(action.getControlMessageProcessors().size(), 0);
+
+        action = (ReceiveMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getMessageSelectorMap().size(), 1);
+        Assert.assertEquals(action.getMessageSelectorMap().get("operation"), "sayHello");
+        Assert.assertNull(action.getMessageSelector());
+        Assert.assertEquals(action.getEndpointUri(), "helloEndpoint");
+
+        Assert.assertEquals(action.getValidationContexts().size(), 3);
+        Assert.assertTrue(action.getValidationContexts().get(0) instanceof HeaderValidationContext);
+        Assert.assertTrue(action.getValidationContexts().get(1) instanceof XmlMessageValidationContext);
+        Assert.assertTrue(action.getValidationContexts().get(2) instanceof JsonMessageValidationContext);
+
+        Assert.assertTrue(action.getMessageBuilder() instanceof DefaultMessageBuilder);
+        messageBuilder = (DefaultMessageBuilder)action.getMessageBuilder();
+
+        Assert.assertEquals(messageBuilder.buildMessagePayload(context, action.getMessageType()),
+                FileUtils.readToString(FileUtils.getFileResource("classpath:org/citrusframework/groovy/test-request-payload.xml")).trim());
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 0);
+        Assert.assertEquals(action.getMessageProcessors().size(), 0);
+        Assert.assertEquals(action.getControlMessageProcessors().size(), 0);
+
+        action = (ReceiveMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertTrue(action.getMessageSelectorMap().isEmpty());
+        Assert.assertEquals(action.getMessageSelector(), "operation = 'sayHello'");
+        Assert.assertEquals(action.getEndpointUri(), "helloEndpoint");
+
+        action = (ReceiveMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getVariableExtractors().size(), 2);
+        Assert.assertTrue(action.getVariableExtractors().get(0) instanceof MessageHeaderVariableExtractor);
+        MessageHeaderVariableExtractor headerVariableExtractor = (MessageHeaderVariableExtractor)action.getVariableExtractors().get(0);
+        Assert.assertTrue(action.getVariableExtractors().get(1) instanceof DelegatingPayloadVariableExtractor);
+        DelegatingPayloadVariableExtractor variableExtractor = (DelegatingPayloadVariableExtractor)action.getVariableExtractors().get(1);
+
+        Assert.assertEquals(variableExtractor.getNamespaces().size(), 0L);
+        Assert.assertEquals(headerVariableExtractor.getHeaderMappings().size(), 1);
+        Assert.assertEquals(headerVariableExtractor.getHeaderMappings().get("operation"), "operation");
+        Assert.assertEquals(variableExtractor.getPathExpressions().size(), 1);
+        Assert.assertEquals(variableExtractor.getPathExpressions().get("/TestMessage/text()"), "text");
+
+        Assert.assertNotNull(action.getDataDictionary());
+
+        action = (ReceiveMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getValidationContexts().size(), 2);
+        Assert.assertTrue(action.getValidationContexts().get(0) instanceof XmlMessageValidationContext);
+        Assert.assertTrue(action.getValidationContexts().get(1) instanceof HeaderValidationContext);
+
+        XmlMessageValidationContext xmlValidationContext = (XmlMessageValidationContext)action.getValidationContexts().get(0);
+        Assert.assertTrue(action.getMessageBuilder() instanceof DefaultMessageBuilder);
+        messageBuilder = (DefaultMessageBuilder)action.getMessageBuilder();
+
+        Assert.assertEquals(messageBuilder.buildMessagePayload(context, action.getMessageType()), "<ns:TestMessage xmlns:ns=\"http://citrusframework.org\">Hello Citrus</ns:TestMessage>");
+
+        Assert.assertEquals(action.getMessageProcessors().size(), 0);
+        Assert.assertEquals(action.getControlMessageProcessors().size(), 1);
+        Assert.assertTrue(action.getControlMessageProcessors().get(0) instanceof DelegatingPathExpressionProcessor);
+        DelegatingPathExpressionProcessor messageProcessor = (DelegatingPathExpressionProcessor)action.getControlMessageProcessors().get(0);
+
+        Assert.assertEquals(messageProcessor.getPathExpressions().size(), 1);
+        Assert.assertEquals(messageProcessor.getPathExpressions().get("/ns:TestMessage/"), "newValue");
+
+        Assert.assertFalse(xmlValidationContext.isSchemaValidationEnabled());
+
+        Assert.assertEquals(xmlValidationContext.getIgnoreExpressions().size(), 1);
+        Assert.assertEquals(xmlValidationContext.getIgnoreExpressions().iterator().next(), "/ns:TestMessage/ns:ignore");
+        Assert.assertEquals(xmlValidationContext.getNamespaces().size(), 1);
+        Assert.assertEquals(xmlValidationContext.getNamespaces().get("ctx"), "http://citrusframework.org/test");
+        Assert.assertEquals(xmlValidationContext.getControlNamespaces().size(), 1);
+        Assert.assertEquals(xmlValidationContext.getControlNamespaces().get("ns"), "http://citrusframework.org");
+
+        action = (ReceiveMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getValidationContexts().size(), 2);
+        Assert.assertTrue(action.getValidationContexts().get(0) instanceof XpathMessageValidationContext);
+        Assert.assertTrue(action.getValidationContexts().get(1) instanceof HeaderValidationContext);
+        XpathMessageValidationContext xPathValidationContext = (XpathMessageValidationContext)action.getValidationContexts().get(0);
+        Assert.assertNull(action.getEndpoint());
+        Assert.assertEquals(action.getEndpointUri(), "direct:helloQueue");
+
+        Assert.assertTrue(xPathValidationContext.isSchemaValidationEnabled());
+
+        Assert.assertEquals(xPathValidationContext.getXpathExpressions().size(), 2);
+        Assert.assertEquals(xPathValidationContext.getXpathExpressions().get("/TestMessage/text"), "Hello Citrus");
+        Assert.assertEquals(xPathValidationContext.getXpathExpressions().get("/TestMessage/foo"), true);
+
+        action = (ReceiveMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getValidationContexts().size(), 2);
+        Assert.assertTrue(action.getValidationContexts().get(0) instanceof XpathMessageValidationContext);
+        Assert.assertTrue(action.getValidationContexts().get(1) instanceof HeaderValidationContext);
+        xPathValidationContext = (XpathMessageValidationContext)action.getValidationContexts().get(0);
+        Assert.assertNull(action.getEndpoint());
+        Assert.assertEquals(action.getEndpointUri(), "direct:helloQueue");
+
+        Assert.assertTrue(xPathValidationContext.isSchemaValidationEnabled());
+
+        Assert.assertEquals(xPathValidationContext.getXpathExpressions().size(), 2);
+        Assert.assertEquals(xPathValidationContext.getXpathExpressions().get("/TestMessage/text"), "Hello Citrus");
+        Assert.assertEquals(xPathValidationContext.getXpathExpressions().get("/TestMessage/foo"), true);
+
+        action = (ReceiveMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getValidationContexts().size(), 3);
+        Assert.assertTrue(action.getValidationContexts().get(0) instanceof ScriptValidationContext);
+        Assert.assertTrue(action.getValidationContexts().get(1) instanceof XpathMessageValidationContext);
+        Assert.assertTrue(action.getValidationContexts().get(2) instanceof HeaderValidationContext);
+        xPathValidationContext = (XpathMessageValidationContext)action.getValidationContexts().get(1);
+        ScriptValidationContext scriptValidationContext = (ScriptValidationContext)action.getValidationContexts().get(0);
+        Assert.assertNull(action.getEndpoint());
+        Assert.assertEquals(action.getEndpointUri(), "direct:helloQueue");
+
+        Assert.assertTrue(xPathValidationContext.isSchemaValidationEnabled());
+
+        Assert.assertEquals(xPathValidationContext.getXpathExpressions().size(), 1);
+        Assert.assertEquals(xPathValidationContext.getXpathExpressions().get("/TestMessage/foo"), true);
+
+        Assert.assertEquals(scriptValidationContext.getScriptType(), "groovy");
+        Assert.assertEquals(scriptValidationContext.getValidationScript().trim(), "assert true");
+
+        action = (ReceiveMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getValidationContexts().size(), 2);
+        Assert.assertTrue(action.getValidationContexts().get(0) instanceof ScriptValidationContext);
+        Assert.assertTrue(action.getValidationContexts().get(1) instanceof HeaderValidationContext);
+        scriptValidationContext = (ScriptValidationContext)action.getValidationContexts().get(0);
+        Assert.assertNull(action.getEndpoint());
+        Assert.assertEquals(action.getEndpointUri(), "direct:helloQueue");
+
+        Assert.assertEquals(scriptValidationContext.getScriptType(), "groovy");
+        Assert.assertEquals(scriptValidationContext.getValidationScriptResourcePath(), "classpath:org/citrusframework/groovy/test-validation-script.groovy");
+
+        action = (ReceiveMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getValidationContexts().size(), 3);
+        Assert.assertTrue(action.getValidationContexts().get(0) instanceof JsonPathMessageValidationContext);
+        Assert.assertTrue(action.getValidationContexts().get(1) instanceof HeaderValidationContext);
+        Assert.assertTrue(action.getValidationContexts().get(2) instanceof JsonMessageValidationContext);
+        JsonPathMessageValidationContext jsonPathValidationContext = (JsonPathMessageValidationContext)action.getValidationContexts().get(0);
+        Assert.assertNull(action.getEndpoint());
+        Assert.assertEquals(action.getEndpointUri(), "direct:helloQueue");
+
+        Assert.assertTrue(action.getMessageBuilder() instanceof DefaultMessageBuilder);
+
+        Assert.assertEquals(jsonPathValidationContext.getJsonPathExpressions().size(), 2);
+        Assert.assertEquals(jsonPathValidationContext.getJsonPathExpressions().get("$.json.text"), "Hello Citrus");
+        Assert.assertEquals(jsonPathValidationContext.getJsonPathExpressions().get("$..foo.bar"), true);
+
+        action = (ReceiveMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getValidationContexts().size(), 3);
+        Assert.assertTrue(action.getValidationContexts().get(0) instanceof JsonPathMessageValidationContext);
+        Assert.assertTrue(action.getValidationContexts().get(1) instanceof HeaderValidationContext);
+        Assert.assertTrue(action.getValidationContexts().get(2) instanceof JsonMessageValidationContext);
+        jsonPathValidationContext = (JsonPathMessageValidationContext)action.getValidationContexts().get(0);
+        Assert.assertNull(action.getEndpoint());
+        Assert.assertEquals(action.getEndpointUri(), "direct:helloQueue");
+
+        Assert.assertTrue(action.getMessageBuilder() instanceof DefaultMessageBuilder);
+
+        Assert.assertEquals(jsonPathValidationContext.getJsonPathExpressions().size(), 2);
+        Assert.assertEquals(jsonPathValidationContext.getJsonPathExpressions().get("$.json.text"), "Hello Citrus");
+        Assert.assertEquals(jsonPathValidationContext.getJsonPathExpressions().get("$..foo.bar"), true);
+
+        action = (ReceiveMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getValidationContexts().size(), 2);
+        Assert.assertTrue(action.getValidationContexts().get(0) instanceof JsonMessageValidationContext);
+        Assert.assertTrue(action.getValidationContexts().get(1) instanceof HeaderValidationContext);
+        JsonMessageValidationContext jsonValidationContext = (JsonMessageValidationContext)action.getValidationContexts().get(0);
+
+        Assert.assertTrue(action.getMessageBuilder() instanceof DefaultMessageBuilder);
+        messageBuilder = (DefaultMessageBuilder)action.getMessageBuilder();
+
+        Assert.assertEquals(messageBuilder.buildMessagePayload(context, action.getMessageType()), "{ \"FooMessage\": { \"foo\": \"Hello World!\" }, { \"bar\": \"@ignore@\" }}");
+
+        Assert.assertEquals(action.getMessageProcessors().size(), 0);
+        Assert.assertEquals(action.getControlMessageProcessors().size(), 1);
+        Assert.assertTrue(action.getControlMessageProcessors().get(0) instanceof DelegatingPathExpressionProcessor);
+        DelegatingPathExpressionProcessor jsonMessageProcessor = (DelegatingPathExpressionProcessor)action.getControlMessageProcessors().get(0);
+
+        Assert.assertEquals(jsonMessageProcessor.getPathExpressions().size(), 1);
+        Assert.assertEquals(jsonMessageProcessor.getPathExpressions().get("$.FooMessage.foo"), "newValue");
+
+        Assert.assertEquals(jsonValidationContext.getIgnoreExpressions().size(), 1);
+        Assert.assertEquals(jsonValidationContext.getIgnoreExpressions().iterator().next(), "$.FooMessage.bar");
+
+        action = (ReceiveMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getVariableExtractors().size(), 2);
+        Assert.assertTrue(action.getVariableExtractors().get(0) instanceof MessageHeaderVariableExtractor);
+        headerVariableExtractor = (MessageHeaderVariableExtractor)action.getVariableExtractors().get(0);
+        Assert.assertTrue(action.getVariableExtractors().get(1) instanceof DelegatingPayloadVariableExtractor);
+        DelegatingPayloadVariableExtractor jsonVariableExtractor = (DelegatingPayloadVariableExtractor) action.getVariableExtractors().get(1);
+
+        Assert.assertEquals(headerVariableExtractor.getHeaderMappings().size(), 1);
+        Assert.assertEquals(headerVariableExtractor.getHeaderMappings().get("operation"), "operation");
+        Assert.assertEquals(jsonVariableExtractor.getPathExpressions().size(), 1);
+        Assert.assertEquals(jsonVariableExtractor.getPathExpressions().get("$.message.text"), "text");
+
+        action = (ReceiveMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getValidators().size(), 1);
+        Assert.assertEquals(action.getValidators().get(0), context.getReferenceResolver().resolve("myValidator", MessageValidator.class));
+        HeaderValidationContext headerValidationContext = (HeaderValidationContext) action.getValidationContexts().get(0);
+        Assert.assertEquals(headerValidationContext.getValidators().size(), 1);
+        Assert.assertEquals(headerValidationContext.getValidators().get(0), context.getReferenceResolver().resolve("myHeaderValidator", HeaderValidator.class));
+
+        action = (ReceiveMessageAction) result.getTestAction(actionIndex);
+        Assert.assertEquals(action.getValidators().size(), 2);
+        Assert.assertEquals(action.getValidators().get(0), context.getReferenceResolver().resolve("myValidator", MessageValidator.class));
+        Assert.assertEquals(action.getValidators().get(1), context.getReferenceResolver().resolve("defaultMessageValidator", MessageValidator.class));
+        headerValidationContext = (HeaderValidationContext) action.getValidationContexts().get(0);
+        Assert.assertEquals(headerValidationContext.getValidators().size(), 2);
+        Assert.assertEquals(headerValidationContext.getValidators().get(0), context.getReferenceResolver().resolve("myHeaderValidator", HeaderValidator.class));
+        Assert.assertEquals(headerValidationContext.getValidators().get(1), context.getReferenceResolver().resolve("defaultHeaderValidator", HeaderValidator.class));
+    }
+
+}

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/SendTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/SendTest.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl;
+
+import java.io.IOException;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.actions.SendMessageAction;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.citrusframework.groovy.NoopMessageProcessor;
+import org.citrusframework.message.DefaultMessage;
+import org.citrusframework.message.DefaultMessageQueue;
+import org.citrusframework.message.DelegatingPathExpressionProcessor;
+import org.citrusframework.message.Message;
+import org.citrusframework.message.MessageQueue;
+import org.citrusframework.message.MessageType;
+import org.citrusframework.spi.BindToRegistry;
+import org.citrusframework.util.FileUtils;
+import org.citrusframework.validation.DefaultMessageHeaderValidator;
+import org.citrusframework.validation.TextEqualsMessageValidator;
+import org.citrusframework.validation.builder.DefaultMessageBuilder;
+import org.citrusframework.validation.context.DefaultValidationContext;
+import org.citrusframework.validation.context.HeaderValidationContext;
+import org.citrusframework.variable.MessageHeaderVariableExtractor;
+import org.citrusframework.variable.dictionary.DataDictionary;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.endpoint.direct.DirectEndpoints.direct;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class SendTest extends AbstractGroovyActionDslTest {
+
+    @BindToRegistry
+    final DataDictionary<?> myDataDictionary = Mockito.mock(DataDictionary.class);
+
+    private final DefaultMessageHeaderValidator headerValidator = new DefaultMessageHeaderValidator();
+    private final TextEqualsMessageValidator validator = new TextEqualsMessageValidator().enableTrim();
+
+    @Test
+    public void shouldLoadSend() throws IOException {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/groovy/dsl/send.test.groovy");
+
+        MessageQueue helloQueue = new DefaultMessageQueue("helloQueue");
+        context.getReferenceResolver().bind("helloQueue", helloQueue);
+        context.getReferenceResolver().bind("helloEndpoint", direct().asynchronous().queue(helloQueue).build());
+
+        context.getReferenceResolver().bind("jsonPathMessageProcessorBuilder", new NoopMessageProcessor.Builder());
+        context.getReferenceResolver().bind("xpathMessageProcessorBuilder", new NoopMessageProcessor.Builder());
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "SendTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 9L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), SendMessageAction.class);
+
+        int actionIndex = 0;
+
+        SendMessageAction action = (SendMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertTrue(action.getMessageBuilder() instanceof DefaultMessageBuilder);
+        DefaultMessageBuilder messageBuilder = (DefaultMessageBuilder)action.getMessageBuilder();
+        Assert.assertEquals(messageBuilder.build(context, MessageType.PLAINTEXT.name()).getPayload(String.class), "Hello from Citrus!");
+
+        Message controlMessage = new DefaultMessage("Hello from Citrus!")
+                                        .setHeader("operation", "sayHello");
+        Message receivedMessage = helloQueue.receive();
+        headerValidator.validateMessage(receivedMessage, controlMessage, context, new HeaderValidationContext());
+        validator.validateMessage(receivedMessage, controlMessage, context, new DefaultValidationContext());
+
+        action = (SendMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertTrue(action.getMessageBuilder() instanceof DefaultMessageBuilder);
+        messageBuilder = (DefaultMessageBuilder)action.getMessageBuilder();
+
+        Assert.assertEquals(messageBuilder.buildMessagePayload(context, action.getMessageType()), "<TestMessage>Hello Citrus</TestMessage>");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 1);
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get("operation"), "sayHello");
+        Assert.assertEquals(action.getMessageProcessors().size(), 0);
+        Assert.assertEquals(action.getEndpointUri(), "helloEndpoint");
+
+        Assert.assertNull(action.getDataDictionary());
+
+        controlMessage = new DefaultMessage("<TestMessage>Hello Citrus</TestMessage>")
+                .setHeader("operation", "sayHello");
+        receivedMessage = helloQueue.receive();
+        headerValidator.validateMessage(receivedMessage, controlMessage, context, new HeaderValidationContext());
+        validator.validateMessage(receivedMessage, controlMessage, context, new DefaultValidationContext());
+
+        action = (SendMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertTrue(action.getMessageBuilder() instanceof DefaultMessageBuilder);
+        messageBuilder = (DefaultMessageBuilder)action.getMessageBuilder();
+
+        Assert.assertEquals(messageBuilder.buildMessagePayload(context, action.getMessageType()), "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" + System.getProperty("line.separator") +
+                "            <TestMessage xmlns=\"http://citrusframework.org/test\">Hello Citrus</TestMessage>");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 1);
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get("operation"), "sayHello");
+        Assert.assertEquals(messageBuilder.buildMessageHeaderData(context).size(), 1);
+        Assert.assertEquals(messageBuilder.buildMessageHeaderData(context).get(0).trim(), "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" + System.getProperty("line.separator") +
+                "            <Header xmlns=\"http://citrusframework.org/test\"><operation>hello</operation></Header>");
+        Assert.assertEquals(action.getMessageProcessors().size(), 0);
+        Assert.assertEquals(action.getEndpointUri(), "helloEndpoint");
+
+        Assert.assertNull(action.getDataDictionary());
+
+        controlMessage = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" + System.getProperty("line.separator") +
+                "            <TestMessage xmlns=\"http://citrusframework.org/test\">Hello Citrus</TestMessage>")
+                .setHeader("operation", "sayHello");
+        receivedMessage = helloQueue.receive();
+        headerValidator.validateMessage(receivedMessage, controlMessage, context, new HeaderValidationContext());
+        validator.validateMessage(receivedMessage, controlMessage, context, new DefaultValidationContext());
+
+        action = (SendMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertTrue(action.getMessageBuilder() instanceof DefaultMessageBuilder);
+        messageBuilder = (DefaultMessageBuilder)action.getMessageBuilder();
+
+        Assert.assertEquals(messageBuilder.buildMessagePayload(context, action.getMessageType()),
+                FileUtils.readToString(FileUtils.getFileResource("classpath:org/citrusframework/groovy/test-request-payload.xml")).trim());
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 0);
+        Assert.assertEquals(action.getMessageProcessors().size(), 0);
+        Assert.assertEquals(action.getEndpointUri(), "helloEndpoint");
+
+        controlMessage = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + System.lineSeparator() +
+                "<TestRequest>" + System.lineSeparator() +
+                "    <Message>Hello World!</Message>" + System.lineSeparator() +
+                "</TestRequest>");
+        receivedMessage = helloQueue.receive();
+        headerValidator.validateMessage(receivedMessage, controlMessage, context, new HeaderValidationContext());
+        validator.validateMessage(receivedMessage, controlMessage, context, new DefaultValidationContext());
+
+        action = (SendMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getVariableExtractors().size(), 1);
+        Assert.assertTrue(action.getVariableExtractors().get(0) instanceof MessageHeaderVariableExtractor);
+        MessageHeaderVariableExtractor headerVariableExtractor = (MessageHeaderVariableExtractor)action.getVariableExtractors().get(0);
+
+        Assert.assertEquals(headerVariableExtractor.getHeaderMappings().size(), 1);
+        Assert.assertEquals(headerVariableExtractor.getHeaderMappings().get("operation"), "operation");
+        Assert.assertEquals(action.getEndpointUri(), "helloEndpoint");
+
+        Assert.assertTrue(action.getMessageBuilder() instanceof DefaultMessageBuilder);
+        messageBuilder = (DefaultMessageBuilder)action.getMessageBuilder();
+
+        Assert.assertEquals(messageBuilder.buildMessagePayload(context, action.getMessageType()), "<TestMessage>Hello Citrus</TestMessage>");
+
+        Assert.assertEquals(action.getMessageProcessors().size(), 1);
+        Assert.assertTrue(action.getMessageProcessors().get(0) instanceof DelegatingPathExpressionProcessor);
+        DelegatingPathExpressionProcessor messageProcessor = (DelegatingPathExpressionProcessor)action.getMessageProcessors().get(0);
+
+        Assert.assertEquals(messageProcessor.getPathExpressions().size(), 1);
+        Assert.assertEquals(messageProcessor.getPathExpressions().get("/TestMessage/text()"), "newValue");
+
+        Assert.assertNotNull(action.getDataDictionary());
+
+        controlMessage = new DefaultMessage("<TestMessage>Hello Citrus</TestMessage>")
+                .setHeader("operation", "sayHello");
+        receivedMessage = helloQueue.receive();
+        headerValidator.validateMessage(receivedMessage, controlMessage, context, new HeaderValidationContext());
+        validator.validateMessage(receivedMessage, controlMessage, context, new DefaultValidationContext());
+
+        action = (SendMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertTrue(action.getMessageBuilder() instanceof DefaultMessageBuilder);
+        messageBuilder = (DefaultMessageBuilder)action.getMessageBuilder();
+
+        Assert.assertEquals(messageBuilder.buildMessagePayload(context, action.getMessageType()), "<TestMessage>Hello Citrus</TestMessage>");
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 8);
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get("intValue"), 5);
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get("longValue"), 10L);
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get("floatValue"), 10.0F);
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get("doubleValue"), 10.0D);
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get("byteValue"), (byte) 1);
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get("shortValue"), (short) 10);
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get("boolValue"), true);
+        Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get("stringValue"), "Hello Citrus");
+
+        Assert.assertNull(action.getEndpoint());
+        Assert.assertEquals(action.getEndpointUri(), "direct:helloQueue");
+
+        Assert.assertEquals(action.getMessageProcessors().size(), 0);
+
+        controlMessage = new DefaultMessage("<TestMessage>Hello Citrus</TestMessage>")
+                .setHeader("intValue" ,5)
+                .setHeader("longValue" ,10L)
+                .setHeader("floatValue" ,10.0F)
+                .setHeader("doubleValue" ,10.0D)
+                .setHeader("byteValue" , (byte) 1)
+                .setHeader("shortValue" , (short) 10)
+                .setHeader("boolValue" ,true)
+                .setHeader("stringValue" ,"Hello Citrus");
+        receivedMessage = helloQueue.receive();
+        headerValidator.validateMessage(receivedMessage, controlMessage, context, new HeaderValidationContext());
+        validator.validateMessage(receivedMessage, controlMessage, context, new DefaultValidationContext());
+
+        action = (SendMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getEndpointUri(), "helloEndpoint");
+
+        Assert.assertTrue(action.getMessageBuilder() instanceof DefaultMessageBuilder);
+        messageBuilder = (DefaultMessageBuilder)action.getMessageBuilder();
+
+        Assert.assertEquals(messageBuilder.buildMessagePayload(context, action.getMessageType()), "{ \"FooMessage\": { \"foo\": \"Hello World!\" }, { \"bar\": \"@ignore@\" }}");
+
+        Assert.assertEquals(action.getMessageProcessors().size(), 1);
+        Assert.assertTrue(action.getMessageProcessors().get(0) instanceof DelegatingPathExpressionProcessor);
+        DelegatingPathExpressionProcessor jsonMessageProcessor = (DelegatingPathExpressionProcessor)action.getMessageProcessors().get(0);
+
+        Assert.assertEquals(jsonMessageProcessor.getPathExpressions().size(), 1);
+        Assert.assertEquals(jsonMessageProcessor.getPathExpressions().get("$.FooMessage.foo"), "newValue");
+
+        controlMessage = new DefaultMessage("{ \"FooMessage\": { \"foo\": \"Hello World!\" }, { \"bar\": \"@ignore@\" }}");
+        receivedMessage = helloQueue.receive();
+        headerValidator.validateMessage(receivedMessage, controlMessage, context, new HeaderValidationContext());
+        validator.validateMessage(receivedMessage, controlMessage, context, new DefaultValidationContext());
+
+        action = (SendMessageAction) result.getTestAction(actionIndex++);
+        Assert.assertTrue(action.isSchemaValidation());
+        Assert.assertEquals(action.getSchema(), "fooSchema");
+        Assert.assertEquals(action.getSchemaRepository(), "fooRepository");
+
+        controlMessage = new DefaultMessage("{ \"FooMessage\": { \"foo\": \"Hello World!\" }, { \"bar\": \"@ignore@\" }}");
+        receivedMessage = helloQueue.receive();
+        headerValidator.validateMessage(receivedMessage, controlMessage, context, new HeaderValidationContext());
+        validator.validateMessage(receivedMessage, controlMessage, context, new DefaultValidationContext());
+
+        action = (SendMessageAction) result.getTestAction(actionIndex);
+        Assert.assertTrue(action.isSchemaValidation());
+        Assert.assertEquals(action.getSchema(), "fooSchema");
+        Assert.assertEquals(action.getSchemaRepository(), "fooRepository");
+
+        controlMessage = new DefaultMessage("<TestMessage>Hello Citrus</TestMessage>");
+        receivedMessage = helloQueue.receive();
+        headerValidator.validateMessage(receivedMessage, controlMessage, context, new HeaderValidationContext());
+        validator.validateMessage(receivedMessage, controlMessage, context, new DefaultValidationContext());
+    }
+}

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/SleepTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/SleepTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl;
+
+import java.util.concurrent.TimeUnit;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.actions.SleepAction;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class SleepTest extends AbstractGroovyActionDslTest {
+
+    @Test
+    public void shouldLoadSleep() {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/groovy/dsl/sleep.test.groovy");
+
+        testLoader.load();
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "SleepTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 1L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), SleepAction.class);
+        Assert.assertEquals(((SleepAction) result.getTestAction(0)).getTime(), "500");
+        Assert.assertEquals(((SleepAction) result.getTestAction(0)).getTimeUnit(), TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    public void shouldLoadDelay() {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/groovy/dsl/delay.test.groovy");
+
+        testLoader.load();
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "DelayTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 1L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), SleepAction.class);
+        Assert.assertEquals(((SleepAction) result.getTestAction(0)).getTime(), "500");
+        Assert.assertEquals(((SleepAction) result.getTestAction(0)).getTimeUnit(), TimeUnit.MILLISECONDS);
+    }
+}

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/StartTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/StartTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.actions.StartServerAction;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.citrusframework.server.Server;
+import org.citrusframework.spi.BindToRegistry;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class StartTest extends AbstractGroovyActionDslTest {
+
+    @BindToRegistry
+    final Server myServer = Mockito.mock(Server.class);
+
+    @BindToRegistry
+    final Server myFooServer = Mockito.mock(Server.class);
+
+    @BindToRegistry
+    final Server myBarServer = Mockito.mock(Server.class);
+
+    @Test
+    public void shouldLoadStart() {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/groovy/dsl/start.test.groovy");
+
+        when(myServer.getName()).thenReturn("myServer");
+        when(myFooServer.getName()).thenReturn("myFooServer");
+        when(myBarServer.getName()).thenReturn("myBarServer");
+
+        testLoader.load();
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "StartTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 3L);
+
+        int actionIndex = 0;
+
+        StartServerAction action = (StartServerAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getClass(), StartServerAction.class);
+        Assert.assertEquals(action.getServers().size(), 1L);
+        Assert.assertEquals(action.getServers().get(0), myServer);
+
+        action = (StartServerAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getClass(), StartServerAction.class);
+        Assert.assertEquals(action.getServers().size(), 1L);
+        Assert.assertEquals(action.getServers().get(0), myServer);
+
+        action = (StartServerAction) result.getTestAction(actionIndex);
+        Assert.assertEquals(action.getServers().size(), 2L);
+        Assert.assertEquals(action.getServers().get(0), myFooServer);
+        Assert.assertEquals(action.getServers().get(1), myBarServer);
+
+        verify(myServer, times(2)).start();
+        verify(myFooServer).start();
+        verify(myBarServer).start();
+    }
+
+}

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/StopTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/StopTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.actions.StopServerAction;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.citrusframework.server.Server;
+import org.citrusframework.spi.BindToRegistry;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class StopTest extends AbstractGroovyActionDslTest {
+
+    @BindToRegistry
+    final Server myServer = Mockito.mock(Server.class);
+
+    @BindToRegistry
+    final Server myFooServer = Mockito.mock(Server.class);
+
+    @BindToRegistry
+    final Server myBarServer = Mockito.mock(Server.class);
+
+    @Test
+    public void shouldLoadStop() {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/groovy/dsl/stop.test.groovy");
+
+        when(myServer.getName()).thenReturn("myServer");
+        when(myServer.isRunning()).thenReturn(true);
+        when(myFooServer.getName()).thenReturn("myFooServer");
+        when(myFooServer.isRunning()).thenReturn(true);
+        when(myBarServer.getName()).thenReturn("myBarServer");
+        when(myBarServer.isRunning()).thenReturn(true);
+
+        testLoader.load();
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "StopTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 3L);
+
+        int actionIndex = 0;
+
+        StopServerAction action = (StopServerAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getClass(), StopServerAction.class);
+        Assert.assertEquals(action.getServers().size(), 1L);
+        Assert.assertEquals(action.getServers().get(0), myServer);
+
+        action = (StopServerAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getClass(), StopServerAction.class);
+        Assert.assertEquals(action.getServers().size(), 1L);
+        Assert.assertEquals(action.getServers().get(0), myServer);
+
+        action = (StopServerAction) result.getTestAction(actionIndex);
+        Assert.assertEquals(action.getServers().size(), 2L);
+        Assert.assertEquals(action.getServers().get(0), myFooServer);
+        Assert.assertEquals(action.getServers().get(1), myBarServer);
+
+        verify(myServer, times(2)).stop();
+        verify(myFooServer).stop();
+        verify(myBarServer).stop();
+    }
+
+}

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/TraceVariablesTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/TraceVariablesTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.actions.TraceVariablesAction;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class TraceVariablesTest extends AbstractGroovyActionDslTest {
+
+    @Test
+    public void shouldLoadTraceVariables() {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/groovy/dsl/trace-variables.test.groovy");
+
+        testLoader.load();
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "TraceVariablesTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 3L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), TraceVariablesAction.class);
+
+        int actionIndex = 0;
+
+        TraceVariablesAction action = (TraceVariablesAction) result.getTestAction(actionIndex++);
+
+        Assert.assertEquals(action.getVariableNames().size(), 0L);
+
+        action = (TraceVariablesAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getVariableNames().size(), 1L);
+        Assert.assertEquals(action.getVariableNames().get(0), "foo");
+
+        action = (TraceVariablesAction) result.getTestAction(actionIndex);
+        Assert.assertEquals(action.getVariableNames().size(), 2L);
+        Assert.assertEquals(action.getVariableNames().get(0), "foo");
+        Assert.assertEquals(action.getVariableNames().get(1), "bar");
+    }
+
+}

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/TransformTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/TransformTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.actions.TransformAction;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.springframework.util.StringUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class TransformTest extends AbstractGroovyActionDslTest {
+
+    @Test
+    public void shouldLoadTransform() {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/groovy/dsl/transform.test.groovy");
+
+        testLoader.load();
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "TransformTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 2L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), TransformAction.class);
+
+        int actionIndex = 0;
+
+        TransformAction action = (TransformAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getTargetVariable(), "result");
+        Assert.assertTrue(StringUtils.hasText(action.getXmlData()));
+        Assert.assertNull(action.getXmlResourcePath());
+        Assert.assertTrue(StringUtils.hasText(action.getXsltData()));
+        Assert.assertNull(action.getXsltResourcePath());
+
+        Assert.assertTrue(context.getVariable("result").contains("<p>Message: Hello World!</p>"));
+
+        action = (TransformAction) result.getTestAction(actionIndex);
+        Assert.assertEquals(action.getTargetVariable(), "transform-result");
+        Assert.assertFalse(StringUtils.hasText(action.getXmlData()));
+        Assert.assertNotNull(action.getXmlResourcePath());
+        Assert.assertEquals(action.getXmlResourcePath(), "classpath:org/citrusframework/groovy/transform-source.xml");
+        Assert.assertFalse(StringUtils.hasText(action.getXsltData()));
+        Assert.assertNotNull(action.getXsltResourcePath());
+        Assert.assertEquals(action.getXsltResourcePath(), "classpath:org/citrusframework/groovy/transform.xslt");
+
+        Assert.assertTrue(context.getVariable("transform-result").contains("<p>Message: Hello World!</p>"));
+    }
+
+}

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/AssertTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/AssertTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl.container;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.actions.FailAction;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.citrusframework.groovy.dsl.AbstractGroovyActionDslTest;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class AssertTest extends AbstractGroovyActionDslTest {
+
+    @Test
+    public void shouldLoadAssert() {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/groovy/dsl/container/assert.test.groovy");
+
+        testLoader.load();
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "AssertTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 1L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), org.citrusframework.container.Assert.class);
+        Assert.assertEquals(((org.citrusframework.container.Assert) result.getTestAction(0)).getException(), CitrusRuntimeException.class);
+        Assert.assertEquals(((org.citrusframework.container.Assert) result.getTestAction(0)).getMessage(), "Something went wrong");
+        Assert.assertEquals(((org.citrusframework.container.Assert) result.getTestAction(0)).getActionCount(), 1L);
+        Assert.assertEquals(((org.citrusframework.container.Assert) result.getTestAction(0)).getAction().getClass(), FailAction.class);
+    }
+}

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/AsyncTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/AsyncTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl.container;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.actions.EchoAction;
+import org.citrusframework.container.Async;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.citrusframework.groovy.dsl.AbstractGroovyActionDslTest;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class AsyncTest extends AbstractGroovyActionDslTest {
+
+    @Test
+    public void shouldLoadAsync() {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/groovy/dsl/container/async.test.groovy");
+
+        testLoader.load();
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "AsyncTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 2L);
+
+        Assert.assertEquals(result.getTestAction(0).getClass(), Async.class);
+
+        int actionIndex = 0;
+
+        Async action = (Async) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getActionCount(), 2L);
+        Assert.assertEquals(action.getSuccessActions().size(), 0L);
+        Assert.assertEquals(action.getErrorActions().size(), 0L);
+
+        action = (Async) result.getTestAction(actionIndex);
+        Assert.assertEquals(action.getActionCount(), 1L);
+        Assert.assertEquals(action.getSuccessActions().size(), 1L);
+        Assert.assertEquals(((EchoAction)action.getSuccessActions().get(0)).getMessage(), "Success!");
+        Assert.assertEquals(action.getErrorActions().size(), 1L);
+        Assert.assertEquals(((EchoAction)action.getErrorActions().get(0)).getMessage(), "Failed!");
+
+    }
+
+}

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/CatchTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/CatchTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl.container;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.actions.EchoAction;
+import org.citrusframework.actions.FailAction;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.citrusframework.groovy.dsl.AbstractGroovyActionDslTest;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class CatchTest extends AbstractGroovyActionDslTest {
+
+    @Test
+    public void shouldLoadCatch() {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/groovy/dsl/container/catch.test.groovy");
+
+        testLoader.load();
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "CatchTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 1L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), org.citrusframework.container.Catch.class);
+        Assert.assertEquals(((org.citrusframework.container.Catch) result.getTestAction(0)).getException(), CitrusRuntimeException.class.getName());
+        Assert.assertEquals(((org.citrusframework.container.Catch) result.getTestAction(0)).getActionCount(), 2L);
+        Assert.assertEquals(((org.citrusframework.container.Catch) result.getTestAction(0)).getTestAction(0).getClass(), EchoAction.class);
+        Assert.assertEquals(((org.citrusframework.container.Catch) result.getTestAction(0)).getTestAction(1).getClass(), FailAction.class);
+    }
+}

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/ConditionalTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/ConditionalTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl.container;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.actions.EchoAction;
+import org.citrusframework.actions.FailAction;
+import org.citrusframework.container.Conditional;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.citrusframework.groovy.dsl.AbstractGroovyActionDslTest;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class ConditionalTest extends AbstractGroovyActionDslTest {
+
+    @Test
+    public void shouldLoadConditional() {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/groovy/dsl/container/conditional.test.groovy");
+
+        testLoader.load();
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "ConditionalTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 2L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), Conditional.class);
+        Assert.assertEquals(((Conditional) result.getTestAction(0)).getCondition(), "${shouldRun}");
+        Assert.assertEquals(((Conditional) result.getTestAction(0)).getActionCount(), 1L);
+        Assert.assertEquals(((Conditional) result.getTestAction(0)).getTestAction(0).getClass(), EchoAction.class);
+
+        Assert.assertEquals(result.getTestAction(1).getClass(), Conditional.class);
+        Assert.assertEquals(((Conditional) result.getTestAction(1)).getCondition(), "${shouldNotRun}");
+        Assert.assertEquals(((Conditional) result.getTestAction(1)).getActionCount(), 1L);
+        Assert.assertEquals(((Conditional) result.getTestAction(1)).getTestAction(0).getClass(), FailAction.class);
+    }
+
+}

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/IterateTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/IterateTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl.container;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.actions.EchoAction;
+import org.citrusframework.container.Iterate;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.citrusframework.groovy.dsl.AbstractGroovyActionDslTest;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class IterateTest extends AbstractGroovyActionDslTest {
+
+    @Test
+    public void shouldLoadIterate() {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/groovy/dsl/container/iterate.test.groovy");
+
+        testLoader.load();
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "IterateTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 3L);
+
+        Assert.assertEquals(result.getTestAction(0).getClass(), Iterate.class);
+
+        Iterate action = (Iterate) result.getTestAction(0);
+        Assert.assertEquals(action.getCondition(), "i < 3");
+        Assert.assertEquals(action.getIndexName(), "i");
+        Assert.assertEquals(action.getStep(), 1);
+        Assert.assertEquals(action.getStart(), 1);
+        Assert.assertEquals(action.getActionCount(), 1L);
+        Assert.assertEquals(action.getTestAction(0).getClass(), EchoAction.class);
+
+        action = (Iterate) result.getTestAction(1);
+        Assert.assertEquals(result.getTestAction(0).getClass(), Iterate.class);
+        Assert.assertEquals(action.getCondition(), "index <= 2");
+        Assert.assertEquals(action.getIndexName(), "index");
+        Assert.assertEquals(action.getStep(), 1);
+        Assert.assertEquals(action.getStart(), 1);
+        Assert.assertEquals(action.getActionCount(), 1L);
+        Assert.assertEquals(action.getTestAction(0).getClass(), EchoAction.class);
+
+        action = (Iterate) result.getTestAction(2);
+        Assert.assertEquals(action.getCondition(), "i <= 10");
+        Assert.assertEquals(action.getIndexName(), "i");
+        Assert.assertEquals(action.getStep(), 5);
+        Assert.assertEquals(action.getStart(), 0);
+        Assert.assertEquals(action.getActionCount(), 2L);
+        Assert.assertEquals(action.getTestAction(0).getClass(), EchoAction.class);
+        Assert.assertEquals(action.getTestAction(1).getClass(), EchoAction.class);
+    }
+
+}

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/ParallelTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/ParallelTest.java
@@ -17,25 +17,25 @@
  * limitations under the License.
  */
 
-package org.citrusframework.yaml.container;
+package org.citrusframework.groovy.dsl.container;
 
 import org.citrusframework.TestCase;
 import org.citrusframework.TestCaseMetaInfo;
 import org.citrusframework.actions.EchoAction;
 import org.citrusframework.container.Parallel;
-import org.citrusframework.yaml.YamlTestLoader;
-import org.citrusframework.yaml.actions.AbstractYamlActionTest;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.citrusframework.groovy.dsl.AbstractGroovyActionDslTest;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 /**
  * @author Christoph Deppisch
  */
-public class ParallelTest extends AbstractYamlActionTest {
+public class ParallelTest extends AbstractGroovyActionDslTest {
 
     @Test
     public void shouldLoadParallel() {
-        YamlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/yaml/container/parallel-test.yaml");
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/groovy/dsl/container/parallel.test.groovy");
 
         testLoader.load();
         TestCase result = testLoader.getTestCase();

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/RepeatOnErrorTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/RepeatOnErrorTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl.container;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.actions.EchoAction;
+import org.citrusframework.container.RepeatOnErrorUntilTrue;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.citrusframework.groovy.dsl.AbstractGroovyActionDslTest;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class RepeatOnErrorTest extends AbstractGroovyActionDslTest {
+
+    @Test
+    public void shouldLoadRepeatOnError() {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/groovy/dsl/container/repeat-on-error.test.groovy");
+
+        testLoader.load();
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "RepeatOnErrorTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 4L);
+
+        Assert.assertEquals(result.getTestAction(0).getClass(), RepeatOnErrorUntilTrue.class);
+
+        RepeatOnErrorUntilTrue action = (RepeatOnErrorUntilTrue) result.getTestAction(0);
+        Assert.assertEquals(action.getCondition(), "i > 3");
+        Assert.assertEquals(action.getIndexName(), "i");
+        Assert.assertEquals(action.getStart(), 1);
+        Assert.assertEquals(action.getAutoSleep(), Long.valueOf(1000L));
+        Assert.assertEquals(action.getActionCount(), 1);
+        Assert.assertEquals(action.getTestAction(0).getClass(), EchoAction.class);
+
+        action = (RepeatOnErrorUntilTrue) result.getTestAction(1);
+        Assert.assertEquals(action.getCondition(), "index >= 2");
+        Assert.assertEquals(action.getIndexName(), "index");
+        Assert.assertEquals(action.getStart(), 1);
+        Assert.assertEquals(action.getAutoSleep(), Long.valueOf(1000L));
+        Assert.assertEquals(action.getActionCount(), 1);
+        Assert.assertEquals(action.getTestAction(0).getClass(), EchoAction.class);
+
+        action = (RepeatOnErrorUntilTrue) result.getTestAction(2);
+        Assert.assertEquals(action.getCondition(), "i >= 10");
+        Assert.assertEquals(action.getIndexName(), "i");
+        Assert.assertEquals(action.getStart(), 1);
+        Assert.assertEquals(action.getAutoSleep(), Long.valueOf(500L));
+        Assert.assertEquals(action.getActionCount(), 2);
+        Assert.assertEquals(action.getTestAction(0).getClass(), EchoAction.class);
+        Assert.assertEquals(action.getTestAction(1).getClass(), EchoAction.class);
+
+        action = (RepeatOnErrorUntilTrue) result.getTestAction(3);
+        Assert.assertEquals(action.getCondition(), "i >= 5");
+        Assert.assertEquals(action.getIndexName(), "i");
+        Assert.assertEquals(action.getStart(), 1);
+        Assert.assertEquals(action.getAutoSleep(), Long.valueOf(250L));
+        Assert.assertEquals(action.getActionCount(), 1);
+        Assert.assertEquals(action.getTestAction(0).getClass(), EchoAction.class);
+    }
+
+}

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/RepeatTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/RepeatTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl.container;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.actions.EchoAction;
+import org.citrusframework.container.RepeatUntilTrue;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.citrusframework.groovy.dsl.AbstractGroovyActionDslTest;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class RepeatTest extends AbstractGroovyActionDslTest {
+
+    @Test
+    public void shouldLoadRepeat() {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/groovy/dsl/container/repeat.test.groovy");
+
+        testLoader.load();
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "RepeatTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 3L);
+
+        Assert.assertEquals(result.getTestAction(0).getClass(), RepeatUntilTrue.class);
+
+        RepeatUntilTrue action = (RepeatUntilTrue) result.getTestAction(0);
+        Assert.assertEquals(action.getCondition(), "i < 3");
+        Assert.assertEquals(action.getIndexName(), "i");
+        Assert.assertEquals(action.getStart(), 1);
+        Assert.assertEquals(action.getActionCount(), 1);
+        Assert.assertEquals(action.getTestAction(0).getClass(), EchoAction.class);
+
+        action = (RepeatUntilTrue) result.getTestAction(1);
+        Assert.assertEquals(action.getCondition(), "index <= 2");
+        Assert.assertEquals(action.getIndexName(), "index");
+        Assert.assertEquals(action.getStart(), 1);
+        Assert.assertEquals(action.getActionCount(), 1);
+        Assert.assertEquals(action.getTestAction(0).getClass(), EchoAction.class);
+
+        action = (RepeatUntilTrue) result.getTestAction(2);
+        Assert.assertEquals(action.getCondition(), "i <= 10");
+        Assert.assertEquals(action.getIndexName(), "i");
+        Assert.assertEquals(action.getStart(), 1);
+        Assert.assertEquals(action.getActionCount(), 2);
+        Assert.assertEquals(action.getTestAction(0).getClass(), EchoAction.class);
+        Assert.assertEquals(action.getTestAction(1).getClass(), EchoAction.class);
+    }
+
+}

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/SequentialTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/SequentialTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl.container;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.container.Sequence;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.citrusframework.groovy.dsl.AbstractGroovyActionDslTest;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class SequentialTest extends AbstractGroovyActionDslTest {
+
+    @Test
+    public void shouldLoadSequential() {
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/groovy/dsl/container/sequential.test.groovy");
+
+        testLoader.load();
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "SequentialTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 1L);
+
+        Assert.assertEquals(result.getTestAction(0).getClass(), Sequence.class);
+        Assert.assertEquals(((Sequence) result.getTestAction(0)).getActionCount(), 2L);
+    }
+
+}

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/TimerTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/TimerTest.java
@@ -17,24 +17,24 @@
  * limitations under the License.
  */
 
-package org.citrusframework.yaml.container;
+package org.citrusframework.groovy.dsl.container;
 
 import org.citrusframework.TestCase;
 import org.citrusframework.TestCaseMetaInfo;
 import org.citrusframework.container.Timer;
-import org.citrusframework.yaml.YamlTestLoader;
-import org.citrusframework.yaml.actions.AbstractYamlActionTest;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.citrusframework.groovy.dsl.AbstractGroovyActionDslTest;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 /**
  * @author Christoph Deppisch
  */
-public class TimerTest extends AbstractYamlActionTest {
+public class TimerTest extends AbstractGroovyActionDslTest {
 
     @Test
     public void shouldLoadTimer() {
-        YamlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/yaml/container/timer-test.yaml");
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/groovy/dsl/container/timer.test.groovy");
 
         testLoader.load();
         TestCase result = testLoader.getTestCase();

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/WaitForTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/WaitForTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl.container;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.actions.EchoAction;
+import org.citrusframework.condition.ActionCondition;
+import org.citrusframework.condition.Condition;
+import org.citrusframework.condition.FileCondition;
+import org.citrusframework.condition.HttpCondition;
+import org.citrusframework.condition.MessageCondition;
+import org.citrusframework.container.Wait;
+import org.citrusframework.groovy.GroovyTestLoader;
+import org.citrusframework.groovy.dsl.AbstractGroovyActionDslTest;
+import org.citrusframework.message.DefaultMessage;
+import org.citrusframework.message.DefaultMessageStore;
+import org.citrusframework.message.MessageStore;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class WaitForTest extends AbstractGroovyActionDslTest {
+
+    private static final String DEFAULT_WAIT_TIME = "5000";
+    private static final String DEFAULT_INTERVAL = "1000";
+    private static final String DEFAULT_TIMEOUT = "1000";
+    private static final String DEFAULT_RESPONSE_CODE = "200";
+
+    @Test
+    public void shouldLoadWaitFor() {
+        String httpUrl = "https://citrusframework.org";
+        String filePath = "classpath:org/citrusframework/groovy/test-request-payload.xml";
+
+        MessageStore messageStore = new DefaultMessageStore();
+        messageStore.storeMessage("request", new DefaultMessage("Citrus rocks!"));
+        context.setMessageStore(messageStore);
+
+        GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/groovy/dsl/container/wait-for.test.groovy");
+
+        testLoader.load();
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "WaitForTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 6L);
+
+        Assert.assertEquals(result.getTestAction(0).getClass(), Wait.class);
+
+        int actionIndex = 0;
+
+        Wait action = (Wait) result.getTestAction(actionIndex++);
+        Condition condition = getFileCondition(filePath);
+        validateWaitAction(action, DEFAULT_WAIT_TIME, DEFAULT_INTERVAL, condition);
+
+        action = (Wait) result.getTestAction(actionIndex++);
+        validateWaitAction(action, "10000", "2000", condition);
+
+        action = (Wait) result.getTestAction(actionIndex++);
+        condition = getHttpCondition(httpUrl, DEFAULT_RESPONSE_CODE, DEFAULT_TIMEOUT);
+        validateWaitAction(action, DEFAULT_WAIT_TIME, DEFAULT_INTERVAL, condition);
+
+        action = (Wait) result.getTestAction(actionIndex++);
+        condition = getHttpCondition(httpUrl + "/doesnotexist", "404", "2000");
+        ((HttpCondition)condition).setMethod("GET");
+        validateWaitAction(action, "3000", DEFAULT_INTERVAL, condition);
+
+        action = (Wait) result.getTestAction(actionIndex++);
+        condition = getMessageCondition("request");
+        validateWaitAction(action, DEFAULT_WAIT_TIME, DEFAULT_INTERVAL, condition);
+
+        action = (Wait) result.getTestAction(actionIndex);
+        condition = getActionCondition();
+        validateWaitAction(action, DEFAULT_WAIT_TIME, DEFAULT_INTERVAL, condition);
+    }
+
+    private Condition getFileCondition(String path) {
+        FileCondition condition = new FileCondition();
+        condition.setFilePath(path);
+        return condition;
+    }
+
+    private Condition getMessageCondition(String name) {
+        MessageCondition condition = new MessageCondition();
+        condition.setMessageName(name);
+        return condition;
+    }
+
+    private Condition getActionCondition() {
+        return new ActionCondition(new EchoAction.Builder().message("Citrus rocks!").build());
+    }
+
+    private Condition getHttpCondition(String url, String responseCode, String timeout) {
+        HttpCondition condition = new HttpCondition();
+        condition.setUrl(url);
+        condition.setHttpResponseCode(responseCode);
+        condition.setTimeout(timeout);
+        return condition;
+    }
+
+    private void validateWaitAction(Wait action, String expectedMilliseconds, String expectedInterval, Condition expectedCondition) {
+        Assert.assertEquals(action.getTime(), expectedMilliseconds);
+        Assert.assertEquals(action.getInterval(), expectedInterval);
+
+        if (!(expectedCondition instanceof ActionCondition)) {
+            Assert.assertEquals(action.getCondition().getClass(), expectedCondition.getClass());
+        }
+
+        if (expectedCondition instanceof HttpCondition) {
+            HttpCondition condition = (HttpCondition) action.getCondition();
+            Assert.assertNotNull(condition);
+            Assert.assertEquals(condition.getName(), expectedCondition.getName());
+            Assert.assertEquals(condition.getUrl(), ((HttpCondition) expectedCondition).getUrl());
+            Assert.assertEquals(condition.getTimeout(), ((HttpCondition) expectedCondition).getTimeout());
+            Assert.assertEquals(condition.getMethod(), ((HttpCondition) expectedCondition).getMethod());
+        } else if (expectedCondition instanceof FileCondition) {
+            FileCondition condition = (FileCondition) action.getCondition();
+            Assert.assertNotNull(condition);
+            Assert.assertEquals(condition.getName(), expectedCondition.getName());
+            Assert.assertEquals(condition.getFilePath(), ((FileCondition) expectedCondition).getFilePath());
+        } else if (expectedCondition instanceof MessageCondition) {
+            MessageCondition condition = (MessageCondition) action.getCondition();
+            Assert.assertNotNull(condition);
+            Assert.assertEquals(condition.getName(), expectedCondition.getName());
+            Assert.assertEquals(condition.getMessageName(), ((MessageCondition) expectedCondition).getMessageName());
+        } else if (expectedCondition instanceof ActionCondition) {
+            ActionCondition condition = (ActionCondition) action.getCondition();
+            Assert.assertNotNull(condition);
+            Assert.assertEquals(condition.getAction().getName(), ((ActionCondition) expectedCondition).getAction().getName());
+            Assert.assertEquals(((EchoAction) condition.getAction()).getMessage(), ((EchoAction)((ActionCondition) expectedCondition).getAction()).getMessage());
+        }
+    }
+
+}

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/validation/TextEqualsMessageValidator.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/validation/TextEqualsMessageValidator.java
@@ -33,13 +33,28 @@ import org.testng.Assert;
  */
 public class TextEqualsMessageValidator extends DefaultMessageValidator {
 
+    private boolean trim = false;
+
     @Override
     public void validateMessage(Message receivedMessage, Message controlMessage, TestContext context, ValidationContext validationContext) {
         Logger log = LoggerFactory.getLogger("TextEqualsMessageValidator");
 
+        if (controlMessage == null || controlMessage.getPayload() == null || controlMessage.getPayload(String.class).isEmpty()) {
+            LOG.debug("Skip message payload validation as no control message was defined");
+            return;
+        }
+
         log.debug("Start text equals validation ...");
 
-        Assert.assertEquals(receivedMessage.getPayload(String.class), controlMessage.getPayload(String.class), "Validation failed - " +
+        String controlPayload = controlMessage.getPayload(String.class);
+        String receivedPayload = receivedMessage.getPayload(String.class);
+
+        if (trim) {
+            controlPayload = controlPayload.trim();
+            receivedPayload = receivedPayload.trim();
+        }
+
+        Assert.assertEquals(receivedPayload, controlPayload, "Validation failed - " +
                 "expected message contents not equal!");
 
         log.info("Text validation successful: All values OK");
@@ -48,5 +63,10 @@ public class TextEqualsMessageValidator extends DefaultMessageValidator {
     @Override
     public boolean supportsMessageType(String messageType, Message message) {
         return true;
+    }
+
+    public TextEqualsMessageValidator enableTrim() {
+        this.trim = true;
+        return this;
     }
 }

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/action.test.groovy
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/action.test.groovy
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl
+
+import static org.citrusframework.groovy.dsl.actions.Action.action
+
+name "ActionTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+actions {
+    $(action().reference("echoBuilder"))
+    $(action().ref("echo"))
+}

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/actions.groovy
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/actions.groovy
@@ -17,6 +17,11 @@
  * limitations under the License.
  */
 
+package org.citrusframework.groovy.dsl
+
+import static org.citrusframework.actions.EchoAction.Builder.echo
+import static org.citrusframework.container.Iterate.Builder.iterate
+
 actions {
     $(echo("Hello from Citrus!"))
 

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/apply-template.test.groovy
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/apply-template.test.groovy
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl
+
+import static org.citrusframework.container.Template.Builder.applyTemplate
+name "ApplyTemplateTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+actions {
+    $(applyTemplate().templateName("myTemplate"))
+    $(applyTemplate().templateName("print")
+        .parameter("text", "Hello from Citrus!")
+        .parameter("message", """
+            <HelloRequest>
+               <Text>Hello from Citrus!</Text>
+            </HelloRequest>
+        """))
+    $(applyTemplate().file("classpath:org/citrusframework/groovy/echo-template.groovy"))
+}

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/container/assert.test.groovy
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/container/assert.test.groovy
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl.container
+
+import org.citrusframework.exceptions.CitrusRuntimeException
+
+import static org.citrusframework.container.Assert.Builder.assertException
+import static org.citrusframework.actions.FailAction.Builder.fail
+
+name "AssertTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+actions {
+    $(assertException()
+        .exception(CitrusRuntimeException)
+        .message("Something went wrong")
+        .when(fail().message("Something went wrong")))
+}

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/container/async.test.groovy
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/container/async.test.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl.container
+
+
+import static org.citrusframework.actions.EchoAction.Builder.echo
+import static org.citrusframework.container.Async.Builder.async
+
+name "AsyncTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+actions {
+    $(async()
+        .actions(
+            echo().message("1"),
+            echo().message("2")
+        ))
+
+    $(async()
+        .actions(echo().message("Try"))
+        .successActions(echo().message("Success!"))
+        .errorActions(echo().message("Failed!")))
+}

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/container/catch.test.groovy
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/container/catch.test.groovy
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl.container
+
+import static org.citrusframework.actions.EchoAction.Builder.echo
+import static org.citrusframework.actions.FailAction.Builder.fail
+import static org.citrusframework.container.Catch.Builder.catchException
+
+name "CatchTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+actions {
+    $(catchException()
+        .when(
+            echo().message("Citrus rocks!"),
+            fail().message("Something went wrong")
+        ))
+}

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/container/conditional.test.groovy
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/container/conditional.test.groovy
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl.container
+
+import static org.citrusframework.actions.EchoAction.Builder.echo
+import static org.citrusframework.actions.FailAction.Builder.fail
+import static org.citrusframework.container.Conditional.Builder.conditional
+
+name "ConditionalTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+variables {
+    shouldRun=true
+    shouldNotRun=false
+}
+
+actions {
+    $(conditional()
+        .when('${shouldRun}')
+        .actions(echo().message("Hello from Citrus!")))
+    $(conditional()
+        .when('${shouldNotRun}')
+        .actions(fail().message("Should not execute")))
+}

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/container/iterate.test.groovy
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/container/iterate.test.groovy
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl.container
+
+import static org.citrusframework.actions.EchoAction.Builder.echo
+import static org.citrusframework.container.Iterate.Builder.iterate
+
+name "IterateTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+actions {
+    $(iterate()
+        .condition("i < 3")
+        .actions(echo().message("Hello Citrus!")))
+    $(iterate()
+        .condition("index <= 2")
+        .index("index")
+        .actions(echo().message("Hello Citrus!")))
+    $(iterate()
+        .condition("i <= 10")
+        .startsWith(0)
+        .step(5)
+        .actions(
+            echo().message("Hello Citrus!"),
+            echo().message("Hello You!")
+        ))
+}

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/container/parallel.test.groovy
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/container/parallel.test.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl.container
+
+import static org.citrusframework.actions.EchoAction.Builder.echo
+import static org.citrusframework.container.Parallel.Builder.parallel
+
+name "ParallelTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+actions {
+    $(parallel()
+        .actions(
+            echo().message("1"),
+            echo().message("2"),
+        ))
+
+    $(parallel()
+        .actions(
+            parallel()
+                .actions(
+                        echo().message("1"),
+                        echo().message("2"),
+                ),
+            echo().message("3"),
+            echo().message("4")
+        ))
+}

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/container/repeat-on-error.test.groovy
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/container/repeat-on-error.test.groovy
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl.container
+
+import static org.citrusframework.actions.EchoAction.Builder.echo
+import static org.citrusframework.container.RepeatOnErrorUntilTrue.Builder.repeatOnError
+
+name "RepeatOnErrorTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+actions {
+    $(repeatOnError()
+        .until("i > 3")
+        .actions(
+            echo().message("Hello Citrus!")
+        ))
+
+    $(repeatOnError()
+        .until("index >= 2")
+        .index("index")
+        .actions(
+            echo().message("Hello Citrus!")
+        ))
+
+    $(repeatOnError()
+        .until("i >= 10")
+        .autoSleep(500L)
+        .actions(
+            echo().message("Hello Citrus!"),
+            echo().message("Hello You!")
+        ))
+
+    $(repeatOnError()
+        .until("i >= 5")
+        .autoSleep(250L)
+        .actions(
+            echo().message("Hello Citrus!")
+        ))
+}

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/container/repeat.test.groovy
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/container/repeat.test.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl.container
+
+import static org.citrusframework.actions.EchoAction.Builder.echo
+import static org.citrusframework.container.RepeatUntilTrue.Builder.repeat
+
+name "RepeatTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+actions {
+    $(repeat()
+        .until("i < 3")
+        .actions(echo().message("Hello Citrus!")))
+    $(repeat()
+        .until("index <= 2")
+        .index("index")
+        .actions(echo().message("Hello Citrus!")))
+    $(repeat()
+        .until("i <= 10")
+        .actions(
+            echo().message("Hello Citrus!"),
+            echo().message("Hello You!")
+        ))
+}

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/container/sequential.test.groovy
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/container/sequential.test.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl.container
+
+import static org.citrusframework.actions.EchoAction.Builder.echo
+import static org.citrusframework.container.Sequence.Builder.sequential
+
+name "SequentialTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+actions {
+    $(sequential()
+        .actions(
+            echo().message("Hello Citrus!"),
+            echo().message("Citrus rocks!"),
+        ))
+}

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/container/timer.test.groovy
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/container/timer.test.groovy
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl.container
+
+import static org.citrusframework.actions.EchoAction.Builder.echo
+import static org.citrusframework.container.Timer.Builder.timer
+
+name "TimerTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+actions {
+    $(timer()
+        .id("timer1")
+        .fork(true)
+        .delay(5000)
+        .interval(2000)
+        .repeatCount(1)
+        .actions(
+            echo().message("1")
+        )
+    )
+
+    $(timer()
+        .id("timer2")
+        .fork(false)
+        .delay(500)
+        .interval(200)
+        .repeatCount(2)
+        .actions(
+            echo().message("1"),
+            echo().message("2")
+        )
+    )
+
+    $(timer()
+        .fork(true)
+        .actions(
+            echo().message("1")
+        )
+    )
+}

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/container/wait-for.test.groovy
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/container/wait-for.test.groovy
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl.container
+
+import java.time.Duration
+
+import static org.citrusframework.actions.EchoAction.Builder.echo
+import static org.citrusframework.container.Wait.Builder.waitFor
+
+name "WaitForTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+actions {
+    $(waitFor()
+        .file()
+        .path("classpath:org/citrusframework/groovy/test-request-payload.xml"))
+
+    $(waitFor()
+        .file()
+        .path("classpath:org/citrusframework/groovy/test-request-payload.xml")
+        .time(Duration.ofMillis(10000))
+        .interval(2000))
+
+    $(waitFor()
+        .http()
+        .url("https://citrusframework.org"))
+
+    $(waitFor()
+        .http()
+        .url("https://citrusframework.org/doesnotexist")
+        .time(Duration.ofMillis(3000))
+        .timeout(2000)
+        .method("GET")
+        .status(404))
+
+    $(waitFor()
+        .message()
+            .name("request"))
+
+    $(waitFor()
+        .execution()
+            .action(echo().message("Citrus rocks!")))
+}

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/create-variables.test.groovy
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/create-variables.test.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl
+
+import static org.citrusframework.actions.CreateVariablesAction.Builder.createVariable
+
+name "CreateVariablesTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+actions {
+    $(createVariable("foo", "bar"));
+    $(createVariable("text", "Hello Citrus!"));
+    $(createVariable("foobar", "bars"));
+}

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/delay.test.groovy
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/delay.test.groovy
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl
+
+import static org.citrusframework.actions.SleepAction.Builder.delay
+
+name "DelayTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+actions {
+    $(delay().milliseconds(500L))
+}

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/echo.test.groovy
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/echo.test.groovy
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl
+
+import static org.citrusframework.actions.EchoAction.Builder.echo
+
+name "EchoTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+actions {
+    $(echo().message("Hello from Citrus!"))
+}

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/expect-timeout.test.groovy
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/expect-timeout.test.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl
+
+
+import static org.citrusframework.actions.ReceiveTimeoutAction.Builder.expectTimeout
+
+name "ExpectTimeoutTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+configuration {
+    queues {
+        queue('helloQueue')
+    }
+
+    endpoints {
+        direct('helloEndpoint')
+                .asynchronous()
+                .queue('helloQueue')
+    }
+}
+
+actions {
+    $(expectTimeout().endpoint(helloEndpoint))
+
+    $(expectTimeout().endpoint("direct:helloQueue"))
+
+    $(expectTimeout().endpoint("helloEndpoint")
+            .timeout(500)
+            .selector("operation='Test'"))
+
+    $(expectTimeout().endpoint("helloEndpoint")
+            .timeout(500)
+            .selector(["operation":'Test']))
+}

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/fail.test.groovy
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/fail.test.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl
+
+import static org.citrusframework.actions.FailAction.Builder.fail
+import static org.citrusframework.container.Assert.Builder.assertException;
+
+name "FailTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+actions {
+    $(assertException().message("Something went wrong")
+            .when(fail("Something went wrong")))
+    $(assertException().message("Something went wrong")
+            .when(fail().message("Something went wrong")))
+}

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/json.test.groovy
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/json.test.groovy
@@ -33,11 +33,11 @@ configuration {
 }
 
 given:
-    - createVariables()
-            .variable("text", "Citrus rocks!")
+    $(createVariables()
+        .variable("text", "Citrus rocks!"))
 
 when:
-    - send().endpoint(hello)
+    $(send().endpoint(hello)
             .message {
                 body {
                     json()
@@ -49,10 +49,10 @@ when:
                 headers {
                     operation = "sayHello"
                 }
-            }
+            })
 
 then:
-    - receive().endpoint(hello)
+    $(receive().endpoint(hello)
             .message {
                 body().json {
                     greeting {
@@ -63,4 +63,4 @@ then:
                 headers {
                     operation = "sayHello"
                 }
-            }
+            })

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/load-properties.test.groovy
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/load-properties.test.groovy
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl
+
+import static org.citrusframework.actions.LoadPropertiesAction.Builder.load;
+
+name "LoadPropertiesTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+actions {
+    $(load("classpath:org/citrusframework/groovy/load.properties"))
+}

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/print.test.groovy
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/print.test.groovy
@@ -19,12 +19,14 @@
 
 package org.citrusframework.groovy.dsl
 
+import static org.citrusframework.actions.EchoAction.Builder.print
+
 name "PrintTest"
 author "Christoph"
 status "FINAL"
 description "Sample test in Groovy"
 
 actions {
-    $(log("Hello from Citrus!"))
-    $(log().message("Hello"))
+    $(print().message("Hello from Citrus!"))
+    $(print().message("Hello"))
 }

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/print.test.groovy
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/print.test.groovy
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl
+
+name "PrintTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+actions {
+    $(log("Hello from Citrus!"))
+    $(log().message("Hello"))
+}

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/purge-endpoints.test.groovy
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/purge-endpoints.test.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl
+
+import static org.citrusframework.actions.PurgeEndpointAction.Builder.purgeEndpoints
+
+name "PurgeEndpointTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+actions {
+    $(purgeEndpoints().endpointNames("testEndpoint1", "testEndpoint2")
+            .endpoint("testEndpoint3"))
+
+    $(purgeEndpoints().endpoints(testEndpoint1, testEndpoint2)
+            .endpoint(testEndpoint3))
+
+    $(purgeEndpoints()
+            .selector("operation = 'sayHello'")
+            .endpoint("testEndpoint")
+            .timeout(500)
+            .sleep(100))
+
+    $(purgeEndpoints()
+            .selector(["operation": 'sayHello'])
+            .endpoint("testEndpoint"))
+
+    $(purgeEndpoints()
+            .selector(["operation": 'sayHello', "id": 12345])
+            .endpoint("testEndpoint"))
+}

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/receive.test.groovy
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/receive.test.groovy
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl
+
+import org.citrusframework.message.MessageType
+
+import static org.citrusframework.dsl.MessageSupport.MessageBodySupport.fromBody
+import static org.citrusframework.dsl.MessageSupport.MessageHeaderSupport.fromHeaders
+import static org.citrusframework.dsl.PathExpressionSupport.path
+import static org.citrusframework.validation.json.JsonMessageValidationContext.Builder.json
+import static org.citrusframework.validation.json.JsonPathMessageValidationContext.Builder.jsonPath
+import static org.citrusframework.validation.script.ScriptValidationContext.Builder.groovy
+import static org.citrusframework.validation.xml.XmlMessageValidationContext.Builder.xml
+import static org.citrusframework.validation.xml.XpathMessageValidationContext.Builder.xpath
+
+name "ReceiveTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+actions {
+    $(receive()
+            .endpoint(helloEndpoint)
+            .timeout(10000L)
+            .message()
+            .header("operation", "sayHello")
+            .body("Hello from Citrus!")
+    )
+
+    $(receive()
+            .endpoint("helloEndpoint")
+            .message()
+            .body("<TestMessage>Hello Citrus</TestMessage>")
+            .header("operation", "sayHello")
+    )
+
+    $(receive()
+            .endpoint("helloEndpoint")
+            .message()
+            .body("""
+                <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+                <TestMessage xmlns="http://citrusframework.org/test">Hello Citrus</TestMessage>
+            """)
+            .header("operation", "sayHello")
+            .header("""
+                <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+                <Header xmlns="http://citrusframework.org/test"><operation>hello</operation></Header>
+            """)
+    )
+
+    $(receive()
+            .endpoint("helloEndpoint")
+            .timeout(1000L)
+            .selector(["operation": "sayHello"])
+            .message()
+                .body()
+                    .resource("classpath:org/citrusframework/groovy/test-request-payload.xml")
+    )
+
+    $(receive()
+            .endpoint("helloEndpoint")
+            .selector("operation = 'sayHello'")
+            .message()
+            .body("<TestMessage>Hello Citrus</TestMessage>")
+    )
+
+    $(receive()
+            .endpoint("helloEndpoint")
+            .message()
+            .dictionary(myDataDictionary)
+            .body("<TestMessage>Hello Citrus</TestMessage>")
+            .extract(fromHeaders().header("operation", "operation"))
+            .extract(fromBody().expression("/TestMessage/text()", "text"))
+    )
+
+    $(receive()
+            .endpoint("helloEndpoint")
+            .message()
+            .body("<ns:TestMessage xmlns:ns=\"http://citrusframework.org\">Hello Citrus</ns:TestMessage>")
+            .process(path().expression("/ns:TestMessage/", "newValue"))
+            .validate(xml()
+                    .ignore("/ns:TestMessage/ns:ignore")
+                    .namespaceContext("ctx", "http://citrusframework.org/test")
+                    .namespace("ns", "http://citrusframework.org")
+                    .schemaValidation(false))
+    )
+
+    $(receive()
+            .endpoint("direct:helloQueue")
+            .message()
+            .validate(path()
+                    .expression("/TestMessage/text", "Hello Citrus")
+                    .expression("/TestMessage/foo", true))
+    )
+
+    $(receive()
+            .endpoint("direct:helloQueue")
+            .message()
+            .validate(xpath()
+                    .expression("/TestMessage/text", "Hello Citrus")
+                    .expression("/TestMessage/foo", true))
+    )
+
+    $(receive()
+            .endpoint("direct:helloQueue")
+            .message()
+            .validate(groovy().script("assert true"))
+            .validate(path().expression("/TestMessage/foo", true))
+    )
+
+    $(receive()
+            .endpoint("direct:helloQueue")
+            .message()
+            .validate(groovy().scriptResource("classpath:org/citrusframework/groovy/test-validation-script.groovy"))
+    )
+
+    $(receive()
+            .endpoint("direct:helloQueue")
+            .message()
+            .type(MessageType.JSON)
+            .validate(path()
+                    .expression('$.json.text', "Hello Citrus")
+                    .expression('$..foo.bar', true))
+    )
+
+    $(receive()
+            .endpoint("direct:helloQueue")
+            .message()
+            .type(MessageType.JSON)
+            .validate(jsonPath()
+                    .expression('$.json.text', "Hello Citrus")
+                    .expression('$..foo.bar', true))
+    )
+
+    $(receive()
+            .endpoint("direct:helloQueue")
+            .message()
+            .body('{ "FooMessage": { "foo": "Hello World!" }, { "bar": "@ignore@" }}')
+            .type(MessageType.JSON)
+            .validate(json().ignore('$.FooMessage.bar'))
+            .process(jsonPath().expression('$.FooMessage.foo', "newValue"))
+    )
+
+    $(receive()
+            .endpoint("helloEndpoint")
+            .message()
+            .type(MessageType.JSON)
+            .body('{ "message": { "text": "Hello World!" }, { "bar": "@ignore@" }}')
+            .extract(fromHeaders().expression("operation", "operation"))
+            .extract(fromBody().expression('$.message.text', "text"))
+    )
+
+    $(receive()
+            .endpoint("helloEndpoint")
+            .message()
+            .body('<TestMessage>Hello Citrus</TestMessage>')
+            .validator(myValidator)
+            .validator(myHeaderValidator)
+            .header("operation", "sayHello")
+    )
+
+    $(receive()
+            .endpoint("helloEndpoint")
+            .message()
+            .body('<TestMessage>Hello Citrus</TestMessage>')
+            .validators(myValidator,defaultMessageValidator)
+            .validators(myHeaderValidator,defaultHeaderValidator)
+            .header("operation", "sayHello")
+    )
+}

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/sample.test.groovy
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/sample.test.groovy
@@ -40,31 +40,32 @@ variables {
 }
 
 given:
-    - echo("Hello from Groovy!")
+    $(echo("Hello from Groovy!"))
 
 when:
-    - send().endpoint(hello)
+    $(send().endpoint(hello)
             .message()
             .body('${foo} #${num}')
-            .header("foo", "bar")
-    - send().endpoint("goodbye")
+            .header("foo", "bar"))
+
+    $(send().endpoint("goodbye")
             .message()
-            .body('#${num} ${foo}')
+            .body('#${num} ${foo}'))
 
 then:
-    - receive().endpoint(hello)
+    $(receive().endpoint(hello)
             .message()
             .header("foo", "bar")
-            .body("bar #1")
-    - receive().endpoint("goodbye")
+            .body("bar #1"))
+
+    $(receive().endpoint("goodbye")
             .message()
-            .body("#1 bar")
+            .body("#1 bar"))
 
 $(echo().message("Test finished successfully!"))
 
 doFinally {
-    echo("In finally bock!")
+    $(echo("In finally bock!"))
 
-    delay().milliseconds(100)
+    $(delay().milliseconds(100))
 }
-

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/send.test.groovy
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/send.test.groovy
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl
+
+import org.citrusframework.message.MessageType
+
+import static org.citrusframework.dsl.MessageSupport.MessageHeaderSupport.fromHeaders
+import static org.citrusframework.dsl.PathExpressionSupport.path
+import static org.citrusframework.validation.json.JsonPathMessageValidationContext.Builder.jsonPath
+
+name "SendTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+actions {
+    $(send()
+        .endpoint(helloEndpoint)
+        .message()
+        .header("operation", "sayHello")
+        .body("Hello from Citrus!")
+    )
+
+    $(send()
+        .endpoint("helloEndpoint")
+        .message()
+        .body("<TestMessage>Hello Citrus</TestMessage>")
+        .header("operation", "sayHello")
+    )
+
+    $(send()
+        .endpoint("helloEndpoint")
+        .message()
+        .body("""
+            <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+            <TestMessage xmlns="http://citrusframework.org/test">Hello Citrus</TestMessage>
+        """)
+        .header("operation", "sayHello")
+        .header("""
+            <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+            <Header xmlns="http://citrusframework.org/test"><operation>hello</operation></Header>
+        """)
+    )
+
+    $(send()
+        .endpoint("helloEndpoint")
+        .message()
+        .body()
+        .resource("classpath:org/citrusframework/groovy/test-request-payload.xml")
+    )
+
+    $(send()
+        .endpoint("helloEndpoint")
+        .message()
+        .header("operation", "sayHello")
+        .dictionary(myDataDictionary)
+        .body("<TestMessage>Hello Citrus</TestMessage>")
+        .process(path().expression("/TestMessage/text()", "newValue"))
+        .extract(fromHeaders().header("operation", "operation"))
+    )
+
+    $(send()
+        .endpoint("direct:helloQueue")
+        .message()
+        .body("<TestMessage>Hello Citrus</TestMessage>")
+        .header("intValue", 5)
+        .header("longValue", 10L)
+        .header("floatValue", 10.0F)
+        .header("doubleValue", 10.0D)
+        .header("byteValue", (byte) 1)
+        .header("shortValue", (short) 10)
+        .header("boolValue", true)
+        .header("stringValue", "Hello Citrus")
+    )
+
+    $(send()
+        .endpoint("helloEndpoint")
+        .message()
+        .body('{ "FooMessage": { "foo": "Hello World!" }, { "bar": "@ignore@" }}')
+        .type(MessageType.JSON)
+        .process(jsonPath().expression('$.FooMessage.foo', "newValue"))
+    )
+
+    $(send()
+        .endpoint("helloEndpoint")
+        .message()
+        .type(MessageType.JSON)
+        .schemaValidation(true)
+        .schema("fooSchema")
+        .schemaRepository("fooRepository")
+        .body('{ "FooMessage": { "foo": "Hello World!" }, { "bar": "@ignore@" }}')
+    )
+
+    $(send()
+        .endpoint("helloEndpoint")
+        .message()
+        .type(MessageType.XML)
+        .schemaValidation(true)
+        .schema("fooSchema")
+        .schemaRepository("fooRepository")
+        .body('<TestMessage>Hello Citrus</TestMessage>')
+    )
+
+}

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/sleep.test.groovy
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/sleep.test.groovy
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl
+
+import static org.citrusframework.actions.SleepAction.Builder.sleep
+
+name "SleepTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+actions {
+    $(sleep().milliseconds(500L))
+}

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/start.test.groovy
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/start.test.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl
+
+import static org.citrusframework.actions.StartServerAction.Builder.start
+
+name "StartTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+actions {
+    $(start().server(myServer))
+    $(start().server("myServer"))
+    $(start().server("myFooServer", "myBarServer"))
+}

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/stop.test.groovy
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/stop.test.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl
+
+import static org.citrusframework.actions.StopServerAction.Builder.stop
+
+name "StopTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+actions {
+    $(stop().server(myServer))
+    $(stop().server("myServer"))
+    $(stop().server("myFooServer", "myBarServer"))
+}

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/trace-variables.test.groovy
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/trace-variables.test.groovy
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl
+
+import static org.citrusframework.actions.TraceVariablesAction.Builder.traceVariables
+
+name "TraceVariablesTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+variables {
+    foo="fooValue"
+    bar="barValue"
+}
+
+actions {
+    $(traceVariables())
+    $(traceVariables().variable("foo"))
+    $(traceVariables().variables("foo", "bar"))
+}

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/transform.test.groovy
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/transform.test.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy.dsl
+
+import static org.citrusframework.actions.TransformAction.Builder.transform
+
+name "TransformTest"
+author "Christoph"
+status "FINAL"
+description "Sample test in Groovy"
+
+actions {
+    $(transform()
+        .source("""
+            <TestRequest>
+              <Message>Hello World!</Message>
+            </TestRequest>
+        """)
+        .xslt("""
+            <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+              <xsl:template match="/">
+              <html>
+                  <body>
+                      <h2>Test Request</h2>
+                      <p>Message: <xsl:value-of select="TestRequest/Message"/></p>
+                  </body>
+              </html>
+              </xsl:template>
+            </xsl:stylesheet>
+        """)
+        .result("result"))
+
+    $(transform()
+            .sourceFile("classpath:org/citrusframework/groovy/transform-source.xml")
+            .xsltFile("classpath:org/citrusframework/groovy/transform.xslt")
+    )
+}

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/xml.test.groovy
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/dsl/xml.test.groovy
@@ -33,12 +33,12 @@ configuration {
 }
 
 given:
-    - createVariables()
-            .variable("text", "Citrus rocks!")
-            .variable("language", "eng")
+    $(createVariables()
+        .variable("text", "Citrus rocks!")
+        .variable("language", "eng"))
 
 when:
-    - send().endpoint(hello)
+    $(send().endpoint(hello)
             .message {
                 body {
                     xml()
@@ -49,10 +49,10 @@ when:
                 headers {
                     operation = "sayHello"
                 }
-            }
+            })
 
 then:
-    - receive().endpoint(hello)
+    $(receive().endpoint(hello)
             .message {
                 body().xml {
                     greeting(language: '${language}') {
@@ -62,4 +62,4 @@ then:
                 headers {
                     operation = "sayHello"
                 }
-            }
+            })

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/echo-template.groovy
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/echo-template.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy
+
+import static org.citrusframework.actions.EchoAction.Builder.echo
+
+name "echo"
+description "Sample template in Groovy"
+
+parameters {
+    message="Citrus rocks!"
+}
+
+actions {
+    $(echo().message('${message}'))
+}

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/load.properties
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/load.properties
@@ -1,0 +1,1 @@
+property.load.test=Citrus rocks!

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/template-parameters.groovy
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/template-parameters.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy
+
+import static org.citrusframework.actions.EchoAction.Builder.echo
+
+name "myTemplate"
+description "Sample template in Groovy"
+
+globalContext(false)
+
+parameters {
+    foo = ""
+    bar = "barValue"
+    baz = """
+        foo
+        bar
+        baz
+    """
+}
+
+actions {
+    $(echo().message("Citrus rocks!"))
+    $(echo().message('${foo} ${bar}'))
+}

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/template.groovy
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/template.groovy
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.groovy
+
+import static org.citrusframework.actions.EchoAction.Builder.echo
+
+name "myTemplate"
+description "Sample template in Groovy"
+
+actions {
+    $(echo().message("Citrus rocks!"))
+}

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/test-request-payload.xml
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/test-request-payload.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TestRequest>
+    <Message>Hello World!</Message>
+</TestRequest>

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/test-validation-script.groovy
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/test-validation-script.groovy
@@ -1,0 +1,2 @@
+assert root.Message.name() == 'Message'
+assert root.Message.text() == 'Hello World!'

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/transform-source.xml
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/transform-source.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TestRequest>
+	<Message>Hello World!</Message>
+</TestRequest>

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/transform.xslt
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/groovy/transform.xslt
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:template match="/">
+	<html>
+		<body>
+			<h2>Test Request</h2>
+			<p>Message: <xsl:value-of select="TestRequest/Message"/></p>
+		</body>  
+	</html>
+</xsl:template>
+</xsl:stylesheet>

--- a/runtime/citrus-groovy/src/test/resources/org/citrusframework/integration/groovy/sample.it.groovy
+++ b/runtime/citrus-groovy/src/test/resources/org/citrusframework/integration/groovy/sample.it.groovy
@@ -64,5 +64,5 @@ then {
 $(echo().message("Test finished successfully!"))
 
 doFinally {
-    delay().milliseconds(100)
+    $(delay().milliseconds(100))
 }

--- a/runtime/citrus-junit/src/test/resources/org/citrusframework/junit/integration/sample.it.groovy
+++ b/runtime/citrus-junit/src/test/resources/org/citrusframework/junit/integration/sample.it.groovy
@@ -64,5 +64,5 @@ then {
 $(echo().message("Test finished successfully!"))
 
 doFinally {
-    delay().milliseconds(100)
+    $(delay().milliseconds(100))
 }

--- a/runtime/citrus-junit5/src/test/resources/org/citrusframework/junit/jupiter/integration/groovy/sample.it.groovy
+++ b/runtime/citrus-junit5/src/test/resources/org/citrusframework/junit/jupiter/integration/groovy/sample.it.groovy
@@ -64,5 +64,5 @@ then {
 $(echo().message("Test finished successfully!"))
 
 doFinally {
-    delay().milliseconds(100)
+    $(delay().milliseconds(100))
 }

--- a/runtime/citrus-xml/src/main/java/org/citrusframework/xml/actions/ApplyTemplate.java
+++ b/runtime/citrus-xml/src/main/java/org/citrusframework/xml/actions/ApplyTemplate.java
@@ -19,21 +19,20 @@
 
 package org.citrusframework.xml.actions;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlType;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.citrusframework.TestActionBuilder;
 import org.citrusframework.container.Template;
 import org.citrusframework.spi.ReferenceResolver;
 import org.citrusframework.spi.ReferenceResolverAware;
-import org.citrusframework.spi.SimpleReferenceResolver;
-import org.citrusframework.xml.TemplateLoader;
+import org.citrusframework.xml.XmlTemplateLoader;
 
 /**
  * @author Christoph Deppisch
@@ -43,9 +42,6 @@ public class ApplyTemplate implements TestActionBuilder<Template>, ReferenceReso
 
     private final Template.Builder builder = new Template.Builder();
 
-    private String filePath;
-    private ReferenceResolver referenceResolver;
-
     @XmlAttribute
     public ApplyTemplate setName(String name) {
         builder.templateName(name);
@@ -53,8 +49,14 @@ public class ApplyTemplate implements TestActionBuilder<Template>, ReferenceReso
     }
 
     @XmlAttribute
+    public void setTemplateName(String name) {
+        builder.templateName(name);
+    }
+
+    @XmlAttribute
     public ApplyTemplate setFile(String filePath) {
-        this.filePath = filePath;
+        builder.file(filePath);
+        builder.loader(new XmlTemplateLoader());
         return this;
     }
 
@@ -72,27 +74,12 @@ public class ApplyTemplate implements TestActionBuilder<Template>, ReferenceReso
 
     @Override
     public Template build() {
-        if (filePath != null) {
-            Template local = new TemplateLoader(filePath)
-                    .withReferenceResolver(referenceResolver)
-                    .load()
-                    .build();
-
-            SimpleReferenceResolver temporaryReferenceResolver = new SimpleReferenceResolver();
-            temporaryReferenceResolver.bind(local.getTemplateName(), local);
-
-            builder.withReferenceResolver(temporaryReferenceResolver);
-            builder.templateName(local.getTemplateName());
-        } else {
-            builder.withReferenceResolver(referenceResolver);
-        }
-
         return builder.build();
     }
 
     @Override
     public void setReferenceResolver(ReferenceResolver referenceResolver) {
-        this.referenceResolver = referenceResolver;
+        builder.setReferenceResolver(referenceResolver);
     }
 
     @XmlAccessorType(XmlAccessType.FIELD)

--- a/runtime/citrus-xml/src/main/java/org/citrusframework/xml/actions/MessageSupport.java
+++ b/runtime/citrus-xml/src/main/java/org/citrusframework/xml/actions/MessageSupport.java
@@ -94,7 +94,7 @@ public final class MessageSupport {
         }
 
         if (!pathExpressions.isEmpty()) {
-            builder.message().process(new DelegatingPathExpressionProcessor(pathExpressions));
+            builder.message().process(new DelegatingPathExpressionProcessor.Builder().expressions(pathExpressions).build());
         }
 
         if (message.dataDictionary != null) {

--- a/runtime/citrus-xml/src/main/java/org/citrusframework/xml/actions/Receive.java
+++ b/runtime/citrus-xml/src/main/java/org/citrusframework/xml/actions/Receive.java
@@ -18,12 +18,6 @@
  */
 package org.citrusframework.xml.actions;
 
-import jakarta.xml.bind.annotation.XmlAccessType;
-import jakarta.xml.bind.annotation.XmlAccessorType;
-import jakarta.xml.bind.annotation.XmlAttribute;
-import jakarta.xml.bind.annotation.XmlElement;
-import jakarta.xml.bind.annotation.XmlRootElement;
-import jakarta.xml.bind.annotation.XmlType;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -32,6 +26,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.TestActionBuilder;
 import org.citrusframework.TestActor;
 import org.citrusframework.actions.ReceiveMessageAction;
@@ -251,7 +251,7 @@ public class Receive implements TestActionBuilder<ReceiveMessageAction>, Referen
         for (Namespace namespace : getNamespaces()) {
             namespaces.put(namespace.prefix, namespace.value);
         }
-        xmlValidationContext.setNamespaces(namespaces);
+        xmlValidationContext.namespaceContext(namespaces);
 
         //check for validate elements, these elements can either have script, xpath or namespace validation information
         //for now we only handle xpath validation

--- a/runtime/citrus-xml/src/main/resources/META-INF/citrus/template/loader/xml
+++ b/runtime/citrus-xml/src/main/resources/META-INF/citrus/template/loader/xml
@@ -1,0 +1,1 @@
+type=org.citrusframework.xml.XmlTemplateLoader

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-4.0.0-SNAPSHOT.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-4.0.0-SNAPSHOT.xsd
@@ -700,6 +700,7 @@
   <xs:element name="sql" type="tns:Sql"/>
   <xs:element name="groovy" type="tns:Groovy"/>
   <xs:element name="http" type="tns:Http"/>
+  <xs:element name="soap" type="tns:Soap"/>
   <xs:element name="camel" type="tns:Camel"/>
 
   <xs:complexType name="Plsql">
@@ -999,6 +1000,161 @@
         <xs:attribute name="reason-phrase" type="xs:string"/>
         <xs:attribute name="version" type="xs:string"/>
         <xs:attribute name="content-type" type="xs:string"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="Soap">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:choice>
+        <xs:element name="receive-request">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="selector" type="xs:string" minOccurs="0"/>
+              <xs:element name="message" type="tns:SoapRequest"/>
+              <xs:element name="validate" minOccurs="0" maxOccurs="unbounded" type="tns:Validate"/>
+              <xs:element name="extract" minOccurs="0" maxOccurs="unbounded" type="tns:Extract"/>
+            </xs:sequence>
+            <xs:attribute name="timeout" type="xs:int"/>
+            <xs:attribute name="select" type="xs:string"/>
+            <xs:attribute name="validator" type="xs:string"/>
+            <xs:attribute name="validators" type="xs:string"/>
+            <xs:attribute name="header-validator" type="xs:string"/>
+            <xs:attribute name="header-validators" type="xs:string"/>
+            <xs:attribute name="attachment-validator" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="receive-response">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="selector" type="xs:string" minOccurs="0"/>
+              <xs:element name="message" type="tns:SoapResponse"/>
+              <xs:element name="validate" minOccurs="0" maxOccurs="unbounded" type="tns:Validate"/>
+              <xs:element name="extract" minOccurs="0" maxOccurs="unbounded" type="tns:Extract"/>
+            </xs:sequence>
+            <xs:attribute name="timeout" type="xs:int"/>
+            <xs:attribute name="select" type="xs:string"/>
+            <xs:attribute name="validator" type="xs:string"/>
+            <xs:attribute name="validators" type="xs:string"/>
+            <xs:attribute name="header-validator" type="xs:string"/>
+            <xs:attribute name="header-validators" type="xs:string"/>
+            <xs:attribute name="attachment-validator" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="send-request">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="message" type="tns:SoapRequest"/>
+              <xs:element name="extract" minOccurs="0" maxOccurs="unbounded" type="tns:Extract"/>
+            </xs:sequence>
+            <xs:attribute name="uri" type="xs:string"/>
+            <xs:attribute name="fork" type="xs:boolean"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="send-response">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="message" type="tns:SoapResponse"/>
+              <xs:element name="extract" minOccurs="0" maxOccurs="unbounded" type="tns:Extract"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="send-fault">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="message" type="tns:SoapFault"/>
+              <xs:element name="extract" minOccurs="0" maxOccurs="unbounded" type="tns:Extract"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="assert-fault">
+          <xs:complexType>
+            <xs:complexContent>
+              <xs:extension base="tns:SoapFault">
+                <xs:sequence>
+                  <xs:element name="when" type="tns:TestActions"/>
+                </xs:sequence>
+                <xs:attribute name="validator" type="xs:string"/>
+              </xs:extension>
+            </xs:complexContent>
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
+    </xs:sequence>
+    <xs:attribute name="actor" type="xs:string"/>
+    <xs:attribute name="client" type="xs:string"/>
+    <xs:attribute name="server" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="SoapMessageType">
+    <xs:complexContent>
+      <xs:extension base="tns:MessageType">
+        <xs:sequence>
+          <xs:element name="attachment" minOccurs="0" maxOccurs="unbounded">
+            <xs:complexType>
+              <xs:choice>
+                <xs:element name="content" type="xs:string"/>
+                <xs:element name="resource">
+                  <xs:complexType>
+                    <xs:attribute name="file" use="required" type="xs:string"/>
+                  </xs:complexType>
+                </xs:element>
+              </xs:choice>
+              <xs:attribute name="content-id" type="xs:string"/>
+              <xs:attribute name="content-type" type="xs:string"/>
+              <xs:attribute name="charset" type="xs:string"/>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="SoapRequest">
+    <xs:complexContent>
+      <xs:extension base="tns:SoapMessageType">
+        <xs:attribute name="soap-action" type="xs:string"/>
+        <xs:attribute name="mtom-enabled" type="xs:boolean"/>
+        <xs:attribute name="path" type="xs:string"/>
+        <xs:attribute name="content-type" type="xs:string"/>
+        <xs:attribute name="accept" type="xs:string"/>
+        <xs:attribute name="version" type="xs:string"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="SoapResponse">
+    <xs:complexContent>
+      <xs:extension base="tns:SoapMessageType">
+        <xs:attribute name="status" type="xs:string"/>
+        <xs:attribute name="reason-phrase" type="xs:string"/>
+        <xs:attribute name="version" type="xs:string"/>
+        <xs:attribute name="content-type" type="xs:string"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="SoapFault">
+    <xs:complexContent>
+      <xs:extension base="tns:SoapResponse">
+        <xs:sequence>
+          <xs:element name="fault-detail" minOccurs="0" maxOccurs="unbounded">
+            <xs:complexType>
+              <xs:choice>
+                <xs:element name="content" type="xs:string"/>
+                <xs:element name="resource">
+                  <xs:complexType>
+                    <xs:attribute name="file" use="required" type="xs:string"/>
+                  </xs:complexType>
+                </xs:element>
+              </xs:choice>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+        <xs:attribute name="fault-code" type="xs:string"/>
+        <xs:attribute name="fault-string" type="xs:string"/>
+        <xs:attribute name="fault-actor" type="xs:string"/>
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-4.0.0-SNAPSHOT.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-4.0.0-SNAPSHOT.xsd
@@ -696,8 +696,12 @@
   <xs:element name="trace-variables" type="tns:TraceVariables"/>
   <xs:element name="transform" type="tns:Transform"/>
   <xs:element name="wait-for" type="tns:WaitFor"/>
+
+  <!-- Additional modules -->
   <xs:element name="plsql" type="tns:Plsql"/>
   <xs:element name="sql" type="tns:Sql"/>
+  <xs:element name="purge-jms-queues" type="tns:PurgeQueues"/>
+  <xs:element name="purge-channels" type="tns:PurgeChannels"/>
   <xs:element name="groovy" type="tns:Groovy"/>
   <xs:element name="http" type="tns:Http"/>
   <xs:element name="soap" type="tns:Soap"/>
@@ -784,6 +788,41 @@
     </xs:sequence>
     <xs:attribute name="datasource" type="xs:string" use="required"/>
     <xs:attribute name="ignore-errors" type="xs:boolean"/>
+  </xs:complexType>
+
+  <xs:complexType name="PurgeQueues">
+    <xs:annotation>
+      <xs:documentation>Continuously receives messages from a destination until no more messages are left - emulating the purge operation</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:element name="queue" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:string"/>
+          <xs:attribute name="ref" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="connection-factory" type="xs:string"/>
+    <xs:attribute name="timeout" type="xs:int"/>
+    <xs:attribute name="sleep" type="xs:int"/>
+  </xs:complexType>
+
+  <xs:complexType name="PurgeChannels">
+    <xs:annotation>
+      <xs:documentation>Continuously receives messages from a Spring Integration message channel destination until no more messages are left - emulating the purge operation</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:element name="channel" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:string"/>
+          <xs:attribute name="ref" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="channel-resolver" type="xs:string"/>
+    <xs:attribute name="message-selector" type="xs:string"/>
   </xs:complexType>
 
   <xs:complexType name="Groovy">

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-4.0.0-SNAPSHOT.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-4.0.0-SNAPSHOT.xsd
@@ -702,6 +702,7 @@
   <xs:element name="http" type="tns:Http"/>
   <xs:element name="soap" type="tns:Soap"/>
   <xs:element name="camel" type="tns:Camel"/>
+  <xs:element name="selenium" type="tns:Selenium"/>
 
   <xs:complexType name="Plsql">
     <xs:sequence>
@@ -1157,6 +1158,243 @@
         <xs:attribute name="fault-actor" type="xs:string"/>
       </xs:extension>
     </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="Selenium">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:choice>
+        <xs:element name="start">
+          <xs:complexType>
+            <xs:attribute name="browser" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="stop">
+          <xs:complexType>
+            <xs:attribute name="browser" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="clear-cache"/>
+
+        <xs:element name="find">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="element" type="WebElementType"/>
+              <xs:element name="validate">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="attributes" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="attribute" minOccurs="1" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:attribute name="name" type="xs:string" use="required"/>
+                              <xs:attribute name="value" type="xs:string" use="required"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="styles" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="style" minOccurs="1" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:attribute name="name" type="xs:string" use="required"/>
+                              <xs:attribute name="value" type="xs:string" use="required"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                  <xs:attribute name="text" type="xs:string"/>
+                  <xs:attribute name="tag-name" type="xs:string"/>
+                  <xs:attribute name="displayed" type="xs:boolean"/>
+                  <xs:attribute name="enabled" type="xs:boolean"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="page">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="arguments" minOccurs="0">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="argument" type="xs:string" maxOccurs="unbounded"/>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string"/>
+            <xs:attribute name="type" type="xs:string"/>
+            <xs:attribute name="validator" type="xs:string"/>
+            <xs:attribute name="action" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="click">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="element" type="WebElementType"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="hover">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="element" type="WebElementType"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="set-input">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="element" type="WebElementType"/>
+            </xs:sequence>
+            <xs:attribute name="value" type="xs:string" use="required"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="check-input">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="element" type="WebElementType"/>
+            </xs:sequence>
+            <xs:attribute name="checked" type="xs:boolean" use="required"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="dropdown-select">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="element" type="WebElementType"/>
+              <xs:element name="options" minOccurs="0">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="option" type="xs:string" minOccurs="1" maxOccurs="unbounded"/>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="option" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="wait">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="element" type="WebElementType"/>
+            </xs:sequence>
+            <xs:attribute name="until" type="xs:string" use="required"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="javascript">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="script"/>
+              <xs:element name="arguments" minOccurs="0">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="argument" type="xs:string" minOccurs="1" maxOccurs="unbounded"/>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="errors" minOccurs="0">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="error" type="xs:string" minOccurs="1" maxOccurs="unbounded"/>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="argument" type="xs:string"/>
+            <xs:attribute name="error" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="screenshot">
+          <xs:complexType>
+            <xs:attribute name="output-dir" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="navigate">
+          <xs:complexType>
+            <xs:attribute name="page" type="xs:string" use="required"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="open-window">
+          <xs:complexType>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="close-window">
+          <xs:complexType>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="switch-window">
+          <xs:complexType>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="store-file">
+          <xs:complexType>
+            <xs:attribute name="file-path" type="xs:string" use="required"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="get-stored-file">
+          <xs:complexType>
+            <xs:attribute name="file-name" type="xs:string" use="required"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="alert">
+          <xs:annotation>
+            <xs:documentation>Access current alert dialog and perform action (accept, dismiss)</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="text" type="xs:string" minOccurs="0"/>
+            </xs:sequence>
+            <xs:attribute name="text" type="xs:string"/>
+            <xs:attribute name="accept" type="xs:boolean" use="required"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
+    </xs:sequence>
+    <xs:attribute name="browser" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="WebElementType">
+    <xs:sequence>
+      <xs:element name="property">
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:string" use="required"/>
+          <xs:attribute name="value" type="xs:string" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:string"/>
+    <xs:attribute name="name" type="xs:string"/>
+    <xs:attribute name="tag-name" type="xs:string"/>
+    <xs:attribute name="class-name" type="xs:string"/>
+    <xs:attribute name="css-selector" type="xs:string"/>
+    <xs:attribute name="link-text" type="xs:string"/>
+    <xs:attribute name="xpath" type="xs:string"/>
   </xs:complexType>
 
 </xs:schema>

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-4.0.0-SNAPSHOT.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-4.0.0-SNAPSHOT.xsd
@@ -700,6 +700,7 @@
   <xs:element name="sql" type="tns:Sql"/>
   <xs:element name="groovy" type="tns:Groovy"/>
   <xs:element name="http" type="tns:Http"/>
+  <xs:element name="camel" type="tns:Camel"/>
 
   <xs:complexType name="Plsql">
     <xs:sequence>
@@ -791,6 +792,105 @@
         <xs:attribute name="use-script-template" type="xs:boolean"/>
       </xs:extension>
     </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="Camel">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:choice>
+        <xs:element name="create-routes">
+          <xs:annotation>
+            <xs:documentation>Creates new Camel routes on the fly</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:any processContents="skip" namespace="http://camel.apache.org/schema/spring"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="start-routes">
+          <xs:annotation>
+            <xs:documentation>Start Camel routes on context</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="route" minOccurs="1" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:attribute name="id" use="required"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="stop-routes">
+          <xs:annotation>
+            <xs:documentation>Start Camel routes on context</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="route" minOccurs="1" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:attribute name="id" use="required"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="remove-routes">
+          <xs:annotation>
+            <xs:documentation>Start Camel routes on context</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="route" minOccurs="1" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:attribute name="id" use="required"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="control-bus">
+          <xs:annotation>
+            <xs:documentation>Executes operations on Camel control bus</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:choice>
+                <xs:element name="route">
+                  <xs:complexType>
+                    <xs:attribute name="id" type="xs:string" use="required"/>
+                    <xs:attribute name="action" use="required">
+                      <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                          <xs:enumeration value="start"/>
+                          <xs:enumeration value="stop"/>
+                          <xs:enumeration value="suspend"/>
+                          <xs:enumeration value="resume"/>
+                          <xs:enumeration value="status"/>
+                          <xs:enumeration value="stats"/>
+                        </xs:restriction>
+                      </xs:simpleType>
+                    </xs:attribute>
+                  </xs:complexType>
+                </xs:element>
+                <xs:element name="language">
+                  <xs:complexType>
+                    <xs:simpleContent>
+                      <xs:extension base="xs:string">
+                        <xs:attribute name="type" type="xs:string" default="simple"/>
+                      </xs:extension>
+                    </xs:simpleContent>
+                  </xs:complexType>
+                </xs:element>
+              </xs:choice>
+              <xs:element name="result" type="xs:string" minOccurs="0"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
+    </xs:sequence>
+    <xs:attribute name="camel-context" type="xs:string"/>
   </xs:complexType>
 
   <xs:complexType name="Http">

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
@@ -700,6 +700,7 @@
   <xs:element name="sql" type="tns:Sql"/>
   <xs:element name="groovy" type="tns:Groovy"/>
   <xs:element name="http" type="tns:Http"/>
+  <xs:element name="soap" type="tns:Soap"/>
   <xs:element name="camel" type="tns:Camel"/>
 
   <xs:complexType name="Plsql">
@@ -999,6 +1000,161 @@
         <xs:attribute name="reason-phrase" type="xs:string"/>
         <xs:attribute name="version" type="xs:string"/>
         <xs:attribute name="content-type" type="xs:string"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="Soap">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:choice>
+        <xs:element name="receive-request">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="selector" type="xs:string" minOccurs="0"/>
+              <xs:element name="message" type="tns:SoapRequest"/>
+              <xs:element name="validate" minOccurs="0" maxOccurs="unbounded" type="tns:Validate"/>
+              <xs:element name="extract" minOccurs="0" maxOccurs="unbounded" type="tns:Extract"/>
+            </xs:sequence>
+            <xs:attribute name="timeout" type="xs:int"/>
+            <xs:attribute name="select" type="xs:string"/>
+            <xs:attribute name="validator" type="xs:string"/>
+            <xs:attribute name="validators" type="xs:string"/>
+            <xs:attribute name="header-validator" type="xs:string"/>
+            <xs:attribute name="header-validators" type="xs:string"/>
+            <xs:attribute name="attachment-validator" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="receive-response">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="selector" type="xs:string" minOccurs="0"/>
+              <xs:element name="message" type="tns:SoapResponse"/>
+              <xs:element name="validate" minOccurs="0" maxOccurs="unbounded" type="tns:Validate"/>
+              <xs:element name="extract" minOccurs="0" maxOccurs="unbounded" type="tns:Extract"/>
+            </xs:sequence>
+            <xs:attribute name="timeout" type="xs:int"/>
+            <xs:attribute name="select" type="xs:string"/>
+            <xs:attribute name="validator" type="xs:string"/>
+            <xs:attribute name="validators" type="xs:string"/>
+            <xs:attribute name="header-validator" type="xs:string"/>
+            <xs:attribute name="header-validators" type="xs:string"/>
+            <xs:attribute name="attachment-validator" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="send-request">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="message" type="tns:SoapRequest"/>
+              <xs:element name="extract" minOccurs="0" maxOccurs="unbounded" type="tns:Extract"/>
+            </xs:sequence>
+            <xs:attribute name="uri" type="xs:string"/>
+            <xs:attribute name="fork" type="xs:boolean"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="send-response">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="message" type="tns:SoapResponse"/>
+              <xs:element name="extract" minOccurs="0" maxOccurs="unbounded" type="tns:Extract"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="send-fault">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="message" type="tns:SoapFault"/>
+              <xs:element name="extract" minOccurs="0" maxOccurs="unbounded" type="tns:Extract"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="assert-fault">
+          <xs:complexType>
+            <xs:complexContent>
+              <xs:extension base="tns:SoapFault">
+                <xs:sequence>
+                  <xs:element name="when" type="tns:TestActions"/>
+                </xs:sequence>
+                <xs:attribute name="validator" type="xs:string"/>
+              </xs:extension>
+            </xs:complexContent>
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
+    </xs:sequence>
+    <xs:attribute name="actor" type="xs:string"/>
+    <xs:attribute name="client" type="xs:string"/>
+    <xs:attribute name="server" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="SoapMessageType">
+    <xs:complexContent>
+      <xs:extension base="tns:MessageType">
+        <xs:sequence>
+          <xs:element name="attachment" minOccurs="0" maxOccurs="unbounded">
+            <xs:complexType>
+              <xs:choice>
+                <xs:element name="content" type="xs:string"/>
+                <xs:element name="resource">
+                  <xs:complexType>
+                    <xs:attribute name="file" use="required" type="xs:string"/>
+                  </xs:complexType>
+                </xs:element>
+              </xs:choice>
+              <xs:attribute name="content-id" type="xs:string"/>
+              <xs:attribute name="content-type" type="xs:string"/>
+              <xs:attribute name="charset" type="xs:string"/>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="SoapRequest">
+    <xs:complexContent>
+      <xs:extension base="tns:SoapMessageType">
+        <xs:attribute name="soap-action" type="xs:string"/>
+        <xs:attribute name="mtom-enabled" type="xs:boolean"/>
+        <xs:attribute name="path" type="xs:string"/>
+        <xs:attribute name="content-type" type="xs:string"/>
+        <xs:attribute name="accept" type="xs:string"/>
+        <xs:attribute name="version" type="xs:string"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="SoapResponse">
+    <xs:complexContent>
+      <xs:extension base="tns:SoapMessageType">
+        <xs:attribute name="status" type="xs:string"/>
+        <xs:attribute name="reason-phrase" type="xs:string"/>
+        <xs:attribute name="version" type="xs:string"/>
+        <xs:attribute name="content-type" type="xs:string"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="SoapFault">
+    <xs:complexContent>
+      <xs:extension base="tns:SoapResponse">
+        <xs:sequence>
+          <xs:element name="fault-detail" minOccurs="0" maxOccurs="unbounded">
+            <xs:complexType>
+              <xs:choice>
+                <xs:element name="content" type="xs:string"/>
+                <xs:element name="resource">
+                  <xs:complexType>
+                    <xs:attribute name="file" use="required" type="xs:string"/>
+                  </xs:complexType>
+                </xs:element>
+              </xs:choice>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+        <xs:attribute name="fault-code" type="xs:string"/>
+        <xs:attribute name="fault-string" type="xs:string"/>
+        <xs:attribute name="fault-actor" type="xs:string"/>
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
@@ -696,8 +696,12 @@
   <xs:element name="trace-variables" type="tns:TraceVariables"/>
   <xs:element name="transform" type="tns:Transform"/>
   <xs:element name="wait-for" type="tns:WaitFor"/>
+
+  <!-- Additional modules -->
   <xs:element name="plsql" type="tns:Plsql"/>
   <xs:element name="sql" type="tns:Sql"/>
+  <xs:element name="purge-jms-queues" type="tns:PurgeQueues"/>
+  <xs:element name="purge-channels" type="tns:PurgeChannels"/>
   <xs:element name="groovy" type="tns:Groovy"/>
   <xs:element name="http" type="tns:Http"/>
   <xs:element name="soap" type="tns:Soap"/>
@@ -784,6 +788,41 @@
     </xs:sequence>
     <xs:attribute name="datasource" type="xs:string" use="required"/>
     <xs:attribute name="ignore-errors" type="xs:boolean"/>
+  </xs:complexType>
+
+  <xs:complexType name="PurgeQueues">
+    <xs:annotation>
+      <xs:documentation>Continuously receives messages from a destination until no more messages are left - emulating the purge operation</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:element name="queue" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:string"/>
+          <xs:attribute name="ref" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="connection-factory" type="xs:string"/>
+    <xs:attribute name="timeout" type="xs:int"/>
+    <xs:attribute name="sleep" type="xs:int"/>
+  </xs:complexType>
+
+  <xs:complexType name="PurgeChannels">
+    <xs:annotation>
+      <xs:documentation>Continuously receives messages from a Spring Integration message channel destination until no more messages are left - emulating the purge operation</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:element name="channel" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:string"/>
+          <xs:attribute name="ref" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="channel-resolver" type="xs:string"/>
+    <xs:attribute name="message-selector" type="xs:string"/>
   </xs:complexType>
 
   <xs:complexType name="Groovy">

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
@@ -702,6 +702,7 @@
   <xs:element name="http" type="tns:Http"/>
   <xs:element name="soap" type="tns:Soap"/>
   <xs:element name="camel" type="tns:Camel"/>
+  <xs:element name="selenium" type="tns:Selenium"/>
 
   <xs:complexType name="Plsql">
     <xs:sequence>
@@ -1157,6 +1158,243 @@
         <xs:attribute name="fault-actor" type="xs:string"/>
       </xs:extension>
     </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="Selenium">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:choice>
+        <xs:element name="start">
+          <xs:complexType>
+            <xs:attribute name="browser" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="stop">
+          <xs:complexType>
+            <xs:attribute name="browser" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="clear-cache"/>
+
+        <xs:element name="find">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="element" type="WebElementType"/>
+              <xs:element name="validate">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="attributes" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="attribute" minOccurs="1" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:attribute name="name" type="xs:string" use="required"/>
+                              <xs:attribute name="value" type="xs:string" use="required"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="styles" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="style" minOccurs="1" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:attribute name="name" type="xs:string" use="required"/>
+                              <xs:attribute name="value" type="xs:string" use="required"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                  <xs:attribute name="text" type="xs:string"/>
+                  <xs:attribute name="tag-name" type="xs:string"/>
+                  <xs:attribute name="displayed" type="xs:boolean"/>
+                  <xs:attribute name="enabled" type="xs:boolean"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="page">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="arguments" minOccurs="0">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="argument" type="xs:string" maxOccurs="unbounded"/>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string"/>
+            <xs:attribute name="type" type="xs:string"/>
+            <xs:attribute name="validator" type="xs:string"/>
+            <xs:attribute name="action" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="click">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="element" type="WebElementType"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="hover">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="element" type="WebElementType"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="set-input">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="element" type="WebElementType"/>
+            </xs:sequence>
+            <xs:attribute name="value" type="xs:string" use="required"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="check-input">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="element" type="WebElementType"/>
+            </xs:sequence>
+            <xs:attribute name="checked" type="xs:boolean" use="required"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="dropdown-select">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="element" type="WebElementType"/>
+              <xs:element name="options" minOccurs="0">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="option" type="xs:string" minOccurs="1" maxOccurs="unbounded"/>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="option" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="wait">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="element" type="WebElementType"/>
+            </xs:sequence>
+            <xs:attribute name="until" type="xs:string" use="required"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="javascript">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="script"/>
+              <xs:element name="arguments" minOccurs="0">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="argument" type="xs:string" minOccurs="1" maxOccurs="unbounded"/>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="errors" minOccurs="0">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="error" type="xs:string" minOccurs="1" maxOccurs="unbounded"/>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="argument" type="xs:string"/>
+            <xs:attribute name="error" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="screenshot">
+          <xs:complexType>
+            <xs:attribute name="output-dir" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="navigate">
+          <xs:complexType>
+            <xs:attribute name="page" type="xs:string" use="required"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="open-window">
+          <xs:complexType>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="close-window">
+          <xs:complexType>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="switch-window">
+          <xs:complexType>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="store-file">
+          <xs:complexType>
+            <xs:attribute name="file-path" type="xs:string" use="required"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="get-stored-file">
+          <xs:complexType>
+            <xs:attribute name="file-name" type="xs:string" use="required"/>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="alert">
+          <xs:annotation>
+            <xs:documentation>Access current alert dialog and perform action (accept, dismiss)</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="text" type="xs:string" minOccurs="0"/>
+            </xs:sequence>
+            <xs:attribute name="text" type="xs:string"/>
+            <xs:attribute name="accept" type="xs:boolean" use="required"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
+    </xs:sequence>
+    <xs:attribute name="browser" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="WebElementType">
+    <xs:sequence>
+      <xs:element name="property">
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:string" use="required"/>
+          <xs:attribute name="value" type="xs:string" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:string"/>
+    <xs:attribute name="name" type="xs:string"/>
+    <xs:attribute name="tag-name" type="xs:string"/>
+    <xs:attribute name="class-name" type="xs:string"/>
+    <xs:attribute name="css-selector" type="xs:string"/>
+    <xs:attribute name="link-text" type="xs:string"/>
+    <xs:attribute name="xpath" type="xs:string"/>
   </xs:complexType>
 
 </xs:schema>

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
@@ -700,6 +700,7 @@
   <xs:element name="sql" type="tns:Sql"/>
   <xs:element name="groovy" type="tns:Groovy"/>
   <xs:element name="http" type="tns:Http"/>
+  <xs:element name="camel" type="tns:Camel"/>
 
   <xs:complexType name="Plsql">
     <xs:sequence>
@@ -791,6 +792,105 @@
         <xs:attribute name="use-script-template" type="xs:boolean"/>
       </xs:extension>
     </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="Camel">
+    <xs:sequence>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:choice>
+        <xs:element name="create-routes">
+          <xs:annotation>
+            <xs:documentation>Creates new Camel routes on the fly</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:any processContents="skip" namespace="http://camel.apache.org/schema/spring"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="start-routes">
+          <xs:annotation>
+            <xs:documentation>Start Camel routes on context</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="route" minOccurs="1" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:attribute name="id" use="required"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="stop-routes">
+          <xs:annotation>
+            <xs:documentation>Start Camel routes on context</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="route" minOccurs="1" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:attribute name="id" use="required"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="remove-routes">
+          <xs:annotation>
+            <xs:documentation>Start Camel routes on context</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="route" minOccurs="1" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:attribute name="id" use="required"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="control-bus">
+          <xs:annotation>
+            <xs:documentation>Executes operations on Camel control bus</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:choice>
+                <xs:element name="route">
+                  <xs:complexType>
+                    <xs:attribute name="id" type="xs:string" use="required"/>
+                    <xs:attribute name="action" use="required">
+                      <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                          <xs:enumeration value="start"/>
+                          <xs:enumeration value="stop"/>
+                          <xs:enumeration value="suspend"/>
+                          <xs:enumeration value="resume"/>
+                          <xs:enumeration value="status"/>
+                          <xs:enumeration value="stats"/>
+                        </xs:restriction>
+                      </xs:simpleType>
+                    </xs:attribute>
+                  </xs:complexType>
+                </xs:element>
+                <xs:element name="language">
+                  <xs:complexType>
+                    <xs:simpleContent>
+                      <xs:extension base="xs:string">
+                        <xs:attribute name="type" type="xs:string" default="simple"/>
+                      </xs:extension>
+                    </xs:simpleContent>
+                  </xs:complexType>
+                </xs:element>
+              </xs:choice>
+              <xs:element name="result" type="xs:string" minOccurs="0"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
+    </xs:sequence>
+    <xs:attribute name="camel-context" type="xs:string"/>
   </xs:complexType>
 
   <xs:complexType name="Http">

--- a/runtime/citrus-xml/src/test/java/org/citrusframework/xml/actions/ReceiveTest.java
+++ b/runtime/citrus-xml/src/test/java/org/citrusframework/xml/actions/ReceiveTest.java
@@ -232,7 +232,9 @@ public class ReceiveTest extends AbstractXmlActionTest {
         Assert.assertEquals(xmlValidationContext.getIgnoreExpressions().size(), 1);
         Assert.assertEquals(xmlValidationContext.getIgnoreExpressions().iterator().next(), "/ns:TestMessage/ns:ignore");
         Assert.assertEquals(xmlValidationContext.getNamespaces().size(), 1);
-        Assert.assertEquals(xmlValidationContext.getNamespaces().get("ns"), "http://citrusframework.org");
+        Assert.assertEquals(xmlValidationContext.getNamespaces().get("ctx"), "http://citrusframework.org/test");
+        Assert.assertEquals(xmlValidationContext.getControlNamespaces().size(), 1);
+        Assert.assertEquals(xmlValidationContext.getControlNamespaces().get("ns"), "http://citrusframework.org");
 
         action = (ReceiveMessageAction) result.getTestAction(actionIndex++);
         Assert.assertEquals(action.getValidationContexts().size(), 3);

--- a/runtime/citrus-xml/src/test/java/org/citrusframework/xml/container/TemplateTest.java
+++ b/runtime/citrus-xml/src/test/java/org/citrusframework/xml/container/TemplateTest.java
@@ -20,7 +20,7 @@
 package org.citrusframework.xml.container;
 
 import org.citrusframework.container.Template;
-import org.citrusframework.xml.TemplateLoader;
+import org.citrusframework.xml.XmlTemplateLoader;
 import org.citrusframework.xml.actions.AbstractXmlActionTest;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -32,10 +32,9 @@ public class TemplateTest extends AbstractXmlActionTest {
 
     @Test
     public void shouldLoadTemplate() {
-        Template template = new TemplateLoader("classpath:org/citrusframework/xml/container/template-test.xml")
+        Template template = new XmlTemplateLoader()
                 .withReferenceResolver(context.getReferenceResolver())
-                .load()
-                .build();
+                .load("classpath:org/citrusframework/xml/container/template-test.xml");
 
         Assert.assertEquals(template.getTemplateName(), "myTemplate");
         Assert.assertEquals(template.getName(), "template:myTemplate");
@@ -43,10 +42,9 @@ public class TemplateTest extends AbstractXmlActionTest {
         Assert.assertEquals(template.getActions().size(), 1);
         Assert.assertTrue(template.isGlobalContext());
 
-        template = new TemplateLoader("classpath:org/citrusframework/xml/container/template-parameters-test.xml")
+        template = new XmlTemplateLoader()
                 .withReferenceResolver(context.getReferenceResolver())
-                .load()
-                .build();
+                .load("classpath:org/citrusframework/xml/container/template-parameters-test.xml");
         Assert.assertEquals(template.getTemplateName(), "myTemplate");
         Assert.assertEquals(template.getName(), "template:myTemplate");
         Assert.assertEquals(template.getParameter().size(), 3);

--- a/runtime/citrus-xml/src/test/resources/org/citrusframework/xml/actions/receive-test.xml
+++ b/runtime/citrus-xml/src/test/resources/org/citrusframework/xml/actions/receive-test.xml
@@ -119,7 +119,10 @@
         <expression path="/ns:TestMessage/" value="newValue"/>
       </message>
       <ignore path="/ns:TestMessage/ns:ignore"/>
-      <namespace prefix="ns" value="http://citrusframework.org"/>
+      <namespace prefix="ctx" value="http://citrusframework.org/test"/>
+      <validate>
+        <namespace prefix="ns" value="http://citrusframework.org"/>
+      </validate>
     </receive>
 
     <receive endpoint="direct:helloQueue">

--- a/runtime/citrus-yaml/src/main/java/org/citrusframework/yaml/YamlTemplateLoader.java
+++ b/runtime/citrus-yaml/src/main/java/org/citrusframework/yaml/YamlTemplateLoader.java
@@ -21,6 +21,7 @@ package org.citrusframework.yaml;
 
 import java.io.IOException;
 
+import org.citrusframework.container.TemplateLoader;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.spi.ReferenceResolver;
 import org.citrusframework.spi.ReferenceResolverAware;
@@ -34,36 +35,29 @@ import org.yaml.snakeyaml.constructor.Constructor;
 /**
  * @author Christoph Deppisch
  */
-public class TemplateLoader implements ReferenceResolverAware {
+public class YamlTemplateLoader implements ReferenceResolverAware, TemplateLoader {
 
     private final Yaml yaml;
-    private final String source;
 
-    private Template template;
     private ReferenceResolver referenceResolver;
 
     /**
      * Default constructor.
      */
-    public TemplateLoader(String source) {
-        this.source = source;
+    public YamlTemplateLoader() {
         yaml = new Yaml(new Constructor(Template.class, new LoaderOptions()));
     }
 
-    public Template load() {
-        if (template == null) {
-            Resource yamlSource = FileUtils.getFileResource(source);
-
-            try {
-                template = yaml.load(FileUtils.readToString(yamlSource));
-            } catch (IOException e) {
-                throw new CitrusRuntimeException("Failed to load YAML template for source '" + source + "'", e);
-            }
-
+    @Override
+    public org.citrusframework.container.Template load(String filePath) {
+        try {
+            Resource yamlSource = FileUtils.getFileResource(filePath);
+            Template template = yaml.load(FileUtils.readToString(yamlSource));
             template.setReferenceResolver(referenceResolver);
+            return template.build();
+        } catch (IOException e) {
+            throw new CitrusRuntimeException("Failed to load YAML template for source '" + filePath + "'", e);
         }
-
-        return template;
     }
 
     @Override
@@ -76,7 +70,7 @@ public class TemplateLoader implements ReferenceResolverAware {
      * @param referenceResolver
      * @return
      */
-    public TemplateLoader withReferenceResolver(ReferenceResolver referenceResolver) {
+    public YamlTemplateLoader withReferenceResolver(ReferenceResolver referenceResolver) {
         setReferenceResolver(referenceResolver);
         return this;
     }

--- a/runtime/citrus-yaml/src/main/java/org/citrusframework/yaml/actions/ApplyTemplate.java
+++ b/runtime/citrus-yaml/src/main/java/org/citrusframework/yaml/actions/ApplyTemplate.java
@@ -25,8 +25,7 @@ import org.citrusframework.TestActionBuilder;
 import org.citrusframework.container.Template;
 import org.citrusframework.spi.ReferenceResolver;
 import org.citrusframework.spi.ReferenceResolverAware;
-import org.citrusframework.spi.SimpleReferenceResolver;
-import org.citrusframework.yaml.TemplateLoader;
+import org.citrusframework.yaml.YamlTemplateLoader;
 
 /**
  * @author Christoph Deppisch
@@ -35,15 +34,17 @@ public class ApplyTemplate implements TestActionBuilder<Template>, ReferenceReso
 
     private final Template.Builder builder = new Template.Builder();
 
-    private String filePath;
-    private ReferenceResolver referenceResolver;
-
     public void setName(String name) {
         builder.templateName(name);
     }
 
+    public void setTemplateName(String name) {
+        builder.templateName(name);
+    }
+
     public void setFile(String filePath) {
-        this.filePath = filePath;
+        builder.file(filePath);
+        builder.loader(new YamlTemplateLoader());
     }
 
     public void setParameters(List<Parameter> parameters) {
@@ -56,27 +57,12 @@ public class ApplyTemplate implements TestActionBuilder<Template>, ReferenceReso
 
     @Override
     public Template build() {
-        if (filePath != null) {
-            Template local = new TemplateLoader(filePath)
-                    .withReferenceResolver(referenceResolver)
-                    .load()
-                    .build();
-
-            SimpleReferenceResolver temporaryReferenceResolver = new SimpleReferenceResolver();
-            temporaryReferenceResolver.bind(local.getTemplateName(), local);
-
-            builder.withReferenceResolver(temporaryReferenceResolver);
-            builder.templateName(local.getTemplateName());
-        } else {
-            builder.withReferenceResolver(referenceResolver);
-        }
-
         return builder.build();
     }
 
     @Override
     public void setReferenceResolver(ReferenceResolver referenceResolver) {
-        this.referenceResolver = referenceResolver;
+        builder.setReferenceResolver(referenceResolver);
     }
 
     public static class Parameter {

--- a/runtime/citrus-yaml/src/main/java/org/citrusframework/yaml/actions/MessageSupport.java
+++ b/runtime/citrus-yaml/src/main/java/org/citrusframework/yaml/actions/MessageSupport.java
@@ -89,7 +89,7 @@ public final class MessageSupport {
         }
 
         if (!pathExpressions.isEmpty()) {
-            builder.message().process(new DelegatingPathExpressionProcessor(pathExpressions));
+            builder.message().process(new DelegatingPathExpressionProcessor.Builder().expressions(pathExpressions).build());
         }
 
         if (message.dataDictionary != null) {

--- a/runtime/citrus-yaml/src/main/java/org/citrusframework/yaml/actions/Receive.java
+++ b/runtime/citrus-yaml/src/main/java/org/citrusframework/yaml/actions/Receive.java
@@ -237,7 +237,7 @@ public class Receive implements TestActionBuilder<ReceiveMessageAction>, Referen
         for (Namespace namespace : getNamespace()) {
             namespaces.put(namespace.prefix, namespace.value);
         }
-        xmlValidationContext.setNamespaces(namespaces);
+        xmlValidationContext.namespaceContext(namespaces);
 
         //check for validate elements, these elements can either have script, xpath or namespace validation information
         //for now we only handle xpath validation

--- a/runtime/citrus-yaml/src/main/java/org/citrusframework/yaml/actions/Start.java
+++ b/runtime/citrus-yaml/src/main/java/org/citrusframework/yaml/actions/Start.java
@@ -19,12 +19,10 @@
 
 package org.citrusframework.yaml.actions;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.citrusframework.TestActionBuilder;
 import org.citrusframework.actions.StartServerAction;
-import org.citrusframework.server.Server;
 import org.citrusframework.spi.ReferenceResolver;
 import org.citrusframework.spi.ReferenceResolverAware;
 
@@ -35,31 +33,22 @@ public class Start implements TestActionBuilder<StartServerAction>, ReferenceRes
 
     private final StartServerAction.Builder builder = new StartServerAction.Builder();
 
-    private final List<String> servers = new ArrayList<>();
-    private ReferenceResolver referenceResolver;
-
     public void setServer(String server) {
-        this.servers.add(server);
+        builder.server(server);
     }
 
     public void setServers(List<ServerRef> servers) {
-        servers.forEach(server -> this.servers.add(server.name));
+        servers.forEach(server -> builder.server(server.name));
     }
 
     @Override
     public StartServerAction build() {
-        if (referenceResolver != null) {
-            for (String server : servers) {
-                builder.server(referenceResolver.resolve(server, Server.class));
-            }
-        }
-
         return builder.build();
     }
 
     @Override
     public void setReferenceResolver(ReferenceResolver referenceResolver) {
-        this.referenceResolver = referenceResolver;
+        builder.setReferenceResolver(referenceResolver);
     }
 
     public static class ServerRef {

--- a/runtime/citrus-yaml/src/main/java/org/citrusframework/yaml/actions/Stop.java
+++ b/runtime/citrus-yaml/src/main/java/org/citrusframework/yaml/actions/Stop.java
@@ -19,12 +19,10 @@
 
 package org.citrusframework.yaml.actions;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.citrusframework.TestActionBuilder;
 import org.citrusframework.actions.StopServerAction;
-import org.citrusframework.server.Server;
 import org.citrusframework.spi.ReferenceResolver;
 import org.citrusframework.spi.ReferenceResolverAware;
 
@@ -35,31 +33,22 @@ public class Stop implements TestActionBuilder<StopServerAction>, ReferenceResol
 
     private final StopServerAction.Builder builder = new StopServerAction.Builder();
 
-    private final List<String> servers = new ArrayList<>();
-    private ReferenceResolver referenceResolver;
-
     public void setServer(String server) {
-        this.servers.add(server);
+        builder.server(server);
     }
 
     public void setServers(List<ServerRef> servers) {
-        servers.forEach(server -> this.servers.add(server.name));
+        servers.forEach(server -> builder.server(server.name));
     }
 
     @Override
     public StopServerAction build() {
-        if (referenceResolver != null) {
-            for (String server : servers) {
-                builder.server(referenceResolver.resolve(server, Server.class));
-            }
-        }
-
         return builder.build();
     }
 
     @Override
     public void setReferenceResolver(ReferenceResolver referenceResolver) {
-        this.referenceResolver = referenceResolver;
+        builder.setReferenceResolver(referenceResolver);
     }
 
     public static class ServerRef {

--- a/runtime/citrus-yaml/src/main/resources/META-INF/citrus/template/loader/yaml
+++ b/runtime/citrus-yaml/src/main/resources/META-INF/citrus/template/loader/yaml
@@ -1,0 +1,1 @@
+type=org.citrusframework.yaml.YamlTemplateLoader

--- a/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/actions/AbstractYamlActionTest.java
+++ b/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/actions/AbstractYamlActionTest.java
@@ -23,8 +23,6 @@ import org.citrusframework.Citrus;
 import org.citrusframework.CitrusContext;
 import org.citrusframework.CitrusInstanceManager;
 import org.citrusframework.DefaultTestCaseRunner;
-import org.citrusframework.TestAction;
-import org.citrusframework.TestActionBuilder;
 import org.citrusframework.annotations.CitrusAnnotations;
 import org.citrusframework.context.StaticTestContextFactory;
 import org.citrusframework.context.TestContext;
@@ -65,20 +63,9 @@ public class AbstractYamlActionTest extends AbstractTestNGUnitTest {
     protected YamlTestLoader createTestLoader(String sourcePath) {
         YamlTestLoader testLoader = new YamlTestLoader(this.getClass(), "Test", this.getClass().getPackageName());
         CitrusAnnotations.injectAll(testLoader, citrus, context);
-        CitrusAnnotations.injectTestRunner(testLoader, new NoopTestCaseRunner(context));
+        CitrusAnnotations.injectTestRunner(testLoader, new DefaultTestCaseRunner(context));
         testLoader.setSource(sourcePath);
 
         return testLoader;
-    }
-
-    protected static class NoopTestCaseRunner extends DefaultTestCaseRunner {
-        public NoopTestCaseRunner(TestContext context) {
-            super(context);
-        }
-
-        @Override
-        public <T extends TestAction> T run(TestActionBuilder<T> builder) {
-            return builder.build();
-        }
     }
 }

--- a/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/actions/ReceiveTest.java
+++ b/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/actions/ReceiveTest.java
@@ -155,12 +155,12 @@ public class ReceiveTest extends AbstractYamlActionTest {
         Assert.assertTrue(action.getMessageBuilder() instanceof DefaultMessageBuilder);
         messageBuilder = (DefaultMessageBuilder)action.getMessageBuilder();
 
-        Assert.assertEquals(messageBuilder.buildMessagePayload(context, action.getMessageType()), "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>"+System.getProperty("line.separator")+
+        Assert.assertEquals(messageBuilder.buildMessagePayload(context, action.getMessageType()), "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" + System.getProperty("line.separator") +
                 "<TestMessage xmlns=\"http://citrusframework.org/test\">Hello Citrus</TestMessage>");
         Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 1);
         Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get("operation"), "sayHello");
         Assert.assertEquals(messageBuilder.buildMessageHeaderData(context).size(), 1);
-        Assert.assertEquals(messageBuilder.buildMessageHeaderData(context).get(0).trim(), "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>"+System.getProperty("line.separator")+
+        Assert.assertEquals(messageBuilder.buildMessageHeaderData(context).get(0).trim(), "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" + System.getProperty("line.separator") +
                 "<Header xmlns=\"http://citrusframework.org/test\"><operation>hello</operation></Header>");
         Assert.assertEquals(action.getMessageProcessors().size(), 0);
         Assert.assertEquals(action.getControlMessageProcessors().size(), 0);
@@ -234,7 +234,9 @@ public class ReceiveTest extends AbstractYamlActionTest {
         Assert.assertEquals(xmlValidationContext.getIgnoreExpressions().size(), 1);
         Assert.assertEquals(xmlValidationContext.getIgnoreExpressions().iterator().next(), "/ns:TestMessage/ns:ignore");
         Assert.assertEquals(xmlValidationContext.getNamespaces().size(), 1);
-        Assert.assertEquals(xmlValidationContext.getNamespaces().get("ns"), "http://citrusframework.org");
+        Assert.assertEquals(xmlValidationContext.getNamespaces().get("ctx"), "http://citrusframework.org/test");
+        Assert.assertEquals(xmlValidationContext.getControlNamespaces().size(), 1);
+        Assert.assertEquals(xmlValidationContext.getControlNamespaces().get("ns"), "http://citrusframework.org");
 
         action = (ReceiveMessageAction) result.getTestAction(actionIndex++);
         Assert.assertEquals(action.getValidationContexts().size(), 3);

--- a/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/actions/SendTest.java
+++ b/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/actions/SendTest.java
@@ -113,17 +113,20 @@ public class SendTest extends AbstractYamlActionTest {
         Assert.assertTrue(action.getMessageBuilder() instanceof DefaultMessageBuilder);
         messageBuilder = (DefaultMessageBuilder)action.getMessageBuilder();
 
-        Assert.assertEquals(messageBuilder.buildMessagePayload(context, action.getMessageType()), "<TestMessage xmlns=\"http://citrusframework.org/test\">Hello Citrus</TestMessage>");
+        Assert.assertEquals(messageBuilder.buildMessagePayload(context, action.getMessageType()), "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" + System.getProperty("line.separator") +
+                "<TestMessage xmlns=\"http://citrusframework.org/test\">Hello Citrus</TestMessage>");
         Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 1);
         Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get("operation"), "sayHello");
         Assert.assertEquals(messageBuilder.buildMessageHeaderData(context).size(), 1);
-        Assert.assertEquals(messageBuilder.buildMessageHeaderData(context).get(0).trim(), "<Header xmlns=\"http://citrusframework.org/test\"><operation>hello</operation></Header>");
+        Assert.assertEquals(messageBuilder.buildMessageHeaderData(context).get(0).trim(), "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" + System.getProperty("line.separator") +
+                "<Header xmlns=\"http://citrusframework.org/test\"><operation>hello</operation></Header>");
         Assert.assertEquals(action.getMessageProcessors().size(), 0);
         Assert.assertEquals(action.getEndpointUri(), "helloEndpoint");
 
         Assert.assertNull(action.getDataDictionary());
 
-        controlMessage = new DefaultMessage("<TestMessage xmlns=\"http://citrusframework.org/test\">Hello Citrus</TestMessage>")
+        controlMessage = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" + System.getProperty("line.separator") +
+                "<TestMessage xmlns=\"http://citrusframework.org/test\">Hello Citrus</TestMessage>")
                 .setHeader("operation", "sayHello");
         receivedMessage = helloQueue.receive();
         headerValidator.validateMessage(receivedMessage, controlMessage, context, new HeaderValidationContext());

--- a/runtime/citrus-yaml/src/test/resources/org/citrusframework/yaml/actions/receive-test.yaml
+++ b/runtime/citrus-yaml/src/test/resources/org/citrusframework/yaml/actions/receive-test.yaml
@@ -27,7 +27,7 @@ actions:
           - data: |
               <?xml version="1.0" encoding="UTF-8" standalone="no"?>
               <Header xmlns="http://citrusframework.org/test"><operation>hello</operation></Header>
-          - name: "operation"
+          - name: operation
             value: "sayHello"
         body:
           data: |
@@ -79,8 +79,12 @@ actions:
       ignore:
         - path: "/ns:TestMessage/ns:ignore"
       namespace:
-        - prefix: "ns"
-          value: "http://citrusframework.org"
+        - prefix: "ctx"
+          value: "http://citrusframework.org/test"
+      validate:
+        - namespace:
+            - prefix: "ns"
+              value: "http://citrusframework.org"
   - receive:
       endpoint: "direct:helloQueue"
       validate:

--- a/runtime/citrus-yaml/src/test/resources/org/citrusframework/yaml/actions/send-test.yaml
+++ b/runtime/citrus-yaml/src/test/resources/org/citrusframework/yaml/actions/send-test.yaml
@@ -24,11 +24,13 @@ actions:
       message:
         headers:
           - data: |
+              <?xml version="1.0" encoding="UTF-8" standalone="no"?>
               <Header xmlns="http://citrusframework.org/test"><operation>hello</operation></Header>
           - name: operation
             value: "sayHello"
         body:
           data: |
+            <?xml version="1.0" encoding="UTF-8" standalone="no"?>
             <TestMessage xmlns="http://citrusframework.org/test">Hello Citrus</TestMessage>
   - send:
       endpoint: helloEndpoint
@@ -36,7 +38,6 @@ actions:
         body:
           resource:
             file: "classpath:org/citrusframework/yaml/test-request-payload.xml"
-
   - send:
       endpoint: helloEndpoint
       message:

--- a/src/manual/endpoint-camel.adoc
+++ b/src/manual/endpoint-camel.adoc
@@ -818,7 +818,7 @@ public class CamelControlBusIT extends TestNGCitrusSpringSupport {
     </camel:control-bus>
 
     <camel:control-bus camel-context="camelContext">
-      <camel:language type="simple">${camelContext.getRouteStatus('route_3')}</camel:language>
+      <camel:language type="simple">${camelContext.getRouteController().getRouteStatus('route_3')}</camel:language>
       <camel:result>Started</camel:result>
     </camel:control-bus>
   </actions>

--- a/validation/citrus-validation-json/src/main/java/org/citrusframework/validation/json/JsonPathVariableExtractor.java
+++ b/validation/citrus-validation-json/src/main/java/org/citrusframework/validation/json/JsonPathVariableExtractor.java
@@ -20,17 +20,23 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import org.citrusframework.context.TestContext;
-import org.citrusframework.exceptions.CitrusRuntimeException;
-import org.citrusframework.json.JsonPathUtils;
-import org.citrusframework.message.Message;
-import org.citrusframework.variable.VariableExtractor;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.ReadContext;
 import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
 import net.minidev.json.parser.JSONParser;
 import net.minidev.json.parser.ParseException;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.json.JsonPathUtils;
+import org.citrusframework.message.DelegatingPathExpressionProcessor;
+import org.citrusframework.message.Message;
+import org.citrusframework.message.MessageProcessor;
+import org.citrusframework.message.MessageProcessorAdapter;
+import org.citrusframework.validation.PathExpressionValidationContext;
+import org.citrusframework.validation.ValidationContextAdapter;
+import org.citrusframework.validation.context.ValidationContext;
+import org.citrusframework.variable.VariableExtractor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.CollectionUtils;
@@ -103,7 +109,7 @@ public class JsonPathVariableExtractor implements VariableExtractor {
     /**
      * Fluent builder.
      */
-    public static final class Builder implements VariableExtractor.Builder<JsonPathVariableExtractor, Builder> {
+    public static final class Builder implements VariableExtractor.Builder<JsonPathVariableExtractor, Builder>, MessageProcessorAdapter, ValidationContextAdapter {
         private final Map<String, Object> expressions = new LinkedHashMap<>();
 
         @Override
@@ -116,6 +122,20 @@ public class JsonPathVariableExtractor implements VariableExtractor {
         public Builder expression(final String expression, final Object variableName) {
             this.expressions.put(expression, variableName);
             return this;
+        }
+
+        @Override
+        public MessageProcessor asProcessor() {
+            return new DelegatingPathExpressionProcessor.Builder()
+                    .expressions(expressions)
+                    .build();
+        }
+
+        @Override
+        public ValidationContext asValidationContext() {
+            return new PathExpressionValidationContext.Builder()
+                    .expressions(expressions)
+                    .build();
         }
 
         @Override

--- a/validation/citrus-validation-xml/src/main/java/org/citrusframework/validation/xml/XpathPayloadVariableExtractor.java
+++ b/validation/citrus-validation-xml/src/main/java/org/citrusframework/validation/xml/XpathPayloadVariableExtractor.java
@@ -27,8 +27,14 @@ import javax.xml.namespace.NamespaceContext;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.exceptions.UnknownElementException;
+import org.citrusframework.message.DelegatingPathExpressionProcessor;
 import org.citrusframework.message.Message;
+import org.citrusframework.message.MessageProcessor;
+import org.citrusframework.message.MessageProcessorAdapter;
 import org.citrusframework.util.XMLUtils;
+import org.citrusframework.validation.PathExpressionValidationContext;
+import org.citrusframework.validation.ValidationContextAdapter;
+import org.citrusframework.validation.context.ValidationContext;
 import org.citrusframework.variable.VariableExtractor;
 import org.citrusframework.xml.xpath.XPathExpressionResult;
 import org.citrusframework.xml.xpath.XPathUtils;
@@ -132,7 +138,8 @@ public class XpathPayloadVariableExtractor implements VariableExtractor {
     /**
      * Fluent builder.
      */
-    public static final class Builder implements VariableExtractor.Builder<XpathPayloadVariableExtractor, Builder>, XmlNamespaceAware {
+    public static final class Builder implements VariableExtractor.Builder<XpathPayloadVariableExtractor, Builder>,
+            XmlNamespaceAware, MessageProcessorAdapter, ValidationContextAdapter {
         private final Map<String, Object> expressions = new HashMap<>();
         private final Map<String, String> namespaces = new HashMap<>();
 
@@ -174,6 +181,20 @@ public class XpathPayloadVariableExtractor implements VariableExtractor {
         @Override
         public void setNamespaces(Map<String, String> namespaces) {
             namespaces(namespaces);
+        }
+
+        @Override
+        public MessageProcessor asProcessor() {
+            return new DelegatingPathExpressionProcessor.Builder()
+                    .expressions(expressions)
+                    .build();
+        }
+
+        @Override
+        public ValidationContext asValidationContext() {
+            return new PathExpressionValidationContext.Builder()
+                    .expressions(expressions)
+                    .build();
         }
 
         @Override


### PR DESCRIPTION
* Add finalized support for YAML DSL
* Add finalized support for XML DSL
* Add finalized support for Groovy DSL
* Implementation and unit tests for each of those DSL variations for
  * citrus-sql
  * citrus-jms
  * citrus-camel
  * citrus-ws
  * citrus-springintegration
  * citrus-selenium