### PR TITLE
update dependency versions

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.8.1/apache-maven-3.8.1-bin.zip
+distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.9.5/apache-maven-3.9.5-bin.zip

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ You need following software on your machine in order to start developing:
   Installed JDK plus JAVA_HOME environment variable set
   up and pointing to your Java installation directory. Used to compile and build the Citrus code.
 
-* Maven 3.8.4+
+* Maven 3.9.5+
   Citrus projects will fit best with [Maven](https://maven.apache.org).
   However, it is not required to use Maven. You can also run tests using [Gradle](https://gradle.org/) for instance.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Citrus framework:
 Installed JDK plus JAVA_HOME environment variable set
 up and pointing to your Java installation directory. Used to compile and build the Citrus code.
 
-* Maven 3.8.4+
+* Maven 3.9.5+
 Citrus projects will fit best with [Maven](https://maven.apache.org).
 However, it is not required to use Maven. You can also run tests using [Gradle](https://gradle.org/) for instance.
 

--- a/connectors/citrus-selenium/pom.xml
+++ b/connectors/citrus-selenium/pom.xml
@@ -61,10 +61,6 @@
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>htmlunit-driver</artifactId>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
 
     <dependency>
       <groupId>org.eclipse.jetty.toolchain</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
     <project.docs.version>${project.version}</project.docs.version>
     <java.version>17</java.version>
 
-    <maven.version>3.8.4</maven.version>
+    <maven.version>3.9.5</maven.version>
     <maven.compiler.version>3.11.0</maven.compiler.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
     <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -167,31 +167,30 @@
     <asciidoctor.maven.plugin.version>2.2.4</asciidoctor.maven.plugin.version>
     <jaxb.maven.plugin.version>3.1.0</jaxb.maven.plugin.version>
 
-    <activemq.artemis.version>2.30.0</activemq.artemis.version>
+    <activemq.artemis.version>2.31.0</activemq.artemis.version>
     <angus-mail.version>2.0.2</angus-mail.version>
-    <apache.ant.version>1.10.13</apache.ant.version>
-    <apache.camel.version>4.0.0</apache.camel.version>
-    <arquillian.version>1.7.0.Final</arquillian.version>
+    <apache.ant.version>1.10.14</apache.ant.version>
+    <apache.camel.version>4.0.1</apache.camel.version>
+    <arquillian.version>1.7.1.Final</arquillian.version>
     <bouncycastle.version>1.70</bouncycastle.version>
-    <byte.buddy.version>1.14.5</byte.buddy.version>
+    <byte.buddy.version>1.14.8</byte.buddy.version>
     <citrus.db.version>0.1.4</citrus.db.version>
-    <commons.dbcp2.version>2.9.0</commons.dbcp2.version>
+    <commons.dbcp2.version>2.10.0</commons.dbcp2.version>
     <commons.cli.version>1.5.0</commons.cli.version>
     <commons.codec.version>1.16.0</commons.codec.version>
-    <commons.io.version>2.13.0</commons.io.version>
+    <commons.io.version>2.14.0</commons.io.version>
     <commons.lang.version>2.6</commons.lang.version>
     <commons.logging.api.version>1.1</commons.logging.api.version>
     <commons.logging.version>1.2</commons.logging.version>
-    <commons.net.version>3.9.0</commons.net.version>
-    <cucumber.version>7.13.0</cucumber.version>
-    <docker-java.version>3.3.2</docker-java.version>
-    <dropwizard.metrics.version>4.2.19</dropwizard.metrics.version>
+    <commons.net.version>3.10.0</commons.net.version>
+    <cucumber.version>7.14.0</cucumber.version>
+    <docker-java.version>3.3.3</docker-java.version>
+    <dropwizard.metrics.version>4.2.20</dropwizard.metrics.version>
     <ftpserver.version>1.2.0</ftpserver.version>
-    <groovy.version>3.0.18</groovy.version>
-    <google.guava.version>32.1.1-jre</google.guava.version>
+    <groovy.version>3.0.19</groovy.version>
     <greenmail.version>2.0.0</greenmail.version>
     <hamcrest.version>2.2</hamcrest.version>
-    <htmlunit.version>4.10.0</htmlunit.version>
+    <htmlunit.version>4.13.0</htmlunit.version>
     <httpclient.version>5.2.1</httpclient.version>
     <hsqldb.version>2.7.2</hsqldb.version>
     <jackson.version>2.15.2</jackson.version>
@@ -203,51 +202,51 @@
     <jakarta.servlet-api.version>6.0.0</jakarta.servlet-api.version>
     <jakarta.validation.version>3.0.2</jakarta.validation.version>
     <jakarta.websocket-api.version>2.1.1</jakarta.websocket-api.version>
-    <jakarta.xml.bind-api.version>4.0.0</jakarta.xml.bind-api.version>
+    <jakarta.xml.bind-api.version>4.0.1</jakarta.xml.bind-api.version>
     <jakarta.xml.soap-api.version>3.0.0</jakarta.xml.soap-api.version>
-    <javapoet.version>1.11.1</javapoet.version>
-    <jaxb.version>4.0.2</jaxb.version>
-    <jetty.version>11.0.15</jetty.version>
+    <javapoet.version>1.13.0</javapoet.version>
+    <jaxb.version>4.0.3</jaxb.version>
+    <jetty.version>11.0.16</jetty.version>
     <jetty.websocket-api.version>2.0.0</jetty.websocket-api.version>
     <jsch.version>0.1.55</jsch.version>
     <json-path.version>2.8.0</json-path.version>
-    <json-schema-validator.version>1.0.86</json-schema-validator.version>
+    <json-schema-validator.version>1.0.87</json-schema-validator.version>
     <json-smart.version>2.5.0</json-smart.version>
     <jtidy.version>r938</jtidy.version>
     <junit.jupiter.version>5.10.0</junit.jupiter.version>
     <junit.platform.version>1.10.0</junit.platform.version>
     <junit.version>4.13.2</junit.version>
-    <junixsocket.version>2.6.2</junixsocket.version>
+    <junixsocket.version>2.8.1</junixsocket.version>
     <k8s.client.version>1.4.34</k8s.client.version>
     <k8s.model.version>1.0.65</k8s.model.version>
-    <kafka.version>3.5.1</kafka.version>
+    <kafka.version>3.6.0</kafka.version>
     <log4j2.version>2.20.0</log4j2.version>
-    <mockito.version>5.4.0</mockito.version>
+    <mockito.version>5.6.0</mockito.version>
     <mockftpserver.version>3.1.0</mockftpserver.version>
-    <okhttp.version>4.10.0</okhttp.version>
+    <okhttp.version>4.11.0</okhttp.version>
     <saaj.version>3.0.2</saaj.version>
-    <selenium.version>4.10.0</selenium.version>
+    <selenium.version>4.13.0</selenium.version>
     <shrinkwrap.impl.version>1.2.6</shrinkwrap.impl.version>
-    <shrinkwrap.resolver.version>3.1.4</shrinkwrap.resolver.version>
-    <slf4j.version>2.0.7</slf4j.version>
-    <snappy.version>1.1.10.4</snappy.version>
+    <shrinkwrap.resolver.version>3.2.1</shrinkwrap.resolver.version>
+    <slf4j.version>2.0.9</slf4j.version>
+    <snappy.version>1.1.10.5</snappy.version>
     <snakeyaml.version>2.0</snakeyaml.version>
-    <spring.version>6.0.11</spring.version>
-    <spring.ws.version>4.0.5</spring.ws.version>
-    <spring.integration.version>6.1.2</spring.integration.version>
+    <spring.version>6.0.12</spring.version>
+    <spring.ws.version>4.0.6</spring.ws.version>
+    <spring.integration.version>6.1.3</spring.integration.version>
     <spring.restdocs.version>3.0.0</spring.restdocs.version>
     <sshd.version>2.10.0</sshd.version>
     <swagger.version>1.6.9</swagger.version>
     <swagger.parser.version>2.1.16</swagger.parser.version>
     <testng.version>7.8.0</testng.version>
-    <vertx.version>4.4.4</vertx.version>
+    <vertx.version>4.4.5</vertx.version>
     <wsdl4j.version>1.6.3</wsdl4j.version>
     <xbean-spring.version>4.23</xbean-spring.version>
     <xmlbeans.version>3.0.0</xmlbeans.version>
     <xmlbeans-xpath.version>2.6.0</xmlbeans-xpath.version>
     <xerces.version>2.12.2</xerces.version>
     <xstream.version>1.4.20</xstream.version>
-    <zookeeper.version>3.8.2</zookeeper.version>
+    <zookeeper.version>3.9.1</zookeeper.version>
 
     <skip.integration.tests>false</skip.integration.tests>
     <skip.unit.tests>false</skip.unit.tests>
@@ -813,11 +812,6 @@
         <groupId>org.seleniumhq.selenium</groupId>
         <artifactId>htmlunit-driver</artifactId>
         <version>${htmlunit.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>
-        <version>${google.guava.version}</version>
       </dependency>
       <dependency>
         <groupId>net.bytebuddy</groupId>

--- a/runtime/citrus-quarkus/pom.xml
+++ b/runtime/citrus-quarkus/pom.xml
@@ -15,7 +15,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <quarkus.platform.version>3.3.2</quarkus.platform.version>
+    <quarkus.platform.version>3.4.2</quarkus.platform.version>
   </properties>
 
   <dependencyManagement>

--- a/tools/archetypes/jms/src/main/resources/archetype-resources/pom.xml
+++ b/tools/archetypes/jms/src/main/resources/archetype-resources/pom.xml
@@ -11,7 +11,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>17</java.version>
 
-    <maven.version>3.8.4</maven.version>
+    <maven.version>3.9.5</maven.version>
     <maven.compiler.version>3.11.0</maven.compiler.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
     <maven.compiler.source>${java.version}</maven.compiler.source>

--- a/tools/archetypes/quickstart/src/main/resources/archetype-resources/pom.xml
+++ b/tools/archetypes/quickstart/src/main/resources/archetype-resources/pom.xml
@@ -11,7 +11,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>17</java.version>
 
-    <maven.version>3.8.4</maven.version>
+    <maven.version>3.9.5</maven.version>
     <maven.compiler.version>3.11.0</maven.compiler.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
     <maven.compiler.source>${java.version}</maven.compiler.source>

--- a/tools/archetypes/soap/src/main/resources/archetype-resources/pom.xml
+++ b/tools/archetypes/soap/src/main/resources/archetype-resources/pom.xml
@@ -11,7 +11,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>17</java.version>
 
-    <maven.version>3.8.4</maven.version>
+    <maven.version>3.9.5</maven.version>
     <maven.compiler.version>3.11.0</maven.compiler.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
     <maven.compiler.source>${java.version}</maven.compiler.source>


### PR DESCRIPTION
updates most dependencies to the latest versions. PATCH or MINOR updates only.

intentionally removed: `com.google.guava:guava` - unused.

intentionally excluded, because it is known to cause problems with jackson:
* `org.yaml:snakeyaml` ............................... 2.0 -> 2.2

left out breaking changes:
* `jetty` from 11 to 12.
  * https://github.com/citrusframework/citrus/issues/1010
* `org.apache.xmlbeans:xmlbeans` from 3.0.0 to 5.1.1
  * https://github.com/citrusframework/citrus/issues/1011
* `io.swagger:swagger-core` to `io.swagger.core.v3:swagger-core`
  * https://github.com/citrusframework/citrus/issues/1012

I will submit this separately with a bit more careful testing.

remaining updates, some of them breaking and NOT final (therefore not done). I also didn't check the version ranges in between:

* `com.icegreen:greenmail` ........................... 2.0.0 -> 2.1.0-alpha-2
* `com.squareup.okhttp3:okhttp` ...................... 4.11.0 -> 5.0.0-alpha.11
* `org.apache.httpcomponents.client5:httpclient5` .... 5.2.1 -> 5.3-alpha1
* `org.apache.logging.log4j:log4j-api` ............... 2.20.0 -> 3.0.0-alpha1
* `org.apache.logging.log4j:log4j-slf4j2-impl` ....... 2.20.0 -> 3.0.0-alpha1
* `org.apache.maven:maven-plugin-api` ................ 3.9.5 -> 4.0.0-alpha-7
* `org.jboss.shrinkwrap:shrinkwrap-impl-base` ........ 1.2.6 -> 2.0.0-beta-1
* `org.seleniumhq.selenium:htmlunit-driver` .......... 4.10.0 -> 4.13.0
* `org.apache.logging.log4j:log4j-slf4j2-impl` ....... 2.20.0 -> 3.0.0-alpha1

and then finally, regarding the k8s client, there is an ongoing separate issue #889:
* `io.fabric8:kubernetes-client` ..................... 1.4.34 -> 6.9.0
* `io.fabric8:kubernetes-model` ...................... 1.0.65 -> 6.9.0
