### PR TITLE
fix(#1046): Resolve excessive class pass scanning by caching scan res…

### DIFF
--- a/core/citrus-api/src/main/java/org/citrusframework/message/MessageSelector.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/message/MessageSelector.java
@@ -1,8 +1,8 @@
 package org.citrusframework.message;
 
-import java.util.HashMap;
 import java.util.Map;
 
+import java.util.concurrent.ConcurrentHashMap;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.spi.ResourcePathTypeResolver;
 import org.citrusframework.spi.TypeResolver;
@@ -24,7 +24,7 @@ public interface MessageSelector {
     /** Type resolver to find custom message selectors on classpath via resource path lookup */
     TypeResolver TYPE_RESOLVER = new ResourcePathTypeResolver(RESOURCE_PATH);
 
-    Map<String, MessageSelectorFactory> factories = new HashMap<>();
+    Map<String, MessageSelectorFactory> factories = new ConcurrentHashMap<>();
 
     /**
      * Resolves all available selectors from resource path lookup. Scans classpath for validator meta information
@@ -36,7 +36,7 @@ public interface MessageSelector {
             factories.putAll(TYPE_RESOLVER.resolveAll());
 
             if (logger.isDebugEnabled()) {
-                factories.forEach((k, v) -> logger.debug(String.format("Found value matcher '%s' as %s", k, v.getClass())));
+                factories.forEach((k, v) -> logger.debug(String.format("Found message selector '%s' as %s", k, v.getClass())));
             }
         }
         return factories;

--- a/core/citrus-api/src/main/java/org/citrusframework/spi/ResourcePathTypeResolver.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/spi/ResourcePathTypeResolver.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -29,13 +30,18 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Type resolver resolves references via resource path lookup. Provided resource paths should point to a resource in classpath
- * (e.g. META-INF/my/resource/path/file-name). The resolver will try to locate the resource as classpath resource and read the file as property
- * file. By default, the resolver reads the default type resolver property {@link TypeResolver#DEFAULT_TYPE_PROPERTY} and instantiates a new instance
- * for the given type information.
- *
+ * Type resolver resolves references via resource path lookup. Provided resource paths should point
+ * to a resource in classpath (e.g. META-INF/my/resource/path/file-name). The resolver will try to
+ * locate the resource as classpath resource and read the file as property file. By default, the
+ * resolver reads the default type resolver property {@link TypeResolver#DEFAULT_TYPE_PROPERTY} and
+ * instantiates a new instance for the given type information. Note that, in order to reduce classpath
+ * scanning, the resolver caches the results of specific classpath scans.
+ * <p>
  * A possible property file content that represents the resource in classpath could look like this:
  * type=org.citrusframework.MySpecialPojo
+ * <p>
+ * Users can define custom property names to read instead of the default
+ * {@link TypeResolver#DEFAULT_TYPE_PROPERTY}.
  *
  * Users can define custom property names to read instead of the default {@link TypeResolver#DEFAULT_TYPE_PROPERTY}.
  * @author Christoph Deppisch
@@ -56,6 +62,17 @@ public class ResourcePathTypeResolver implements TypeResolver {
 
     /** Zip entries as String, so the archive is read only once */
     private final List<String> zipEntriesAsString = Collections.synchronizedList(new ArrayList<>());
+
+    /**
+     * Cached properties loaded from classpath scans.
+     */
+    private final Map<String, Properties> resourceProperties = new ConcurrentHashMap<>();
+
+
+    /**
+     * Cached specifc type names as resolved from classpath.
+     */
+    private final Map<String, Map<String, String>> typeCache = new ConcurrentHashMap<>();
 
     /**
      * Default constructor using META-INF resource base path.
@@ -82,70 +99,88 @@ public class ResourcePathTypeResolver implements TypeResolver {
     }
 
     @Override
-    public <T> T resolve(String resourcePath, String property, Object ... initargs) {
-        String type = resolveProperty(resourcePath, property);
+    public <T> T resolve(String resourcePath, String property, Object... initargs) {
+        String cacheKey = toCacheKey(resourcePath, property, "NO_KEY_PROPERTY");
 
-        try {
-            if (initargs.length == 0) {
-                return (T) Class.forName(type).getDeclaredConstructor().newInstance();
-            } else {
-                return (T) getConstructor(Class.forName(type), initargs).newInstance(initargs);
-            }
-        } catch (ClassNotFoundException | IllegalAccessException | InstantiationException |
-                 NoSuchMethodException | InvocationTargetException e) {
-
-            try {
-                if (Arrays.stream(Class.forName(type).getFields()).anyMatch(f -> f.getName().equals(INSTANCE) &&
-                        Modifier.isStatic(f.getModifiers()))) {
-                    return (T) Class.forName(type).getField(INSTANCE).get(null);
-                }
-            } catch (IllegalAccessException | NoSuchFieldException | ClassNotFoundException e1) {
-                throw new CitrusRuntimeException(String.format("Failed to resolve classpath resource of type '%s'", type), e1);
-            }
-
-            logger.warn(String.format("Neither static instance nor accessible default constructor (%s) is given on type '%s'",
-                    Arrays.toString(getParameterTypes(initargs)), type));
-            throw new CitrusRuntimeException(String.format("Failed to resolve classpath resource of type '%s'", type), e);
-        }
+        Map<String, String> map = typeCache.computeIfAbsent(
+            cacheKey,
+            key -> Collections.singletonMap(key,
+                resolveProperty(resourcePath, property)));
+        return (T) instantiateType(map.get(cacheKey), initargs);
     }
 
     @Override
     public <T> Map<String, T> resolveAll(String path, String property, String keyProperty) {
-        Map<String, T> resources = new HashMap<>();
-        final String fullPath = getFullResourcePath(path);
 
+        Map<String, String> typeLookup = typeCache.computeIfAbsent(
+            toCacheKey(path, property, keyProperty), k ->
+                 determineTypeLookup(path, property, keyProperty)
+            );
+
+        Map<String, T> resources = new HashMap<>();
+        typeLookup.forEach((p, type) -> resources.put(p, (T) instantiateType(type)));
+
+        return resources;
+    }
+
+    /**
+     * Determine the type lookup by performing relevant classpath scans.
+     */
+    private Map<String, String> determineTypeLookup(String path, String property,
+        String keyProperty) {
+        Map<String, String> typeLookup = new HashMap<>();
+
+        final String fullPath = getFullResourcePath(path);
         try {
             Stream.concat(
-                    classpathResourceResolver.getResources(fullPath).stream().filter(Objects::nonNull),
+                    classpathResourceResolver.getResources(fullPath).stream()
+                        .filter(Objects::nonNull),
                     resolveAllFromJar(fullPath))
-                    .forEach(resourcePath -> {
-                        Path fileName = resourcePath.getFileName();
-                        if (fileName == null) {
-                            logger.warn(String.format("Skip unsupported resource '%s' for resource lookup", resourcePath));
-                            return;
-                        }
+                .forEach(resourcePath -> {
+                    Path fileName = resourcePath.getFileName();
+                    if (fileName == null) {
+                        logger.warn(String.format(
+                            "Skip unsupported resource '%s' for resource lookup",
+                            resourcePath));
+                        return;
+                    }
 
-                        if (property.equals(TYPE_PROPERTY_WILDCARD)) {
-                            Properties properties = readAsProperties(fullPath + "/" + fileName);
-                            for (Map.Entry<Object, Object> prop : properties.entrySet()) {
-                                T resource = resolve(fullPath + "/" + fileName, prop.getKey().toString());
-                                resources.put(fileName + "." + prop.getKey().toString(), resource);
-                            }
+                    if (property.equals(TYPE_PROPERTY_WILDCARD)) {
+                        Properties properties = readAsProperties(fullPath + "/" + fileName);
+                        for (Map.Entry<Object, Object> prop : properties.entrySet()) {
+                            String type =
+                                resolveProperty(fullPath + "/" + fileName,
+                                    prop.getKey().toString());
+                            typeLookup.put(fileName + "." + prop.getKey().toString(),
+                                type);
+                        }
+                    } else {
+                        String type =
+                            resolveProperty(fullPath + "/" + fileName, property);
+                        if (keyProperty != null) {
+                            typeLookup.put(
+                                resolveProperty(fullPath + "/" + fileName, keyProperty),
+                                type);
                         } else {
-                            T resource = resolve(fullPath + "/" + fileName, property);
-
-                            if (keyProperty != null) {
-                                resources.put(resolveProperty(fullPath + "/" + fileName, keyProperty), resource);
-                            } else {
-                                resources.put(fileName.toString(), resource);
-                            }
+                            typeLookup.put(fileName.toString(), type);
                         }
-                    });
+                    }
+                });
         } catch (IOException e) {
             logger.warn(String.format("Failed to resolve resources in '%s'", fullPath), e);
         }
 
-        return resources;
+        return typeLookup;
+    }
+
+    private String toCacheKey(String path, String property, String keyProperty) {
+        StringBuilder builder = new StringBuilder();
+        builder.append(path);
+        builder.append("$$$");
+        builder.append(property);
+        builder.append("$$$");
+        builder.append(keyProperty);
+        return builder.toString();
     }
 
     private Stream<Path> resolveAllFromJar(String path) {
@@ -199,7 +234,7 @@ public class ResourcePathTypeResolver implements TypeResolver {
         final Class<?>[] parameterTypes = getParameterTypes(initargs);
 
         Optional<Constructor<?>> exactMatch = Arrays.stream(type.getDeclaredConstructors())
-                .filter(constructor -> Arrays.equals(constructor.getParameterTypes(), parameterTypes))
+                .filter(constructor -> Arrays.equals(replacePrimitiveTypes(constructor), parameterTypes))
                 .findFirst();
 
         if (exactMatch.isPresent()) {
@@ -232,25 +267,32 @@ public class ResourcePathTypeResolver implements TypeResolver {
 
     /**
      * Read resource from classpath and load content as properties.
+     * The properties found on the classpath will be cached.
+     *
      * @param resourcePath
      * @return
      */
     private Properties readAsProperties(String resourcePath) {
-        String path = getFullResourcePath(resourcePath);
+        return resourceProperties.computeIfAbsent(resourcePath, k -> {
+            String path = getFullResourcePath(resourcePath);
 
-        InputStream in = ResourcePathTypeResolver.class.getClassLoader().getResourceAsStream(path);
-        if (in == null) {
-            throw new CitrusRuntimeException(String.format("Failed to locate resource path '%s'", path));
-        }
+            InputStream in = ResourcePathTypeResolver.class.getClassLoader()
+                .getResourceAsStream(path);
+            if (in == null) {
+                throw new CitrusRuntimeException(
+                    String.format("Failed to locate resource path '%s'", path));
+            }
 
-        try {
-            Properties config = new Properties();
-            config.load(in);
+            try {
+                Properties config = new Properties();
+                config.load(in);
 
-            return config;
-        } catch (IOException e) {
-            throw new CitrusRuntimeException(String.format("Unable to load properties from resource path configuration at '%s'", path), e);
-        }
+                return config;
+            } catch (IOException e) {
+                throw new CitrusRuntimeException(String.format(
+                    "Unable to load properties from resource path configuration at '%s'", path), e);
+            }
+        });
     }
 
     /**
@@ -275,5 +317,65 @@ public class ResourcePathTypeResolver implements TypeResolver {
      */
     private Class<?>[] getParameterTypes(Object... initargs) {
         return Arrays.stream(initargs).map(Object::getClass).toArray(Class[]::new);
+    }
+
+    /**
+     * Instantiate a type by its name.
+     */
+    public <T> T instantiateType(String type, Object... initargs) {
+        try {
+            if (initargs.length == 0) {
+                return (T) Class.forName(type).getDeclaredConstructor().newInstance();
+            } else {
+                return (T) getConstructor(Class.forName(type), initargs).newInstance(initargs);
+            }
+        } catch (ClassNotFoundException | IllegalAccessException | InstantiationException |
+                 NoSuchMethodException | InvocationTargetException e) {
+
+            try {
+                if (Arrays.stream(Class.forName(type).getFields())
+                    .anyMatch(f -> f.getName().equals(INSTANCE) &&
+                        Modifier.isStatic(f.getModifiers()))) {
+                    return (T) Class.forName(type).getField(INSTANCE).get(null);
+                }
+            } catch (IllegalAccessException | NoSuchFieldException |
+                     ClassNotFoundException e1) {
+                throw new CitrusRuntimeException(
+                    String.format("Failed to resolve classpath resource of type '%s'", type),
+                    e1);
+            }
+
+            logger.warn(String.format(
+                "Neither static instance nor accessible default constructor (%s) is given on type '%s'",
+                Arrays.toString(getParameterTypes(initargs)), type));
+            throw new CitrusRuntimeException(
+                String.format("Failed to resolve classpath resource of type '%s'", type), e);
+        }
+
+    }
+
+    /**
+     * Get the types of a constructor. Primitive types are converted to their respective object type.
+     * @param constructor
+     * @return the types of the constructor (primitive types converted to object types)
+     */
+    private static Class<?>[] replacePrimitiveTypes(Constructor<?> constructor) {
+        Class<?>[] constructorParameters = constructor.getParameterTypes();
+        for (int i=0;i<constructorParameters.length;i++) {
+            if (constructorParameters[i] == int.class) {
+                constructorParameters[i] = Integer.class;
+            } else if (constructorParameters[i] == short.class) {
+                constructorParameters[i] = Short.class;
+            } else if (constructorParameters[i] == double.class) {
+                constructorParameters[i] = Double.class;
+            } else if (constructorParameters[i] == float.class) {
+                constructorParameters[i] = Float.class;
+            } else if (constructorParameters[i] == char.class) {
+                constructorParameters[i] = Character.class;
+            } else if (constructorParameters[i] == boolean.class) {
+                constructorParameters[i] = Boolean.class;
+            }
+        }
+        return constructorParameters;
     }
 }

--- a/core/citrus-api/src/main/java/org/citrusframework/validation/ValueMatcher.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/validation/ValueMatcher.java
@@ -1,9 +1,9 @@
 package org.citrusframework.validation;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import java.util.concurrent.ConcurrentHashMap;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.spi.ResourcePathTypeResolver;
@@ -25,7 +25,7 @@ public interface ValueMatcher {
     /** Type resolver to find custom message validators on classpath via resource path lookup */
     TypeResolver TYPE_RESOLVER = new ResourcePathTypeResolver(RESOURCE_PATH);
 
-    Map<String, ValueMatcher> validators = new HashMap<>();
+    Map<String, ValueMatcher> validators = new ConcurrentHashMap<>();
 
     /**
      * Resolves all available validators from resource path lookup. Scans classpath for validator meta information
@@ -37,7 +37,7 @@ public interface ValueMatcher {
             validators.putAll(TYPE_RESOLVER.resolveAll());
 
             if (logger.isDebugEnabled()) {
-                validators.forEach((k, v) -> logger.debug(String.format("Found value matcher '%s' as %s", k, v.getClass())));
+                validators.forEach((k, v) -> logger.debug(String.format("Found validator '%s' as %s", k, v.getClass())));
             }
         }
         return validators;

--- a/core/citrus-api/src/test/java/org/citrusframework/spi/ResourcePathTypeResolverTest.java
+++ b/core/citrus-api/src/test/java/org/citrusframework/spi/ResourcePathTypeResolverTest.java
@@ -4,6 +4,8 @@ import java.util.Map;
 
 import org.citrusframework.spi.mocks.Bar;
 import org.citrusframework.spi.mocks.Foo;
+import org.citrusframework.spi.mocks.FooWithParams;
+import org.citrusframework.spi.mocks.SingletonFoo;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -21,11 +23,12 @@ public class ResourcePathTypeResolverTest {
         Assert.assertEquals(new ResourcePathTypeResolver("META-INF/mocks").resolveProperty("foo", "name"), "fooMock");
         Assert.assertEquals(new ResourcePathTypeResolver("META-INF/mocks").resolveProperty("META-INF/mocks/foo", "name"), "fooMock");
         Assert.assertEquals(new ResourcePathTypeResolver("META-INF/mocks").resolveProperty("bar", "name"), "barMock");
+        Assert.assertEquals(new ResourcePathTypeResolver().resolveProperty("mocks/foo", TypeResolver.DEFAULT_TYPE_PROPERTY), Foo.class.getName());
+        Assert.assertEquals(new ResourcePathTypeResolver().resolve("mocksWithParams/fooWithParams", 1,(short)2,3.d,4.f, 'c', true, new int[]{1,2,3},"StringParam").getClass(), FooWithParams.class);
     }
 
     @Test
     public void testResolve() {
-        Assert.assertEquals(new ResourcePathTypeResolver().resolve("mocks/foo").getClass(), Foo.class);
         Assert.assertEquals(new ResourcePathTypeResolver("META-INF/mocks").resolve("foo").getClass(), Foo.class);
         Assert.assertEquals(new ResourcePathTypeResolver("META-INF/mocks").resolve("bar").getClass(), Bar.class);
         Assert.assertEquals(new ResourcePathTypeResolver("META-INF/mocks").resolve("foo", TypeResolver.DEFAULT_TYPE_PROPERTY).getClass(), Foo.class);
@@ -34,31 +37,39 @@ public class ResourcePathTypeResolverTest {
     @Test
     public void testResolveAll() {
         Map<String, Object> resolved = new ResourcePathTypeResolver().resolveAll("mocks");
-        Assert.assertEquals(resolved.size(), 2L);
+        Assert.assertEquals(resolved.size(), 3L);
         Assert.assertNotNull(resolved.get("foo"));
         Assert.assertEquals(resolved.get("foo").getClass(), Foo.class);
         Assert.assertNotNull(resolved.get("bar"));
         Assert.assertEquals(resolved.get("bar").getClass(), Bar.class);
+        Assert.assertNotNull(resolved.get("singletonFoo"));
+        Assert.assertEquals(resolved.get("singletonFoo").getClass(), SingletonFoo.class);
 
         resolved = new ResourcePathTypeResolver("META-INF/mocks").resolveAll();
-        Assert.assertEquals(resolved.size(), 2L);
+        Assert.assertEquals(resolved.size(), 3L);
         Assert.assertNotNull(resolved.get("foo"));
         Assert.assertEquals(resolved.get("foo").getClass(), Foo.class);
         Assert.assertNotNull(resolved.get("bar"));
         Assert.assertEquals(resolved.get("bar").getClass(), Bar.class);
+        Assert.assertNotNull(resolved.get("singletonFoo"));
+        Assert.assertEquals(resolved.get("singletonFoo").getClass(), SingletonFoo.class);
 
         resolved = new ResourcePathTypeResolver().resolveAll("mocks", TypeResolver.DEFAULT_TYPE_PROPERTY, "name");
-        Assert.assertEquals(resolved.size(), 2L);
+        Assert.assertEquals(resolved.size(), 3L);
         Assert.assertNotNull(resolved.get("fooMock"));
         Assert.assertEquals(resolved.get("fooMock").getClass(), Foo.class);
         Assert.assertNotNull(resolved.get("barMock"));
         Assert.assertEquals(resolved.get("barMock").getClass(), Bar.class);
+        Assert.assertNotNull(resolved.get("singletonFooMock"));
+        Assert.assertEquals(resolved.get("singletonFooMock").getClass(), SingletonFoo.class);
 
         resolved = new ResourcePathTypeResolver().resolveAll("all", TypeResolver.TYPE_PROPERTY_WILDCARD);
-        Assert.assertEquals(resolved.size(), 2L);
+        Assert.assertEquals(resolved.size(), 3L);
         Assert.assertNotNull(resolved.get("mocks.foo"));
         Assert.assertEquals(resolved.get("mocks.foo").getClass(), Foo.class);
         Assert.assertNotNull(resolved.get("mocks.bar"));
         Assert.assertEquals(resolved.get("mocks.bar").getClass(), Bar.class);
+        Assert.assertNotNull(resolved.get("mocks.singletonFoo"));
+        Assert.assertEquals(resolved.get("mocks.singletonFoo").getClass(), SingletonFoo.class);
     }
 }

--- a/core/citrus-api/src/test/java/org/citrusframework/spi/mocks/FooWithParams.java
+++ b/core/citrus-api/src/test/java/org/citrusframework/spi/mocks/FooWithParams.java
@@ -1,0 +1,11 @@
+package org.citrusframework.spi.mocks;
+
+/**
+ * @author Thorsten Schlathoelter
+ */
+public class FooWithParams {
+
+    public FooWithParams(int intParam, short shortParam,  double doubleParam, float floatParam,
+        char charParam, boolean booleanParm, int[] intArrayParam, String stringParam) {
+    }
+}

--- a/core/citrus-api/src/test/java/org/citrusframework/spi/mocks/SingletonFoo.java
+++ b/core/citrus-api/src/test/java/org/citrusframework/spi/mocks/SingletonFoo.java
@@ -1,0 +1,12 @@
+package org.citrusframework.spi.mocks;
+
+/**
+ * @author Thorsten Schlathoelter
+ */
+public class SingletonFoo {
+
+    public static final SingletonFoo INSTANCE = new SingletonFoo();
+
+    private SingletonFoo() {
+    }
+}

--- a/core/citrus-api/src/test/resources/META-INF/all/mocks
+++ b/core/citrus-api/src/test/resources/META-INF/all/mocks
@@ -1,2 +1,3 @@
 foo=org.citrusframework.spi.mocks.Foo
 bar=org.citrusframework.spi.mocks.Bar
+singletonFoo=org.citrusframework.spi.mocks.SingletonFoo

--- a/core/citrus-api/src/test/resources/META-INF/mocks/singletonFoo
+++ b/core/citrus-api/src/test/resources/META-INF/mocks/singletonFoo
@@ -1,0 +1,2 @@
+name=singletonFooMock
+type=org.citrusframework.spi.mocks.SingletonFoo

--- a/core/citrus-api/src/test/resources/META-INF/mocksWithParams/fooWithParams
+++ b/core/citrus-api/src/test/resources/META-INF/mocksWithParams/fooWithParams
@@ -1,0 +1,2 @@
+name=fooWithParams
+type=org.citrusframework.spi.mocks.FooWithParams

--- a/core/citrus-spring/src/main/java/org/citrusframework/config/CitrusNamespaceParserRegistry.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/config/CitrusNamespaceParserRegistry.java
@@ -16,9 +16,9 @@
 
 package org.citrusframework.config;
 
-import java.util.HashMap;
 import java.util.Map;
 
+import java.util.concurrent.ConcurrentHashMap;
 import org.citrusframework.config.handler.CitrusTestCaseNamespaceHandler;
 import org.citrusframework.config.xml.*;
 import org.citrusframework.spi.ResourcePathTypeResolver;
@@ -44,7 +44,7 @@ public final class CitrusNamespaceParserRegistry {
     private static final ResourcePathTypeResolver TYPE_RESOLVER = new ResourcePathTypeResolver(RESOURCE_PATH);
 
     /** Parser registry as map */
-    private static final Map<String, BeanDefinitionParser> BEAN_PARSER = new HashMap<>();
+    private static final Map<String, BeanDefinitionParser> BEAN_PARSER = new ConcurrentHashMap<>();
 
     static {
         registerParser("testcase", new TestCaseParser());

--- a/runtime/citrus-yaml/src/main/java/org/citrusframework/yaml/actions/YamlTestActionBuilder.java
+++ b/runtime/citrus-yaml/src/main/java/org/citrusframework/yaml/actions/YamlTestActionBuilder.java
@@ -48,12 +48,12 @@ public interface YamlTestActionBuilder {
      * @return
      */
     static Map<String, TestActionBuilder<?>> lookup() {
-        Map<String, TestActionBuilder<?>> loader = TYPE_RESOLVER.resolveAll();
+        Map<String, TestActionBuilder<?>> builders = TYPE_RESOLVER.resolveAll();
 
         if (logger.isDebugEnabled()) {
-            loader.forEach((k, v) -> logger.debug(String.format("Found YAML test action builder '%s' as %s", k, v.getClass())));
+            builders.forEach((k, v) -> logger.debug(String.format("Found YAML test action builder '%s' as %s", k, v.getClass())));
         }
-        return loader;
+        return builders;
     }
 
     /**


### PR DESCRIPTION
Classpath scanning massively kicked in on our simulator, when a TestContext was created. Mainly due to the fact, that the org.citrusframework.variable.SegmentVariableExtractorRegistry uses the type resolver for each instance, although it could probably be a singelton.

Since the scan does a lot of file io, multiple, processes significantly slow down scenario execution time. This hold also true for parallel execution of tests, as they all try to access the limited file io resource.

I ended up implementing a caching of scanned resources in the ResourcePathTypeResolver. Although This patch solved our issues, please review carefully. 