### PR TITLE
chore: remove automatic sql variable extraction

### DIFF
--- a/connectors/citrus-sql/src/main/java/org/citrusframework/actions/ExecutePLSQLAction.java
+++ b/connectors/citrus-sql/src/main/java/org/citrusframework/actions/ExecutePLSQLAction.java
@@ -16,13 +16,6 @@
 
 package org.citrusframework.actions;
 
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.StringTokenizer;
-import javax.sql.DataSource;
-
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.util.FileUtils;
@@ -31,6 +24,13 @@ import org.springframework.core.io.Resource;
 import org.springframework.dao.DataAccessException;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.util.StringUtils;
+
+import javax.sql.DataSource;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
 
 /**
  * Class executes PLSQL statements either declared inline as PLSQL statements or given by an
@@ -103,9 +103,13 @@ public class ExecutePLSQLAction extends AbstractDatabaseConnectingTestAction {
      * @param context
      */
     protected void executeStatements(List<String> statements, TestContext context) {
-        for (String stmt : statements) {
+        if (getJdbcTemplate() == null) {
+            throw new CitrusRuntimeException("No JdbcTemplate configured for sql execution!");
+        }
+
+        for (String statement : statements) {
             try {
-                final String toExecute = context.replaceDynamicContentInString(stmt.trim());
+                final String toExecute = context.replaceDynamicContentInString(statement.trim());
 
                 if (logger.isDebugEnabled()) {
                     logger.debug("Executing PLSQL statement: " + toExecute);

--- a/connectors/citrus-sql/src/main/java/org/citrusframework/actions/ExecuteSQLAction.java
+++ b/connectors/citrus-sql/src/main/java/org/citrusframework/actions/ExecuteSQLAction.java
@@ -16,12 +16,12 @@
 
 package org.citrusframework.actions;
 
-import java.util.List;
-import javax.sql.DataSource;
-
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.springframework.transaction.support.TransactionTemplate;
+
+import javax.sql.DataSource;
+import java.util.List;
 
 /**
  * Test action execute SQL statements. Use this action when executing
@@ -80,14 +80,18 @@ public class ExecuteSQLAction extends AbstractDatabaseConnectingTestAction {
      * @param context
      */
     protected void executeStatements(List<String> statements, TestContext context) {
-        for (String stmt : statements)  {
+        if (getJdbcTemplate() == null) {
+            throw new CitrusRuntimeException("No JdbcTemplate configured for sql execution!");
+        }
+
+        for (String statement : statements) {
             try {
                 final String toExecute;
 
-                if (stmt.trim().endsWith(";")) {
-                    toExecute = context.replaceDynamicContentInString(stmt.trim().substring(0, stmt.trim().length()-1));
+                if (statement.trim().endsWith(";")) {
+                    toExecute = context.replaceDynamicContentInString(statement.trim().substring(0, statement.trim().length() - 1));
                 } else {
-                    toExecute = context.replaceDynamicContentInString(stmt.trim());
+                    toExecute = context.replaceDynamicContentInString(statement.trim());
                 }
 
                 if (logger.isDebugEnabled()) {

--- a/connectors/citrus-sql/src/main/java/org/citrusframework/actions/ExecuteSQLQueryAction.java
+++ b/connectors/citrus-sql/src/main/java/org/citrusframework/actions/ExecuteSQLQueryAction.java
@@ -16,17 +16,6 @@
 
 package org.citrusframework.actions;
 
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import javax.sql.DataSource;
-
 import org.apache.commons.codec.binary.Base64;
 import org.citrusframework.CitrusSettings;
 import org.citrusframework.context.TestContext;
@@ -44,6 +33,17 @@ import org.springframework.core.io.Resource;
 import org.springframework.dao.DataAccessException;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.util.CollectionUtils;
+
+import javax.sql.DataSource;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 
 /**
  * Action executes SQL queries and offers result set validation.
@@ -123,12 +123,6 @@ public class ExecuteSQLQueryAction extends AbstractDatabaseConnectingTestAction 
 
             // fill the request test context variables (extract tag)
             fillContextVariables(columnValuesMap, context);
-
-            // legacy: save all columns as variables TODO: remove in major version upgrade
-            for (Entry<String, List<String>> column : columnValuesMap.entrySet()) {
-                List<String> columnValues = column.getValue();
-                context.setVariable(column.getKey().toUpperCase(), columnValues.get(0) == null ? NULL_VALUE : columnValues.get(0));
-            }
         } catch (DataAccessException e) {
             logger.error("Failed to execute SQL statement", e);
             throw new CitrusRuntimeException(e);

--- a/connectors/citrus-sql/src/test/java/org/citrusframework/actions/ExecutePLSQLActionTest.java
+++ b/connectors/citrus-sql/src/test/java/org/citrusframework/actions/ExecutePLSQLActionTest.java
@@ -16,14 +16,20 @@
 
 package org.citrusframework.actions;
 
+import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.testng.AbstractTestNGUnitTest;
 import org.mockito.Mockito;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.PlatformTransactionManager;
+import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static org.mockito.Mockito.*;
+import java.util.Collections;
+
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 
 /**
@@ -42,93 +48,93 @@ public class ExecutePLSQLActionTest extends AbstractTestNGUnitTest {
                 .jdbcTemplate(jdbcTemplate);
     }
 
-	@Test
-	public void testPLSQLExecutionWithInlineScript() {
-	    String stmt = "DECLARE " +
-                "Zahl1 number(2);" +
-                "Text varchar(20) := 'Hello World!';" +
-             "BEGIN" +
-                "EXECUTE IMMEDIATE \"" +
-                    "select number_of_greetings into Zahl1 from Greetings where text='Hello World!';\"" +
-             "END;/";
-
-	    executePLSQLActionBuilder.sqlScript(stmt);
-
-	    String controlStatement = "DECLARE " +
-                "Zahl1 number(2);" +
-                "Text varchar(20) := 'Hello World!';" +
-             "BEGIN" +
-                "EXECUTE IMMEDIATE \"" +
-                    "select number_of_greetings into Zahl1 from Greetings where text='Hello World!';\"" +
-             "END;";
-
-	    reset(jdbcTemplate);
-	    executePLSQLActionBuilder.build().execute(context);
-	    verify(jdbcTemplate).execute(controlStatement);
-	}
-
-	@Test
-	public void testPLSQLExecutionWithTransaction() {
-	    String stmt = "DECLARE " +
-                "Zahl1 number(2);" +
-                "Text varchar(20) := 'Hello World!';" +
-             "BEGIN" +
-                "EXECUTE IMMEDIATE \"" +
-                    "select number_of_greetings into Zahl1 from Greetings where text='Hello World!';\"" +
-             "END;/";
-
-	    executePLSQLActionBuilder.transactionManager(transactionManager);
-	    executePLSQLActionBuilder.sqlScript(stmt);
-
-	    String controlStatement = "DECLARE " +
-                "Zahl1 number(2);" +
-                "Text varchar(20) := 'Hello World!';" +
-             "BEGIN" +
-                "EXECUTE IMMEDIATE \"" +
-                    "select number_of_greetings into Zahl1 from Greetings where text='Hello World!';\"" +
-             "END;";
-
-	    reset(jdbcTemplate, transactionManager);
-	    executePLSQLActionBuilder.build().execute(context);
-	    verify(jdbcTemplate).execute(controlStatement);
-	}
-
-	@Test
-    public void testPLSQLExecutionWithInlineScriptNoEndingCharacter() {
+    @Test
+    public void testPLSQLExecutionWithInlineScript() {
         String stmt = "DECLARE " +
                 "Zahl1 number(2);" +
                 "Text varchar(20) := 'Hello World!';" +
-             "BEGIN" +
+                "BEGIN" +
                 "EXECUTE IMMEDIATE \"" +
-                    "select number_of_greetings into Zahl1 from Greetings where text='Hello World!';\"" +
-             "END;";
+                "select number_of_greetings into Zahl1 from Greetings where text='Hello World!';\"" +
+                "END;/";
 
         executePLSQLActionBuilder.sqlScript(stmt);
 
         String controlStatement = "DECLARE " +
                 "Zahl1 number(2);" +
                 "Text varchar(20) := 'Hello World!';" +
-             "BEGIN" +
+                "BEGIN" +
                 "EXECUTE IMMEDIATE \"" +
-                    "select number_of_greetings into Zahl1 from Greetings where text='Hello World!';\"" +
-             "END;";
+                "select number_of_greetings into Zahl1 from Greetings where text='Hello World!';\"" +
+                "END;";
 
         reset(jdbcTemplate);
         executePLSQLActionBuilder.build().execute(context);
         verify(jdbcTemplate).execute(controlStatement);
     }
 
-	@Test
+    @Test
+    public void testPLSQLExecutionWithTransaction() {
+        String stmt = "DECLARE " +
+                "Zahl1 number(2);" +
+                "Text varchar(20) := 'Hello World!';" +
+                "BEGIN" +
+                "EXECUTE IMMEDIATE \"" +
+                "select number_of_greetings into Zahl1 from Greetings where text='Hello World!';\"" +
+                "END;/";
+
+        executePLSQLActionBuilder.transactionManager(transactionManager);
+        executePLSQLActionBuilder.sqlScript(stmt);
+
+        String controlStatement = "DECLARE " +
+                "Zahl1 number(2);" +
+                "Text varchar(20) := 'Hello World!';" +
+                "BEGIN" +
+                "EXECUTE IMMEDIATE \"" +
+                "select number_of_greetings into Zahl1 from Greetings where text='Hello World!';\"" +
+                "END;";
+
+        reset(jdbcTemplate, transactionManager);
+        executePLSQLActionBuilder.build().execute(context);
+        verify(jdbcTemplate).execute(controlStatement);
+    }
+
+    @Test
+    public void testPLSQLExecutionWithInlineScriptNoEndingCharacter() {
+        String stmt = "DECLARE " +
+                "Zahl1 number(2);" +
+                "Text varchar(20) := 'Hello World!';" +
+                "BEGIN" +
+                "EXECUTE IMMEDIATE \"" +
+                "select number_of_greetings into Zahl1 from Greetings where text='Hello World!';\"" +
+                "END;";
+
+        executePLSQLActionBuilder.sqlScript(stmt);
+
+        String controlStatement = "DECLARE " +
+                "Zahl1 number(2);" +
+                "Text varchar(20) := 'Hello World!';" +
+                "BEGIN" +
+                "EXECUTE IMMEDIATE \"" +
+                "select number_of_greetings into Zahl1 from Greetings where text='Hello World!';\"" +
+                "END;";
+
+        reset(jdbcTemplate);
+        executePLSQLActionBuilder.build().execute(context);
+        verify(jdbcTemplate).execute(controlStatement);
+    }
+
+    @Test
     public void testPLSQLExecutionWithFileResource() {
         executePLSQLActionBuilder.sqlResource("classpath:org/citrusframework/actions/test-plsql.sql");
 
         String controlStatement = "DECLARE\n" +
                 "    Zahl1 number(2);\n" +
                 "    Text varchar(20) := 'Hello World!';\n" +
-             "BEGIN\n" +
+                "BEGIN\n" +
                 "    EXECUTE IMMEDIATE \"\n" +
-                    "        select number_of_greetings into Zahl1 from Greetings where text='Hello World!';\"\n" +
-             "END;";
+                "        select number_of_greetings into Zahl1 from Greetings where text='Hello World!';\"\n" +
+                "END;";
 
         reset(jdbcTemplate);
 
@@ -137,37 +143,37 @@ public class ExecutePLSQLActionTest extends AbstractTestNGUnitTest {
         verify(jdbcTemplate).execute(controlStatement);
     }
 
-	@Test
+    @Test
     public void testPLSQLExecutionWithInlineScriptVariableSupport() {
-	    context.setVariable("myText", "Hello World!");
-	    context.setVariable("tableName", "Greetings");
+        context.setVariable("myText", "Hello World!");
+        context.setVariable("tableName", "Greetings");
 
         String stmt = "DECLARE " +
                 "Zahl1 number(2);" +
                 "Text varchar(20) := '${myText}';" +
-             "BEGIN" +
+                "BEGIN" +
                 "EXECUTE IMMEDIATE \"" +
-                    "select number_of_greetings into Zahl1 from ${tableName} where text='${myText}';\"" +
-             "END;/";
+                "select number_of_greetings into Zahl1 from ${tableName} where text='${myText}';\"" +
+                "END;/";
 
         executePLSQLActionBuilder.sqlScript(stmt);
 
         String controlStatement = "DECLARE " +
                 "Zahl1 number(2);" +
                 "Text varchar(20) := 'Hello World!';" +
-             "BEGIN" +
+                "BEGIN" +
                 "EXECUTE IMMEDIATE \"" +
-                    "select number_of_greetings into Zahl1 from Greetings where text='Hello World!';\"" +
-             "END;";
+                "select number_of_greetings into Zahl1 from Greetings where text='Hello World!';\"" +
+                "END;";
 
         reset(jdbcTemplate);
         executePLSQLActionBuilder.build().execute(context);
         verify(jdbcTemplate).execute(controlStatement);
     }
 
-	@Test
+    @Test
     public void testPLSQLExecutionWithFileResourceVariableSupport() {
-	    context.setVariable("myText", "Hello World!");
+        context.setVariable("myText", "Hello World!");
         context.setVariable("tableName", "Greetings");
 
         executePLSQLActionBuilder.sqlResource("classpath:org/citrusframework/actions/test-plsql-with-variables.sql");
@@ -175,64 +181,75 @@ public class ExecutePLSQLActionTest extends AbstractTestNGUnitTest {
         String controlStatement = "DECLARE\n" +
                 "    Zahl1 number(2);\n" +
                 "    Text varchar(20) := 'Hello World!';\n" +
-             "BEGIN\n" +
+                "BEGIN\n" +
                 "    EXECUTE IMMEDIATE \"\n" +
-                    "        select number_of_greetings into Zahl1 from Greetings where text='Hello World!';\"\n" +
-             "END;";
+                "        select number_of_greetings into Zahl1 from Greetings where text='Hello World!';\"\n" +
+                "END;";
 
         reset(jdbcTemplate);
         executePLSQLActionBuilder.build().execute(context);
         verify(jdbcTemplate).execute(controlStatement);
     }
 
-	@Test
+    @Test
     public void testPLSQLExecutionWithMultipleInlineStatements() {
         String stmt = "DECLARE " +
                 "Zahl1 number(2);" +
                 "Text varchar(20) := 'Hello World!';" +
-             "BEGIN" +
+                "BEGIN" +
                 "EXECUTE IMMEDIATE \"" +
-                    "select number_of_greetings into Zahl1 from Greetings where text='Hello World!';\"" +
-             "END;" +
-             "/" +
-             "DECLARE " +
+                "select number_of_greetings into Zahl1 from Greetings where text='Hello World!';\"" +
+                "END;" +
+                "/" +
+                "DECLARE " +
                 "Zahl1 number(2);" +
                 "Text varchar(20) := 'Hello World!';" +
-             "BEGIN" +
+                "BEGIN" +
                 "EXECUTE IMMEDIATE \"" +
-                    "select number_of_greetings into Zahl1 from Greetings where text='Hello World!';\"" +
-             "END;" +
-             "/";
+                "select number_of_greetings into Zahl1 from Greetings where text='Hello World!';\"" +
+                "END;" +
+                "/";
 
         executePLSQLActionBuilder.sqlScript(stmt);
 
         String controlStatement = "DECLARE " +
                 "Zahl1 number(2);" +
                 "Text varchar(20) := 'Hello World!';" +
-             "BEGIN" +
+                "BEGIN" +
                 "EXECUTE IMMEDIATE \"" +
-                    "select number_of_greetings into Zahl1 from Greetings where text='Hello World!';\"" +
-             "END;";
+                "select number_of_greetings into Zahl1 from Greetings where text='Hello World!';\"" +
+                "END;";
 
         reset(jdbcTemplate);
         executePLSQLActionBuilder.build().execute(context);
         verify(jdbcTemplate, times(2)).execute(controlStatement);
     }
 
-	@Test
+    @Test
     public void testPLSQLExecutionWithFileResourceMultipleStmts() {
         executePLSQLActionBuilder.sqlResource("classpath:org/citrusframework/actions/test-plsql-multiple-stmts.sql");
 
         String controlStatement = "DECLARE\n" +
                 "    Zahl1 number(2);\n" +
                 "    Text varchar(20) := 'Hello World!';\n" +
-             "BEGIN\n" +
+                "BEGIN\n" +
                 "    EXECUTE IMMEDIATE \"\n" +
-                    "        select number_of_greetings into Zahl1 from Greetings where text='Hello World!';\"\n" +
-             "END;";
+                "        select number_of_greetings into Zahl1 from Greetings where text='Hello World!';\"\n" +
+                "END;";
 
         reset(jdbcTemplate);
         executePLSQLActionBuilder.build().execute(context);
         verify(jdbcTemplate, times(2)).execute(controlStatement);
+    }
+
+    @Test
+    public void testNoJdbcTemplateConfigured() {
+        // Special ExecuteSQLQueryAction without a JdbcTemplate
+        executePLSQLActionBuilder = new ExecutePLSQLAction.Builder().jdbcTemplate(null);
+        executePLSQLActionBuilder.statements(Collections.singletonList("statement"));
+
+        CitrusRuntimeException exception = Assert.expectThrows(CitrusRuntimeException.class, () -> executePLSQLActionBuilder.build().execute(context));
+
+        Assert.assertEquals(exception.getMessage(), "No JdbcTemplate configured for sql execution!");
     }
 }

--- a/connectors/citrus-sql/src/test/java/org/citrusframework/actions/dsl/ExecuteSQLQueryTestActionBuilderTest.java
+++ b/connectors/citrus-sql/src/test/java/org/citrusframework/actions/dsl/ExecuteSQLQueryTestActionBuilderTest.java
@@ -16,25 +16,22 @@
 
 package org.citrusframework.actions.dsl;
 
-import java.io.IOException;
+import org.citrusframework.DefaultTestCaseRunner;
+import org.citrusframework.TestCase;
+import org.citrusframework.UnitTestSupport;
+import org.citrusframework.actions.ExecuteSQLQueryAction;
+import org.mockito.Mockito;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import org.citrusframework.DefaultTestCaseRunner;
-import org.citrusframework.TestCase;
-import org.citrusframework.UnitTestSupport;
-import org.citrusframework.actions.ExecuteSQLQueryAction;
-import org.citrusframework.validation.script.sql.SqlResultSetScriptValidator;
-import org.mockito.Mockito;
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.core.io.Resource;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.transaction.PlatformTransactionManager;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 
 import static org.citrusframework.actions.ExecuteSQLQueryAction.Builder.query;
 import static org.mockito.Mockito.anyString;
@@ -49,19 +46,16 @@ public class ExecuteSQLQueryTestActionBuilderTest extends UnitTestSupport {
 
     private final JdbcTemplate jdbcTemplate = Mockito.mock(JdbcTemplate.class);
     private final PlatformTransactionManager transactionManager = Mockito.mock(PlatformTransactionManager.class);
-    private final Resource resource = Mockito.mock(Resource.class);
-
-    private final SqlResultSetScriptValidator validator = Mockito.mock(SqlResultSetScriptValidator.class);
 
     @Test
-    public void testExecuteSQLQueryWithResource() throws IOException {
+    public void testExecuteSQLQueryWithResource() {
         List<Map<String, Object>> results = new ArrayList<>();
-        results.add(Collections.<String, Object>singletonMap("NAME", "Leonard"));
+        results.add(Collections.singletonMap("NAME", "Leonard"));
 
         reset(jdbcTemplate);
 
         when(jdbcTemplate.queryForList(anyString())).thenReturn(results)
-                                                    .thenReturn(Collections.singletonList(Collections.<String, Object>singletonMap("CNT_EPISODES", "100000")));
+                .thenReturn(Collections.singletonList(Collections.singletonMap("CNT_EPISODES", "100000")));
         DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
         builder.variable("episodeId", "citrus:randomNumber(5)");
 
@@ -69,28 +63,28 @@ public class ExecuteSQLQueryTestActionBuilderTest extends UnitTestSupport {
                 .sqlResource(new ClassPathResource("org/citrusframework/actions/dsl/query-script.sql"))
                 .validate("NAME", "Leonard")
                 .validate("CNT_EPISODES", "100000")
-                .extract("NAME", "actorName"));
+                .extract("NAME", "actorName")
+                .extract("CNT_EPISODES", "episodesCount"));
 
-        Assert.assertNotNull(context.getVariable("NAME"));
         Assert.assertNotNull(context.getVariable("actorName"));
-        Assert.assertNotNull(context.getVariable("CNT_EPISODES"));
-        Assert.assertEquals(context.getVariable("NAME"), "Leonard");
+        Assert.assertNotNull(context.getVariable("episodesCount"));
         Assert.assertEquals(context.getVariable("actorName"), "Leonard");
-        Assert.assertEquals(context.getVariable("CNT_EPISODES"), "100000");
+        Assert.assertEquals(context.getVariable("episodesCount"), "100000");
 
         TestCase test = builder.getTestCase();
         Assert.assertEquals(test.getActionCount(), 1);
         Assert.assertEquals(test.getActions().get(0).getClass(), ExecuteSQLQueryAction.class);
 
-        ExecuteSQLQueryAction action = (ExecuteSQLQueryAction)test.getActions().get(0);
+        ExecuteSQLQueryAction action = (ExecuteSQLQueryAction) test.getActions().get(0);
 
         Assert.assertEquals(action.getName(), "sql-query");
         Assert.assertEquals(action.getControlResultSet().size(), 2);
         Set<Map.Entry<String, List<String>>> rows = action.getControlResultSet().entrySet();
         Assert.assertEquals(getRow("NAME", rows).toString(), "NAME=[Leonard]");
         Assert.assertEquals(getRow("CNT_EPISODES", rows).toString(), "CNT_EPISODES=[100000]");
-        Assert.assertEquals(action.getExtractVariables().size(), 1);
-        Assert.assertEquals(action.getExtractVariables().entrySet().iterator().next().toString(), "NAME=actorName");
+        Assert.assertEquals(action.getExtractVariables().size(), 2);
+        Assert.assertEquals(action.getExtractVariables().get("NAME"), "actorName");
+        Assert.assertEquals(action.getExtractVariables().get("CNT_EPISODES"), "episodesCount");
         Assert.assertNull(action.getScriptValidationContext());
         Assert.assertEquals(action.getJdbcTemplate(), jdbcTemplate);
         Assert.assertEquals(action.getStatements().size(), 2);
@@ -101,40 +95,40 @@ public class ExecuteSQLQueryTestActionBuilderTest extends UnitTestSupport {
     @Test
     public void testExecuteSQLQueryWithStatements() {
         List<Map<String, Object>> results = new ArrayList<>();
-        results.add(Collections.<String, Object>singletonMap("NAME", "Penny"));
-        results.add(Collections.<String, Object>singletonMap("NAME", "Sheldon"));
+        results.add(Collections.singletonMap("NAME", "Penny"));
+        results.add(Collections.singletonMap("NAME", "Sheldon"));
 
         reset(jdbcTemplate);
         when(jdbcTemplate.queryForList("SELECT NAME FROM ACTORS")).thenReturn(results);
-        when(jdbcTemplate.queryForList("SELECT COUNT(*) as CNT_EPISODES FROM EPISODES")).thenReturn(Collections.singletonList(Collections.<String, Object>singletonMap("CNT_EPISODES", "9999")));
+        when(jdbcTemplate.queryForList("SELECT COUNT(*) as CNT_EPISODES FROM EPISODES")).thenReturn(Collections.singletonList(Collections.singletonMap("CNT_EPISODES", "9999")));
         DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
         builder.$(query().jdbcTemplate(jdbcTemplate)
-            .statement("SELECT NAME FROM ACTORS")
-            .statement("SELECT COUNT(*) as CNT_EPISODES FROM EPISODES")
-            .validate("NAME", "Penny", "Sheldon")
-            .validate("CNT_EPISODES", "9999")
-            .extract("CNT_EPISODES", "cntEpisodes"));
+                .statement("SELECT NAME FROM ACTORS")
+                .statement("SELECT COUNT(*) as CNT_EPISODES FROM EPISODES")
+                .validate("NAME", "Penny", "Sheldon")
+                .validate("CNT_EPISODES", "9999")
+                .extract("NAME", "actorName")
+                .extract("CNT_EPISODES", "episodesCount"));
 
-        Assert.assertNotNull(context.getVariable("NAME"));
-        Assert.assertNotNull(context.getVariable("CNT_EPISODES"));
-        Assert.assertNotNull(context.getVariable("cntEpisodes"));
-        Assert.assertEquals(context.getVariable("NAME"), "Penny");
-        Assert.assertEquals(context.getVariable("CNT_EPISODES"), "9999");
-        Assert.assertEquals(context.getVariable("cntEpisodes"), "9999");
+        Assert.assertNotNull(context.getVariable("actorName"));
+        Assert.assertNotNull(context.getVariable("episodesCount"));
+        Assert.assertEquals(context.getVariable("actorName"), "Penny;Sheldon");
+        Assert.assertEquals(context.getVariable("episodesCount"), "9999");
 
         TestCase test = builder.getTestCase();
         Assert.assertEquals(test.getActionCount(), 1);
         Assert.assertEquals(test.getActions().get(0).getClass(), ExecuteSQLQueryAction.class);
 
-        ExecuteSQLQueryAction action = (ExecuteSQLQueryAction)test.getActions().get(0);
+        ExecuteSQLQueryAction action = (ExecuteSQLQueryAction) test.getActions().get(0);
 
         Assert.assertEquals(action.getName(), "sql-query");
         Assert.assertEquals(action.getControlResultSet().size(), 2);
         Set<Map.Entry<String, List<String>>> rows = action.getControlResultSet().entrySet();
         Assert.assertEquals(getRow("NAME", rows).toString(), "NAME=[Penny, Sheldon]");
         Assert.assertEquals(getRow("CNT_EPISODES", rows).toString(), "CNT_EPISODES=[9999]");
-        Assert.assertEquals(action.getExtractVariables().size(), 1);
-        Assert.assertEquals(action.getExtractVariables().entrySet().iterator().next().toString(), "CNT_EPISODES=cntEpisodes");
+        Assert.assertEquals(action.getExtractVariables().size(), 2);
+        Assert.assertEquals(action.getExtractVariables().get("NAME"), "actorName");
+        Assert.assertEquals(action.getExtractVariables().get("CNT_EPISODES"), "episodesCount");
         Assert.assertEquals(action.getStatements().size(), 2);
         Assert.assertEquals(action.getStatements().toString(), "[SELECT NAME FROM ACTORS, SELECT COUNT(*) as CNT_EPISODES FROM EPISODES]");
         Assert.assertNull(action.getScriptValidationContext());
@@ -146,43 +140,43 @@ public class ExecuteSQLQueryTestActionBuilderTest extends UnitTestSupport {
     @Test
     public void testExecuteSQLQueryWithTransaction() {
         List<Map<String, Object>> results = new ArrayList<>();
-        results.add(Collections.<String, Object>singletonMap("NAME", "Penny"));
-        results.add(Collections.<String, Object>singletonMap("NAME", "Sheldon"));
+        results.add(Collections.singletonMap("NAME", "Penny"));
+        results.add(Collections.singletonMap("NAME", "Sheldon"));
 
         reset(jdbcTemplate, transactionManager);
         when(jdbcTemplate.queryForList("SELECT NAME FROM ACTORS")).thenReturn(results);
-        when(jdbcTemplate.queryForList("SELECT COUNT(*) as CNT_EPISODES FROM EPISODES")).thenReturn(Collections.singletonList(Collections.<String, Object>singletonMap("CNT_EPISODES", "9999")));
+        when(jdbcTemplate.queryForList("SELECT COUNT(*) as CNT_EPISODES FROM EPISODES")).thenReturn(Collections.singletonList(Collections.singletonMap("CNT_EPISODES", "9999")));
         DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
         builder.$(query().jdbcTemplate(jdbcTemplate)
-            .transactionManager(transactionManager)
-            .transactionTimeout(5000)
-            .transactionIsolationLevel("ISOLATION_READ_COMMITTED")
-            .statement("SELECT NAME FROM ACTORS")
-            .statement("SELECT COUNT(*) as CNT_EPISODES FROM EPISODES")
-            .validate("NAME", "Penny", "Sheldon")
-            .validate("CNT_EPISODES", "9999")
-            .extract("CNT_EPISODES", "cntEpisodes"));
+                .transactionManager(transactionManager)
+                .transactionTimeout(5000)
+                .transactionIsolationLevel("ISOLATION_READ_COMMITTED")
+                .statement("SELECT NAME FROM ACTORS")
+                .statement("SELECT COUNT(*) as CNT_EPISODES FROM EPISODES")
+                .validate("NAME", "Penny", "Sheldon")
+                .validate("CNT_EPISODES", "9999")
+                .extract("NAME", "actorName")
+                .extract("CNT_EPISODES", "episodesCount"));
 
-        Assert.assertNotNull(context.getVariable("NAME"));
-        Assert.assertNotNull(context.getVariable("CNT_EPISODES"));
-        Assert.assertNotNull(context.getVariable("cntEpisodes"));
-        Assert.assertEquals(context.getVariable("NAME"), "Penny");
-        Assert.assertEquals(context.getVariable("CNT_EPISODES"), "9999");
-        Assert.assertEquals(context.getVariable("cntEpisodes"), "9999");
+        Assert.assertNotNull(context.getVariable("actorName"));
+        Assert.assertNotNull(context.getVariable("episodesCount"));
+        Assert.assertEquals(context.getVariable("actorName"), "Penny;Sheldon");
+        Assert.assertEquals(context.getVariable("episodesCount"), "9999");
 
         TestCase test = builder.getTestCase();
         Assert.assertEquals(test.getActionCount(), 1);
         Assert.assertEquals(test.getActions().get(0).getClass(), ExecuteSQLQueryAction.class);
 
-        ExecuteSQLQueryAction action = (ExecuteSQLQueryAction)test.getActions().get(0);
+        ExecuteSQLQueryAction action = (ExecuteSQLQueryAction) test.getActions().get(0);
 
         Assert.assertEquals(action.getName(), "sql-query");
         Assert.assertEquals(action.getControlResultSet().size(), 2);
         Set<Map.Entry<String, List<String>>> rows = action.getControlResultSet().entrySet();
         Assert.assertEquals(getRow("NAME", rows).toString(), "NAME=[Penny, Sheldon]");
         Assert.assertEquals(getRow("CNT_EPISODES", rows).toString(), "CNT_EPISODES=[9999]");
-        Assert.assertEquals(action.getExtractVariables().size(), 1);
-        Assert.assertEquals(action.getExtractVariables().entrySet().iterator().next().toString(), "CNT_EPISODES=cntEpisodes");
+        Assert.assertEquals(action.getExtractVariables().size(), 2);
+        Assert.assertEquals(action.getExtractVariables().get("NAME"), "actorName");
+        Assert.assertEquals(action.getExtractVariables().get("CNT_EPISODES"), "episodesCount");
         Assert.assertEquals(action.getStatements().size(), 2);
         Assert.assertEquals(action.getStatements().toString(), "[SELECT NAME FROM ACTORS, SELECT COUNT(*) as CNT_EPISODES FROM EPISODES]");
         Assert.assertNull(action.getScriptValidationContext());
@@ -195,6 +189,7 @@ public class ExecuteSQLQueryTestActionBuilderTest extends UnitTestSupport {
 
     /**
      * Gets row from result set with given column name.
+     *
      * @param columnName
      * @param rows
      * @return


### PR DESCRIPTION
one must explicitly call `extract` using column- plut target-variable-names in order to extract data from the result into the current `TestContext`.

BREAKING CHANGE: sql queries no longer automatically extract variables