### PR TITLE
chore: citrus resource wrapper for classpath resources

### DIFF
--- a/core/citrus-api/src/main/java/org/citrusframework/spi/PropertiesLoader.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/spi/PropertiesLoader.java
@@ -1,0 +1,52 @@
+package org.citrusframework.spi;
+
+import org.citrusframework.exceptions.CitrusRuntimeException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+public final class PropertiesLoader {
+
+    private PropertiesLoader() {
+        // Not intended for instantiation
+    }
+
+    public static Properties loadProperties(Resource resource) {
+        Properties properties = new Properties();
+        try (InputStream inputStream = resource.getInputStream()) {
+            System.out.println("Resource: " + resource);
+            loadProperties(resource.getLocation(), properties, inputStream);
+        } catch (IOException e) {
+            throwPropertiesLoadingFailedException(resource.getLocation(), e);
+        }
+        return properties;
+    }
+
+    public static Properties loadProperties(String path) {
+        Properties properties = new Properties();
+        try (InputStream in = ResourcePathTypeResolver.class.getClassLoader().getResourceAsStream(path)) {
+            if (in == null) {
+                throw new CitrusRuntimeException(String.format("Failed to locate resource path '%s'!", path));
+            }
+
+            loadProperties(path, properties, in);
+        } catch (IOException e) {
+            throwPropertiesLoadingFailedException(path, e);
+        }
+
+        return properties;
+    }
+
+    private static void throwPropertiesLoadingFailedException(String path, IOException e) {
+        throw new CitrusRuntimeException(String.format("Unable to load properties from resource path configuration at '%s'", path), e);
+    }
+
+    private static void loadProperties(String path, Properties properties, InputStream in) throws IOException {
+        if (path.endsWith(".xml")) {
+            properties.loadFromXML(in);
+        } else {
+            properties.load(in);
+        }
+    }
+}

--- a/core/citrus-api/src/main/java/org/citrusframework/spi/ResourcePathTypeResolver.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/spi/ResourcePathTypeResolver.java
@@ -7,7 +7,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
@@ -28,6 +27,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
+
+import static org.citrusframework.spi.PropertiesLoader.loadProperties;
 
 /**
  * Type resolver resolves references via resource path lookup. Provided resource paths should point
@@ -288,23 +289,7 @@ public class ResourcePathTypeResolver implements TypeResolver {
     private Properties readAsProperties(String resourcePath) {
         return resourceProperties.computeIfAbsent(resourcePath, k -> {
             String path = getFullResourcePath(resourcePath);
-
-            try(InputStream in = ResourcePathTypeResolver.class.getClassLoader().getResourceAsStream(path)) {
-                if (in == null) {
-                    throw new CitrusRuntimeException(String.format("Failed to locate resource path '%s'!", path));
-                }
-
-                Properties config = new Properties();
-                if (resourcePath.endsWith(".xml")) {
-                    config.loadFromXML(in);
-                } else {
-                    config.load(in);
-                }
-
-                return config;
-            } catch (IOException e) {
-                throw new CitrusRuntimeException(String.format("Unable to load properties from resource path configuration at '%s'", path), e);
-            }
+            return loadProperties(path);
         });
     }
 

--- a/core/citrus-base/src/main/java/org/citrusframework/variable/dictionary/AbstractDataDictionary.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/variable/dictionary/AbstractDataDictionary.java
@@ -16,18 +16,17 @@
 
 package org.citrusframework.variable.dictionary;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Properties;
-
 import org.citrusframework.context.TestContext;
-import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.message.AbstractMessageProcessor;
 import org.citrusframework.spi.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.citrusframework.spi.PropertiesLoader.loadProperties;
 
 /**
  * Abstract data dictionary implementation provides global scope handling.
@@ -75,27 +74,17 @@ public abstract class AbstractDataDictionary<T> extends AbstractMessageProcessor
         if (mappingFile != null) {
             logger.debug("Reading data dictionary mapping: {}", mappingFile.getLocation());
 
-            Properties props = new Properties();
-            try (InputStream inputStream = mappingFile.getInputStream()) {
-                if (mappingFile.getLocation().endsWith(".xml")) {
-                    props.loadFromXML(inputStream);
-                } else {
-                    props.load(inputStream);
-                }
-            } catch (IOException e) {
-                throw new CitrusRuntimeException(e);
-            }
-
-            for (Map.Entry<Object, Object> entry : props.entrySet()) {
+            Properties properties = loadProperties(mappingFile);
+            for (Map.Entry<Object, Object> entry : properties.entrySet()) {
                 String key = entry.getKey().toString();
 
-                logger.debug("Loading data dictionary mapping: {}={}", key, props.getProperty(key));
+                logger.debug("Loading data dictionary mapping: {}={}", key, properties.getProperty(key));
 
                 if (logger.isDebugEnabled() && mappings.containsKey(key)) {
-                    logger.warn("Overwriting data dictionary mapping '{}'; old value: {} new value: {}", key, mappings.get(key), props.getProperty(key));
+                    logger.warn("Overwriting data dictionary mapping '{}'; old value: {} new value: {}", key, mappings.get(key), properties.getProperty(key));
                 }
 
-                mappings.put(key, props.getProperty(key));
+                mappings.put(key, properties.getProperty(key));
             }
 
             logger.info("Loaded data dictionary mapping: {}", mappingFile.getLocation());

--- a/core/citrus-spring/src/main/java/org/citrusframework/spi/CitrusResourceWrapper.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/spi/CitrusResourceWrapper.java
@@ -19,14 +19,15 @@
 
 package org.citrusframework.spi;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.core.convert.converter.ConditionalConverter;
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 
 public class CitrusResourceWrapper implements Resource {
 
@@ -43,6 +44,10 @@ public class CitrusResourceWrapper implements Resource {
     @Override
     public String getLocation() {
         try {
+            if (delegate instanceof ClassPathResource classPathResource) {
+                return classPathResource.getURI().toString();
+            }
+
             return delegate.getFile().getPath();
         } catch (IOException e) {
             return delegate.toString();

--- a/core/citrus-spring/src/test/java/org/citrusframework/spi/CitrusResourceWrapperTest.java
+++ b/core/citrus-spring/src/test/java/org/citrusframework/spi/CitrusResourceWrapperTest.java
@@ -1,0 +1,41 @@
+package org.citrusframework.spi;
+
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.FileUrlResource;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class CitrusResourceWrapperTest {
+
+    @Test
+    public void readUriFromClasspathResource() throws IOException {
+        String resource = "citrus-application.properties";
+        ClassPathResource classPathResource = mock(ClassPathResource.class);
+        doReturn(URI.create(resource)).when(classPathResource).getURI();
+
+        CitrusResourceWrapper fixture = new CitrusResourceWrapper(classPathResource);
+
+        assertTrue(fixture.getLocation().endsWith(resource), "Fixture location should resolve URI from classpath resource!");
+        verify(classPathResource).getURI();
+    }
+
+    @Test
+    public void readFileFromOtherResources() throws IOException {
+        String resource = "citrus-application.properties";
+        FileUrlResource classPathResource = mock(FileUrlResource.class);
+        doReturn(File.createTempFile(getClass().getSimpleName(), resource)).when(classPathResource).getFile();
+
+        CitrusResourceWrapper fixture = new CitrusResourceWrapper(classPathResource);
+
+        assertTrue(fixture.getLocation().endsWith(resource), "Fixture location should resolve URI from classpath resource!");
+        verify(classPathResource).getFile();
+    }
+}


### PR DESCRIPTION
after https://github.com/citrusframework/citrus/pull/1067 I figured that it'd be best to centralize property loading, so errors can be minimalized in the future.
additionally, classpath resources seem to require special treatment in the citrus/spring resource wrapper. that has been done poorly so far.

with this the [citrusframework/citrus-simulator builds on `4.1.0-SNAPSHOT`](https://github.com/citrusframework/citrus-simulator/pull/219). I think it would be fair to release `4.0.2` as soon as possible @christophd.