### PR TITLE
feat: static access to extractor builders

### DIFF
--- a/validation/citrus-validation-json/src/main/java/org/citrusframework/validation/json/JsonPathVariableExtractor.java
+++ b/validation/citrus-validation-json/src/main/java/org/citrusframework/validation/json/JsonPathVariableExtractor.java
@@ -112,6 +112,10 @@ public class JsonPathVariableExtractor implements VariableExtractor {
     public static final class Builder implements VariableExtractor.Builder<JsonPathVariableExtractor, Builder>, MessageProcessorAdapter, ValidationContextAdapter {
         private final Map<String, Object> expressions = new LinkedHashMap<>();
 
+        public static Builder fromJsonPath() {
+            return new Builder();
+        }
+
         @Override
         public Builder expressions(Map<String, Object> expressions) {
             this.expressions.putAll(expressions);

--- a/validation/citrus-validation-xml/src/main/java/org/citrusframework/validation/xml/XpathPayloadVariableExtractor.java
+++ b/validation/citrus-validation-xml/src/main/java/org/citrusframework/validation/xml/XpathPayloadVariableExtractor.java
@@ -51,15 +51,14 @@ import org.w3c.dom.Node;
  * @author Christoph Deppisch
  */
 public class XpathPayloadVariableExtractor implements VariableExtractor {
+    /** Logger */
+    private static final Logger LOG = LoggerFactory.getLogger(XpathPayloadVariableExtractor.class);
 
     /** Map defines xpath expressions and target variable names */
     private final Map<String, Object> xPathExpressions;
 
     /** Namespace definitions used in xpath expressions */
     private final Map<String, String> namespaces;
-
-    /** Logger */
-    private static final Logger LOG = LoggerFactory.getLogger(XpathPayloadVariableExtractor.class);
 
     public XpathPayloadVariableExtractor() {
         this(new Builder());
@@ -142,6 +141,10 @@ public class XpathPayloadVariableExtractor implements VariableExtractor {
             XmlNamespaceAware, MessageProcessorAdapter, ValidationContextAdapter {
         private final Map<String, Object> expressions = new HashMap<>();
         private final Map<String, String> namespaces = new HashMap<>();
+
+        public static Builder fromXpath() {
+            return new Builder();
+        }
 
         /**
          * Adds explicit namespace declaration for later path validation expressions.


### PR DESCRIPTION
you already have access to `fromHeaders` and `fromBody`, but not for JSON or XPaths.