### PR TITLE
fix(#1049): Starting JBang script support

### DIFF
--- a/core/citrus-api/src/main/java/org/citrusframework/CitrusSettings.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/CitrusSettings.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.logging.LogManager;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -65,7 +66,19 @@ public final class CitrusSettings {
             if (logger.isTraceEnabled()) {
                 logger.trace("Unable to locate Citrus application properties", e);
             } else {
-                logger.info("Unable to locate Citrus application properties");
+                logger.debug("Unable to locate Citrus application properties");
+            }
+        }
+
+        try (InputStream is = CitrusSettings.class.getClassLoader().getResourceAsStream("logging.properties")) {
+            if (is != null) {
+                LogManager.getLogManager().readConfiguration(is);
+            }
+        } catch (Exception e) {
+            if (logger.isTraceEnabled()) {
+                logger.trace("Unable to configure Java util logging", e);
+            } else {
+                logger.info("Unable to configure Java util logging");
             }
         }
     }

--- a/core/citrus-api/src/main/java/org/citrusframework/TestClass.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/TestClass.java
@@ -16,26 +16,23 @@
 
 package org.citrusframework;
 
+import org.citrusframework.exceptions.CitrusRuntimeException;
+
 /**
  * @author Christoph Deppisch
  * @since 2.7
  */
-public class TestClass {
+public class TestClass extends TestSource {
 
-    /** Test name and optional method */
-    private String name;
-    private String method;
+    /** Optional test method */
+    private final String method;
 
-    public TestClass() {
-        super();
+    public TestClass(Class<?> type) {
+        this(type, null);
     }
 
-    public TestClass(String name) {
-        this.name = name;
-    }
-
-    public TestClass(String name, String method) {
-        this(name);
+    public TestClass(Class<?> type, String method) {
+        super(type);
         this.method = method;
     }
 
@@ -49,33 +46,6 @@ public class TestClass {
     }
 
     /**
-     * Sets the method.
-     *
-     * @param method
-     */
-    public void setMethod(String method) {
-        this.method = method;
-    }
-
-    /**
-     * Gets the name.
-     *
-     * @return
-     */
-    public String getName() {
-        return name;
-    }
-
-    /**
-     * Sets the name.
-     *
-     * @param name
-     */
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    /**
      * Read String representation and construct proper test class instance. Read optional method name information and class name using format
      * "fully.qualified.class.Name#optionalMethodName()"
      *
@@ -83,20 +53,23 @@ public class TestClass {
      * @return
      */
     public static TestClass fromString(String testClass) {
-        String className;
-        String methodName = null;
-        if (testClass.contains("#")) {
-            className = testClass.substring(0, testClass.indexOf("#"));
-            methodName = testClass.substring(testClass.indexOf("#") + 1);
-        } else {
-            className = testClass;
-        }
+        try {
+            String className;
+            String methodName = null;
+            if (testClass.contains("#")) {
+                className = testClass.substring(0, testClass.indexOf("#"));
+                methodName = testClass.substring(testClass.indexOf("#") + 1);
+            } else {
+                className = testClass;
+            }
 
-        TestClass test = new TestClass(className);
-        if (methodName != null && !methodName.isBlank()) {
-            test.setMethod(methodName);
-        }
+            if (methodName != null && !methodName.isBlank()) {
+                return new TestClass(Class.forName(className), methodName);
+            }
 
-        return test;
+            return new TestClass(Class.forName(className));
+        } catch (ClassNotFoundException e) {
+            throw new CitrusRuntimeException("Failed to create test class", e);
+        }
     }
 }

--- a/core/citrus-api/src/main/java/org/citrusframework/TestSource.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/TestSource.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2006-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework;
+
+/**
+ * @author Christoph Deppisch
+ * @since 4.0
+ */
+public class TestSource {
+
+    /** Test type, name and optional sourceFile */
+    private final String type;
+    private final String name;
+    private final String filePath;
+
+    public TestSource(String type, String name) {
+        this(type, name, null);
+    }
+
+    public TestSource(String type, String name, String filePath) {
+        this.type = type;
+        this.name = name;
+        this.filePath = filePath;
+    }
+
+    public TestSource(Class<?> testClass) {
+        this("java", testClass.getName());
+    }
+
+    /**
+     * The test source type. Usually one of java, xml, groovy, yaml.
+     * @return
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * Gets the name.
+     * @return
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Optional source file path.
+     * @return
+     */
+    public String getFilePath() {
+        return filePath;
+    }
+}

--- a/core/citrus-api/src/main/java/org/citrusframework/main/TestRunConfiguration.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/main/TestRunConfiguration.java
@@ -25,7 +25,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.citrusframework.TestClass;
+import org.citrusframework.TestSource;
 
 /**
  * @author Christoph Deppisch
@@ -33,14 +33,14 @@ import org.citrusframework.TestClass;
  */
 public class TestRunConfiguration {
 
-    /** Test to execute at runtime */
+    /** Test engine */
     private String engine = "junit4";
 
     /** Test to execute at runtime */
-    private List<TestClass> testClasses = new ArrayList<>();
+    private final List<TestSource> sources = new ArrayList<>();
 
     /** Package to execute at runtime */
-    private List<String> packages = new ArrayList<>();
+    private final List<String> packages = new ArrayList<>();
 
     /** Include tests based on these test name pattern */
     private String[] includes = new String[] { "^.*IT$", "^.*ITCase$", "^IT.*$" };
@@ -68,21 +68,21 @@ public class TestRunConfiguration {
     }
 
     /**
-     * Gets the testClasses.
+     * Gets the sources.
      *
      * @return
      */
-    public List<TestClass> getTestClasses() {
-        return testClasses;
+    public List<TestSource> getTestSources() {
+        return sources;
     }
 
     /**
-     * Sets the testClasses.
+     * Sets the sources.
      *
-     * @param testClasses
+     * @param sources
      */
-    public void setTestClasses(List<TestClass> testClasses) {
-        this.testClasses = testClasses;
+    public void setTestSources(List<TestSource> sources) {
+        this.sources.addAll(sources);
     }
 
     /**
@@ -100,7 +100,7 @@ public class TestRunConfiguration {
      * @param packages
      */
     public void setPackages(List<String> packages) {
-        this.packages = packages;
+        this.packages.addAll(packages);
     }
 
     /**

--- a/core/citrus-base/src/main/java/org/citrusframework/main/scan/ClassPathTestScanner.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/main/scan/ClassPathTestScanner.java
@@ -72,7 +72,7 @@ public class ClassPathTestScanner extends AbstractTestScanner {
 
             return classes.stream()
                     .distinct()
-                    .map(TestClass::new)
+                    .map(TestClass::fromString)
                     .collect(Collectors.toList());
         } catch (IOException e) {
             throw new CitrusRuntimeException(String.format("Failed to scan classpath package '%s'", packageName), e);

--- a/core/citrus-base/src/main/java/org/citrusframework/main/scan/JarFileTestScanner.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/main/scan/JarFileTestScanner.java
@@ -57,7 +57,7 @@ public class JarFileTestScanner extends AbstractTestScanner {
                     String className = FileUtils.getBaseName(entry.getName()).replace( "/", "." );
                     if (packageToScan.replace( ".", "/" ).startsWith(entry.getName()) && isIncluded(className)) {
                         logger.info("Found test class candidate in test jar file: " +  entry.getName());
-                        testClasses.add(new TestClass(className));
+                        testClasses.add(TestClass.fromString(className));
                     }
                 }
             } catch (IOException e) {

--- a/core/citrus-base/src/main/java/org/citrusframework/util/FileUtils.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/util/FileUtils.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import java.util.Stack;
 
 import org.citrusframework.CitrusSettings;
+import org.citrusframework.TestSource;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.spi.Resource;
@@ -426,5 +427,18 @@ public abstract class FileUtils {
      */
     public static String constructContentType(String contentType, Charset charset) {
         return contentType + FILE_PATH_CHARSET_PARAMETER + charset;
+    }
+
+    /**
+     * Read String representation and construct proper test source instance.
+     * Extract source type from give file extension and try to set proper test source name from given file name.
+     *
+     * @param sourceFile
+     * @return
+     */
+    public static TestSource getTestSource(String sourceFile) {
+        String ext = getFileExtension(sourceFile);
+        String name = getFileName(sourceFile);
+        return new TestSource(ext, name, sourceFile);
     }
 }

--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -1,0 +1,9 @@
+{
+  "catalogs": {},
+  "aliases": {
+    "citrus": {
+      "script-ref": "tools/jbang/dist/CitrusJBang.java",
+      "description": "Run Citrus tests"
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,7 @@
     <angus-mail.version>2.0.2</angus-mail.version>
     <apache.ant.version>1.10.14</apache.ant.version>
     <apache.camel.version>4.1.0</apache.camel.version>
+    <ascii-table-version>1.8.0</ascii-table-version>
     <bouncycastle.version>1.76</bouncycastle.version>
     <byte.buddy.version>1.14.9</byte.buddy.version>
     <citrus.db.version>0.1.4</citrus.db.version>
@@ -202,6 +203,7 @@
     <jakarta.websocket-api.version>2.1.1</jakarta.websocket-api.version>
     <jakarta.xml.bind-api.version>4.0.1</jakarta.xml.bind-api.version>
     <jakarta.xml.soap-api.version>3.0.1</jakarta.xml.soap-api.version>
+    <jansi.version>2.4.0</jansi.version>
     <javapoet.version>1.13.0</javapoet.version>
     <jaxb.version>4.0.3</jaxb.version>
     <jetty.version>11.0.17</jetty.version>
@@ -223,6 +225,7 @@
     <mockftpserver.version>3.1.0</mockftpserver.version>
     <netty.version>4.1.100.Final</netty.version>
     <okhttp.version>4.12.0</okhttp.version>
+    <picoli-version>4.7.5</picoli-version>
     <saaj.version>3.0.3</saaj.version>
     <selenium.version>4.14.1</selenium.version>
     <slf4j.version>2.0.9</slf4j.version>
@@ -852,6 +855,18 @@
         <version>${json-schema-validator.version}</version>
       </dependency>
 
+      <!-- Citrus JBang -->
+      <dependency>
+        <groupId>info.picocli</groupId>
+        <artifactId>picocli</artifactId>
+        <version>${picoli-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.github.freva</groupId>
+        <artifactId>ascii-table</artifactId>
+        <version>${ascii-table-version}</version>
+      </dependency>
+
       <!-- Logging -->
       <dependency>
         <groupId>org.slf4j</groupId>
@@ -861,6 +876,11 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>jcl-over-slf4j</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>jul-to-slf4j</artifactId>
         <version>${slf4j.version}</version>
       </dependency>
       <dependency>
@@ -874,10 +894,22 @@
         <version>${log4j2.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-core</artifactId>
+        <version>${log4j2.version}</version>
+      </dependency>
+      <dependency>
         <groupId>commons-logging</groupId>
         <artifactId>commons-logging</artifactId>
         <version>${commons.logging.version}</version>
         <scope>provided</scope>
+      </dependency>
+
+      <!-- Color logging -->
+      <dependency>
+        <groupId>org.fusesource.jansi</groupId>
+        <artifactId>jansi</artifactId>
+        <version>${jansi.version}</version>
       </dependency>
 
       <dependency>
@@ -1100,6 +1132,11 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jul-to-slf4j</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/runtime/citrus-cucumber/src/main/resources/META-INF/citrus/engine/feature
+++ b/runtime/citrus-cucumber/src/main/resources/META-INF/citrus/engine/feature
@@ -1,0 +1,1 @@
+type=org.citrusframework.cucumber.CucumberTestEngine

--- a/runtime/citrus-cucumber/src/test/java/org/citrusframework/cucumber/CucumberTestEngineTest.java
+++ b/runtime/citrus-cucumber/src/test/java/org/citrusframework/cucumber/CucumberTestEngineTest.java
@@ -21,7 +21,7 @@ package org.citrusframework.cucumber;
 
 import java.util.Collections;
 
-import org.citrusframework.TestClass;
+import org.citrusframework.TestSource;
 import org.citrusframework.cucumber.integration.echo.EchoFeatureIT;
 import org.citrusframework.main.TestEngine;
 import org.citrusframework.main.TestRunConfiguration;
@@ -45,7 +45,7 @@ public class CucumberTestEngineTest {
     @Test
     public void testRunClass() {
         TestRunConfiguration configuration = new TestRunConfiguration();
-        configuration.setTestClasses(Collections.singletonList(new TestClass(EchoFeatureIT.class.getName())));
+        configuration.setTestSources(Collections.singletonList(new TestSource(EchoFeatureIT.class)));
 
         CucumberTestEngine engine = new CucumberTestEngine(configuration);
         engine.run();

--- a/runtime/citrus-groovy/src/test/resources/logging.properties
+++ b/runtime/citrus-groovy/src/test/resources/logging.properties
@@ -1,0 +1,21 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+.level=INFO
+handlers=org.slf4j.bridge.SLF4JBridgeHandler
+java.util.logging.ConsoleHandler.level=INFO
+java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter

--- a/runtime/citrus-junit/src/test/java/org/citrusframework/junit/JUnit4TestEngineTest.java
+++ b/runtime/citrus-junit/src/test/java/org/citrusframework/junit/JUnit4TestEngineTest.java
@@ -18,7 +18,7 @@ package org.citrusframework.junit;
 
 import java.util.Collections;
 
-import org.citrusframework.TestClass;
+import org.citrusframework.TestSource;
 import org.citrusframework.junit.scan.SampleJUnit4Test;
 import org.citrusframework.main.TestEngine;
 import org.citrusframework.main.TestRunConfiguration;
@@ -45,7 +45,7 @@ public class JUnit4TestEngineTest {
     @Test
     public void testRunClass() {
         TestRunConfiguration configuration = new TestRunConfiguration();
-        configuration.setTestClasses(Collections.singletonList(new TestClass(SampleJUnit4Test.class.getName())));
+        configuration.setTestSources(Collections.singletonList(new TestSource(SampleJUnit4Test.class)));
 
         runTestEngine(configuration, 0L, 1L);
     }

--- a/runtime/citrus-main/src/main/java/org/citrusframework/main/CitrusAppOptions.java
+++ b/runtime/citrus-main/src/main/java/org/citrusframework/main/CitrusAppOptions.java
@@ -24,7 +24,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.citrusframework.TestClass;
+import org.citrusframework.TestSource;
 import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.util.FileUtils;
 import org.citrusframework.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -152,19 +154,15 @@ public class CitrusAppOptions<T extends CitrusAppConfiguration> {
             protected void doProcess(T configuration, String arg, String value, LinkedList<String> remainingArgs) {
                 if (StringUtils.hasText(value)) {
 
-                    String className = value;
-                    String methodName = null;
-                    if (value.contains("#")) {
-                        className = value.substring(0, value.indexOf("#"));
-                        methodName = value.substring(value.indexOf("#") + 1);
+                    TestSource source;
+                    if (FileUtils.getFileExtension(value).isEmpty()) {
+                        // no file extension assume it is a Java class name
+                        source = TestClass.fromString(value);
+                    } else {
+                        source = FileUtils.getTestSource(value);
                     }
 
-                    TestClass testClass = new TestClass(className);
-                    if (StringUtils.hasText(methodName)) {
-                        testClass.setMethod(methodName);
-                    }
-
-                    configuration.getTestClasses().add(testClass);
+                    configuration.getTestSources().add(source);
                 } else {
                     throw new CitrusRuntimeException("Missing parameter value for -t/--test option");
                 }

--- a/runtime/citrus-testng/src/main/java/org/citrusframework/testng/main/TestNGCitrusTest.java
+++ b/runtime/citrus-testng/src/main/java/org/citrusframework/testng/main/TestNGCitrusTest.java
@@ -1,0 +1,106 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.testng.main;
+
+import org.citrusframework.Citrus;
+import org.citrusframework.TestCaseRunner;
+import org.citrusframework.annotations.CitrusAnnotations;
+import org.citrusframework.annotations.CitrusFramework;
+import org.citrusframework.annotations.CitrusResource;
+import org.citrusframework.annotations.CitrusTest;
+import org.citrusframework.common.TestLoader;
+import org.citrusframework.common.TestSourceAware;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.report.TestListeners;
+import org.citrusframework.testng.TestNGCitrusSupport;
+import org.citrusframework.util.FileUtils;
+import org.citrusframework.util.StringUtils;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Optional;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+/**
+ * TestNG test wrapper to run Citrus polyglot test definitions such as XML, YAML, Groovy.
+ * Usually this test is run with TestNG engine in a main CLI.
+ * The test is provided with test name and test source file parameters usually specified as part of the TestNG XML suite configuration.
+ * The test loads the polyglot Citrus test resource via respective test loader implementation.
+ *
+ * This is not supposed to be a valid base class for arbitrary Citrus Java test cases.
+ * For such as use case scenario please refer to the Citrus TestNG support classes instead.
+ */
+public class TestNGCitrusTest extends TestNGCitrusSupport {
+
+    public static final String TEST_NAME_PARAM = "name";
+    public static final String TEST_SOURCE_PARAM = "source";
+
+    @CitrusFramework
+    Citrus citrus;
+
+    @CitrusResource
+    private TestContext context;
+
+    private String name;
+    private String source;
+
+    @Parameters({ TEST_NAME_PARAM, TEST_SOURCE_PARAM })
+    @BeforeMethod
+    public void beforeTest(String name, String source) {
+        this.name = name;
+        this.source = source;
+    }
+
+    @Test
+    @CitrusTest
+    @Parameters( "runner" )
+    public void execute(@Optional @CitrusResource TestCaseRunner runner) {
+        String type;
+        if (StringUtils.hasText(source)) {
+            type = FileUtils.getFileExtension(source);
+        } else {
+            type = FileUtils.getFileExtension(name);
+        }
+
+        name(name);
+
+        TestLoader testLoader = TestLoader.lookup(type)
+                .orElseThrow(() -> new CitrusRuntimeException(String.format("Failed to resolve test loader for type %s", type)));
+
+        testLoader.setTestClass(this.getClass());
+        testLoader.setTestName(name);
+
+        if (testLoader instanceof TestSourceAware sourceAwareTestLoader) {
+            sourceAwareTestLoader.setSource(source);
+        }
+
+        TestListeners original = context.getTestListeners();
+        try {
+            // Remove all test listeners as test would be reported twice
+            context.setTestListeners(new TestListeners());
+            CitrusAnnotations.injectAll(testLoader, citrus, context);
+            CitrusAnnotations.injectTestRunner(testLoader, runner);
+            testLoader.load();
+        } finally {
+            // bring back original test listeners so test outcome is reported properly
+            context.setTestListeners(original);
+        }
+    }
+}

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/integration/inject/ResourceInjectionJavaIT.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/integration/inject/ResourceInjectionJavaIT.java
@@ -75,7 +75,7 @@ public class ResourceInjectionJavaIT extends TestNGCitrusSpringSupport {
     }
 
     @Test(dataProvider = "testData")
-    @CitrusParameters( { "data", "designer", "context" })
+    @CitrusParameters( { "data", "runner", "context" })
     @CitrusTest
     public void injectResourcesCombinedWithParameter(String data,
                                                     @CitrusResource TestCaseRunner runner,
@@ -101,7 +101,7 @@ public class ResourceInjectionJavaIT extends TestNGCitrusSpringSupport {
     }
 
     @Test(dataProvider = "testDataObjects")
-    @CitrusParameters( { "dataContainer", "designer", "context" })
+    @CitrusParameters( { "dataContainer", "runner", "context" })
     @CitrusTest
     public void injectResourcesCombinedWithObjectParameter(DataContainer dataContainer,
                                                           @CitrusResource TestCaseRunner runner,

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/testng/TestNGEngineTest.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/testng/TestNGEngineTest.java
@@ -19,6 +19,7 @@ package org.citrusframework.testng;
 import java.util.Collections;
 
 import org.citrusframework.TestClass;
+import org.citrusframework.TestSource;
 import org.citrusframework.main.TestEngine;
 import org.citrusframework.main.TestRunConfiguration;
 import org.citrusframework.testng.scan.SampleTestNGTest;
@@ -39,15 +40,23 @@ public class TestNGEngineTest {
         configuration.setIncludes(new String[] { ".*Test" });
         configuration.setPackages(Collections.singletonList(SampleTestNGTest.class.getPackage().getName()));
 
-        runTestEngine(configuration, 0L, 1L);
+        runTestEngine(configuration, 1L);
     }
 
     @Test
     public void testRunClass() {
         TestRunConfiguration configuration = new TestRunConfiguration();
-        configuration.setTestClasses(Collections.singletonList(new TestClass(SampleTestNGTest.class.getName())));
+        configuration.setTestSources(Collections.singletonList(new TestSource(SampleTestNGTest.class)));
 
-        runTestEngine(configuration, 0L, 1L);
+        runTestEngine(configuration, 1L);
+    }
+
+    @Test
+    public void testRunMethod() {
+        TestRunConfiguration configuration = new TestRunConfiguration();
+        configuration.setTestSources(Collections.singletonList(TestClass.fromString(SampleTestNGTest.class.getName() + "#sampleTest()")));
+
+        runTestEngine(configuration, 1L);
     }
 
     @Test
@@ -56,7 +65,7 @@ public class TestNGEngineTest {
         configuration.setIncludes(new String[] { ".*Foo" });
         configuration.setPackages(Collections.singletonList(SampleTestNGTest.class.getPackage().getName()));
 
-        runTestEngine(configuration, 0L, 0L);
+        runTestEngine(configuration, 0L);
     }
 
     @Test
@@ -66,12 +75,12 @@ public class TestNGEngineTest {
         Assert.assertEquals(TestEngine.lookup(configuration).getClass(), TestNGEngine.class);
     }
 
-    private void runTestEngine(TestRunConfiguration configuration, long failure, long passed) {
+    private void runTestEngine(TestRunConfiguration configuration, long passed) {
         TestNGEngine engine = new TestNGEngine(configuration);
         engine.addTestListener(new ISuiteListener() {
             @Override
             public void onFinish(ISuite suite) {
-                Assert.assertEquals(suite.getResults().values().iterator().next().getTestContext().getFailedTests().size(), failure);
+                Assert.assertEquals(suite.getResults().values().iterator().next().getTestContext().getFailedTests().size(), 0L);
                 Assert.assertEquals(suite.getResults().values().iterator().next().getTestContext().getPassedTests().size(), passed);
             }
 

--- a/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/main/TestNGEngineTest.java
+++ b/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/main/TestNGEngineTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2006-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaml.main;
+
+import java.util.Collections;
+
+import org.citrusframework.TestSource;
+import org.citrusframework.common.TestLoader;
+import org.citrusframework.main.TestRunConfiguration;
+import org.citrusframework.testng.TestNGEngine;
+import org.testng.Assert;
+import org.testng.ISuite;
+import org.testng.ISuiteListener;
+import org.testng.annotations.Test;
+
+/**
+ * @author Christoph Deppisch
+ * @since 2.7.4
+ */
+public class TestNGEngineTest {
+
+    @Test
+    public void testRunMethod() {
+        TestRunConfiguration configuration = new TestRunConfiguration();
+        configuration.setTestSources(Collections.singletonList(new TestSource(TestLoader.YAML, "echoTest", "org/citrusframework/yaml/actions/echo-test.yaml")));
+
+        TestNGEngine engine = new TestNGEngine(configuration);
+        engine.addTestListener(new ISuiteListener() {
+            @Override
+            public void onFinish(ISuite suite) {
+                Assert.assertEquals(suite.getResults().values().iterator().next().getTestContext().getFailedTests().size(), 0L);
+                Assert.assertEquals(suite.getResults().values().iterator().next().getTestContext().getPassedTests().size(), 1L);
+            }
+
+            @Override
+            public void onStart(ISuite suite) {
+            }
+        });
+        engine.run();
+    }
+
+}

--- a/tools/jbang/dist/CitrusJBang.java
+++ b/tools/jbang/dist/CitrusJBang.java
@@ -1,0 +1,42 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//JAVA 17+
+//REPOS mavencentral
+//DEPS org.citrusframework:citrus:${citrus.jbang.version:4.1.0-SNAPSHOT}@pom
+//DEPS org.citrusframework:citrus-base:${citrus.jbang.version:4.1.0-SNAPSHOT}
+//DEPS org.citrusframework:citrus-main:${citrus.jbang.version:4.1.0-SNAPSHOT}
+//DEPS org.citrusframework:citrus-jbang:${citrus.jbang.version:4.1.0-SNAPSHOT}
+//DEPS org.citrusframework:citrus-groovy:${citrus.jbang.version:4.1.0-SNAPSHOT}
+//DEPS org.citrusframework:citrus-xml:${citrus.jbang.version:4.1.0-SNAPSHOT}
+//DEPS org.citrusframework:citrus-yaml:${citrus.jbang.version:4.1.0-SNAPSHOT}
+package main;
+
+import org.citrusframework.jbang.CitrusJBangMain;
+
+/**
+ * Main to run CitrusJBang
+ */
+public class CitrusJBang {
+
+    public static void main(String... args) {
+        CitrusJBangMain.run(args);
+    }
+
+}

--- a/tools/jbang/pom.xml
+++ b/tools/jbang/pom.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.citrusframework</groupId>
+    <artifactId>citrus-tools</artifactId>
+    <version>4.1.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>citrus-jbang</artifactId>
+  <name>Citrus :: Tools :: JBang</name>
+  <description>Citrus JBang</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.citrusframework</groupId>
+      <artifactId>citrus-base</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.citrusframework</groupId>
+      <artifactId>citrus-main</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <!-- CLI -->
+    <dependency>
+      <groupId>info.picocli</groupId>
+      <artifactId>picocli</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.github.freva</groupId>
+      <artifactId>ascii-table</artifactId>
+    </dependency>
+
+    <!-- Logging -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jul-to-slf4j</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
+    <!-- Color logging -->
+    <dependency>
+      <groupId>org.fusesource.jansi</groupId>
+      <artifactId>jansi</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>${maven.resource.plugin.version}</version>
+        <executions>
+          <execution>
+            <id>copy-jbang-main</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${basedir}/dist</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${project.build.sourceDirectory}/main</directory>
+                  <includes>
+                    <include>*.java</include>
+                  </includes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>${maven.antrun.plugin.version}</version>
+        <executions>
+          <execution>
+            <phase>prepare-package</phase>
+            <configuration>
+              <target>
+                <chmod file="${basedir}/dist/*.java" perm="u+x" />
+              </target>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/tools/jbang/src/main/java/main/CitrusJBang.java
+++ b/tools/jbang/src/main/java/main/CitrusJBang.java
@@ -1,0 +1,42 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//JAVA 17+
+//REPOS mavencentral
+//DEPS org.citrusframework:citrus:${citrus.jbang.version:4.1.0-SNAPSHOT}@pom
+//DEPS org.citrusframework:citrus-base:${citrus.jbang.version:4.1.0-SNAPSHOT}
+//DEPS org.citrusframework:citrus-main:${citrus.jbang.version:4.1.0-SNAPSHOT}
+//DEPS org.citrusframework:citrus-jbang:${citrus.jbang.version:4.1.0-SNAPSHOT}
+//DEPS org.citrusframework:citrus-groovy:${citrus.jbang.version:4.1.0-SNAPSHOT}
+//DEPS org.citrusframework:citrus-xml:${citrus.jbang.version:4.1.0-SNAPSHOT}
+//DEPS org.citrusframework:citrus-yaml:${citrus.jbang.version:4.1.0-SNAPSHOT}
+package main;
+
+import org.citrusframework.jbang.CitrusJBangMain;
+
+/**
+ * Main to run CitrusJBang
+ */
+public class CitrusJBang {
+
+    public static void main(String... args) {
+        CitrusJBangMain.run(args);
+    }
+
+}

--- a/tools/jbang/src/main/java/org/citrusframework/jbang/CitrusJBangMain.java
+++ b/tools/jbang/src/main/java/org/citrusframework/jbang/CitrusJBangMain.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.jbang;
+
+import java.util.concurrent.Callable;
+
+import org.citrusframework.jbang.commands.Complete;
+import org.citrusframework.jbang.commands.Init;
+import org.citrusframework.jbang.commands.ListTests;
+import org.citrusframework.jbang.commands.Run;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+@Command(name = "citrus", description = "Citrus JBang CLI", mixinStandardHelpOptions = true)
+public class CitrusJBangMain implements Callable<Integer> {
+    private static CommandLine commandLine;
+
+    public static void run(String... args) {
+        CitrusJBangMain main = new CitrusJBangMain();
+        commandLine = new CommandLine(main)
+                .addSubcommand("init", new CommandLine(new Init(main)))
+                .addSubcommand("run", new CommandLine(new Run(main)))
+                .addSubcommand("ls", new CommandLine(new ListTests(main)))
+                .addSubcommand("completion", new CommandLine(new Complete(main)));
+
+        commandLine.getCommandSpec().versionProvider(() -> new String[] { "4.1.0-SNAPSHOT" });
+
+        int exitCode = commandLine.execute(args);
+        System.exit(exitCode);
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        commandLine.execute("--help");
+        return 0;
+    }
+
+}

--- a/tools/jbang/src/main/java/org/citrusframework/jbang/JsonSupport.java
+++ b/tools/jbang/src/main/java/org/citrusframework/jbang/JsonSupport.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.jbang;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+public class JsonSupport {
+
+    private static final ObjectMapper OBJECT_MAPPER;
+
+    static {
+        OBJECT_MAPPER = new ObjectMapper()
+                .setDefaultPropertyInclusion(JsonInclude.Value.construct(JsonInclude.Include.NON_EMPTY, JsonInclude.Include.NON_EMPTY))
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING)
+                .enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING)
+                .disable(JsonParser.Feature.AUTO_CLOSE_SOURCE)
+                .enable(MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES);
+    }
+
+    public static ObjectMapper json() {
+        return OBJECT_MAPPER;
+    }
+
+}

--- a/tools/jbang/src/main/java/org/citrusframework/jbang/LoggingSupport.java
+++ b/tools/jbang/src/main/java/org/citrusframework/jbang/LoggingSupport.java
@@ -1,0 +1,81 @@
+/*
+ *  Copyright 2023 the original author or authors.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements. See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.citrusframework.jbang;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
+
+public class LoggingSupport {
+
+    private static final AtomicBoolean LOG_INIT_DONE = new AtomicBoolean();
+
+    private LoggingSupport() {
+        // prevent instantiation of utility class
+    }
+
+    public static void configureLog(
+            String level, boolean color, String engine) {
+        if (LOG_INIT_DONE.compareAndSet(false, true)) {
+            long pid = ProcessHandle.current().pid();
+            System.setProperty("pid", Long.toString(pid));
+
+            if ("cucumber".equals(engine)) {
+                Configurator.initialize("CitrusJBang", "log4j2-cucumber.properties");
+            } else if (!color) {
+                Configurator.initialize("CitrusJBang", "log4j2-no-color.properties");
+            } else {
+                Configurator.initialize("CitrusJBang", "log4j2.properties");
+            }
+        }
+
+        setRootLoggingLevel(level);
+    }
+
+    public static void setRootLoggingLevel(String level) {
+        if (level != null) {
+            level = level.toLowerCase();
+
+            switch (level) {
+                case "off" -> Configurator.setRootLevel(Level.OFF);
+                case "trace" -> Configurator.setRootLevel(Level.TRACE);
+                case "debug" -> Configurator.setRootLevel(Level.DEBUG);
+                case "info" -> Configurator.setRootLevel(Level.INFO);
+                case "warn" -> Configurator.setRootLevel(Level.WARN);
+                case "error" -> Configurator.setRootLevel(Level.ERROR);
+                case "fatal" -> Configurator.setRootLevel(Level.FATAL);
+                default -> {
+                    Configurator.setRootLevel(Level.INFO);
+                }
+            }
+        }
+    }
+
+    public static class LoggingLevels implements Iterable<String> {
+
+        @Override
+        public Iterator<String> iterator() {
+            return List.of("ERROR", "WARN", "INFO", "DEBUG", "TRACE").iterator();
+        }
+    }
+}

--- a/tools/jbang/src/main/java/org/citrusframework/jbang/commands/CitrusCommand.java
+++ b/tools/jbang/src/main/java/org/citrusframework/jbang/commands/CitrusCommand.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.citrusframework.jbang.commands;
+
+import java.io.File;
+import java.util.Stack;
+import java.util.concurrent.Callable;
+
+import org.citrusframework.jbang.CitrusJBangMain;
+import picocli.CommandLine;
+import picocli.CommandLine.IParameterConsumer;
+import picocli.CommandLine.Model.ArgSpec;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.ParameterException;
+
+public abstract class CitrusCommand implements Callable<Integer> {
+
+    @CommandLine.Spec
+    CommandSpec spec;
+
+    private final CitrusJBangMain main;
+    private File citrusDir;
+
+    //CHECKSTYLE:OFF
+    @CommandLine.Option(names = { "-h", "--help" }, usageHelp = true, description = "Display the help and sub-commands")
+    private boolean helpRequested = false;
+    //CHECKSTYLE:ON
+
+    public CitrusCommand(CitrusJBangMain main) {
+        this.main = main;
+    }
+
+    public CitrusJBangMain getMain() {
+        return main;
+    }
+
+    public File getStatusFile(String pid) {
+        if (citrusDir == null) {
+            citrusDir = new File(System.getProperty("user.home"), ".citrus");
+        }
+        return new File(citrusDir, pid + "-status.json");
+    }
+
+    public File getOutputFile(String pid) {
+        if (citrusDir == null) {
+            citrusDir = new File(System.getProperty("user.home"), ".citrus");
+        }
+        return new File(citrusDir, pid + "-output.json");
+    }
+
+    protected abstract static class ParameterConsumer<T> implements IParameterConsumer {
+
+        @Override
+        public void consumeParameters(Stack<String> args, ArgSpec argSpec, CommandSpec cmdSpec) {
+            if (args.isEmpty()) {
+                throw new ParameterException(cmdSpec.commandLine(), "Error: missing required parameter");
+            }
+            T cmd = (T) cmdSpec.userObject();
+            doConsumeParameters(args, cmd);
+        }
+
+        protected abstract void doConsumeParameters(Stack<String> args, T cmd);
+    }
+
+}

--- a/tools/jbang/src/main/java/org/citrusframework/jbang/commands/Complete.java
+++ b/tools/jbang/src/main/java/org/citrusframework/jbang/commands/Complete.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.citrusframework.jbang.commands;
+
+import java.io.PrintStream;
+
+import org.citrusframework.jbang.CitrusJBangMain;
+import picocli.AutoComplete;
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "complete", description = "Generate completion script for bash/zsh")
+public class Complete extends CitrusCommand {
+
+    public Complete(CitrusJBangMain main) {
+        super(main);
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        String script = AutoComplete.bash(
+                spec.parent().name(),
+                spec.parent().commandLine());
+
+        // not PrintWriter.println: scripts with Windows line separators fail in strange
+        // ways!
+        PrintStream out = System.out;
+        out.print(script);
+        out.print('\n');
+        out.flush();
+        return 0;
+    }
+
+}

--- a/tools/jbang/src/main/java/org/citrusframework/jbang/commands/Init.java
+++ b/tools/jbang/src/main/java/org/citrusframework/jbang/commands/Init.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.citrusframework.jbang.commands;
+
+import java.io.File;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Stack;
+
+import org.citrusframework.util.FileUtils;
+import org.citrusframework.jbang.CitrusJBangMain;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+@Command(name = "init", description = "Creates a new Citrus test")
+public class Init extends CitrusCommand {
+
+    @Parameters(description = "Name of integration file (or a github link)", arity = "1",
+                paramLabel = "<file>", parameterConsumer = FileConsumer.class)
+    private Path filePath; // Defined only for file path completion; the field never used
+
+    private String file;
+
+    @Option(names = {
+            "-dir",
+            "--directory" }, description = "Directory where the files will be created", defaultValue = ".")
+    private String directory;
+
+    public Init(CitrusJBangMain main) {
+        super(main);
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        String ext = FileUtils.getFileExtension(file);
+        String name = FileUtils.getBaseName(file);
+        String content;
+        try (InputStream is = Init.class.getClassLoader().getResourceAsStream("templates/" + ext + ".tmpl")) {
+            if (is == null) {
+                System.out.println("Error: Unsupported file type: " + ext);
+                return 1;
+            }
+            content = FileUtils.readToString(is, StandardCharsets.UTF_8);
+        }
+
+        if (!directory.equals(".")) {
+            File dir = new File(directory);
+            // ensure target dir is created
+            dir.mkdirs();
+        }
+        File target = new File(directory, file);
+        content = content.replaceFirst("\\{\\{ \\.Name }}", name);
+
+        Files.write(target.toPath(), content.getBytes(StandardCharsets.UTF_8));
+        return 0;
+    }
+
+    static class FileConsumer extends ParameterConsumer<Init> {
+        @Override
+        protected void doConsumeParameters(Stack<String> args, Init cmd) {
+            String arg = args.pop();
+            cmd.file = arg;
+        }
+    }
+
+}

--- a/tools/jbang/src/main/java/org/citrusframework/jbang/commands/ListTests.java
+++ b/tools/jbang/src/main/java/org/citrusframework/jbang/commands/ListTests.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.citrusframework.jbang.commands;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.citrusframework.util.FileUtils;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.freva.asciitable.AsciiTable;
+import com.github.freva.asciitable.Column;
+import com.github.freva.asciitable.HorizontalAlign;
+import com.github.freva.asciitable.OverflowBehaviour;
+import main.CitrusJBang;
+import org.citrusframework.jbang.JsonSupport;
+import org.citrusframework.jbang.CitrusJBangMain;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+@Command(name = "ls", description = "List running Citrus tests")
+public class ListTests extends CitrusCommand {
+
+    @CommandLine.Option(names = { "--sort" },
+                        description = "Sort by pid, name or age", defaultValue = "pid")
+    String sort;
+
+    @CommandLine.Option(names = { "--pid" },
+                        description = "List only pid in the output")
+    boolean pid;
+
+    public ListTests(CitrusJBangMain main) {
+        super(main);
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        List<Row> rows = new ArrayList<>();
+
+        final long cur = ProcessHandle.current().pid();
+        ProcessHandle.allProcesses()
+                .filter(ph -> ph.pid() != cur)
+                .forEach(ph -> {
+                    if (ph.info().commandLine().orElse("").contains(CitrusJBang.class.getSimpleName())) {
+                        Row row = new Row();
+                        row.pid = "" + ph.pid();
+                        row.uptime = extractSince(ph);
+                        row.ago = printSince(row.uptime);
+                        row.name = extractName(ph);
+                        row.status = ph.isAlive() ? "Running" : "Finished";
+                        rows.add(row);
+                    }
+                });
+
+        // sort rows
+        rows.sort(this::sortRow);
+
+        if (pid) {
+            rows.forEach(r -> System.out.println(r.pid));
+        } else {
+            System.out.println(AsciiTable.getTable(AsciiTable.NO_BORDERS, rows, Arrays.asList(
+                    new Column().header("PID").headerAlign(HorizontalAlign.CENTER).with(r -> r.pid),
+                    new Column().header("NAME").dataAlign(HorizontalAlign.LEFT)
+                            .maxWidth(40, OverflowBehaviour.ELLIPSIS_RIGHT)
+                            .with(r -> r.name),
+                    new Column().header("STATUS").headerAlign(HorizontalAlign.CENTER).with(r -> r.status),
+                    new Column().header("AGE").headerAlign(HorizontalAlign.CENTER).with(r -> r.ago))));
+        }
+
+        return 0;
+    }
+
+    private String extractName(ProcessHandle ph) {
+        String cl = ph.info().commandLine().orElse("");
+        String citrusJBangRun = String.format("main.%s run ", CitrusJBang.class.getSimpleName());
+        if (cl.contains(citrusJBangRun)) {
+            return cl.substring(cl.indexOf(citrusJBangRun) + citrusJBangRun.length());
+        }
+
+        return "";
+    }
+
+    private String printSince(long timestamp) {
+        long age = System.currentTimeMillis() - timestamp;
+        Duration duration = Duration.ofMillis(age);
+
+        StringBuilder sb = new StringBuilder();
+        if (duration.toDays() > 0) {
+            sb.append(duration.toDays()).append("d").append(duration.toHours() % 24).append("h");
+        } else if (duration.toHours() > 0) {
+            sb.append(duration.toHours() % 24).append("h").append(duration.toMinutes() % 60).append("m");
+        } else if (duration.toMinutes() > 0) {
+            sb.append(duration.toMinutes() % 60).append("m").append(duration.toSeconds() % 60).append("s");
+        } else if (duration.toSeconds() > 0) {
+            sb.append(duration.toSeconds() % 60).append("s");
+        } else if (duration.toMillis() > 0) {
+            // less than a second so just report it as zero
+            sb.append("0s");
+        }
+
+        return sb.toString();
+    }
+
+    protected int sortRow(Row o1, Row o2) {
+        String s = sort;
+        int negate = 1;
+        if (s.startsWith("-")) {
+            s = s.substring(1);
+            negate = -1;
+        }
+        switch (s) {
+            case "pid":
+                return Long.compare(Long.parseLong(o1.pid), Long.parseLong(o2.pid)) * negate;
+            case "name":
+                return o1.name.compareToIgnoreCase(o2.name) * negate;
+            case "age":
+                return Long.compare(o1.uptime, o2.uptime) * negate;
+            default:
+                return 0;
+        }
+    }
+
+    private JsonNode loadStatus(long pid) {
+        try {
+            File f = getStatusFile("" + pid);
+            if (f != null && f.exists()) {
+                try (FileInputStream fis = new FileInputStream(f)) {
+                    String text = FileUtils.readToString(fis);
+                    return JsonSupport.json().reader().readTree(text);
+                }
+            }
+        } catch (IOException e) {
+            // ignore
+        }
+        return null;
+    }
+
+    static long extractSince(ProcessHandle ph) {
+        long since = 0;
+        if (ph.info().startInstant().isPresent()) {
+            since = ph.info().startInstant().get().toEpochMilli();
+        }
+        return since;
+    }
+
+    private static class Row {
+        String pid;
+        String name;
+        String status;
+        String ago;
+        long uptime;
+    }
+
+}

--- a/tools/jbang/src/main/java/org/citrusframework/jbang/commands/Run.java
+++ b/tools/jbang/src/main/java/org/citrusframework/jbang/commands/Run.java
@@ -1,0 +1,295 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.citrusframework.jbang.commands;
+
+import java.awt.*;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.UnsupportedFlavorException;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Stack;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.citrusframework.CitrusInstanceManager;
+import org.citrusframework.jbang.CitrusJBangMain;
+import org.citrusframework.jbang.LoggingSupport;
+import org.citrusframework.main.TestEngine;
+import org.citrusframework.main.TestRunConfiguration;
+import org.citrusframework.report.TestReporter;
+import org.citrusframework.report.TestResults;
+import org.citrusframework.util.FileUtils;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+@Command(name = "run", description = "Run as local Citrus test")
+public class Run extends CitrusCommand {
+
+    public static final String WORK_DIR = ".citrus-jbang";
+
+    private static final String[] ACCEPTED_FILE_EXT
+            = new String[] { ".feature", "test.groovy", "it.groovy", "test.yaml", "it.yaml",
+            "Test.xml", "IT.xml", "test.xml", "it.xml", "Test.java", "IT.java", "TestCase.java", "ITCase.java" };
+
+    private static final String CLIPBOARD_GENERATED_FILE = WORK_DIR + "/generated-clipboard";
+
+    private static final Pattern PACKAGE_PATTERN = Pattern.compile(
+            "^\\s*package\\s+([a-zA-Z][\\.\\w]*)\\s*;.*$", Pattern.MULTILINE);
+
+    private static final Pattern CLASS_PATTERN = Pattern.compile(
+            "^\\s*public class\\s+([a-zA-Z0-9]*)[\\s+|;].*$", Pattern.MULTILINE);
+
+    @Option(names = { "--logging" }, defaultValue = "true", description = "Can be used to turn off logging")
+    private boolean logging = true;
+
+    @Option(names = { "--logging-level" }, completionCandidates = LoggingSupport.LoggingLevels.class,
+            defaultValue = "info", description = "Logging level")
+    private String loggingLevel;
+
+    @Option(names = { "--logging-color" }, defaultValue = "true", description = "Use colored logging")
+    private boolean loggingColor = true;
+
+    @Parameters(description = "The test file(s) to run. If no files specified then application.properties is used as source for which files to run.",
+                arity = "0..9", paramLabel = "<files>", parameterConsumer = FilesConsumer.class)
+    Path[] filePaths; // Defined only for file path completion; the field never used
+
+    String[] files;
+
+    public Run(CitrusJBangMain main) {
+        super(main);
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        return run();
+    }
+
+    private int run() throws Exception {
+        File work = new File(WORK_DIR);
+        removeDir(work);
+        if (!work.mkdirs()) {
+            System.err.println("Failed to create working directory " + WORK_DIR);
+            return 1;
+        }
+
+        // if no specific file to run then try to auto-detect
+        if (files == null || files.length == 0) {
+            // auto-detect test files
+            files = new File(".").list((dir, name) -> Arrays.stream(ACCEPTED_FILE_EXT).anyMatch(name::endsWith));
+        }
+
+        // filter out duplicate files
+        if (files != null && files.length > 0) {
+            files = Arrays.stream(files).distinct().toArray(String[]::new);
+        }
+
+        List<String> tests = new ArrayList<>();
+        if (files != null) {
+            for (String file : files) {
+                if (file.startsWith("clipboard") && !(new File(file).exists())) {
+                    file = loadFromClipboard(file);
+                } else if (skipFile(file)) {
+                    continue;
+                }
+
+                // check if file exist
+                File inputFile = FileUtils.getFileResource(file).getFile();
+                if (!inputFile.exists() && !inputFile.isFile()) {
+                    System.err.println("File does not exist: " + file);
+                    return 1;
+                }
+
+                tests.add(file);
+            }
+        }
+
+        if (tests.isEmpty()) {
+            System.err.println("No tests to run in current directory");
+            return 1;
+        }
+
+        final TestRunConfiguration configuration = getRunConfiguration(tests);
+        final TestEngine engine = TestEngine.lookup(configuration);
+        final ExitStatusTestReporter exitStatus = new ExitStatusTestReporter();
+        CitrusInstanceManager.addInstanceProcessor(instance -> instance.addTestReporter(exitStatus));
+
+        if (logging) {
+            LoggingSupport.configureLog(loggingLevel, loggingColor, configuration.getEngine());
+        } else {
+            LoggingSupport.configureLog("off", false, configuration.getEngine());
+        }
+
+        engine.run();
+        return exitStatus.exitStatus();
+    }
+
+    private TestRunConfiguration getRunConfiguration(List<String> files) {
+        TestRunConfiguration configuration = new TestRunConfiguration();
+
+        String ext = FileUtils.getFileExtension(files.get(0));
+        if (ext.equals("feature")) {
+            configuration.setEngine("cucumber");
+        } else {
+            configuration.setEngine("testng");
+        }
+
+        configuration.setTestSources(files.stream()
+                .map(FileUtils::getTestSource)
+                .collect(Collectors.toList()));
+
+        return configuration;
+    }
+
+    private String loadFromClipboard(String file) throws UnsupportedFlavorException, IOException {
+        // run from clipboard (not real file exists)
+        String ext = FileUtils.getFileExtension(file);
+        if (ext.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "When running from clipboard, an extension is required to let Citrus know what kind of file to use");
+        }
+        Clipboard c = Toolkit.getDefaultToolkit().getSystemClipboard();
+        Object t = c.getData(DataFlavor.stringFlavor);
+        if (t != null) {
+            String fn = CLIPBOARD_GENERATED_FILE + "." + ext;
+            if ("java".equals(ext)) {
+                String fqn = determineClassName(t.toString());
+                if (fqn == null) {
+                    throw new IllegalArgumentException(
+                            "Cannot determine the Java class name from the source in the clipboard");
+                }
+                fn = fqn + ".java";
+            }
+            Files.writeString(Paths.get(fn), t.toString());
+            file = "file:" + fn;
+        }
+        return file;
+    }
+
+    private boolean skipFile(String name) {
+        if (name.startsWith(".")) {
+            return true;
+        }
+        if ("pom.xml".equalsIgnoreCase(name)) {
+            return true;
+        }
+        if ("build.gradle".equalsIgnoreCase(name)) {
+            return true;
+        }
+
+        // skip dirs
+        File f = new File(name);
+        if (f.exists() && f.isDirectory()) {
+            return true;
+        }
+
+        String on = FileUtils.getBaseName(name);
+        on = on.toLowerCase(Locale.ROOT);
+        if (on.endsWith("readme")) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static void removeDir(File d) {
+        String[] list = d.list();
+        if (list == null) {
+            list = new String[0];
+        }
+        for (String s : list) {
+            File f = new File(d, s);
+            if (f.isDirectory()) {
+                removeDir(f);
+            } else {
+                delete(f);
+            }
+        }
+        delete(d);
+    }
+
+    private static void delete(File f) {
+        if (!f.delete()) {
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException ex) {
+                // Ignore Exception
+            }
+            if (!f.delete()) {
+                f.deleteOnExit();
+            }
+        }
+    }
+
+    private static String determineClassName(String content) {
+        Matcher matcher = PACKAGE_PATTERN.matcher(content);
+        String pn = matcher.find() ? matcher.group(1) : null;
+
+        matcher = CLASS_PATTERN.matcher(content);
+        String cn = matcher.find() ? matcher.group(1) : null;
+
+        String fqn;
+        if (pn != null) {
+            fqn = pn + "." + cn;
+        } else {
+            fqn = cn;
+        }
+        return fqn;
+    }
+
+    static class FilesConsumer extends ParameterConsumer<Run> {
+        @Override
+        protected void doConsumeParameters(Stack<String> args, Run cmd) {
+            List<String> files = new ArrayList<>();
+            while (!args.isEmpty()) {
+                String arg = args.pop();
+                files.add(arg);
+            }
+            cmd.files = files.toArray(String[]::new);
+        }
+    }
+
+    /**
+     * Special test reporter provides proper exit status based on successful/failed tests.
+     */
+    private static class ExitStatusTestReporter implements TestReporter {
+        private static final int DEFAULT = 0;
+        private static final int ERRORS = 1;
+
+        private int exitStatus = DEFAULT;
+
+        @Override
+        public void generateReport(TestResults testResults) {
+            if (testResults.getFailed() > 0) {
+                exitStatus = ERRORS;
+            }
+        }
+
+        int exitStatus() {
+            return exitStatus;
+        }
+    }
+}

--- a/tools/jbang/src/main/resources/citrus-application.properties
+++ b/tools/jbang/src/main/resources/citrus-application.properties
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+citrus.default.message.type=JSON

--- a/tools/jbang/src/main/resources/cucumber.properties
+++ b/tools/jbang/src/main/resources/cucumber.properties
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+cucumber.object-factory=org.citrusframework.cucumber.backend.CitrusObjectFactory
+cucumber.glue=org.citrusframework.yaks
+cucumber.plugin=pretty
+cucumber.publish.quiet=true

--- a/tools/jbang/src/main/resources/log4j2-cucumber.properties
+++ b/tools/jbang/src/main/resources/log4j2-cucumber.properties
@@ -1,0 +1,32 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+#
+# The logging properties used
+# Extra logging related to initialization of Log4j
+# Set to debug or trace if log4j initialization is failing
+status = warn
+
+# Console appender configuration
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+# logging style that is similar to Cucumber
+appender.console.layout.pattern = %-5level| %msg%n
+
+# Root logger level
+rootLogger = INFO, STDOUT

--- a/tools/jbang/src/main/resources/log4j2-no-color.properties
+++ b/tools/jbang/src/main/resources/log4j2-no-color.properties
@@ -1,0 +1,32 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+#
+# The logging properties used
+# Extra logging related to initialization of Log4j
+# Set to debug or trace if log4j initialization is failing
+status = warn
+
+# Console appender configuration
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+# logging style that is similar to spring boot (no color)
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS} %5p %pid --- [%15.15t] %-35.35c : %m%n
+
+# Root logger level
+rootLogger = INFO, STDOUT

--- a/tools/jbang/src/main/resources/log4j2.properties
+++ b/tools/jbang/src/main/resources/log4j2.properties
@@ -1,0 +1,32 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+#
+# The logging properties used
+# Extra logging related to initialization of Log4j
+# Set to debug or trace if log4j initialization is failing
+status = warn
+
+# Console appender configuration
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+# logging style that is similar to spring boot
+appender.console.layout.pattern = %style{%d{yyyy-MM-dd HH:mm:ss.SSS}}{Dim} %highlight{%5p} %style{%pid}{Magenta} %style{---}{Dim} %style{[%15.15t]}{Dim} %style{%-35.35c}{Cyan} : %m%n
+
+# Root logger level
+rootLogger = INFO, STDOUT

--- a/tools/jbang/src/main/resources/logging.properties
+++ b/tools/jbang/src/main/resources/logging.properties
@@ -1,0 +1,21 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+.level=SEVERE
+handlers=org.slf4j.bridge.SLF4JBridgeHandler
+java.util.logging.ConsoleHandler.level=SEVERE
+java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter

--- a/tools/jbang/src/main/resources/templates/feature.tmpl
+++ b/tools/jbang/src/main/resources/templates/feature.tmpl
@@ -1,0 +1,8 @@
+Feature: {{ .Name }}
+
+Background:
+  Given variables
+    | message | "Citrus rocks!" |
+
+  Scenario: Print message
+    Then print ${message}

--- a/tools/jbang/src/main/resources/templates/groovy.tmpl
+++ b/tools/jbang/src/main/resources/templates/groovy.tmpl
@@ -1,0 +1,5 @@
+variables {
+    message = "Citrus rocks!"
+}
+
+$(echo('${message}'))

--- a/tools/jbang/src/main/resources/templates/xml.tmpl
+++ b/tools/jbang/src/main/resources/templates/xml.tmpl
@@ -1,0 +1,12 @@
+<test name="{{ .Name }}" author="Citrus" status="FINAL" xmlns="http://citrusframework.org/schema/xml/testcase"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://citrusframework.org/schema/xml/testcase http://citrusframework.org/schema/xml/testcase/citrus-testcase.xsd">
+  <description>Sample test in XML</description>
+  <variables>
+    <variable name="message" value="Citrus rocks!"/>
+  </variables>
+
+  <actions>
+    <echo message="${message}"/>
+  </actions>
+</test>

--- a/tools/jbang/src/main/resources/templates/yaml.tmpl
+++ b/tools/jbang/src/main/resources/templates/yaml.tmpl
@@ -1,0 +1,10 @@
+name: {{ .Name }}
+author: Citrus
+status: FINAL
+description: Sample test in YAML
+variables:
+  - name: message
+    value: Citrus rocks!
+actions:
+  - echo:
+      message: "${message}"

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -18,6 +18,7 @@
     <module>test-generator</module>
     <module>docs-generator</module>
     <module>maven</module>
+    <module>jbang</module>
     <module>archetypes</module>
   </modules>
 


### PR DESCRIPTION
- Introduce TestSource model that holds polyglot test sources (.xml, .yaml, .groovy, .feature)
- Enhance TestNG TestEngine implementation to support running polyglot Citrus tests (xml, yaml, groovy)
- Enhance Cucumber TestEngine to properly handle feature files passed to the run command
- Introduce citrus-jbang module in tools
- Add JBang catalog pointing to Citrus JBang CLI script
- Add CitrusJBangMain script with following commands
- Init command to create test template (.yaml, .xml, .groovy, .feature)
- ListTests command list all running tests
- Run command able to run tests via TestEngine API
- Fix java util logging to send all log events to SLF4J