### PR TITLE
Upgrade Jetty from 11.0.16 to 11.0.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@
     <jakarta.xml.soap-api.version>3.0.0</jakarta.xml.soap-api.version>
     <javapoet.version>1.13.0</javapoet.version>
     <jaxb.version>4.0.3</jaxb.version>
-    <jetty.version>11.0.16</jetty.version>
+    <jetty.version>11.0.17</jetty.version>
     <jetty.websocket-api.version>2.0.0</jetty.websocket-api.version>
     <jsch.version>0.1.55</jsch.version>
     <json-path.version>2.8.0</json-path.version>


### PR DESCRIPTION
it avoids to be affected to CVE-2023-44487
https://blog.vespa.ai/cve-2023-44487/