### PR TITLE
citrus-simulator compatibility fixes

### DIFF
--- a/connectors/citrus-docker/pom.xml
+++ b/connectors/citrus-docker/pom.xml
@@ -86,10 +86,6 @@
     </dependency>
 
     <dependency>
-      <groupId>jakarta.activation</groupId>
-      <artifactId>jakarta.activation-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>jakarta.annotation</groupId>
       <artifactId>jakarta.annotation-api</artifactId>
     </dependency>

--- a/endpoints/citrus-mail/pom.xml
+++ b/endpoints/citrus-mail/pom.xml
@@ -67,25 +67,12 @@
     </dependency>
 
     <dependency>
-      <groupId>jakarta.xml.bind</groupId>
-      <artifactId>jakarta.xml.bind-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.jaxb</groupId>
-      <artifactId>jaxb-runtime</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>com.sun.mail</groupId>
-      <artifactId>jakarta.mail</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.icegreen</groupId>
       <artifactId>greenmail</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.sun.activation</groupId>
-      <artifactId>jakarta.activation</artifactId>
+      <groupId>org.eclipse.angus</groupId>
+      <artifactId>jakarta.mail</artifactId>
     </dependency>
 
     <!-- Test scoped dependencies -->

--- a/endpoints/citrus-mail/src/main/java/org/citrusframework/mail/client/MailEndpointConfiguration.java
+++ b/endpoints/citrus-mail/src/main/java/org/citrusframework/mail/client/MailEndpointConfiguration.java
@@ -16,12 +16,13 @@
 
 package org.citrusframework.mail.client;
 
-import java.util.Properties;
-
+import jakarta.mail.Authenticator;
 import org.citrusframework.endpoint.AbstractEndpointConfiguration;
 import org.citrusframework.mail.message.MailMessageConverter;
 import org.citrusframework.mail.model.MailMarshaller;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
 
 /**
  * @author Christoph Deppisch
@@ -41,14 +42,14 @@ public class MailEndpointConfiguration extends AbstractEndpointConfiguration {
     /** Password */
     private String password;
 
+    /** An optional username + password authenticator **/
+    private Authenticator authenticator;
+
     /** Protocol */
     private String protocol = JavaMailSenderImpl.DEFAULT_PROTOCOL;
 
     /** Java mail properties */
-    private Properties javaMailProperties;
-
-    /** Mail sender implementation */
-    private JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
+    private Properties javaMailProperties = new Properties();
 
     /** Mail message marshaller converts from XML to mail message object */
     private MailMarshaller marshaller = new MailMarshaller();
@@ -56,24 +57,7 @@ public class MailEndpointConfiguration extends AbstractEndpointConfiguration {
     /** Mail message converter */
     private MailMessageConverter messageConverter = new MailMessageConverter();
 
-    /**
-     * Gets the mail protocol.
-     * @return the mail protocol.
-     */
-    public String getProtocol() {
-        return protocol;
-    }
-
-    /**
-     * Set the mail protocol. Default is "smtp".
-     * @param protocol
-     */
-    public void setProtocol(String protocol) {
-        this.protocol = protocol;
-        javaMailSender.setProtocol(protocol);
-    }
-
-    /**
+      /**
      * Gets the mail host.
      * @return the mail host.
      */
@@ -83,11 +67,11 @@ public class MailEndpointConfiguration extends AbstractEndpointConfiguration {
 
     /**
      * Set the mail server host, typically an SMTP host.
-     * @param host
+     * @param host the mail server host.
      */
     public void setHost(String host) {
         this.host = host;
-        javaMailSender.setHost(host);
+        getJavaMailProperties().setProperty("mail."+ getProtocol()+".host", host);
     }
 
     /**
@@ -101,11 +85,11 @@ public class MailEndpointConfiguration extends AbstractEndpointConfiguration {
     /**
      * Set the mail server port.
      * Default is the Java mail port for SMTP (25).
-     * @param port
+     * @param port the mail server port.
      */
     public void setPort(int port) {
         this.port = port;
-        javaMailSender.setPort(port);
+        getJavaMailProperties().put("mail."+getProtocol()+".port", "25");
     }
 
     /**
@@ -117,19 +101,18 @@ public class MailEndpointConfiguration extends AbstractEndpointConfiguration {
     }
 
     /**
-     * Set the username for accessing the mail host. Underlying mail seesion
+     * Set the username for accessing the mail host. The underlying mail session
      * has to be configured with the property <code>"mail.smtp.auth"</code> set to
      * <code>true</code>.
-     * @param username
+     * @param username the username for accessing the mail host.
      */
     public void setUsername(String username) {
         this.username = username;
-        javaMailSender.setUsername(username);
     }
 
     /**
      * Gets the mail password.
-     * @return the mail ppassword.
+     * @return the mail password.
      */
     public String getPassword() {
         return password;
@@ -139,11 +122,42 @@ public class MailEndpointConfiguration extends AbstractEndpointConfiguration {
      * Set the password for accessing the mail host. Underlying mail seesion
      * has to be configured with the property <code>"mail.smtp.auth"</code> set to
      * <code>true</code>.
-     * @param password
+     * @param password the password for accessing the mail host.
      */
     public void setPassword(String password) {
         this.password = password;
-        javaMailSender.setPassword(password);
+    }
+
+    /**
+     * Gets the authenticator.
+     * @return The authenticator.
+     */
+    public Authenticator getAuthenticator() {
+        return authenticator;
+    }
+
+    /**
+     * Sets the authenticator.
+     * @param authenticator the authenticator.
+     */
+    public void setAuthenticator(Authenticator authenticator) {
+        this.authenticator = authenticator;
+    }
+
+    /**
+     * Gets the mail protocol.
+     * @return the mail protocol.
+     */
+    public String getProtocol() {
+        return protocol;
+    }
+
+    /**
+     * Set the mailing protocol. Default is "smtp".
+     * @param protocol the mailing protocol.
+     */
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
     }
 
     /**
@@ -157,16 +171,15 @@ public class MailEndpointConfiguration extends AbstractEndpointConfiguration {
     /**
      * Set JavaMail properties for the mail session such as <code>"mail.smtp.auth"</code>
      * when using username and password. New session is created when properties are set.
-     * @param javaMailProperties
+     * @param javaMailProperties all mailing properties.
      */
     public void setJavaMailProperties(Properties javaMailProperties) {
         this.javaMailProperties = javaMailProperties;
-        javaMailSender.setJavaMailProperties(javaMailProperties);
     }
 
     /**
      * Gets the mail message marshaller implementation.
-     * @return
+     * @return the mail message marshaller.
      */
     public MailMarshaller getMarshaller() {
         return marshaller;
@@ -174,31 +187,15 @@ public class MailEndpointConfiguration extends AbstractEndpointConfiguration {
 
     /**
      * Sets the mail message marshaller implementation.
-     * @param marshaller
+     * @param marshaller the mail message marshaller.
      */
     public void setMarshaller(MailMarshaller marshaller) {
         this.marshaller = marshaller;
     }
 
     /**
-     * Gets the Java mail sender implementation.
-     * @return
-     */
-    public JavaMailSenderImpl getJavaMailSender() {
-        return javaMailSender;
-    }
-
-    /**
-     * Sets the Java mail sender implementation.
-     * @param javaMailSender
-     */
-    public void setJavaMailSender(JavaMailSenderImpl javaMailSender) {
-        this.javaMailSender = javaMailSender;
-    }
-
-    /**
      * Gets the mail message converter.
-     * @return
+     * @return the mail message converter.
      */
     public MailMessageConverter getMessageConverter() {
         return messageConverter;
@@ -206,7 +203,7 @@ public class MailEndpointConfiguration extends AbstractEndpointConfiguration {
 
     /**
      * Sets the mail message converter.
-     * @param messageConverter
+     * @param messageConverter the mail message converter.
      */
     public void setMessageConverter(MailMessageConverter messageConverter) {
         this.messageConverter = messageConverter;

--- a/endpoints/citrus-mail/src/main/java/org/citrusframework/mail/client/MailSender.java
+++ b/endpoints/citrus-mail/src/main/java/org/citrusframework/mail/client/MailSender.java
@@ -1,0 +1,15 @@
+package org.citrusframework.mail.client;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.Transport;
+import jakarta.mail.internet.MimeMessage;
+
+/**
+ * This class exists mainly for testing purposes (mocking).
+ */
+public class MailSender {
+
+    public void send(MimeMessage mimeMessage) throws MessagingException {
+        Transport.send(mimeMessage);
+    }
+}

--- a/endpoints/citrus-mail/src/main/java/org/citrusframework/mail/message/MailMessageConverter.java
+++ b/endpoints/citrus-mail/src/main/java/org/citrusframework/mail/message/MailMessageConverter.java
@@ -18,6 +18,7 @@ package org.citrusframework.mail.message;
 
 import jakarta.mail.MessagingException;
 import jakarta.mail.Multipart;
+import jakarta.mail.Session;
 import jakarta.mail.internet.MimeMessage;
 import jakarta.mail.internet.MimePart;
 import javax.xml.transform.Source;
@@ -70,7 +71,10 @@ public class MailMessageConverter implements MessageConverter<MimeMailMessage, M
         MailRequest mailMessage = getMailRequest(message, endpointConfiguration);
 
         try {
-            MimeMessage mimeMessage = endpointConfiguration.getJavaMailSender().createMimeMessage();
+            Session session = Session.getInstance(endpointConfiguration.getJavaMailProperties(), endpointConfiguration.getAuthenticator());
+            session.setDebug(log.isDebugEnabled());
+
+            MimeMessage mimeMessage = new MimeMessage(session);
             MimeMailMessage mimeMailMessage = new MimeMailMessage(new MimeMessageHelper(mimeMessage,
                     mailMessage.getBody().hasAttachments(),
                     parseCharsetFromContentType(mailMessage.getBody().getContentType())));

--- a/endpoints/citrus-mail/src/test/java/org/citrusframework/mail/config/annotation/MailClientConfigParserTest.java
+++ b/endpoints/citrus-mail/src/test/java/org/citrusframework/mail/config/annotation/MailClientConfigParserTest.java
@@ -97,27 +97,30 @@ public class MailClientConfigParserTest extends AbstractTestNGUnitTest {
 
         // 1st mail mailClient
         Assert.assertEquals(mailClient1.getName(), "mailClient1");
-        Assert.assertEquals(mailClient1.getEndpointConfiguration().getJavaMailSender().getHost(), "localhost");
-        Assert.assertEquals(mailClient1.getEndpointConfiguration().getJavaMailSender().getPort(), 25000);
+        Assert.assertEquals(mailClient1.getEndpointConfiguration().getHost(), "localhost");
+        Assert.assertEquals(mailClient1.getEndpointConfiguration().getPort(), 25000);
+        Assert.assertEquals(mailClient1.getEndpointConfiguration().getJavaMailProperties().getProperty("mail.smtp.host"), "localhost");
+        Assert.assertEquals(mailClient1.getEndpointConfiguration().getJavaMailProperties().getProperty("mail.smtp.port"), "25000");
         Assert.assertNull(mailClient1.getActor());
 
         // 2nd mail mailClient
         Assert.assertEquals(mailClient2.getName(), "mailClient2");
-        Assert.assertEquals(mailClient2.getEndpointConfiguration().getJavaMailSender().getHost(), "localhost");
-        Assert.assertEquals(mailClient2.getEndpointConfiguration().getJavaMailSender().getPort(), 25000);
-        Assert.assertEquals(mailClient2.getEndpointConfiguration().getJavaMailSender().getUsername(), "mailus");
-        Assert.assertEquals(mailClient2.getEndpointConfiguration().getJavaMailSender().getPassword(), "secret");
-        Assert.assertEquals(mailClient2.getEndpointConfiguration().getJavaMailSender().getJavaMailProperties().get("mail.smtp.auth"), "true");
+        Assert.assertEquals(mailClient2.getEndpointConfiguration().getHost(), "localhost");
+        Assert.assertEquals(mailClient2.getEndpointConfiguration().getPort(), 25000);
+        Assert.assertEquals(mailClient2.getEndpointConfiguration().getUsername(), "mailus");
+        Assert.assertEquals(mailClient2.getEndpointConfiguration().getPassword(), "secret");
+        Assert.assertNotNull(mailClient2.getEndpointConfiguration().getAuthenticator());
+        Assert.assertEquals(mailClient2.getEndpointConfiguration().getJavaMailProperties().get("mail.smtp.auth"), "true");
         Assert.assertNull(mailClient2.getActor());
 
         // 3rd mail mailClient
         Assert.assertEquals(mailClient3.getName(), "mailClient3");
-        Assert.assertEquals(mailClient3.getEndpointConfiguration().getJavaMailSender().getHost(), "localhost");
-        Assert.assertEquals(mailClient3.getEndpointConfiguration().getJavaMailSender().getPort(), 25000);
+        Assert.assertEquals(mailClient3.getEndpointConfiguration().getHost(), "localhost");
+        Assert.assertEquals(mailClient3.getEndpointConfiguration().getPort(), 25000);
         Assert.assertNotNull(mailClient3.getActor());
         Assert.assertEquals(mailClient3.getEndpointConfiguration().getMessageConverter(), messageConverter);
         Assert.assertEquals(mailClient3.getEndpointConfiguration().getMarshaller(), marshaller);
-        Assert.assertEquals(mailClient3.getEndpointConfiguration().getJavaMailSender().getJavaMailProperties(), mailProperties);
+        Assert.assertEquals(mailClient3.getEndpointConfiguration().getJavaMailProperties(), mailProperties);
     }
 
     @Test

--- a/endpoints/citrus-mail/src/test/java/org/citrusframework/mail/config/xml/MailClientParserTest.java
+++ b/endpoints/citrus-mail/src/test/java/org/citrusframework/mail/config/xml/MailClientParserTest.java
@@ -40,28 +40,30 @@ public class MailClientParserTest extends AbstractBeanDefinitionParserTest {
         // 1st mail sender
         MailClient sender = senders.get("mailClient1");
         Assert.assertEquals(sender.getName(), "mailClient1");
-        Assert.assertEquals(sender.getEndpointConfiguration().getJavaMailSender().getHost(), "localhost");
-        Assert.assertEquals(sender.getEndpointConfiguration().getJavaMailSender().getPort(), 25000);
+        Assert.assertEquals(sender.getEndpointConfiguration().getHost(), "localhost");
+        Assert.assertEquals(sender.getEndpointConfiguration().getPort(), 25000);
+        Assert.assertEquals(sender.getEndpointConfiguration().getJavaMailProperties().getProperty("mail.smtp.host"), "localhost");
+        Assert.assertEquals(sender.getEndpointConfiguration().getJavaMailProperties().getProperty("mail.smtp.port"), "25000");
         Assert.assertNull(sender.getActor());
 
         // 2nd mail sender
         sender = senders.get("mailClient2");
         Assert.assertEquals(sender.getName(), "mailClient2");
-        Assert.assertEquals(sender.getEndpointConfiguration().getJavaMailSender().getHost(), "localhost");
-        Assert.assertEquals(sender.getEndpointConfiguration().getJavaMailSender().getPort(), 25000);
-        Assert.assertEquals(sender.getEndpointConfiguration().getJavaMailSender().getUsername(), "mailus");
-        Assert.assertEquals(sender.getEndpointConfiguration().getJavaMailSender().getPassword(), "secret");
-        Assert.assertEquals(sender.getEndpointConfiguration().getJavaMailSender().getJavaMailProperties().get("mail.smtp.auth"), "true");
+        Assert.assertEquals(sender.getEndpointConfiguration().getHost(), "localhost");
+        Assert.assertEquals(sender.getEndpointConfiguration().getPort(), 25000);
+        Assert.assertEquals(sender.getEndpointConfiguration().getUsername(), "mailus");
+        Assert.assertEquals(sender.getEndpointConfiguration().getPassword(), "secret");
+        Assert.assertEquals(sender.getEndpointConfiguration().getJavaMailProperties().get("mail.smtp.auth"), "true");
         Assert.assertNull(sender.getActor());
 
         // 3rd mail sender
         sender = senders.get("mailClient3");
         Assert.assertEquals(sender.getName(), "mailClient3");
-        Assert.assertEquals(sender.getEndpointConfiguration().getJavaMailSender().getHost(), "localhost");
-        Assert.assertEquals(sender.getEndpointConfiguration().getJavaMailSender().getPort(), 25000);
+        Assert.assertEquals(sender.getEndpointConfiguration().getHost(), "localhost");
+        Assert.assertEquals(sender.getEndpointConfiguration().getPort(), 25000);
         Assert.assertNotNull(sender.getActor());
         Assert.assertEquals(sender.getEndpointConfiguration().getMessageConverter(), beanDefinitionContext.getBean("messageConverter", MessageConverter.class));
         Assert.assertEquals(sender.getEndpointConfiguration().getMarshaller(), beanDefinitionContext.getBean("marshaller", MailMarshaller.class));
-        Assert.assertEquals(sender.getEndpointConfiguration().getJavaMailSender().getJavaMailProperties().get("mail.transport.protocol"), "smtp");
+        Assert.assertEquals(sender.getEndpointConfiguration().getJavaMailProperties().get("mail.transport.protocol"), "smtp");
     }
 }

--- a/endpoints/citrus-mail/src/test/resources/org/citrusframework/mail/integration/MailServerAcceptIT.xml
+++ b/endpoints/citrus-mail/src/test/resources/org/citrusframework/mail/integration/MailServerAcceptIT.xml
@@ -137,7 +137,7 @@
       </echo>
 
       <parallel>
-        <assert exception="org.springframework.mail.MailSendException">
+        <assert exception="org.citrusframework.exceptions.CitrusRuntimeException">
           <when>
             <send endpoint="advancedMailClient">
               <description>

--- a/endpoints/citrus-mail/src/test/resources/org/citrusframework/mail/integration/MailServerErrorIT.xml
+++ b/endpoints/citrus-mail/src/test/resources/org/citrusframework/mail/integration/MailServerErrorIT.xml
@@ -30,7 +30,7 @@
       </echo>
 
       <parallel>
-        <assert exception="org.springframework.mail.MailSendException">
+        <assert exception="org.citrusframework.exceptions.CitrusRuntimeException">
           <when>
             <send endpoint="advancedMailClient">
               <description>

--- a/endpoints/citrus-ws/pom.xml
+++ b/endpoints/citrus-ws/pom.xml
@@ -101,10 +101,6 @@
       <groupId>com.sun.xml.messaging.saaj</groupId>
       <artifactId>saaj-impl</artifactId>
     </dependency>
-    <dependency>
-      <groupId>com.sun.activation</groupId>
-      <artifactId>jakarta.activation</artifactId>
-    </dependency>
 
     <dependency>
       <groupId>jakarta.xml.bind</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,7 @@
     <jaxb.maven.plugin.version>3.1.0</jaxb.maven.plugin.version>
 
     <activemq.artemis.version>2.30.0</activemq.artemis.version>
+    <angus-mail.version>2.0.2</angus-mail.version>
     <apache.ant.version>1.10.13</apache.ant.version>
     <apache.camel.version>4.0.0-RC1</apache.camel.version>
     <arquillian.version>1.7.0.Final</arquillian.version>
@@ -188,16 +189,15 @@
     <ftpserver.version>1.2.0</ftpserver.version>
     <groovy.version>3.0.18</groovy.version>
     <google.guava.version>32.1.1-jre</google.guava.version>
+    <greenmail.version>2.0.0</greenmail.version>
     <hamcrest.version>2.2</hamcrest.version>
     <htmlunit.version>4.10.0</htmlunit.version>
     <httpclient.version>5.2.1</httpclient.version>
     <hsqldb.version>2.7.2</hsqldb.version>
     <jackson.version>2.15.2</jackson.version>
-    <jakarta.activation.api.version>2.1.2</jakarta.activation.api.version>
-    <jakarta.activation.version>2.0.1</jakarta.activation.version>
-    <jakarta.annotation.version>2.1.1</jakarta.annotation.version>
+    <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
     <jakarta.jms-api.version>3.1.0</jakarta.jms-api.version>
-    <jakarta.mail.version>2.0.1</jakarta.mail.version>
+    <jakarta.mail.version>2.0.2</jakarta.mail.version>
     <jakarta.servlet-api.version>6.0.0</jakarta.servlet-api.version>
     <jakarta.validation.version>3.0.2</jakarta.validation.version>
     <jakarta.websocket-api.version>2.1.1</jakarta.websocket-api.version>
@@ -234,9 +234,8 @@
     <spring.integration.version>6.1.2</spring.integration.version>
     <spring.restdocs.version>3.0.0</spring.restdocs.version>
     <sshd.version>2.10.0</sshd.version>
-    <greenmail.version>2.0.0</greenmail.version>
     <swagger.version>1.6.9</swagger.version>
-    <swagger.parser.version>1.0.64</swagger.parser.version>
+    <swagger.parser.version>2.1.16</swagger.parser.version>
     <testng.version>7.8.0</testng.version>
     <vertx.version>4.4.4</vertx.version>
     <wsdl4j.version>1.6.3</wsdl4j.version>
@@ -267,16 +266,6 @@
         <version>${jakarta.jms-api.version}</version>
       </dependency>
 
-      <dependency>
-        <groupId>jakarta.activation</groupId>
-        <artifactId>jakarta.activation-api</artifactId>
-        <version>${jakarta.activation.api.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.sun.activation</groupId>
-        <artifactId>jakarta.activation</artifactId>
-        <version>${jakarta.activation.version}</version>
-      </dependency>
       <dependency>
         <groupId>com.sun.xml.messaging.saaj</groupId>
         <artifactId>saaj-impl</artifactId>
@@ -589,14 +578,14 @@
         <version>${jetty.version}</version>
       </dependency>
       <dependency>
+        <groupId>jakarta.annotation</groupId>
+        <artifactId>jakarta.annotation-api</artifactId>
+        <version>${jakarta.annotation-api.version}</version>
+      </dependency>
+      <dependency>
         <groupId>jakarta.servlet</groupId>
         <artifactId>jakarta.servlet-api</artifactId>
         <version>${jakarta.servlet-api.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>jakarta.annotation</groupId>
-        <artifactId>jakarta.annotation-api</artifactId>
-        <version>${jakarta.annotation.version}</version>
       </dependency>
       <dependency>
         <groupId>jakarta.websocket</groupId>
@@ -646,14 +635,14 @@
 
       <!-- Citrus mail dependencies -->
       <dependency>
-        <groupId>com.sun.mail</groupId>
-        <artifactId>jakarta.mail</artifactId>
-        <version>${jakarta.mail.version}</version>
-      </dependency>
-      <dependency>
         <groupId>com.icegreen</groupId>
         <artifactId>greenmail</artifactId>
         <version>${greenmail.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.angus</groupId>
+        <artifactId>jakarta.mail</artifactId>
+        <version>${jakarta.mail.version}</version>
       </dependency>
 
       <!-- Citrus vert.x dependencies -->
@@ -857,6 +846,10 @@
           <exclusion>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>mailapi</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -1353,11 +1346,6 @@
               <groupId>org.glassfish.jaxb</groupId>
               <artifactId>jaxb-xjc</artifactId>
               <version>${jaxb.version}</version>
-            </dependency>
-            <dependency>
-              <groupId>jakarta.activation</groupId>
-              <artifactId>jakarta.activation-api</artifactId>
-              <version>${jakarta.activation.api.version}</version>
             </dependency>
             <dependency>
               <groupId>jakarta.xml.bind</groupId>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -24,7 +24,7 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>io.swagger</groupId>
+        <groupId>io.swagger.parser.v3</groupId>
         <artifactId>swagger-parser</artifactId>
         <version>${swagger.parser.version}</version>
       </dependency>

--- a/tools/test-generator/pom.xml
+++ b/tools/test-generator/pom.xml
@@ -63,7 +63,7 @@
     </dependency>
 
     <dependency>
-      <groupId>io.swagger</groupId>
+      <groupId>io.swagger.parser.v3</groupId>
       <artifactId>swagger-parser</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
Compatibility fixes for
the [citrusframework/citrus-simulator](https://github.com/citrusframework/citrus-simulator) project. These changes - mostly in `citrus-jms` and `citrus-mail` - will allow it to build on jdk17 and with the latest Spring- and Boot framework as well.

Progress originally reported in PR: https://github.com/citrusframework/citrus-simulator/pull/163#issuecomment-1657058339.