### PR TITLE
fix(#1055): Avoid duplicate loading of configuration classes

### DIFF
--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/groovy/AbstractGroovyActionDslTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/groovy/AbstractGroovyActionDslTest.java
@@ -63,6 +63,10 @@ public class AbstractGroovyActionDslTest extends AbstractTestNGUnitTest {
         when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
         when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
         when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        doAnswer(invocationOnMock -> {
+            CitrusAnnotations.parseConfiguration(invocationOnMock.getArgument(0, Object.class), citrusContext);
+            return null;
+        }).when(citrusContext).parseConfiguration((Object) any());
         CitrusAnnotations.injectAll(this, citrus, context);
         return context;
     }

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/xml/AbstractXmlActionTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/xml/AbstractXmlActionTest.java
@@ -32,6 +32,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeClass;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
 /**
@@ -56,6 +58,10 @@ public class AbstractXmlActionTest extends AbstractTestNGUnitTest {
         when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
         when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
         when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        doAnswer(invocationOnMock -> {
+            CitrusAnnotations.parseConfiguration(invocationOnMock.getArgument(0, Object.class), citrusContext);
+            return null;
+        }).when(citrusContext).parseConfiguration((Object) any());
         CitrusAnnotations.injectAll(this, citrus, context);
         return context;
     }

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/yaml/AbstractYamlActionTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/yaml/AbstractYamlActionTest.java
@@ -32,6 +32,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeClass;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
 /**
@@ -56,6 +58,10 @@ public class AbstractYamlActionTest extends AbstractTestNGUnitTest {
         when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
         when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
         when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        doAnswer(invocationOnMock -> {
+            CitrusAnnotations.parseConfiguration(invocationOnMock.getArgument(0, Object.class), citrusContext);
+            return null;
+        }).when(citrusContext).parseConfiguration((Object) any());
         CitrusAnnotations.injectAll(this, citrus, context);
         return context;
     }

--- a/connectors/citrus-sql/src/test/java/org/citrusframework/sql/groovy/AbstractGroovyActionDslTest.java
+++ b/connectors/citrus-sql/src/test/java/org/citrusframework/sql/groovy/AbstractGroovyActionDslTest.java
@@ -63,6 +63,10 @@ public class AbstractGroovyActionDslTest extends AbstractTestNGUnitTest {
         when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
         when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
         when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        doAnswer(invocationOnMock -> {
+            CitrusAnnotations.parseConfiguration(invocationOnMock.getArgument(0, Object.class), citrusContext);
+            return null;
+        }).when(citrusContext).parseConfiguration((Object) any());
         CitrusAnnotations.injectAll(this, citrus, context);
         return context;
     }

--- a/connectors/citrus-sql/src/test/java/org/citrusframework/sql/xml/AbstractXmlActionTest.java
+++ b/connectors/citrus-sql/src/test/java/org/citrusframework/sql/xml/AbstractXmlActionTest.java
@@ -34,6 +34,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeClass;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
 /**
@@ -58,6 +60,10 @@ public class AbstractXmlActionTest extends AbstractTestNGUnitTest {
         when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
         when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
         when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        doAnswer(invocationOnMock -> {
+            CitrusAnnotations.parseConfiguration(invocationOnMock.getArgument(0, Object.class), citrusContext);
+            return null;
+        }).when(citrusContext).parseConfiguration((Object) any());
         CitrusAnnotations.injectAll(this, citrus, context);
         return context;
     }

--- a/connectors/citrus-sql/src/test/java/org/citrusframework/sql/yaml/AbstractYamlActionTest.java
+++ b/connectors/citrus-sql/src/test/java/org/citrusframework/sql/yaml/AbstractYamlActionTest.java
@@ -34,6 +34,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeClass;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
 /**
@@ -58,6 +60,10 @@ public class AbstractYamlActionTest extends AbstractTestNGUnitTest {
         when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
         when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
         when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        doAnswer(invocationOnMock -> {
+            CitrusAnnotations.parseConfiguration(invocationOnMock.getArgument(0, Object.class), citrusContext);
+            return null;
+        }).when(citrusContext).parseConfiguration((Object) any());
         CitrusAnnotations.injectAll(this, citrus, context);
         return context;
     }

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/groovy/AbstractGroovyActionDslTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/groovy/AbstractGroovyActionDslTest.java
@@ -63,6 +63,10 @@ public class AbstractGroovyActionDslTest extends AbstractTestNGUnitTest {
         when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
         when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
         when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        doAnswer(invocationOnMock -> {
+            CitrusAnnotations.parseConfiguration(invocationOnMock.getArgument(0, Object.class), citrusContext);
+            return null;
+        }).when(citrusContext).parseConfiguration((Object) any());
         CitrusAnnotations.injectAll(this, citrus, context);
         return context;
     }

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/xml/AbstractXmlActionTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/xml/AbstractXmlActionTest.java
@@ -32,6 +32,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeClass;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
 /**
@@ -56,6 +58,10 @@ public class AbstractXmlActionTest extends AbstractTestNGUnitTest {
         when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
         when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
         when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        doAnswer(invocationOnMock -> {
+            CitrusAnnotations.parseConfiguration(invocationOnMock.getArgument(0, Object.class), citrusContext);
+            return null;
+        }).when(citrusContext).parseConfiguration((Object) any());
         CitrusAnnotations.injectAll(this, citrus, context);
         return context;
     }

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/yaml/AbstractYamlActionTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/yaml/AbstractYamlActionTest.java
@@ -32,6 +32,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeClass;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
 /**
@@ -56,6 +58,10 @@ public class AbstractYamlActionTest extends AbstractTestNGUnitTest {
         when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
         when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
         when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        doAnswer(invocationOnMock -> {
+            CitrusAnnotations.parseConfiguration(invocationOnMock.getArgument(0, Object.class), citrusContext);
+            return null;
+        }).when(citrusContext).parseConfiguration((Object) any());
         CitrusAnnotations.injectAll(this, citrus, context);
         return context;
     }

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/groovy/AbstractGroovyActionDslTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/groovy/AbstractGroovyActionDslTest.java
@@ -63,6 +63,10 @@ public class AbstractGroovyActionDslTest extends AbstractTestNGUnitTest {
         when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
         when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
         when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        doAnswer(invocationOnMock -> {
+            CitrusAnnotations.parseConfiguration(invocationOnMock.getArgument(0, Object.class), citrusContext);
+            return null;
+        }).when(citrusContext).parseConfiguration((Object) any());
         CitrusAnnotations.injectAll(this, citrus, context);
         return context;
     }

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/xml/AbstractXmlActionTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/xml/AbstractXmlActionTest.java
@@ -32,6 +32,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeClass;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
 /**
@@ -56,6 +58,10 @@ public class AbstractXmlActionTest extends AbstractTestNGUnitTest {
         when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
         when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
         when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        doAnswer(invocationOnMock -> {
+            CitrusAnnotations.parseConfiguration(invocationOnMock.getArgument(0, Object.class), citrusContext);
+            return null;
+        }).when(citrusContext).parseConfiguration((Object) any());
         CitrusAnnotations.injectAll(this, citrus, context);
         return context;
     }

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/yaml/AbstractYamlActionTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/yaml/AbstractYamlActionTest.java
@@ -32,6 +32,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeClass;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
 /**
@@ -56,6 +58,10 @@ public class AbstractYamlActionTest extends AbstractTestNGUnitTest {
         when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
         when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
         when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        doAnswer(invocationOnMock -> {
+            CitrusAnnotations.parseConfiguration(invocationOnMock.getArgument(0, Object.class), citrusContext);
+            return null;
+        }).when(citrusContext).parseConfiguration((Object) any());
         CitrusAnnotations.injectAll(this, citrus, context);
         return context;
     }

--- a/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/groovy/AbstractGroovyActionDslTest.java
+++ b/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/groovy/AbstractGroovyActionDslTest.java
@@ -63,6 +63,10 @@ public class AbstractGroovyActionDslTest extends AbstractTestNGUnitTest {
         when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
         when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
         when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        doAnswer(invocationOnMock -> {
+            CitrusAnnotations.parseConfiguration(invocationOnMock.getArgument(0, Object.class), citrusContext);
+            return null;
+        }).when(citrusContext).parseConfiguration((Object) any());
         CitrusAnnotations.injectAll(this, citrus, context);
         return context;
     }

--- a/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/xml/AbstractXmlActionTest.java
+++ b/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/xml/AbstractXmlActionTest.java
@@ -32,6 +32,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeClass;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
 /**
@@ -56,6 +58,10 @@ public class AbstractXmlActionTest extends AbstractTestNGUnitTest {
         when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
         when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
         when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        doAnswer(invocationOnMock -> {
+            CitrusAnnotations.parseConfiguration(invocationOnMock.getArgument(0, Object.class), citrusContext);
+            return null;
+        }).when(citrusContext).parseConfiguration((Object) any());
         CitrusAnnotations.injectAll(this, citrus, context);
         return context;
     }

--- a/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/yaml/AbstractYamlActionTest.java
+++ b/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/yaml/AbstractYamlActionTest.java
@@ -32,6 +32,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeClass;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
 /**
@@ -56,6 +58,10 @@ public class AbstractYamlActionTest extends AbstractTestNGUnitTest {
         when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
         when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
         when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        doAnswer(invocationOnMock -> {
+            CitrusAnnotations.parseConfiguration(invocationOnMock.getArgument(0, Object.class), citrusContext);
+            return null;
+        }).when(citrusContext).parseConfiguration((Object) any());
         CitrusAnnotations.injectAll(this, citrus, context);
         return context;
     }

--- a/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/springintegration/groovy/AbstractGroovyActionDslTest.java
+++ b/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/springintegration/groovy/AbstractGroovyActionDslTest.java
@@ -63,6 +63,10 @@ public class AbstractGroovyActionDslTest extends AbstractTestNGUnitTest {
         when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
         when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
         when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        doAnswer(invocationOnMock -> {
+            CitrusAnnotations.parseConfiguration(invocationOnMock.getArgument(0, Object.class), citrusContext);
+            return null;
+        }).when(citrusContext).parseConfiguration((Object) any());
         CitrusAnnotations.injectAll(this, citrus, context);
         return context;
     }

--- a/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/springintegration/xml/AbstractXmlActionTest.java
+++ b/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/springintegration/xml/AbstractXmlActionTest.java
@@ -32,6 +32,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeClass;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
 /**
@@ -56,6 +58,10 @@ public class AbstractXmlActionTest extends AbstractTestNGUnitTest {
         when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
         when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
         when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        doAnswer(invocationOnMock -> {
+            CitrusAnnotations.parseConfiguration(invocationOnMock.getArgument(0, Object.class), citrusContext);
+            return null;
+        }).when(citrusContext).parseConfiguration((Object) any());
         CitrusAnnotations.injectAll(this, citrus, context);
         return context;
     }

--- a/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/springintegration/yaml/AbstractYamlActionTest.java
+++ b/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/springintegration/yaml/AbstractYamlActionTest.java
@@ -32,6 +32,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeClass;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
 /**
@@ -56,6 +58,10 @@ public class AbstractYamlActionTest extends AbstractTestNGUnitTest {
         when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
         when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
         when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        doAnswer(invocationOnMock -> {
+            CitrusAnnotations.parseConfiguration(invocationOnMock.getArgument(0, Object.class), citrusContext);
+            return null;
+        }).when(citrusContext).parseConfiguration((Object) any());
         CitrusAnnotations.injectAll(this, citrus, context);
         return context;
     }

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/groovy/AbstractGroovyActionDslTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/groovy/AbstractGroovyActionDslTest.java
@@ -63,6 +63,10 @@ public class AbstractGroovyActionDslTest extends AbstractTestNGUnitTest {
         when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
         when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
         when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        doAnswer(invocationOnMock -> {
+            CitrusAnnotations.parseConfiguration(invocationOnMock.getArgument(0, Object.class), citrusContext);
+            return null;
+        }).when(citrusContext).parseConfiguration((Object) any());
         CitrusAnnotations.injectAll(this, citrus, context);
         return context;
     }

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/xml/AbstractXmlActionTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/xml/AbstractXmlActionTest.java
@@ -32,6 +32,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeClass;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
 /**
@@ -56,6 +58,10 @@ public class AbstractXmlActionTest extends AbstractTestNGUnitTest {
         when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
         when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
         when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        doAnswer(invocationOnMock -> {
+            CitrusAnnotations.parseConfiguration(invocationOnMock.getArgument(0, Object.class), citrusContext);
+            return null;
+        }).when(citrusContext).parseConfiguration((Object) any());
         CitrusAnnotations.injectAll(this, citrus, context);
         return context;
     }

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/yaml/AbstractYamlActionTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/yaml/AbstractYamlActionTest.java
@@ -32,6 +32,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeClass;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
 /**
@@ -56,6 +58,10 @@ public class AbstractYamlActionTest extends AbstractTestNGUnitTest {
         when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
         when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
         when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        doAnswer(invocationOnMock -> {
+            CitrusAnnotations.parseConfiguration(invocationOnMock.getArgument(0, Object.class), citrusContext);
+            return null;
+        }).when(citrusContext).parseConfiguration((Object) any());
         CitrusAnnotations.injectAll(this, citrus, context);
         return context;
     }

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/AbstractGroovyActionDslTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/AbstractGroovyActionDslTest.java
@@ -63,6 +63,10 @@ public class AbstractGroovyActionDslTest extends AbstractTestNGUnitTest {
         when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
         when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
         when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        doAnswer(invocationOnMock -> {
+            CitrusAnnotations.parseConfiguration(invocationOnMock.getArgument(0, Object.class), citrusContext);
+            return null;
+        }).when(citrusContext).parseConfiguration((Object) any());
         CitrusAnnotations.injectAll(this, citrus, context);
         return context;
     }

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/xml/AbstractXmlActionTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/xml/AbstractXmlActionTest.java
@@ -34,6 +34,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeClass;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
 /**
@@ -58,6 +60,10 @@ public class AbstractXmlActionTest extends AbstractTestNGUnitTest {
         when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
         when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
         when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        doAnswer(invocationOnMock -> {
+            CitrusAnnotations.parseConfiguration(invocationOnMock.getArgument(0, Object.class), citrusContext);
+            return null;
+        }).when(citrusContext).parseConfiguration((Object) any());
         CitrusAnnotations.injectAll(this, citrus, context);
         return context;
     }

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/yaml/AbstractYamlActionTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/yaml/AbstractYamlActionTest.java
@@ -34,6 +34,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeClass;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
 /**
@@ -58,6 +60,10 @@ public class AbstractYamlActionTest extends AbstractTestNGUnitTest {
         when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
         when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
         when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        doAnswer(invocationOnMock -> {
+            CitrusAnnotations.parseConfiguration(invocationOnMock.getArgument(0, Object.class), citrusContext);
+            return null;
+        }).when(citrusContext).parseConfiguration((Object) any());
         CitrusAnnotations.injectAll(this, citrus, context);
         return context;
     }

--- a/runtime/citrus-quarkus/citrus-quarkus-runtime/src/main/java/org/citrusframework/quarkus/CitrusTestResource.java
+++ b/runtime/citrus-quarkus/citrus-quarkus-runtime/src/main/java/org/citrusframework/quarkus/CitrusTestResource.java
@@ -83,7 +83,7 @@ public class CitrusTestResource implements QuarkusTestResourceLifecycleManager {
         runner.name(testInstance.getClass().getSimpleName());
         runner.start();
 
-        CitrusAnnotations.parseConfiguration(testInstance, citrus.getCitrusContext());
+        citrus.getCitrusContext().parseConfiguration(testInstance);
         CitrusAnnotations.injectEndpoints(testInstance, context);
     }
 

--- a/runtime/citrus-xml/src/test/java/org/citrusframework/xml/actions/AbstractXmlActionTest.java
+++ b/runtime/citrus-xml/src/test/java/org/citrusframework/xml/actions/AbstractXmlActionTest.java
@@ -34,6 +34,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeClass;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
 /**
@@ -58,6 +60,10 @@ public class AbstractXmlActionTest extends AbstractTestNGUnitTest {
         when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
         when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
         when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        doAnswer(invocationOnMock -> {
+            CitrusAnnotations.parseConfiguration(invocationOnMock.getArgument(0, Object.class), citrusContext);
+            return null;
+        }).when(citrusContext).parseConfiguration((Object) any());
         CitrusAnnotations.injectAll(this, citrus, context);
         return context;
     }

--- a/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/actions/AbstractYamlActionTest.java
+++ b/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/actions/AbstractYamlActionTest.java
@@ -32,6 +32,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeClass;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
 /**
@@ -56,6 +58,10 @@ public class AbstractYamlActionTest extends AbstractTestNGUnitTest {
         when(citrusContext.getReferenceResolver()).thenReturn(context.getReferenceResolver());
         when(citrusContext.getMessageValidatorRegistry()).thenReturn(context.getMessageValidatorRegistry());
         when(citrusContext.getTestContextFactory()).thenReturn(new StaticTestContextFactory(context));
+        doAnswer(invocationOnMock -> {
+            CitrusAnnotations.parseConfiguration(invocationOnMock.getArgument(0, Object.class), citrusContext);
+            return null;
+        }).when(citrusContext).parseConfiguration((Object) any());
         CitrusAnnotations.injectAll(this, citrus, context);
         return context;
     }


### PR DESCRIPTION
- Make sure to parse configuration classes for a Citrus instance in an idempotent way
- Do not load configuration multiple times as it may lead to port binding errors for server components

Fixes #1055