### PR TITLE
Removed extra text in the verification message.

### DIFF
--- a/src/manual/runtimes-cucumber.adoc
+++ b/src/manual/runtimes-cucumber.adoc
@@ -151,7 +151,7 @@ public class EchoSteps {
                 receive("echoEndpoint")
                     .message()
                     .type(MessageType.PLAINTEXT)
-                    .body("You just said: " + body));
+                    .body(body));
     }
 
 }


### PR DESCRIPTION
The verification step should contain the expected message and not add extra text.