### PR TITLE
fix: Do not resolveAllFromJar on empty path

### DIFF
--- a/core/citrus-api/src/main/java/org/citrusframework/spi/ResourcePathTypeResolver.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/spi/ResourcePathTypeResolver.java
@@ -117,7 +117,7 @@ public class ResourcePathTypeResolver implements TypeResolver {
         try {
             Stream.concat(
                     classpathResourceResolver.getResources(fullPath).stream().filter(Objects::nonNull),
-                    resolveAllFromJar(path))
+                    resolveAllFromJar(fullPath))
                     .forEach(resourcePath -> {
                         Path fileName = resourcePath.getFileName();
                         if (fileName == null) {


### PR DESCRIPTION
Citrus does not "mvnw verify" on windows any more.
Looking into  the following commit, one can see, that the code was not correctly adjusted for this change. 
[See 6b163eb](https://github.com/citrusframework/citrus/commit/6b163eb115814935a87cb81f8e0da5e91fb1fe6a#r130779285)

The problem occurs, when passing an empty string into resolveAllFromJar. Passing the fullPath variable solves the issue because   getFullResourcePath handles empty paths.