### PR TITLE
Slim down dependency from docker-java to docker-java-core

### DIFF
--- a/connectors/citrus-docker/pom.xml
+++ b/connectors/citrus-docker/pom.xml
@@ -69,11 +69,16 @@
 
     <dependency>
       <groupId>com.github.docker-java</groupId>
-      <artifactId>docker-java</artifactId>
+      <artifactId>docker-java-core</artifactId>
     </dependency>
     <dependency>
       <groupId>com.github.docker-java</groupId>
       <artifactId>docker-java-transport-okhttp</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.github.docker-java</groupId>
+      <artifactId>docker-java-transport-jersey</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>

--- a/connectors/citrus-kubernetes/pom.xml
+++ b/connectors/citrus-kubernetes/pom.xml
@@ -109,7 +109,7 @@
     <!-- Test scoped dependencies -->
     <dependency>
       <groupId>com.github.docker-java</groupId>
-      <artifactId>docker-java</artifactId>
+      <artifactId>docker-java-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -917,7 +917,7 @@
 
       <dependency>
         <groupId>com.github.docker-java</groupId>
-        <artifactId>docker-java</artifactId>
+        <artifactId>docker-java-core</artifactId>
         <version>${docker-java.version}</version>
         <exclusions>
           <exclusion>
@@ -933,6 +933,11 @@
       <dependency>
         <groupId>com.github.docker-java</groupId>
         <artifactId>docker-java-transport-okhttp</artifactId>
+        <version>${docker-java.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.github.docker-java</groupId>
+        <artifactId>docker-java-transport-jersey</artifactId>
         <version>${docker-java.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
it has the main benefit to not have anymore a dependency on Netty

In getting started of docker-java, they are mentioning to use docker-java-core (and not docker-java): https://github.com/docker-java/docker-java/blob/main/docs/getting_started.md#dependencies
(it is comforting me in the fact that it should work nicely)