### PR TITLE
feat(#976): Disable/Override standard Citrus reporters

### DIFF
--- a/core/citrus-spring/src/main/java/org/citrusframework/reporter/ReporterConfig.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/reporter/ReporterConfig.java
@@ -3,8 +3,8 @@ package org.citrusframework.reporter;
 import org.citrusframework.report.HtmlReporter;
 import org.citrusframework.report.JUnitReporter;
 import org.citrusframework.report.LoggingReporter;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.*;
+import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
  * @author Christoph Deppisch
@@ -12,17 +12,28 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class ReporterConfig {
 
-    @Bean(name = "citrusLoggingReporter")
+    public static final String CITRUS_LOGGING_REPORTER = "citrusLoggingReporter";
+    public static final String CITRUS_JUNIT_REPORTER = "citrusJunitReporter";
+    public static final String CITRUS_HTML_REPORTER = "citrusHtmlReporter";
+
+    public static final String DEFAULT_LOGGING_REPORTER_ENABLED_PROPERTY = "citrus.default.logging.reporter.enabled";
+    public static final String DEFAULT_JUNIT_REPORTER_ENABLED_PROPERTY = "citrus.default.junit.reporter.enabled";
+    public static final String DEFAULT_HTML_REPORTER_ENABLED_PROPERTY = "citrus.default.html.reporter.enabled";
+
+    @Bean(name = CITRUS_LOGGING_REPORTER)
+    @Conditional(LoggingReporterEnablementCondition.class)
     public LoggingReporter loggingReporter() {
         return new LoggingReporter();
     }
 
-    @Bean(name = "citrusHtmlReporter")
+    @Bean(name = CITRUS_HTML_REPORTER)
+    @Conditional(HtmlReporterEnablementCondition.class)
     public HtmlReporter htmlReporter() {
         return new HtmlReporter();
     }
 
-    @Bean(name = "citrusJunitReporter")
+    @Bean(name = CITRUS_JUNIT_REPORTER)
+    @Conditional(JunitReporterEnablementCondition.class)
     public JUnitReporter junitReporter() {
         return new JUnitReporter();
     }
@@ -31,4 +42,29 @@ public class ReporterConfig {
     public TestReportersFactory testReporters() {
         return new TestReportersFactory();
     }
+
+    static class LoggingReporterEnablementCondition implements Condition {
+        @Override
+        public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+            return !context.getBeanFactory().containsBean(CITRUS_LOGGING_REPORTER)
+                    && "true".equals(context.getEnvironment().getProperty(DEFAULT_LOGGING_REPORTER_ENABLED_PROPERTY, "true"));
+        }
+    }
+
+    static class JunitReporterEnablementCondition implements Condition {
+        @Override
+        public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+            return !context.getBeanFactory().containsBean(CITRUS_JUNIT_REPORTER)
+                    && "true".equals(context.getEnvironment().getProperty(DEFAULT_JUNIT_REPORTER_ENABLED_PROPERTY, "true"));
+        }
+    }
+
+    static class HtmlReporterEnablementCondition implements Condition {
+        @Override
+        public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+            return !context.getBeanFactory().containsBean(CITRUS_HTML_REPORTER)
+                    && "true".equals(context.getEnvironment().getProperty(DEFAULT_HTML_REPORTER_ENABLED_PROPERTY, "true"));
+        }
+    }
+
 }

--- a/core/citrus-spring/src/test/java/org/citrusframework/UnitTestSupport.java
+++ b/core/citrus-spring/src/test/java/org/citrusframework/UnitTestSupport.java
@@ -25,10 +25,10 @@ public class UnitTestSupport extends AbstractTestNGUnitTest {
     @Autowired
     protected TestContextFactoryBean testContextFactory;
 
-    @Autowired
+    @Autowired(required = false)
     private HtmlReporter htmlReporter;
 
-    @Autowired
+    @Autowired(required = false)
     private JUnitReporter jUnitReporter;
 
     /** Citrus instance */
@@ -57,8 +57,13 @@ public class UnitTestSupport extends AbstractTestNGUnitTest {
     @BeforeMethod
     @Override
     public void prepareTest() {
-        htmlReporter.setEnabled(false);
-        jUnitReporter.setEnabled(false);
+        if (htmlReporter != null) {
+            htmlReporter.setEnabled(false);
+        }
+
+        if (jUnitReporter != null) {
+            jUnitReporter.setEnabled(false);
+        }
         super.prepareTest();
     }
 

--- a/core/citrus-spring/src/test/java/org/citrusframework/reporter/DisabledReporterConfigTest.java
+++ b/core/citrus-spring/src/test/java/org/citrusframework/reporter/DisabledReporterConfigTest.java
@@ -1,0 +1,58 @@
+package org.citrusframework.reporter;
+
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.report.HtmlReporter;
+import org.citrusframework.report.JUnitReporter;
+import org.citrusframework.report.LoggingReporter;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+@ContextConfiguration
+@TestPropertySource(properties = {"citrus.default.logging.reporter.enabled=false",
+        "citrus.default.html.reporter.enabled=false",
+        "citrus.default.junit.reporter.enabled=false"})
+public class DisabledReporterConfigTest extends UnitTestSupport {
+
+    @Test
+    public void testOverridesLoggingReporter() {
+        Assert.assertThrows(NoSuchBeanDefinitionException.class, () -> applicationContext.getBean("citrusLoggingReporter"));
+        Assert.assertTrue(applicationContext.getBean("otherLoggingReporter") instanceof LoggingReporter);
+    }
+
+    @Test
+    public void testOverridesJunitReporter() {
+        Assert.assertThrows(NoSuchBeanDefinitionException.class, () -> applicationContext.getBean("citrusJunitReporter"));
+        Assert.assertTrue(applicationContext.getBean("otherJunitReporter") instanceof JUnitReporter);
+    }
+
+    @Test
+    public void testOverridesHtmlReporter() {
+        Assert.assertThrows(NoSuchBeanDefinitionException.class, () -> applicationContext.getBean("citrusHtmlReporter"));
+        Assert.assertTrue(applicationContext.getBean("otherHtmlReporter") instanceof HtmlReporter);
+    }
+
+    @Configuration
+    public static class OtherReporterConfiguration {
+
+        @Bean
+        public LoggingReporter otherLoggingReporter() {
+            return new LoggingReporter();
+        }
+
+        @Bean
+        public JUnitReporter otherJunitReporter() {
+            return new JUnitReporter();
+        }
+
+        @Bean
+        public HtmlReporter otherHtmlReporter() {
+            return new HtmlReporter();
+        }
+    }
+
+}

--- a/core/citrus-spring/src/test/java/org/citrusframework/reporter/OverrideReporterConfigTest.java
+++ b/core/citrus-spring/src/test/java/org/citrusframework/reporter/OverrideReporterConfigTest.java
@@ -1,0 +1,63 @@
+package org.citrusframework.reporter;
+
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.report.HtmlReporter;
+import org.citrusframework.report.JUnitReporter;
+import org.citrusframework.report.LoggingReporter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.reporter.ReporterConfig.CITRUS_HTML_REPORTER;
+import static org.citrusframework.reporter.ReporterConfig.CITRUS_JUNIT_REPORTER;
+import static org.citrusframework.reporter.ReporterConfig.CITRUS_LOGGING_REPORTER;
+
+@ContextConfiguration
+public class OverrideReporterConfigTest extends UnitTestSupport {
+
+    @Test
+    public void testOverridesLoggingReporter() {
+        Assert.assertTrue(applicationContext.getBean(CITRUS_LOGGING_REPORTER) instanceof OverrideLoggingReporter);
+    }
+
+    @Test
+    public void testOverridesJunitReporter() {
+        Assert.assertTrue(applicationContext.getBean(CITRUS_JUNIT_REPORTER) instanceof OverrideJUnitReporter);
+    }
+
+    @Test
+    public void testOverridesHtmlReporter() {
+        Assert.assertTrue(applicationContext.getBean(CITRUS_HTML_REPORTER) instanceof OverrideHtmlReporter);
+    }
+
+    @Configuration
+    public static class OverrideReporterConfiguration {
+
+        @Bean
+        public LoggingReporter citrusLoggingReporter() {
+            return new OverrideLoggingReporter();
+        }
+
+        @Bean
+        public JUnitReporter citrusJunitReporter() {
+            return new OverrideJUnitReporter();
+        }
+
+        @Bean
+        public HtmlReporter citrusHtmlReporter() {
+            return new OverrideHtmlReporter();
+        }
+
+    }
+
+    private static class OverrideLoggingReporter extends LoggingReporter {
+    }
+
+    private static class OverrideJUnitReporter extends JUnitReporter {
+    }
+
+    private static class OverrideHtmlReporter extends HtmlReporter {
+    }
+}

--- a/core/citrus-spring/src/test/java/org/citrusframework/reporter/ReporterConfigTest.java
+++ b/core/citrus-spring/src/test/java/org/citrusframework/reporter/ReporterConfigTest.java
@@ -1,0 +1,98 @@
+package org.citrusframework.reporter;
+
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.report.HtmlReporter;
+import org.citrusframework.report.JUnitReporter;
+import org.citrusframework.report.LoggingReporter;
+import org.citrusframework.reporter.ReporterConfig.HtmlReporterEnablementCondition;
+import org.citrusframework.reporter.ReporterConfig.JunitReporterEnablementCondition;
+import org.citrusframework.reporter.ReporterConfig.LoggingReporterEnablementCondition;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.env.Environment;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.reporter.ReporterConfig.CITRUS_HTML_REPORTER;
+import static org.citrusframework.reporter.ReporterConfig.CITRUS_JUNIT_REPORTER;
+import static org.citrusframework.reporter.ReporterConfig.CITRUS_LOGGING_REPORTER;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+public class ReporterConfigTest extends UnitTestSupport {
+
+    @Test
+    public void testDefaultLoggingReporter() {
+        Assert.assertTrue(applicationContext.getBean(CITRUS_LOGGING_REPORTER) instanceof  LoggingReporter);
+    }
+
+    @Test
+    public void testDefaultJunitReporter() {
+        Assert.assertTrue(applicationContext.getBean(CITRUS_JUNIT_REPORTER) instanceof  JUnitReporter);
+    }
+
+    @Test
+    public void testDefaultHtmlReporter() {
+        Assert.assertTrue(applicationContext.getBean(CITRUS_HTML_REPORTER) instanceof  HtmlReporter);
+    }
+    @Test
+    public void testLoggerReporterConditionDisabled() {
+
+        Environment environmentMock = mock(Environment.class);
+        ConfigurableListableBeanFactory beanFactoryMock = mock(ConfigurableListableBeanFactory.class);
+        ConditionContext conditionContextMock = mock(ConditionContext.class);
+        doReturn(environmentMock).when(conditionContextMock).getEnvironment();
+        doReturn(beanFactoryMock).when(conditionContextMock).getBeanFactory();
+        doReturn(new LoggingReporter()).when(beanFactoryMock).getBean(CITRUS_LOGGING_REPORTER);
+
+        LoggingReporterEnablementCondition condition = new LoggingReporterEnablementCondition();
+        AnnotatedTypeMetadata annotatedTypeMetadataMock = mock(AnnotatedTypeMetadata.class);
+        Assert.assertFalse(condition.matches(conditionContextMock, annotatedTypeMetadataMock));
+
+        doReturn(null).when(beanFactoryMock).getBean(CITRUS_LOGGING_REPORTER);
+        doReturn("false").when(environmentMock).getProperty(ReporterConfig.DEFAULT_LOGGING_REPORTER_ENABLED_PROPERTY, "true");
+        Assert.assertFalse(condition.matches(conditionContextMock, annotatedTypeMetadataMock));
+
+    }
+
+    @Test
+    public void testJunitReporterConditionDisabledByOtherBean() {
+
+        Environment environmentMock = mock(Environment.class);
+        ConfigurableListableBeanFactory beanFactoryMock = mock(ConfigurableListableBeanFactory.class);
+        ConditionContext conditionContextMock = mock(ConditionContext.class);
+        doReturn(environmentMock).when(conditionContextMock).getEnvironment();
+        doReturn(beanFactoryMock).when(conditionContextMock).getBeanFactory();
+        doReturn(new LoggingReporter()).when(beanFactoryMock).getBean(CITRUS_JUNIT_REPORTER);
+
+        JunitReporterEnablementCondition condition = new JunitReporterEnablementCondition();
+        AnnotatedTypeMetadata annotatedTypeMetadataMock = mock(AnnotatedTypeMetadata.class);
+        Assert.assertFalse(condition.matches(conditionContextMock, annotatedTypeMetadataMock));
+
+        doReturn(null).when(beanFactoryMock).getBean(CITRUS_JUNIT_REPORTER);
+        doReturn("false").when(environmentMock).getProperty(ReporterConfig.DEFAULT_JUNIT_REPORTER_ENABLED_PROPERTY, "true");
+        Assert.assertFalse(condition.matches(conditionContextMock, annotatedTypeMetadataMock));
+
+    }
+
+    @Test
+    public void testHtmlReporterConditionDisabledByOtherBean() {
+
+        Environment environmentMock = mock(Environment.class);
+        ConfigurableListableBeanFactory beanFactoryMock = mock(ConfigurableListableBeanFactory.class);
+        ConditionContext conditionContextMock = mock(ConditionContext.class);
+        doReturn(environmentMock).when(conditionContextMock).getEnvironment();
+        doReturn(beanFactoryMock).when(conditionContextMock).getBeanFactory();
+        doReturn(new LoggingReporter()).when(beanFactoryMock).getBean(CITRUS_HTML_REPORTER);
+
+        HtmlReporterEnablementCondition condition = new HtmlReporterEnablementCondition();
+        AnnotatedTypeMetadata annotatedTypeMetadataMock = mock(AnnotatedTypeMetadata.class);
+        Assert.assertFalse(condition.matches(conditionContextMock, annotatedTypeMetadataMock));
+
+        doReturn(null).when(beanFactoryMock).getBean(CITRUS_HTML_REPORTER);
+        doReturn("false").when(environmentMock).getProperty(ReporterConfig.DEFAULT_HTML_REPORTER_ENABLED_PROPERTY, "true");
+        Assert.assertFalse(condition.matches(conditionContextMock, annotatedTypeMetadataMock));
+
+    }
+}

--- a/src/manual/reporting.adoc
+++ b/src/manual/reporting.adoc
@@ -3,6 +3,38 @@
 
 The framework generates different reports and results after a test run for you. These report and result pages will help you to get an overview of the test cases that were executed and which one were failing.
 
+In the following chapters, we'll provide an overview of the three standard loggers available in Citrus. It's important to note that in Spring, you have the flexibility to replace these standard loggers with your own implementations. This can be achieved by registering custom implementations, as demonstrated in the following code snippet:
+
+[source,java]
+----
+@Configuration
+public static class OverrideReporterConfiguration {
+
+    @Bean
+    public LoggingReporter citrusLoggingReporter() {
+        return new OverrideLoggingReporter();
+    }
+
+    @Bean
+    public JUnitReporter citrusJunitReporter() {
+        return new OverrideJUnitReporter();
+    }
+
+    @Bean
+    public HtmlReporter citrusHtmlReporter() {
+        return new OverrideHtmlReporter();
+    }
+}
+----
+
+In Spring, it is also possible to disable these standard reporters using the following properties:
+[source,properties]
+----
+citrus.default.logging.reporter.enabled=false
+citrus.default.junit.reporter.enabled=false
+citrus.default.html.reporter.enabled=false
+----
+
 [[console-logging]]
 == Console logging
 


### PR DESCRIPTION
The requested feature has been implemented as follows: when you add an override implementation of a Reporter through Spring Configuration, it will automatically suppress the default Citrus reporter. Additionally, if you set the enablement property to 'false,' the Reporter will also be suppressed.

Please note that not all Reporters can be disabled due to Autowiring requirements, and there may be limitations on adding additional reporters through single bean matching. For me it makes most sense, to just override an existing Reporter with an own implementation.

If you have any comments or further requests, feel free to comment.
