### PR TITLE
fix(#978): Allow custom http status codes

### DIFF
--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/actions/HttpClientResponseActionBuilder.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/actions/HttpClientResponseActionBuilder.java
@@ -26,6 +26,7 @@ import org.citrusframework.http.message.HttpMessageUtils;
 import org.citrusframework.message.Message;
 import org.citrusframework.message.builder.ReceiveMessageBuilderSupport;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 
 /**
  * @author Christoph Deppisch
@@ -95,7 +96,7 @@ public class HttpClientResponseActionBuilder extends ReceiveMessageAction.Receiv
          * @return
          */
         public HttpMessageBuilderSupport statusCode(Integer statusCode) {
-            httpMessage.statusCode(statusCode);
+            httpMessage.status(HttpStatusCode.valueOf(statusCode));
             return this;
         }
 

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/actions/HttpServerResponseActionBuilder.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/actions/HttpServerResponseActionBuilder.java
@@ -25,6 +25,7 @@ import org.citrusframework.http.message.HttpMessageUtils;
 import org.citrusframework.message.Message;
 import org.citrusframework.message.builder.SendMessageBuilderSupport;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 
 /**
  * @author Christoph Deppisch
@@ -93,7 +94,7 @@ public class HttpServerResponseActionBuilder extends SendMessageAction.SendMessa
          * @return
          */
         public HttpMessageBuilderSupport statusCode(Integer statusCode) {
-            httpMessage.statusCode(statusCode);
+            httpMessage.status(HttpStatusCode.valueOf(statusCode));
             return this;
         }
 

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/controller/HttpMessageController.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/controller/HttpMessageController.java
@@ -31,10 +31,7 @@ import org.citrusframework.http.client.HttpEndpointConfiguration;
 import org.citrusframework.http.message.HttpMessage;
 import org.citrusframework.http.server.HttpServerSettings;
 import org.citrusframework.message.Message;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.stereotype.Controller;
 import org.springframework.util.CollectionUtils;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -179,7 +176,7 @@ public class HttpMessageController {
             }
 
             if (httpResponse.getStatusCode() == null) {
-                httpResponse.status(HttpStatus.valueOf(endpointConfiguration.getDefaultStatusCode()));
+                httpResponse.status(HttpStatusCode.valueOf(endpointConfiguration.getDefaultStatusCode()));
             }
 
             responseEntity = (ResponseEntity<?>) endpointConfiguration.getMessageConverter().convertOutbound(httpResponse, endpointConfiguration, null);

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/message/HttpMessageConverter.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/message/HttpMessageConverter.java
@@ -16,10 +16,7 @@
 
 package org.citrusframework.http.message;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.citrusframework.context.TestContext;
 import org.citrusframework.http.client.HttpEndpointConfiguration;
@@ -28,11 +25,7 @@ import org.citrusframework.message.MessageConverter;
 import org.citrusframework.message.MessageHeaderUtils;
 import org.citrusframework.message.MessageHeaders;
 import jakarta.servlet.http.Cookie;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.RequestMethod;
 
@@ -91,7 +84,7 @@ public class HttpMessageConverter implements MessageConverter<HttpEntity<?>, Htt
         }
 
         if (message instanceof ResponseEntity<?>) {
-            httpMessage.status(HttpStatus.valueOf(((ResponseEntity<?>) message).getStatusCode().value()));
+            httpMessage.status(((ResponseEntity<?>) message).getStatusCode());
 
             // We've no information here about the HTTP Version in this context.
             // Because HTTP/2 is not supported anyway currently, this should be acceptable.

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/message/HttpMessageConverterTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/message/HttpMessageConverterTest.java
@@ -20,12 +20,7 @@ import org.citrusframework.context.TestContext;
 import org.citrusframework.http.client.HttpEndpointConfiguration;
 import org.citrusframework.message.DefaultMessage;
 import org.citrusframework.message.Message;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.integration.mapping.HeaderMapper;
 import org.springframework.messaging.MessageHeaders;
 import org.testng.annotations.BeforeMethod;
@@ -320,6 +315,19 @@ public class HttpMessageConverterTest {
     }
 
     @Test
+    public void testCustomStatusCodeIsSetOnOutbound(){
+
+        //GIVEN
+        message.setHeader(HttpMessageHeaders.HTTP_STATUS_CODE, "555");
+
+        //WHEN
+        final HttpEntity<?> httpEntity = messageConverter.convertOutbound(message, endpointConfiguration, testContext);
+
+        //THEN
+        assertEquals(HttpStatusCode.valueOf(555), ((ResponseEntity<?>) httpEntity).getStatusCode());
+    }
+
+    @Test
     public void testSpringIntegrationHeaderMapperIsUsedOnOutbound(){
 
         //GIVEN
@@ -441,6 +449,20 @@ public class HttpMessageConverterTest {
 
         //THEN
         assertEquals(HttpStatus.FORBIDDEN, httpMessage.getStatusCode());
+    }
+
+    @Test
+    public void testCustomStatusCodeIsSetOnInbound(){
+
+        //GIVEN
+        final ResponseEntity<?> responseEntity = new ResponseEntity<>(null, null, 555);
+
+        //WHEN
+        final HttpMessage httpMessage =
+                messageConverter.convertInbound(responseEntity, endpointConfiguration, testContext);
+
+        //THEN
+        assertEquals(HttpStatusCode.valueOf(555), httpMessage.getStatusCode());
     }
 
     @Test

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/message/HttpMessageTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/message/HttpMessageTest.java
@@ -18,6 +18,7 @@ package org.citrusframework.http.message;
 
 import org.citrusframework.endpoint.resolver.EndpointUriResolver;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -231,7 +232,7 @@ public class HttpMessageTest {
 
 
         //WHEN
-        final HttpStatus statusCode = httpMessage.getStatusCode();
+        final HttpStatusCode statusCode = httpMessage.getStatusCode();
 
         //THEN
         assertNull(statusCode);
@@ -244,7 +245,7 @@ public class HttpMessageTest {
         httpMessage.header(HttpMessageHeaders.HTTP_STATUS_CODE, "404");
 
         //WHEN
-        final HttpStatus statusCode = httpMessage.getStatusCode();
+        final HttpStatusCode statusCode = httpMessage.getStatusCode();
 
         //THEN
         assertEquals(statusCode, HttpStatus.NOT_FOUND);
@@ -257,7 +258,7 @@ public class HttpMessageTest {
         httpMessage.header(HttpMessageHeaders.HTTP_STATUS_CODE, 403);
 
         //WHEN
-        final HttpStatus statusCode = httpMessage.getStatusCode();
+        final HttpStatusCode statusCode = httpMessage.getStatusCode();
 
         //THEN
         assertEquals(statusCode, HttpStatus.FORBIDDEN);
@@ -270,10 +271,23 @@ public class HttpMessageTest {
         httpMessage.header(HttpMessageHeaders.HTTP_STATUS_CODE, HttpStatus.I_AM_A_TEAPOT);
 
         //WHEN
-        final HttpStatus statusCode = httpMessage.getStatusCode();
+        final HttpStatusCode statusCode = httpMessage.getStatusCode();
 
         //THEN
         assertEquals(statusCode, HttpStatus.I_AM_A_TEAPOT);
+    }
+
+    @Test
+    public void testCanHandleCustomStatusCode() {
+
+        //GIVEN
+        httpMessage.header(HttpMessageHeaders.HTTP_STATUS_CODE, 555);
+
+        //WHEN
+        final HttpStatusCode statusCode = httpMessage.getStatusCode();
+
+        //THEN
+        assertEquals(statusCode, HttpStatusCode.valueOf(555));
     }
 
     @Test

--- a/tools/test-generator/src/main/java/org/citrusframework/generate/provider/http/HttpCodeProvider.java
+++ b/tools/test-generator/src/main/java/org/citrusframework/generate/provider/http/HttpCodeProvider.java
@@ -43,7 +43,11 @@ class HttpCodeProvider {
     }
 
     void provideResponseConfiguration(final CodeBlock.Builder code, final HttpMessage message) {
-        code.add(".response($T.$L)\n", HttpStatus.class, message.getStatusCode().name());
+        if (message.getStatusCode() instanceof HttpStatus) {
+            code.add(".response($T.$L)\n", HttpStatus.class, ((HttpStatus) message.getStatusCode()).name());
+        } else {
+            code.add(".response($T.$L)\n", HttpStatus.class, "Status");
+        }
         messageCodeProvider.provideHeaderAndPayload(code, message);
     }
 

--- a/tools/test-generator/src/main/java/org/citrusframework/generate/provider/http/ReceiveHttpResponseActionProvider.java
+++ b/tools/test-generator/src/main/java/org/citrusframework/generate/provider/http/ReceiveHttpResponseActionProvider.java
@@ -20,6 +20,7 @@ import org.citrusframework.generate.provider.MessageActionProvider;
 import org.citrusframework.http.message.HttpMessage;
 import org.citrusframework.message.MessageHeaders;
 import org.citrusframework.model.testcase.http.*;
+import org.springframework.http.HttpStatus;
 
 import java.util.Optional;
 
@@ -40,8 +41,13 @@ public class ReceiveHttpResponseActionProvider implements MessageActionProvider<
         response.setBody(body);
 
         ReceiveResponseModel.Headers responseHeaders = new ReceiveResponseModel.Headers();
-        responseHeaders.setStatus(message.getStatusCode().toString());
-        responseHeaders.setReasonPhrase(message.getStatusCode().getReasonPhrase());
+        if (message.getStatusCode() instanceof HttpStatus) {
+            responseHeaders.setStatus(((HttpStatus) message.getStatusCode()).toString());
+            responseHeaders.setReasonPhrase(((HttpStatus) message.getStatusCode()).getReasonPhrase());
+        } else {
+            responseHeaders.setStatus("Status" + message.getStatusCode().value());
+            responseHeaders.setReasonPhrase("Custom Status Code " + message.getStatusCode().value());
+        }
 
         message.getHeaders().entrySet().stream()
                 .filter(entry -> !entry.getKey().startsWith(MessageHeaders.PREFIX))

--- a/tools/test-generator/src/main/java/org/citrusframework/generate/provider/http/SendHttpResponseActionProvider.java
+++ b/tools/test-generator/src/main/java/org/citrusframework/generate/provider/http/SendHttpResponseActionProvider.java
@@ -20,6 +20,7 @@ import org.citrusframework.generate.provider.MessageActionProvider;
 import org.citrusframework.http.message.HttpMessage;
 import org.citrusframework.message.MessageHeaders;
 import org.citrusframework.model.testcase.http.*;
+import org.springframework.http.HttpStatus;
 
 import java.util.Optional;
 
@@ -40,8 +41,13 @@ public class SendHttpResponseActionProvider implements MessageActionProvider<Sen
         response.setBody(body);
 
         ResponseHeadersType responseHeaders = new ResponseHeadersType();
-        responseHeaders.setStatus(message.getStatusCode().toString());
-        responseHeaders.setReasonPhrase(message.getStatusCode().getReasonPhrase());
+        if (message.getStatusCode() instanceof HttpStatus) {
+            responseHeaders.setStatus(((HttpStatus) message.getStatusCode()).toString());
+            responseHeaders.setReasonPhrase(((HttpStatus) message.getStatusCode()).getReasonPhrase());
+        } else {
+            responseHeaders.setStatus("Status" + message.getStatusCode().value());
+            responseHeaders.setReasonPhrase("Custom Status Code " + message.getStatusCode().value());
+        }
 
         message.getHeaders().entrySet().stream()
                 .filter(entry -> !entry.getKey().startsWith(MessageHeaders.PREFIX))

--- a/tools/test-generator/src/test/java/org/citrusframework/generate/provider/http/HttpCodeProviderTest.java
+++ b/tools/test-generator/src/test/java/org/citrusframework/generate/provider/http/HttpCodeProviderTest.java
@@ -21,6 +21,7 @@ import org.citrusframework.http.message.HttpMessage;
 import com.squareup.javapoet.CodeBlock;
 import org.apache.hc.core5.http.HttpStatus;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatusCode;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -77,7 +78,7 @@ class HttpCodeProviderTest {
     void testResponseConfiguration() {
 
         //GIVEN
-        message.statusCode(HttpStatus.SC_NOT_FOUND);
+        message.status(HttpStatusCode.valueOf(HttpStatus.SC_NOT_FOUND));
         final String expectedCode = ".response(org.springframework.http.HttpStatus.NOT_FOUND)\n.message()\n";
 
         //WHEN


### PR DESCRIPTION
This pull request will fix [Issue 978](https://github.com/citrusframework/citrus/issues/978). There are a few breaking changes because `HttpMessage` uses now `HttpStatusCode` instead of the `HttpStatus` enum. I also removed the `HttpMessage.statusCode(Integer)` and the `HttpMessage.status(HttpStatus)` method because they are no longer necessary. `HttpMessage.getStatusCode()` returns now a `HttpStatusCode` instead of a `HttpStatus`.