### PR TITLE
Use try-with-resource to close BufferedReaders

### DIFF
--- a/core/citrus-base/src/main/java/org/citrusframework/actions/InputAction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/actions/InputAction.java
@@ -91,11 +91,9 @@ public class InputAction extends AbstractTestAction {
         }
 
 
-        try {
+        try (BufferedReader stdin = getInputReader();) {
             do {
                 logger.info(display);
-
-                BufferedReader stdin = getInputReader();
                 input = stdin.readLine();
             } while (validAnswers != null && !checkAnswer(input));
         } catch (IOException e) {

--- a/core/citrus-base/src/main/java/org/citrusframework/validation/script/TemplateBasedScriptBuilder.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/validation/script/TemplateBasedScriptBuilder.java
@@ -64,9 +64,8 @@ public final class TemplateBasedScriptBuilder {
         StringBuilder scriptBody = new StringBuilder();
         String importStmt = "import ";
 
-        try {
+        try (BufferedReader reader = new BufferedReader(new StringReader(scriptCode));) {
             if (scriptCode.contains(importStmt)) {
-                BufferedReader reader = new BufferedReader(new StringReader(scriptCode));
                 String line;
                 while ((line = reader.readLine()) != null) {
                     if (line.trim().startsWith(importStmt)) {


### PR DESCRIPTION
As discussed on https://github.com/citrusframework/citrus/pull/1001, I changed `BufferedReader` initializations to use try-with-resource.