### PR TITLE
feat(citrus-http): easy json response helpers

### DIFF
--- a/endpoints/citrus-http/pom.xml
+++ b/endpoints/citrus-http/pom.xml
@@ -66,6 +66,15 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
     </dependency>

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/actions/HttpServerActionBuilderTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/actions/HttpServerActionBuilderTest.java
@@ -1,0 +1,55 @@
+package org.citrusframework.http.actions;
+
+import org.citrusframework.endpoint.Endpoint;
+import org.citrusframework.http.message.HttpMessage;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
+
+public class HttpServerActionBuilderTest {
+
+    private static final TestJsonObject JSON_OBJECT_REPRESENTATION = new TestJsonObject("value");
+    private static final String JSON_STRING_REPRESENTATION = """
+        {
+          "property" : "value"
+        }""";
+
+    private HttpServerActionBuilder fixture;
+
+    private static void verifyOkJsonResponse(HttpServerResponseActionBuilder.HttpMessageBuilderSupport httpMessageBuilderSupport) {
+        Object responseMessage = getField(httpMessageBuilderSupport, "httpMessage");
+        assertTrue(responseMessage instanceof HttpMessage);
+
+        HttpMessage httpMessage = (HttpMessage) responseMessage;
+
+        assertEquals(HttpStatus.OK, httpMessage.getStatusCode());
+        assertEquals(MediaType.APPLICATION_JSON_VALUE, httpMessage.getContentType());
+        assertEquals(JSON_STRING_REPRESENTATION, httpMessage.getPayload(String.class).replace("\r\n", "\n"));
+    }
+
+    @BeforeMethod
+    public void beforeMethodSetup() {
+        fixture = new HttpServerActionBuilder(mock(Endpoint.class));
+    }
+
+    @Test
+    public void sendOkJsonFromString() {
+        HttpServerResponseActionBuilder.HttpMessageBuilderSupport httpMessageBuilderSupport = fixture.respondOkJson(JSON_STRING_REPRESENTATION);
+        verifyOkJsonResponse(httpMessageBuilderSupport);
+    }
+
+    @Test
+    public void sendOkJsonFromObject() {
+        HttpServerResponseActionBuilder.HttpMessageBuilderSupport httpMessageBuilderSupport = fixture.respondOkJson(JSON_OBJECT_REPRESENTATION);
+        verifyOkJsonResponse(httpMessageBuilderSupport);
+    }
+
+    private record TestJsonObject(String property) {
+    }
+}


### PR DESCRIPTION
after some discussions in https://github.com/citrusframework/citrus-simulator/pull/221 and https://github.com/citrusframework/citrus-simulator/pull/224, I've decided to move the response helpers into citrus nonetheless.

cc: @novarx.