### PR TITLE
spring and jetty migration

### DIFF
--- a/connectors/citrus-selenium/pom.xml
+++ b/connectors/citrus-selenium/pom.xml
@@ -67,12 +67,12 @@
       <artifactId>jetty-jakarta-websocket-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty.websocket</groupId>
-      <artifactId>websocket-jakarta-common</artifactId>
+      <groupId>org.eclipse.jetty.ee10.websocket</groupId>
+      <artifactId>jetty-ee10-websocket-jakarta-common</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty.websocket</groupId>
-      <artifactId>websocket-jakarta-client</artifactId>
+      <groupId>org.eclipse.jetty.ee10.websocket</groupId>
+      <artifactId>jetty-ee10-websocket-jakarta-client</artifactId>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,4 +21,3 @@
   </modules>
 
 </project>
-

--- a/endpoints/citrus-http/pom.xml
+++ b/endpoints/citrus-http/pom.xml
@@ -101,8 +101,8 @@
       <artifactId>jetty-server</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-servlet</artifactId>
+      <groupId>org.eclipse.jetty.ee10</groupId>
+      <artifactId>jetty-ee10-servlet</artifactId>
     </dependency>
     <dependency>
       <groupId>jakarta.servlet</groupId>

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/client/BasicAuthClientHttpRequestFactory.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/client/BasicAuthClientHttpRequestFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2012 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
 
 package org.citrusframework.http.client;
 
-import java.net.URI;
-
 import org.apache.hc.client5.http.auth.AuthCache;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.Credentials;
@@ -30,10 +28,13 @@ import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.protocol.HttpContext;
 import org.citrusframework.common.InitializingPhase;
-import org.citrusframework.util.ObjectHelper;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+
+import java.net.URI;
+
+import static org.citrusframework.util.ObjectHelper.assertNotNull;
 
 /**
  * Factory bean constructing a client request factory with
@@ -44,22 +45,29 @@ import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
  */
 public class BasicAuthClientHttpRequestFactory implements FactoryBean<HttpComponentsClientHttpRequestFactory>, InitializingPhase {
 
-    /** The target request factory */
+    /**
+     * The target request factory
+     */
     private HttpClientBuilder httpClient;
 
-    /** User credentials for basic authentication */
+    /**
+     * User credentials for basic authentication
+     */
     private Credentials credentials;
 
-    /** Authentiacation scope */
+    /**
+     * Authentiacation scope
+     */
     private AuthScope authScope = new AuthScope(new HttpHost("http", "localhost", 8080));
 
     /**
      * Construct the client factory bean with user credentials.
      */
     public HttpComponentsClientHttpRequestFactory getObject() throws Exception {
-        ObjectHelper.assertNotNull(credentials, "User credentials not set properly!");
+        assertNotNull(credentials, "User credentials not set properly!");
 
         return new HttpComponentsClientHttpRequestFactory(httpClient.build()) {
+
             @Override
             protected HttpContext createHttpContext(HttpMethod httpMethod, URI uri) {
                 // we have to use preemptive authentication
@@ -74,11 +82,11 @@ public class BasicAuthClientHttpRequestFactory implements FactoryBean<HttpCompon
                 BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
                 credentialsProvider.setCredentials(new AuthScope(httpTarget), credentials);
 
-                HttpClientContext ctx = HttpClientContext.create();
-                ctx.setAuthCache(authCache);
-                ctx.setCredentialsProvider(credentialsProvider);
+                HttpClientContext httpClientContext = HttpClientContext.create();
+                httpClientContext.setAuthCache(authCache);
+                httpClientContext.setCredentialsProvider(credentialsProvider);
 
-                return ctx;
+                return httpClientContext;
             }
         };
     }
@@ -112,6 +120,7 @@ public class BasicAuthClientHttpRequestFactory implements FactoryBean<HttpCompon
 
     /**
      * Sets the credentials.
+     *
      * @param credentials the credentials to set
      */
     public void setCredentials(Credentials credentials) {
@@ -120,6 +129,7 @@ public class BasicAuthClientHttpRequestFactory implements FactoryBean<HttpCompon
 
     /**
      * Sets the authScope.
+     *
      * @param authScope the authScope to set
      */
     public void setAuthScope(AuthScope authScope) {
@@ -128,10 +138,10 @@ public class BasicAuthClientHttpRequestFactory implements FactoryBean<HttpCompon
 
     /**
      * Sets the httpClient.
+     *
      * @param httpClient the httpClient to set
      */
     public void setHttpClient(HttpClientBuilder httpClient) {
         this.httpClient = httpClient;
     }
-
 }

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/client/HttpClientBuilder.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/client/HttpClientBuilder.java
@@ -243,8 +243,7 @@ public class HttpClientBuilder extends AbstractEndpointBuilder<HttpClient> {
      * @return
      */
     public HttpClientBuilder authentication(HttpAuthentication auth) {
-        endpoint.getEndpointConfiguration().setRequestFactory(
-                auth.getRequestFactory(endpoint.getEndpointConfiguration().getRequestUrl(), endpoint));
+        endpoint.getEndpointConfiguration().setRequestFactory(auth.getRequestFactory(endpoint.getEndpointConfiguration().getRequestUrl(), endpoint));
         return this;
     }
 
@@ -253,7 +252,8 @@ public class HttpClientBuilder extends AbstractEndpointBuilder<HttpClient> {
      * @return
      */
     public HttpClientBuilder secured(HttpSecureConnection conn) {
-        endpoint.getEndpointConfiguration().getHttpClient()
+        endpoint.getEndpointConfiguration()
+                .getHttpClient()
                 .setConnectionManager(conn.getClientConnectionManager());
         return this;
     }

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/config/annotation/HttpServerConfigParser.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/config/annotation/HttpServerConfigParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2016 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,6 @@
 
 package org.citrusframework.http.config.annotation;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import jakarta.servlet.Filter;
 import org.citrusframework.TestActor;
 import org.citrusframework.config.annotation.AnnotationConfigParser;
@@ -34,12 +27,20 @@ import org.citrusframework.http.security.HttpSecureConnection;
 import org.citrusframework.http.server.HttpServer;
 import org.citrusframework.http.server.HttpServerBuilder;
 import org.citrusframework.spi.ReferenceResolver;
-import org.citrusframework.util.StringUtils;
+import org.eclipse.jetty.ee10.servlet.ServletHandler;
 import org.eclipse.jetty.security.SecurityHandler;
 import org.eclipse.jetty.server.Connector;
-import org.eclipse.jetty.servlet.ServletHandler;
 import org.springframework.http.MediaType;
 import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.stream.Collectors.toMap;
+import static org.apache.commons.lang3.stream.Streams.of;
+import static org.citrusframework.util.StringUtils.hasText;
 
 /**
  * @author Christoph Deppisch
@@ -58,23 +59,23 @@ public class HttpServerConfigParser implements AnnotationConfigParser<HttpServer
 
         builder.debugLogging(annotation.debugLogging());
 
-        if (StringUtils.hasText(annotation.endpointAdapter())) {
+        if (hasText(annotation.endpointAdapter())) {
             builder.endpointAdapter(referenceResolver.resolve(annotation.endpointAdapter(), EndpointAdapter.class));
         }
 
         builder.interceptors(referenceResolver.resolve(annotation.interceptors(), HandlerInterceptor.class));
 
-        if (StringUtils.hasText(annotation.actor())) {
+        if (hasText(annotation.actor())) {
             builder.actor(referenceResolver.resolve(annotation.actor(), TestActor.class));
         }
 
         builder.port(annotation.port());
 
-        if (StringUtils.hasText(annotation.contextConfigLocation())) {
+        if (hasText(annotation.contextConfigLocation())) {
             builder.contextConfigLocation(annotation.contextConfigLocation());
         }
 
-        if (StringUtils.hasText(annotation.resourceBase())) {
+        if (hasText(annotation.resourceBase())) {
             builder.resourceBase(annotation.resourceBase());
         }
 
@@ -86,8 +87,8 @@ public class HttpServerConfigParser implements AnnotationConfigParser<HttpServer
             builder.filters(referenceResolver.resolveAll(Filter.class)
                     .entrySet()
                     .stream()
-                    .filter(entry -> Stream.of(annotation.filters()).anyMatch(f -> f.equals(entry.getKey())))
-                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+                    .filter(entry -> of(annotation.filters()).anyMatch(f -> f.equals(entry.getKey())))
+                    .collect(toMap(Map.Entry::getKey, Map.Entry::getValue)));
         }
 
         Map<String, String> filterMappings = new HashMap<>();
@@ -109,42 +110,42 @@ public class HttpServerConfigParser implements AnnotationConfigParser<HttpServer
             builder.binaryMediaTypes(binaryMediaTypes);
         }
 
-        if (StringUtils.hasText(annotation.connector())) {
+        if (hasText(annotation.connector())) {
             builder.connector(referenceResolver.resolve(annotation.connector(), Connector.class));
         }
 
-        if (StringUtils.hasText(annotation.servletName())) {
+        if (hasText(annotation.servletName())) {
             builder.servletName(annotation.servletName());
         }
 
-        if (StringUtils.hasText(annotation.servletMappingPath())) {
+        if (hasText(annotation.servletMappingPath())) {
             builder.servletMappingPath(annotation.servletMappingPath());
         }
 
-        if (StringUtils.hasText(annotation.contextPath())) {
+        if (hasText(annotation.contextPath())) {
             builder.contextPath(annotation.contextPath());
         }
 
-        if (StringUtils.hasText(annotation.servletHandler())) {
+        if (hasText(annotation.servletHandler())) {
             builder.servletHandler(referenceResolver.resolve(annotation.servletHandler(), ServletHandler.class));
         }
 
-        if (StringUtils.hasText(annotation.securityHandler())) {
+        if (hasText(annotation.securityHandler())) {
             builder.securityHandler(referenceResolver.resolve(annotation.securityHandler(), SecurityHandler.class));
         }
 
-        if (StringUtils.hasText(annotation.messageConverter())) {
+        if (hasText(annotation.messageConverter())) {
             builder.messageConverter(referenceResolver.resolve(annotation.messageConverter(), HttpMessageConverter.class));
         }
 
         builder.defaultStatus(annotation.defaultStatus());
         builder.responseCacheSize(annotation.responseCacheSize());
 
-        if (StringUtils.hasText(annotation.authentication())) {
+        if (hasText(annotation.authentication())) {
             builder.authentication(annotation.securedPath(), referenceResolver.resolve(annotation.authentication(), HttpAuthentication.class));
         }
 
-        if (StringUtils.hasText(annotation.secured())) {
+        if (hasText(annotation.secured())) {
             builder.secured(annotation.securePort(), referenceResolver.resolve(annotation.secured(), HttpSecureConnection.class));
         }
 

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/config/xml/HttpSendResponseActionParser.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/config/xml/HttpSendResponseActionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2015 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,22 +16,25 @@
 
 package org.citrusframework.http.config.xml;
 
-import java.util.List;
-
 import jakarta.servlet.http.Cookie;
-import org.citrusframework.config.util.BeanDefinitionParserUtils;
-import org.citrusframework.config.xml.DescriptionElementParser;
 import org.citrusframework.config.xml.SendMessageActionParser;
 import org.citrusframework.http.message.HttpMessage;
 import org.citrusframework.http.message.HttpMessageBuilder;
 import org.citrusframework.http.message.HttpMessageHeaders;
-import org.citrusframework.util.StringUtils;
 import org.citrusframework.validation.builder.DefaultMessageBuilder;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.util.xml.DomUtils;
 import org.w3c.dom.Element;
+
+import java.util.List;
+
+import static java.lang.Boolean.parseBoolean;
+import static java.lang.Integer.parseInt;
+import static org.citrusframework.config.util.BeanDefinitionParserUtils.setPropertyReference;
+import static org.citrusframework.config.xml.DescriptionElementParser.doParse;
+import static org.citrusframework.util.StringUtils.hasText;
 
 /**
  * @author Christoph Deppisch
@@ -44,8 +47,8 @@ public class HttpSendResponseActionParser extends SendMessageActionParser {
         BeanDefinitionBuilder builder = parseComponent(element, parserContext);
         builder.addPropertyValue("name", "http:" + element.getLocalName());
 
-        DescriptionElementParser.doParse(element, builder);
-        BeanDefinitionParserUtils.setPropertyReference(builder, element.getAttribute("actor"), "actor");
+        doParse(element, builder);
+        setPropertyReference(builder, element.getAttribute("actor"), "actor");
 
         HttpMessage httpMessage = new HttpMessage();
         if (element.hasAttribute("server")) {
@@ -61,17 +64,17 @@ public class HttpSendResponseActionParser extends SendMessageActionParser {
             }
 
             String statusCode = headers.getAttribute("status");
-            if (StringUtils.hasText(statusCode)) {
+            if (hasText(statusCode)) {
                 httpMessage.setHeader(HttpMessageHeaders.HTTP_STATUS_CODE, statusCode);
             }
 
             String reasonPhrase = headers.getAttribute("reason-phrase");
-            if (StringUtils.hasText(reasonPhrase)) {
+            if (hasText(reasonPhrase)) {
                 httpMessage.reasonPhrase(reasonPhrase);
             }
 
             String version = headers.getAttribute("version");
-            if (StringUtils.hasText(version)) {
+            if (hasText(version)) {
                 httpMessage.version(version);
             }
 
@@ -79,10 +82,6 @@ public class HttpSendResponseActionParser extends SendMessageActionParser {
             for (Object item : cookieElements) {
                 Element cookieElement = (Element) item;
                 Cookie cookie = new Cookie(cookieElement.getAttribute("name"), cookieElement.getAttribute("value"));
-
-                if (cookieElement.hasAttribute("comment")) {
-                    cookie.setComment(cookieElement.getAttribute("comment"));
-                }
 
                 if (cookieElement.hasAttribute("path")) {
                     cookie.setPath(cookieElement.getAttribute("path"));
@@ -93,15 +92,11 @@ public class HttpSendResponseActionParser extends SendMessageActionParser {
                 }
 
                 if (cookieElement.hasAttribute("max-age")) {
-                    cookie.setMaxAge(Integer.valueOf(cookieElement.getAttribute("max-age")));
+                    cookie.setMaxAge(parseInt(cookieElement.getAttribute("max-age")));
                 }
 
                 if (cookieElement.hasAttribute("secure")) {
-                    cookie.setSecure(Boolean.valueOf(cookieElement.getAttribute("secure")));
-                }
-
-                if (cookieElement.hasAttribute("version")) {
-                    cookie.setVersion(Integer.valueOf(cookieElement.getAttribute("version")));
+                    cookie.setSecure(parseBoolean(cookieElement.getAttribute("secure")));
                 }
 
                 httpMessage.cookie(cookie);
@@ -111,12 +106,12 @@ public class HttpSendResponseActionParser extends SendMessageActionParser {
         Element body = DomUtils.getChildElementByTagName(element, "body");
         if (body != null) {
             String messageType = body.getAttribute("type");
-            if (StringUtils.hasText(messageType)) {
+            if (hasText(messageType)) {
                 builder.addPropertyValue("messageType", messageType);
             }
 
             String dataDictionary = body.getAttribute("data-dictionary");
-            if (StringUtils.hasText(dataDictionary)) {
+            if (hasText(dataDictionary)) {
                 builder.addPropertyReference("dataDictionary", dataDictionary);
             }
         }

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/interceptor/LoggingClientInterceptor.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/interceptor/LoggingClientInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2012 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,6 @@
 
 package org.citrusframework.http.interceptor;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.List;
-import java.util.Map.Entry;
-import java.util.stream.Collectors;
-
 import org.citrusframework.context.TestContextFactory;
 import org.citrusframework.message.RawMessage;
 import org.citrusframework.report.MessageListeners;
@@ -37,6 +29,16 @@ import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map.Entry;
+
+import static java.lang.String.join;
+import static java.lang.System.lineSeparator;
+
 /**
  * Simple logging interceptor writes Http request and response messages to the console.
  *
@@ -45,10 +47,14 @@ import org.springframework.http.client.ClientHttpResponse;
  */
 public class LoggingClientInterceptor implements ClientHttpRequestInterceptor {
 
-    /** New line characters in logger files */
-    private static final String NEWLINE = System.getProperty("line.separator");
+    /**
+     * New line characters in logger files
+     */
+    private static final String NEWLINE = lineSeparator();
 
-    /** Logger */
+    /**
+     * Logger
+     */
     private static final Logger logger = LoggerFactory.getLogger(LoggingClientInterceptor.class);
 
     private MessageListeners messageListener;
@@ -56,8 +62,7 @@ public class LoggingClientInterceptor implements ClientHttpRequestInterceptor {
     private final TestContextFactory contextFactory = TestContextFactory.newInstance();
 
     @Override
-    public ClientHttpResponse intercept(HttpRequest request, byte[] body,
-        ClientHttpRequestExecution execution) throws IOException {
+    public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
         handleRequest(getRequestContent(request, new String(body)));
 
         ClientHttpResponse response = execution.execute(request, body);
@@ -69,6 +74,7 @@ public class LoggingClientInterceptor implements ClientHttpRequestInterceptor {
 
     /**
      * Handles request messages for logging.
+     *
      * @param request
      */
     public void handleRequest(String request) {
@@ -84,6 +90,7 @@ public class LoggingClientInterceptor implements ClientHttpRequestInterceptor {
 
     /**
      * Handles response messages for logging.
+     *
      * @param response
      */
     public void handleResponse(String response) {
@@ -99,6 +106,7 @@ public class LoggingClientInterceptor implements ClientHttpRequestInterceptor {
 
     /**
      * Checks if message listeners are present on this interceptor.
+     *
      * @return
      */
     public boolean hasMessageListeners() {
@@ -107,6 +115,7 @@ public class LoggingClientInterceptor implements ClientHttpRequestInterceptor {
 
     /**
      * Builds request content string from request and body.
+     *
      * @param request
      * @param body
      * @return
@@ -129,6 +138,7 @@ public class LoggingClientInterceptor implements ClientHttpRequestInterceptor {
 
     /**
      * Builds response content string from response object.
+     *
      * @param response
      * @return
      * @throws IOException
@@ -156,6 +166,7 @@ public class LoggingClientInterceptor implements ClientHttpRequestInterceptor {
 
     /**
      * Append Http headers to string builder.
+     *
      * @param headers
      * @param builder
      */
@@ -163,7 +174,7 @@ public class LoggingClientInterceptor implements ClientHttpRequestInterceptor {
         for (Entry<String, List<String>> headerEntry : headers.entrySet()) {
             builder.append(headerEntry.getKey());
             builder.append(":");
-            builder.append(headerEntry.getValue().stream().collect(Collectors.joining(",")));
+            builder.append(join(",", headerEntry.getValue()));
             builder.append(NEWLINE);
         }
     }
@@ -188,6 +199,7 @@ public class LoggingClientInterceptor implements ClientHttpRequestInterceptor {
         }
 
         @Override
+        @Deprecated(forRemoval = true)
         public int getRawStatusCode() throws IOException {
             return this.response.getRawStatusCode();
         }
@@ -226,10 +238,10 @@ public class LoggingClientInterceptor implements ClientHttpRequestInterceptor {
 
     /**
      * Sets the message listener.
+     *
      * @param messageListener
      */
     public void setMessageListener(MessageListeners messageListener) {
         this.messageListener = messageListener;
     }
-
 }

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/interceptor/MappedInterceptorAdapter.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/interceptor/MappedInterceptorAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,11 @@
 
 package org.citrusframework.http.interceptor;
 
-import org.springframework.util.PathMatcher;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.handler.MappedInterceptor;
-import org.springframework.web.util.UrlPathHelper;
-
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Adapter for {@link org.springframework.web.servlet.handler.MappedInterceptor} conditionally applies interceptor
@@ -35,26 +32,20 @@ import jakarta.servlet.http.HttpServletResponse;
 public class MappedInterceptorAdapter implements HandlerInterceptor {
 
     private final MappedInterceptor mappedInterceptor;
-    private final UrlPathHelper urlPathHelper;
-    private final PathMatcher pathMatcher;
 
     /**
      * Default constructor using mapped interceptor, url path helper as well
      * as path matcher instance.
      *
      * @param mappedInterceptor
-     * @param urlPathHelper
-     * @param pathMatcher
      */
-    public MappedInterceptorAdapter(MappedInterceptor mappedInterceptor, UrlPathHelper urlPathHelper, PathMatcher pathMatcher) {
+    public MappedInterceptorAdapter(MappedInterceptor mappedInterceptor) {
         this.mappedInterceptor = mappedInterceptor;
-        this.urlPathHelper = urlPathHelper;
-        this.pathMatcher = pathMatcher;
     }
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
-        if (mappedInterceptor.matches(urlPathHelper.getLookupPathForRequest(request), pathMatcher)) {
+        if (mappedInterceptor.matches(request)) {
             return mappedInterceptor.getInterceptor().preHandle(request, response, handler);
         }
 
@@ -63,14 +54,14 @@ public class MappedInterceptorAdapter implements HandlerInterceptor {
 
     @Override
     public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, ModelAndView modelAndView) throws Exception {
-        if (mappedInterceptor.matches(urlPathHelper.getLookupPathForRequest(request), pathMatcher)) {
+        if (mappedInterceptor.matches(request)) {
             mappedInterceptor.getInterceptor().postHandle(request, response, handler, modelAndView);
         }
     }
 
     @Override
     public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) throws Exception {
-        if (mappedInterceptor.matches(urlPathHelper.getLookupPathForRequest(request), pathMatcher)) {
+        if (mappedInterceptor.matches(request)) {
             mappedInterceptor.getInterceptor().afterCompletion(request, response, handler, ex);
         }
     }

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/message/CookieEnricher.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/message/CookieEnricher.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2018 the original author or authors
+ *    Copyright 2018-2024 the original author or authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 
 package org.citrusframework.http.message;
 
+import jakarta.servlet.http.Cookie;
 import org.citrusframework.context.TestContext;
 
-import jakarta.servlet.http.Cookie;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -29,6 +29,7 @@ class CookieEnricher {
 
     /**
      * Replaces the dynamic content in the given list of cookies
+     *
      * @param cookies The list of Cookies to
      * @param context The context to replace the variables with
      */
@@ -43,10 +44,6 @@ class CookieEnricher {
                 enrichedCookie.setValue(context.replaceDynamicContentInString(cookie.getValue()));
             }
 
-            if (cookie.getComment() != null) {
-                enrichedCookie.setComment(context.replaceDynamicContentInString(cookie.getComment()));
-            }
-
             if (cookie.getPath() != null) {
                 enrichedCookie.setPath(context.replaceDynamicContentInString(cookie.getPath()));
             }
@@ -56,7 +53,6 @@ class CookieEnricher {
             }
 
             enrichedCookie.setMaxAge(cookie.getMaxAge());
-            enrichedCookie.setVersion(cookie.getVersion());
             enrichedCookie.setHttpOnly(cookie.isHttpOnly());
             enrichedCookie.setSecure(cookie.getSecure());
 
@@ -65,5 +61,4 @@ class CookieEnricher {
 
         return enrichedCookies;
     }
-
 }

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/message/DelegatingHttpEntityMessageConverter.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/message/DelegatingHttpEntityMessageConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2018 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,6 @@
 
 package org.citrusframework.http.message;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import org.citrusframework.util.TypeConversionUtils;
 import org.springframework.http.HttpInputMessage;
 import org.springframework.http.HttpOutputMessage;
 import org.springframework.http.MediaType;
@@ -34,6 +28,15 @@ import org.springframework.http.converter.HttpMessageNotWritableException;
 import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.http.converter.support.AllEncompassingFormHttpMessageConverter;
 import org.springframework.util.MultiValueMap;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
+import static org.citrusframework.util.TypeConversionUtils.convertIfNecessary;
+import static org.springframework.http.MediaType.valueOf;
 
 /**
  * @author Christoph Deppisch
@@ -63,12 +66,16 @@ public class DelegatingHttpEntityMessageConverter extends AbstractHttpMessageCon
         super(MediaType.ALL);
 
         ByteArrayHttpMessageConverter byteArrayHttpMessageConverter = new ByteArrayHttpMessageConverter();
-        byteArrayHttpMessageConverter.setSupportedMediaTypes(Arrays.asList(MediaType.APPLICATION_OCTET_STREAM,
-                                                                            MediaType.APPLICATION_PDF,
-                                                                            MediaType.IMAGE_GIF,
-                                                                            MediaType.IMAGE_JPEG,
-                                                                            MediaType.IMAGE_PNG,
-                                                                            MediaType.valueOf("application/zip")));
+        byteArrayHttpMessageConverter.setSupportedMediaTypes(
+                asList(
+                        MediaType.APPLICATION_OCTET_STREAM,
+                        MediaType.APPLICATION_PDF,
+                        MediaType.IMAGE_GIF,
+                        MediaType.IMAGE_JPEG,
+                        MediaType.IMAGE_PNG,
+                        valueOf("application/zip")
+                )
+        );
 
         if (requestMessageConverters.isEmpty()) {
             requestMessageConverters.add(byteArrayHttpMessageConverter);
@@ -126,14 +133,14 @@ public class DelegatingHttpEntityMessageConverter extends AbstractHttpMessageCon
                 .findFirst()
                 .orElse(defaultResponseMessageConverter);
 
-        if (delegate instanceof ByteArrayHttpMessageConverter) {
-            ((ByteArrayHttpMessageConverter)delegate).write(TypeConversionUtils.convertIfNecessary(responseBody, byte[].class), outputMessage.getHeaders().getContentType(), outputMessage);
-        } else if (delegate instanceof StringHttpMessageConverter) {
-            ((StringHttpMessageConverter)delegate).write(TypeConversionUtils.convertIfNecessary(responseBody, String.class), outputMessage.getHeaders().getContentType(), outputMessage);
-        } else if (delegate instanceof FormHttpMessageConverter) {
-            ((FormHttpMessageConverter)delegate).write(TypeConversionUtils.convertIfNecessary(responseBody, MultiValueMap.class), outputMessage.getHeaders().getContentType(), outputMessage);
+        if (delegate instanceof ByteArrayHttpMessageConverter byteArrayHttpMessageConverter) {
+            byteArrayHttpMessageConverter.write(convertIfNecessary(responseBody, byte[].class), outputMessage.getHeaders().getContentType(), outputMessage);
+        } else if (delegate instanceof StringHttpMessageConverter stringHttpMessageConverter) {
+            stringHttpMessageConverter.write(convertIfNecessary(responseBody, String.class), outputMessage.getHeaders().getContentType(), outputMessage);
+        } else if (delegate instanceof FormHttpMessageConverter formHttpMessageConverter) {
+            formHttpMessageConverter.write(convertIfNecessary(responseBody, MultiValueMap.class), outputMessage.getHeaders().getContentType(), outputMessage);
         } else {
-            throw new HttpMessageNotWritableException(String.format("Failed to find proper message converter for contentType '%s'", outputMessage.getHeaders().getContentType()));
+            throw new HttpMessageNotWritableException(format("Failed to find proper message converter for contentType '%s'", outputMessage.getHeaders().getContentType()));
         }
     }
 

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/security/BasicAuthConstraint.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/security/BasicAuthConstraint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,25 +16,47 @@
 
 package org.citrusframework.http.security;
 
-import org.eclipse.jetty.util.security.Constraint;
+import org.eclipse.jetty.security.Constraint;
+
+import java.util.Set;
+
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.toSet;
+import static org.eclipse.jetty.security.Authenticator.BASIC_AUTH;
+import static org.eclipse.jetty.security.Constraint.Transport.INHERIT;
 
 /**
- * Convenient constraint instantiation for basic authentication and multiple user roles.
- * 
+ * Convenient constraint instantiation for basic authentication and multiple user roles. Access allowed only for
+ * authenticated user with specific role(s).
+ *
  * @author Christoph Deppisch
  * @since 1.3
  */
-public class BasicAuthConstraint extends Constraint {
+public class BasicAuthConstraint implements Constraint {
 
-    /** Serialization thingy. */
-    private static final long serialVersionUID = -2295787554785979668L;
+    private final Set<String> userRoles;
 
-    /**
-     * Default constructor using fields.
-     */
-    public BasicAuthConstraint(String[] roles) {
-        setName(Constraint.__BASIC_AUTH);
-        setRoles(roles);
-        setAuthenticate(true);
+    public BasicAuthConstraint(String[] userRoles) {
+        this.userRoles = stream(userRoles).collect(toSet());
+    }
+
+    @Override
+    public String getName() {
+        return BASIC_AUTH;
+    }
+
+    @Override
+    public Transport getTransport() {
+        return INHERIT;
+    }
+
+    @Override
+    public Authorization getAuthorization() {
+        return Authorization.SPECIFIC_ROLE;
+    }
+
+    @Override
+    public Set<String> getRoles() {
+        return userRoles;
     }
 }

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/security/BasicAuthentication.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/security/BasicAuthentication.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2023 the original author or authors.
+ *  Copyright 2023-2024 the original author or authors.
  *
  *  Licensed to the Apache Software Foundation (ASF) under one or more
  *  contributor license agreements. See the NOTICE file distributed with
@@ -19,9 +19,6 @@
 
 package org.citrusframework.http.security;
 
-import java.net.URL;
-import java.util.Collections;
-
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
 import org.citrusframework.exceptions.CitrusRuntimeException;
@@ -30,7 +27,12 @@ import org.citrusframework.http.client.HttpClient;
 import org.eclipse.jetty.security.SecurityHandler;
 import org.eclipse.jetty.security.authentication.BasicAuthenticator;
 import org.springframework.http.client.ClientHttpRequestFactory;
-import org.springframework.util.StringUtils;
+
+import java.net.URL;
+
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.citrusframework.util.StringUtils.hasText;
 
 /**
  * Basic authentication implementation able to create a proper request factory with basic auth client credentials.
@@ -42,8 +44,7 @@ public class BasicAuthentication implements HttpAuthentication {
     private final String password;
 
     private String realm = "";
-
-    private String[] userRoles = new String[] { "citrus" };
+    private String[] userRoles = new String[]{"citrus"};
 
     public BasicAuthentication(String username, String password) {
         this.username = username;
@@ -54,8 +55,8 @@ public class BasicAuthentication implements HttpAuthentication {
     public SecurityHandler getSecurityHandler(String resourcePath) {
         try {
             SecurityHandlerFactory securityHandlerFactory = new SecurityHandlerFactory();
-            securityHandlerFactory.setUsers(Collections.singletonList(new User(username, password, userRoles)));
-            securityHandlerFactory.setConstraints(Collections.singletonMap(resourcePath, new BasicAuthConstraint(userRoles)));
+            securityHandlerFactory.setUsers(singletonList(new User(username, password, userRoles)));
+            securityHandlerFactory.setConstraints(singletonMap(resourcePath, new BasicAuthConstraint(userRoles)));
 
             securityHandlerFactory.setAuthenticator(new BasicAuthenticator());
             securityHandlerFactory.setRealm(realm);
@@ -78,9 +79,9 @@ public class BasicAuthentication implements HttpAuthentication {
             }
 
             URL url = null;
-            if (StringUtils.hasText(requestUrl)) {
+            if (hasText(requestUrl)) {
                 url = new URL(requestUrl);
-            } else if (httpClient != null && StringUtils.hasText(httpClient.getEndpointConfiguration().getRequestUrl())) {
+            } else if (httpClient != null && hasText(httpClient.getEndpointConfiguration().getRequestUrl())) {
                 url = new URL(httpClient.getEndpointConfiguration().getRequestUrl());
             }
 

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/security/HttpAuthentication.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/security/HttpAuthentication.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2023 the original author or authors.
+ *  Copyright 2023-2024 the original author or authors.
  *
  *  Licensed to the Apache Software Foundation (ASF) under one or more
  *  contributor license agreements. See the NOTICE file distributed with
@@ -27,6 +27,7 @@ public interface HttpAuthentication {
 
     /**
      * Security handler able to set up server user authentication on given resource path.
+     *
      * @param resourcePath
      * @return
      */
@@ -34,13 +35,14 @@ public interface HttpAuthentication {
 
     /**
      * Creates client request factory that uses the given authentication method.
+     *
      * @param requestUrl
      * @param httpClient
      * @return
      */
     ClientHttpRequestFactory getRequestFactory(String requestUrl, HttpClient httpClient);
 
-    static BasicAuthentication basic(String username, String password) {
+    static HttpAuthentication basic(String username, String password) {
         return new BasicAuthentication(username, password);
     }
 }

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/server/AbstractHttpServerBuilder.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/server/AbstractHttpServerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2020-2024 the original author or authors.
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with
@@ -19,27 +19,29 @@
 
 package org.citrusframework.http.server;
 
-import java.util.List;
-import java.util.Map;
-
 import jakarta.servlet.Filter;
 import org.citrusframework.http.message.HttpMessageConverter;
 import org.citrusframework.http.security.HttpAuthentication;
 import org.citrusframework.http.security.HttpSecureConnection;
 import org.citrusframework.server.AbstractServerBuilder;
+import org.eclipse.jetty.ee10.servlet.ServletHandler;
 import org.eclipse.jetty.security.SecurityHandler;
 import org.eclipse.jetty.server.Connector;
-import org.eclipse.jetty.servlet.ServletHandler;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  * @author Christoph Deppisch
  */
 public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractHttpServerBuilder<T, B>> extends AbstractServerBuilder<T, B> {
 
-    /** Endpoint target */
+    /**
+     * Endpoint target
+     */
     private final T endpoint;
 
     private int securePort = 8443;
@@ -58,6 +60,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
 
     /**
      * Sets the port property.
+     *
      * @param port
      * @return
      */
@@ -68,6 +71,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
 
     /**
      * Sets the secure port property.
+     *
      * @param port
      * @return
      */
@@ -78,6 +82,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
 
     /**
      * Sets the context config location.
+     *
      * @param configLocation
      * @return
      */
@@ -88,6 +93,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
 
     /**
      * Sets the resource base.
+     *
      * @param resourceBase
      * @return
      */
@@ -98,6 +104,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
 
     /**
      * Enables/disables the root parent context.
+     *
      * @param rootParentContext
      * @return
      */
@@ -108,6 +115,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
 
     /**
      * Sets the connectors.
+     *
      * @param connectors
      * @return
      */
@@ -118,6 +126,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
 
     /**
      * Sets the connector.
+     *
      * @param connector
      * @return
      */
@@ -128,6 +137,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
 
     /**
      * Sets the filters.
+     *
      * @param filters
      * @return
      */
@@ -138,6 +148,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
 
     /**
      * Sets the filterMappings.
+     *
      * @param filterMappings
      * @return
      */
@@ -148,6 +159,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
 
     /**
      * Sets the binaryMediaTypes.
+     *
      * @param binaryMediaTypes
      * @return
      */
@@ -158,6 +170,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
 
     /**
      * Sets the servlet name.
+     *
      * @param servletName
      * @return
      */
@@ -168,6 +181,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
 
     /**
      * Sets the servlet mapping path.
+     *
      * @param servletMappingPath
      * @return
      */
@@ -178,6 +192,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
 
     /**
      * Sets the context path.
+     *
      * @param contextPath
      * @return
      */
@@ -188,6 +203,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
 
     /**
      * Sets the servlet handler.
+     *
      * @param servletHandler
      * @return
      */
@@ -198,6 +214,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
 
     /**
      * Sets the security handler.
+     *
      * @param securityHandler
      * @return
      */
@@ -208,6 +225,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
 
     /**
      * Sets the message converter.
+     *
      * @param messageConverter
      * @return
      */
@@ -218,6 +236,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
 
     /**
      * Sets the handleAttributeHeaders property.
+     *
      * @param flag
      * @return
      */
@@ -228,6 +247,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
 
     /**
      * Sets the handleCookies property.
+     *
      * @param flag
      * @return
      */
@@ -238,6 +258,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
 
     /**
      * Sets the default status code property.
+     *
      * @param status
      * @return
      */
@@ -248,6 +269,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
 
     /**
      * Sets the default response cache size on this server instance.
+     *
      * @param size
      * @return
      */
@@ -258,6 +280,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
 
     /**
      * Sets the interceptors.
+     *
      * @param interceptors
      * @return
      */

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/servlet/CitrusDispatcherServlet.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/servlet/CitrusDispatcherServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,6 @@
  */
 
 package org.citrusframework.http.servlet;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import org.citrusframework.endpoint.EndpointAdapter;
 import org.citrusframework.http.client.HttpEndpointConfiguration;
@@ -38,7 +35,9 @@ import org.springframework.web.servlet.DispatcherServlet;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.handler.MappedInterceptor;
 import org.springframework.web.servlet.handler.WebRequestHandlerInterceptorAdapter;
-import org.springframework.web.util.UrlPathHelper;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Citrus dispatcher servlet extends Spring's message dispatcher servlet and just
@@ -49,13 +48,19 @@ import org.springframework.web.util.UrlPathHelper;
  */
 public class CitrusDispatcherServlet extends DispatcherServlet {
 
-    /** Logger */
+    /**
+     * Logger
+     */
     private static final Logger logger = LoggerFactory.getLogger(CitrusDispatcherServlet.class);
 
-    /** Http server hosting the servlet */
+    /**
+     * Http server hosting the servlet
+     */
     private HttpServer httpServer;
 
-    /** Default bean names used in default configuration */
+    /**
+     * Default bean names used in default configuration
+     */
     protected static final String LOGGING_INTERCEPTOR_BEAN_NAME = "citrusLoggingInterceptor";
     protected static final String HANDLER_INTERCEPTOR_BEAN_NAME = "citrusHandlerInterceptor";
     protected static final String MESSAGE_CONTROLLER_BEAN_NAME = "citrusHttpMessageController";
@@ -64,6 +69,7 @@ public class CitrusDispatcherServlet extends DispatcherServlet {
     /**
      * Default constructor using http server instance that
      * holds this servlet.
+     *
      * @param httpServer
      */
     public CitrusDispatcherServlet(HttpServer httpServer) {
@@ -81,6 +87,7 @@ public class CitrusDispatcherServlet extends DispatcherServlet {
 
     /**
      * Post process handler interceptors.
+     *
      * @param context
      */
     protected void configureHandlerInterceptor(ApplicationContext context) {
@@ -92,6 +99,7 @@ public class CitrusDispatcherServlet extends DispatcherServlet {
 
     /**
      * Post process message controller.
+     *
      * @param context
      */
     protected void configureMessageController(ApplicationContext context) {
@@ -117,20 +125,22 @@ public class CitrusDispatcherServlet extends DispatcherServlet {
 
     /**
      * Post process message converter.
+     *
      * @param context
      */
     protected void configureMessageConverter(ApplicationContext context) {
         if (context.containsBean(MESSAGE_CONVERTER_BEAN_NAME)) {
             HttpMessageConverter messageConverter = context.getBean(MESSAGE_CONVERTER_BEAN_NAME, HttpMessageConverter.class);
 
-            if (messageConverter instanceof DelegatingHttpEntityMessageConverter) {
-                ((DelegatingHttpEntityMessageConverter) messageConverter).setBinaryMediaTypes(httpServer.getBinaryMediaTypes());
+            if (messageConverter instanceof DelegatingHttpEntityMessageConverter delegatingHttpEntityMessageConverter) {
+                delegatingHttpEntityMessageConverter.setBinaryMediaTypes(httpServer.getBinaryMediaTypes());
             }
         }
     }
 
     /**
      * Adapts object list to handler interceptors.
+     *
      * @param interceptors
      * @param context
      * @return
@@ -145,13 +155,13 @@ public class CitrusDispatcherServlet extends DispatcherServlet {
 
         if (interceptors != null) {
             for (Object interceptor : interceptors) {
-                if (interceptor instanceof MappedInterceptor) {
-                    handlerInterceptors.add(new MappedInterceptorAdapter((MappedInterceptor)interceptor,
-                            new UrlPathHelper(), new AntPathMatcher()));
-                } else if (interceptor instanceof HandlerInterceptor) {
-                    handlerInterceptors.add((HandlerInterceptor) interceptor);
-                } else if (interceptor instanceof WebRequestInterceptor) {
-                    handlerInterceptors.add(new WebRequestHandlerInterceptorAdapter((WebRequestInterceptor) interceptor));
+                if (interceptor instanceof MappedInterceptor mappedInterceptor) {
+                    mappedInterceptor.setPathMatcher(new AntPathMatcher());
+                    handlerInterceptors.add(new MappedInterceptorAdapter(mappedInterceptor));
+                } else if (interceptor instanceof HandlerInterceptor handlerInterceptor) {
+                    handlerInterceptors.add(handlerInterceptor);
+                } else if (interceptor instanceof WebRequestInterceptor webRequestInterceptor) {
+                    handlerInterceptors.add(new WebRequestHandlerInterceptorAdapter(webRequestInterceptor));
                 } else {
                     logger.warn("Unsupported interceptor type: {}", interceptor.getClass().getName());
                 }

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/servlet/GzipHttpServletRequestWrapper.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/servlet/GzipHttpServletRequestWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2018 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,13 @@
 
 package org.citrusframework.http.servlet;
 
-import org.citrusframework.exceptions.CitrusRuntimeException;
-
 import jakarta.servlet.ReadListener;
 import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletRequestWrapper;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+
 import java.io.IOException;
 import java.util.zip.GZIPInputStream;
 
@@ -58,11 +58,11 @@ public class GzipHttpServletRequestWrapper extends HttpServletRequestWrapper {
 
         /**
          * Default constructor using wrapped input stream.
+         *
          * @param request The request to wrap
          * @throws IOException if an I/O error has occurred
          */
         public GzipServletInputStream(ServletRequest request) throws IOException {
-            super();
             gzipStream = new GZIPInputStream(request.getInputStream());
         }
 

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/servlet/GzipServletFilter.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/servlet/GzipServletFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2016 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,13 @@
 
 package org.citrusframework.http.servlet;
 
-import org.springframework.http.HttpHeaders;
-import org.springframework.web.filter.OncePerRequestFilter;
-
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.filter.OncePerRequestFilter;
+
 import java.io.IOException;
 
 /**
@@ -36,8 +36,7 @@ import java.io.IOException;
 public class GzipServletFilter extends OncePerRequestFilter {
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
-                                    FilterChain filterChain) throws ServletException, IOException {
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         HttpServletRequest filteredRequest = request;
         HttpServletResponse filteredResponse = response;
 
@@ -51,8 +50,8 @@ public class GzipServletFilter extends OncePerRequestFilter {
 
         filterChain.doFilter(filteredRequest, filteredResponse);
 
-        if (filteredResponse instanceof GzipHttpServletResponseWrapper) {
-            ((GzipHttpServletResponseWrapper) filteredResponse).finish();
+        if (filteredResponse instanceof GzipHttpServletResponseWrapper gzipHttpServletResponseWrapper) {
+            gzipHttpServletResponseWrapper.finish();
         }
     }
 

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/config/annotation/HttpServerConfigParserTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/config/annotation/HttpServerConfigParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2016 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,6 @@
 package org.citrusframework.http.config.annotation;
 
 import jakarta.servlet.Filter;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-
 import org.citrusframework.TestActor;
 import org.citrusframework.annotations.CitrusAnnotations;
 import org.citrusframework.annotations.CitrusEndpoint;
@@ -36,21 +32,30 @@ import org.citrusframework.jms.config.annotation.JmsEndpointConfigParser;
 import org.citrusframework.jms.config.annotation.JmsSyncEndpointConfigParser;
 import org.citrusframework.spi.ReferenceResolver;
 import org.citrusframework.testng.AbstractTestNGUnitTest;
+import org.eclipse.jetty.ee10.servlet.ServletHandler;
 import org.eclipse.jetty.security.SecurityHandler;
 import org.eclipse.jetty.server.Connector;
-import org.eclipse.jetty.servlet.ServletHandler;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.servlet.HandlerInterceptor;
-import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.citrusframework.config.annotation.AnnotationConfigParser.lookup;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 /**
  * @author Christoph Deppisch
@@ -58,54 +63,54 @@ import static org.mockito.Mockito.when;
 public class HttpServerConfigParserTest extends AbstractTestNGUnitTest {
 
     @CitrusEndpoint(name = "httpServer1")
-    @HttpServerConfig(autoStart=false,
-            port=8081)
+    @HttpServerConfig(autoStart = false,
+            port = 8081)
     private HttpServer httpServer1;
 
     @CitrusEndpoint
-    @HttpServerConfig(autoStart=false,
-            port=8082,
-            contextConfigLocation="classpath:org/citrusframework/http/servlet-context.xml",
-            messageConverter="messageConverter",
-            handleAttributeHeaders=true,
-            handleCookies=true,
-            connector="connector",
-            resourceBase="src/it/resources",
-            rootParentContext=true,
-            debugLogging=true,
+    @HttpServerConfig(autoStart = false,
+            port = 8082,
+            contextConfigLocation = "classpath:org/citrusframework/http/servlet-context.xml",
+            messageConverter = "messageConverter",
+            handleAttributeHeaders = true,
+            handleCookies = true,
+            connector = "connector",
+            resourceBase = "src/it/resources",
+            rootParentContext = true,
+            debugLogging = true,
             binaryMediaTypes = {MediaType.APPLICATION_OCTET_STREAM_VALUE, "application/custom"},
             defaultStatus = HttpStatus.NOT_FOUND,
-            contextPath="/citrus",
-            servletName="citrus-http",
-            servletMappingPath="/foo")
+            contextPath = "/citrus",
+            servletName = "citrus-http",
+            servletMappingPath = "/foo")
     private HttpServer httpServer2;
 
     @CitrusEndpoint
-    @HttpServerConfig(autoStart=false,
-            port=8083,
-            connectors={"connector1", "connector2"},
-            filters={"filter1", "filter2"},
-            filterMappings={"filter2=/filter2/*"})
+    @HttpServerConfig(autoStart = false,
+            port = 8083,
+            connectors = {"connector1", "connector2"},
+            filters = {"filter1", "filter2"},
+            filterMappings = {"filter2=/filter2/*"})
     private HttpServer httpServer3;
 
     @CitrusEndpoint
-    @HttpServerConfig(autoStart=false,
-            port=8084,
-            servletHandler="servletHandler")
+    @HttpServerConfig(autoStart = false,
+            port = 8084,
+            servletHandler = "servletHandler")
     private HttpServer httpServer4;
 
     @CitrusEndpoint
-    @HttpServerConfig(autoStart=false,
-            port=8085,
-            securityHandler="securityHandler",
-            interceptors={ "clientInterceptor1", "clientInterceptor2" },
+    @HttpServerConfig(autoStart = false,
+            port = 8085,
+            securityHandler = "securityHandler",
+            interceptors = {"clientInterceptor1", "clientInterceptor2"},
             actor = "testActor")
     private HttpServer httpServer5;
 
     @CitrusEndpoint
-    @HttpServerConfig(autoStart=false,
-            port=8086,
-            endpointAdapter="endpointAdapter")
+    @HttpServerConfig(autoStart = false,
+            port = 8086,
+            endpointAdapter = "endpointAdapter")
     private HttpServer httpServer6;
 
     @Mock
@@ -148,14 +153,14 @@ public class HttpServerConfigParserTest extends AbstractTestNGUnitTest {
         when(referenceResolver.resolve("connector", Connector.class)).thenReturn(connector1);
         when(referenceResolver.resolve("connector1", Connector.class)).thenReturn(connector1);
         when(referenceResolver.resolve("connector2", Connector.class)).thenReturn(connector2);
-        when(referenceResolver.resolve(new String[] { "connector1", "connector2" }, Connector.class)).thenReturn(Arrays.asList(connector1, connector2));
+        when(referenceResolver.resolve(new String[]{"connector1", "connector2"}, Connector.class)).thenReturn(Arrays.asList(connector1, connector2));
         when(referenceResolver.resolve("filter1", Filter.class)).thenReturn(filter1);
         when(referenceResolver.resolve("filter2", Filter.class)).thenReturn(filter2);
         when(referenceResolver.resolveAll(Filter.class)).thenReturn(filters);
         when(referenceResolver.resolve("testActor", TestActor.class)).thenReturn(testActor);
         when(referenceResolver.resolve("clientInterceptor1", HandlerInterceptor.class)).thenReturn(clientInterceptor1);
         when(referenceResolver.resolve("clientInterceptor2", HandlerInterceptor.class)).thenReturn(clientInterceptor2);
-        when(referenceResolver.resolve(new String[] { "clientInterceptor1", "clientInterceptor2" }, HandlerInterceptor.class)).thenReturn(Arrays.asList(clientInterceptor1, clientInterceptor2));
+        when(referenceResolver.resolve(new String[]{"clientInterceptor1", "clientInterceptor2"}, HandlerInterceptor.class)).thenReturn(Arrays.asList(clientInterceptor1, clientInterceptor2));
         when(referenceResolver.resolve("endpointAdapter", EndpointAdapter.class)).thenReturn(endpointAdapter);
     }
 
@@ -169,131 +174,131 @@ public class HttpServerConfigParserTest extends AbstractTestNGUnitTest {
         CitrusAnnotations.injectEndpoints(this, context);
 
         // 1st message sender
-        Assert.assertNull(httpServer1.getConnector());
-        Assert.assertNull(httpServer1.getServletHandler());
-        Assert.assertNull(httpServer1.getSecurityHandler());
-        Assert.assertEquals(httpServer1.getConnectors().length, 0);
-        Assert.assertEquals(httpServer1.getFilters().size(), 0);
-        Assert.assertEquals(httpServer1.getFilterMappings().size(), 0);
-        Assert.assertEquals(httpServer1.getName(), "httpServer1");
-        Assert.assertEquals(httpServer1.getPort(), 8081);
-        Assert.assertEquals(httpServer1.getContextConfigLocation(), "classpath:org/citrusframework/http/citrus-servlet-context.xml");
-        Assert.assertEquals(httpServer1.getResourceBase(), "src/main/resources");
-        Assert.assertFalse(httpServer1.isHandleAttributeHeaders());
-        Assert.assertFalse(httpServer1.isHandleCookies());
-        Assert.assertFalse(httpServer1.isAutoStart());
-        Assert.assertFalse(httpServer1.isDebugLogging());
-        Assert.assertFalse(httpServer1.isUseRootContextAsParent());
-        Assert.assertEquals(httpServer1.getDefaultStatusCode(), HttpStatus.OK.value());
-        Assert.assertEquals(httpServer1.getContextPath(), "/");
-        Assert.assertEquals(httpServer1.getServletName(), "httpServer1-servlet");
-        Assert.assertEquals(httpServer1.getServletMappingPath(), "/*");
-        Assert.assertEquals(httpServer1.getBinaryMediaTypes().size(), 6L);
+        assertNull(httpServer1.getConnector());
+        assertNull(httpServer1.getServletHandler());
+        assertNull(httpServer1.getSecurityHandler());
+        assertEquals(httpServer1.getConnectors().length, 0);
+        assertEquals(httpServer1.getFilters().size(), 0);
+        assertEquals(httpServer1.getFilterMappings().size(), 0);
+        assertEquals(httpServer1.getName(), "httpServer1");
+        assertEquals(httpServer1.getPort(), 8081);
+        assertEquals(httpServer1.getContextConfigLocation(), "classpath:org/citrusframework/http/citrus-servlet-context.xml");
+        assertEquals(httpServer1.getResourceBase(), "src/main/resources");
+        assertFalse(httpServer1.isHandleAttributeHeaders());
+        assertFalse(httpServer1.isHandleCookies());
+        assertFalse(httpServer1.isAutoStart());
+        assertFalse(httpServer1.isDebugLogging());
+        assertFalse(httpServer1.isUseRootContextAsParent());
+        assertEquals(httpServer1.getDefaultStatusCode(), HttpStatus.OK.value());
+        assertEquals(httpServer1.getContextPath(), "/");
+        assertEquals(httpServer1.getServletName(), "httpServer1-servlet");
+        assertEquals(httpServer1.getServletMappingPath(), "/*");
+        assertEquals(httpServer1.getBinaryMediaTypes().size(), 6L);
 
         // 2nd message sender
-        Assert.assertNotNull(httpServer2.getConnector());
-        Assert.assertEquals(httpServer2.getMessageConverter(), messageConverter);
-        Assert.assertEquals(httpServer2.getConnector(), connector1);
-        Assert.assertEquals(httpServer2.getConnectors().length, 0);
-        Assert.assertEquals(httpServer2.getFilters().size(), 0);
-        Assert.assertEquals(httpServer2.getFilterMappings().size(), 0);
-        Assert.assertEquals(httpServer2.getName(), "httpServer2");
-        Assert.assertEquals(httpServer2.getPort(), 8082);
-        Assert.assertEquals(httpServer2.getContextConfigLocation(), "classpath:org/citrusframework/http/servlet-context.xml");
-        Assert.assertEquals(httpServer2.getResourceBase(), "src/it/resources");
-        Assert.assertTrue(httpServer2.isHandleAttributeHeaders());
-        Assert.assertTrue(httpServer2.isHandleCookies());
-        Assert.assertEquals(httpServer2.getDefaultStatusCode(), HttpStatus.NOT_FOUND.value());
-        Assert.assertFalse(httpServer2.isAutoStart());
-        Assert.assertTrue(httpServer2.isDebugLogging());
-        Assert.assertTrue(httpServer2.isUseRootContextAsParent());
-        Assert.assertEquals(httpServer2.getContextPath(), "/citrus");
-        Assert.assertEquals(httpServer2.getServletName(), "citrus-http");
-        Assert.assertEquals(httpServer2.getServletMappingPath(), "/foo");
-        Assert.assertEquals(httpServer2.getBinaryMediaTypes().size(), 2L);
-        Assert.assertTrue(httpServer2.getBinaryMediaTypes().contains(MediaType.valueOf("application/custom")));
+        assertNotNull(httpServer2.getConnector());
+        assertEquals(httpServer2.getMessageConverter(), messageConverter);
+        assertEquals(httpServer2.getConnector(), connector1);
+        assertEquals(httpServer2.getConnectors().length, 0);
+        assertEquals(httpServer2.getFilters().size(), 0);
+        assertEquals(httpServer2.getFilterMappings().size(), 0);
+        assertEquals(httpServer2.getName(), "httpServer2");
+        assertEquals(httpServer2.getPort(), 8082);
+        assertEquals(httpServer2.getContextConfigLocation(), "classpath:org/citrusframework/http/servlet-context.xml");
+        assertEquals(httpServer2.getResourceBase(), "src/it/resources");
+        assertTrue(httpServer2.isHandleAttributeHeaders());
+        assertTrue(httpServer2.isHandleCookies());
+        assertEquals(httpServer2.getDefaultStatusCode(), HttpStatus.NOT_FOUND.value());
+        assertFalse(httpServer2.isAutoStart());
+        assertTrue(httpServer2.isDebugLogging());
+        assertTrue(httpServer2.isUseRootContextAsParent());
+        assertEquals(httpServer2.getContextPath(), "/citrus");
+        assertEquals(httpServer2.getServletName(), "citrus-http");
+        assertEquals(httpServer2.getServletMappingPath(), "/foo");
+        assertEquals(httpServer2.getBinaryMediaTypes().size(), 2L);
+        assertTrue(httpServer2.getBinaryMediaTypes().contains(MediaType.valueOf("application/custom")));
 
         // 3rd message sender
-        Assert.assertNull(httpServer3.getConnector());
-        Assert.assertNotNull(httpServer3.getConnectors());
-        Assert.assertEquals(httpServer3.getConnectors().length, 2L);
-        Assert.assertNotNull(httpServer3.getFilters());
-        Assert.assertEquals(httpServer3.getFilters().size(), 2L);
-        Assert.assertNotNull(httpServer3.getFilterMappings());
-        Assert.assertEquals(httpServer3.getFilterMappings().size(), 1L);
-        Assert.assertEquals(httpServer3.getName(), "httpServer3");
-        Assert.assertEquals(httpServer3.getPort(), 8083);
-        Assert.assertEquals(httpServer3.getContextConfigLocation(), "classpath:org/citrusframework/http/citrus-servlet-context.xml");
-        Assert.assertEquals(httpServer3.getResourceBase(), "src/main/resources");
-        Assert.assertFalse(httpServer3.isAutoStart());
-        Assert.assertFalse(httpServer3.isUseRootContextAsParent());
-        Assert.assertEquals(httpServer3.getServletName(), "httpServer3-servlet");
+        assertNull(httpServer3.getConnector());
+        assertNotNull(httpServer3.getConnectors());
+        assertEquals(httpServer3.getConnectors().length, 2L);
+        assertNotNull(httpServer3.getFilters());
+        assertEquals(httpServer3.getFilters().size(), 2L);
+        assertNotNull(httpServer3.getFilterMappings());
+        assertEquals(httpServer3.getFilterMappings().size(), 1L);
+        assertEquals(httpServer3.getName(), "httpServer3");
+        assertEquals(httpServer3.getPort(), 8083);
+        assertEquals(httpServer3.getContextConfigLocation(), "classpath:org/citrusframework/http/citrus-servlet-context.xml");
+        assertEquals(httpServer3.getResourceBase(), "src/main/resources");
+        assertFalse(httpServer3.isAutoStart());
+        assertFalse(httpServer3.isUseRootContextAsParent());
+        assertEquals(httpServer3.getServletName(), "httpServer3-servlet");
 
         // 4th message sender
-        Assert.assertNull(httpServer4.getConnector());
-        Assert.assertNotNull(httpServer4.getServletHandler());
-        Assert.assertEquals(httpServer4.getServletHandler(), servletHandler);
-        Assert.assertEquals(httpServer4.getName(), "httpServer4");
-        Assert.assertEquals(httpServer4.getPort(), 8084);
-        Assert.assertEquals(httpServer4.getContextConfigLocation(), "classpath:org/citrusframework/http/citrus-servlet-context.xml");
-        Assert.assertEquals(httpServer4.getResourceBase(), "src/main/resources");
-        Assert.assertFalse(httpServer4.isAutoStart());
-        Assert.assertFalse(httpServer4.isUseRootContextAsParent());
-        Assert.assertEquals(httpServer4.getServletName(), "httpServer4-servlet");
-        Assert.assertNotNull(httpServer4.getInterceptors());
-        Assert.assertEquals(httpServer4.getInterceptors().size(), 0L);
+        assertNull(httpServer4.getConnector());
+        assertNotNull(httpServer4.getServletHandler());
+        assertEquals(httpServer4.getServletHandler(), servletHandler);
+        assertEquals(httpServer4.getName(), "httpServer4");
+        assertEquals(httpServer4.getPort(), 8084);
+        assertEquals(httpServer4.getContextConfigLocation(), "classpath:org/citrusframework/http/citrus-servlet-context.xml");
+        assertEquals(httpServer4.getResourceBase(), "src/main/resources");
+        assertFalse(httpServer4.isAutoStart());
+        assertFalse(httpServer4.isUseRootContextAsParent());
+        assertEquals(httpServer4.getServletName(), "httpServer4-servlet");
+        assertNotNull(httpServer4.getInterceptors());
+        assertEquals(httpServer4.getInterceptors().size(), 0L);
 
         // 5th message sender
-        Assert.assertNull(httpServer5.getConnector());
-        Assert.assertNotNull(httpServer5.getSecurityHandler());
-        Assert.assertEquals(httpServer5.getSecurityHandler(), securityHandler);
-        Assert.assertEquals(httpServer5.getName(), "httpServer5");
-        Assert.assertEquals(httpServer5.getPort(), 8085);
-        Assert.assertEquals(httpServer5.getContextConfigLocation(), "classpath:org/citrusframework/http/citrus-servlet-context.xml");
-        Assert.assertEquals(httpServer5.getResourceBase(), "src/main/resources");
-        Assert.assertFalse(httpServer5.isAutoStart());
-        Assert.assertFalse(httpServer5.isUseRootContextAsParent());
-        Assert.assertEquals(httpServer5.getServletName(), "httpServer5-servlet");
-        Assert.assertNotNull(httpServer5.getInterceptors());
-        Assert.assertEquals(httpServer5.getInterceptors().size(), 2L);
+        assertNull(httpServer5.getConnector());
+        assertNotNull(httpServer5.getSecurityHandler());
+        assertEquals(httpServer5.getSecurityHandler(), securityHandler);
+        assertEquals(httpServer5.getName(), "httpServer5");
+        assertEquals(httpServer5.getPort(), 8085);
+        assertEquals(httpServer5.getContextConfigLocation(), "classpath:org/citrusframework/http/citrus-servlet-context.xml");
+        assertEquals(httpServer5.getResourceBase(), "src/main/resources");
+        assertFalse(httpServer5.isAutoStart());
+        assertFalse(httpServer5.isUseRootContextAsParent());
+        assertEquals(httpServer5.getServletName(), "httpServer5-servlet");
+        assertNotNull(httpServer5.getInterceptors());
+        assertEquals(httpServer5.getInterceptors().size(), 2L);
 
         // 6th message sender
-        Assert.assertNull(httpServer6.getConnector());
-        Assert.assertNotNull(httpServer6.getEndpointAdapter());
-        Assert.assertEquals(httpServer6.getEndpointAdapter(), endpointAdapter);
-        Assert.assertEquals(httpServer6.getName(), "httpServer6");
-        Assert.assertEquals(httpServer6.getPort(), 8086);
-        Assert.assertEquals(httpServer6.getContextConfigLocation(), "classpath:org/citrusframework/http/citrus-servlet-context.xml");
-        Assert.assertEquals(httpServer6.getResourceBase(), "src/main/resources");
-        Assert.assertFalse(httpServer6.isAutoStart());
-        Assert.assertFalse(httpServer6.isUseRootContextAsParent());
-        Assert.assertEquals(httpServer6.getServletName(), "httpServer6-servlet");
+        assertNull(httpServer6.getConnector());
+        assertNotNull(httpServer6.getEndpointAdapter());
+        assertEquals(httpServer6.getEndpointAdapter(), endpointAdapter);
+        assertEquals(httpServer6.getName(), "httpServer6");
+        assertEquals(httpServer6.getPort(), 8086);
+        assertEquals(httpServer6.getContextConfigLocation(), "classpath:org/citrusframework/http/citrus-servlet-context.xml");
+        assertEquals(httpServer6.getResourceBase(), "src/main/resources");
+        assertFalse(httpServer6.isAutoStart());
+        assertFalse(httpServer6.isUseRootContextAsParent());
+        assertEquals(httpServer6.getServletName(), "httpServer6-servlet");
     }
 
     @Test
     public void testLookupAll() {
-        Map<String, AnnotationConfigParser> validators = AnnotationConfigParser.lookup();
-        Assert.assertEquals(validators.size(), 8L);
-        Assert.assertNotNull(validators.get("direct.async"));
-        Assert.assertEquals(validators.get("direct.async").getClass(), DirectEndpointConfigParser.class);
-        Assert.assertNotNull(validators.get("direct.sync"));
-        Assert.assertEquals(validators.get("direct.sync").getClass(), DirectSyncEndpointConfigParser.class);
-        Assert.assertNotNull(validators.get("jms.async"));
-        Assert.assertEquals(validators.get("jms.async").getClass(), JmsEndpointConfigParser.class);
-        Assert.assertNotNull(validators.get("jms.sync"));
-        Assert.assertEquals(validators.get("jms.sync").getClass(), JmsSyncEndpointConfigParser.class);
-        Assert.assertNotNull(validators.get("channel.async"));
-        Assert.assertEquals(validators.get("channel.async").getClass(), ChannelEndpointConfigParser.class);
-        Assert.assertNotNull(validators.get("channel.sync"));
-        Assert.assertEquals(validators.get("channel.sync").getClass(), ChannelSyncEndpointConfigParser.class);
-        Assert.assertNotNull(validators.get("http.client"));
-        Assert.assertEquals(validators.get("http.client").getClass(), HttpClientConfigParser.class);
-        Assert.assertNotNull(validators.get("http.server"));
-        Assert.assertEquals(validators.get("http.server").getClass(), HttpServerConfigParser.class);
+        Map<String, AnnotationConfigParser> validators = lookup();
+        assertEquals(validators.size(), 8L);
+        assertNotNull(validators.get("direct.async"));
+        assertEquals(validators.get("direct.async").getClass(), DirectEndpointConfigParser.class);
+        assertNotNull(validators.get("direct.sync"));
+        assertEquals(validators.get("direct.sync").getClass(), DirectSyncEndpointConfigParser.class);
+        assertNotNull(validators.get("jms.async"));
+        assertEquals(validators.get("jms.async").getClass(), JmsEndpointConfigParser.class);
+        assertNotNull(validators.get("jms.sync"));
+        assertEquals(validators.get("jms.sync").getClass(), JmsSyncEndpointConfigParser.class);
+        assertNotNull(validators.get("channel.async"));
+        assertEquals(validators.get("channel.async").getClass(), ChannelEndpointConfigParser.class);
+        assertNotNull(validators.get("channel.sync"));
+        assertEquals(validators.get("channel.sync").getClass(), ChannelSyncEndpointConfigParser.class);
+        assertNotNull(validators.get("http.client"));
+        assertEquals(validators.get("http.client").getClass(), HttpClientConfigParser.class);
+        assertNotNull(validators.get("http.server"));
+        assertEquals(validators.get("http.server").getClass(), HttpServerConfigParser.class);
     }
 
     @Test
     public void testLookupByQualifier() {
-        Assert.assertTrue(AnnotationConfigParser.lookup("http.server").isPresent());
+        assertTrue(lookup("http.server").isPresent());
     }
 }

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/config/xml/HttpServerParserTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/config/xml/HttpServerParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,8 +34,13 @@ import jakarta.jms.ConnectionFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 /**
  * @author Christoph Deppisch
@@ -46,101 +51,101 @@ public class HttpServerParserTest extends AbstractBeanDefinitionParserTest {
     public void testHttpServerParser() {
         Map<String, HttpServer> servers = beanDefinitionContext.getBeansOfType(HttpServer.class);
 
-        Assert.assertEquals(servers.size(), 5);
+        assertEquals(servers.size(), 5);
 
         // 1st message sender
         HttpServer server = servers.get("httpServer1");
-        Assert.assertNull(server.getConnector());
-        Assert.assertNull(server.getServletHandler());
-        Assert.assertNull(server.getSecurityHandler());
-        Assert.assertEquals(server.getConnectors().length, 0);
-        Assert.assertEquals(server.getFilters().size(), 0);
-        Assert.assertEquals(server.getFilterMappings().size(), 0);
-        Assert.assertEquals(server.getName(), "httpServer1");
-        Assert.assertEquals(server.getPort(), 8081);
-        Assert.assertEquals(server.getContextConfigLocation(), "classpath:org/citrusframework/http/citrus-servlet-context.xml");
-        Assert.assertEquals(server.getResourceBase(), "src/main/resources");
-        Assert.assertFalse(server.isAutoStart());
-        Assert.assertFalse(server.isDebugLogging());
-        Assert.assertFalse(server.isUseRootContextAsParent());
-        Assert.assertEquals(server.getDefaultStatusCode(), HttpStatus.OK.value());
-        Assert.assertEquals(server.getResponseCacheSize(), HttpServerSettings.responseCacheSize());
-        Assert.assertEquals(server.getContextPath(), "/");
-        Assert.assertEquals(server.getServletName(), "httpServer1-servlet");
-        Assert.assertEquals(server.getServletMappingPath(), "/*");
-        Assert.assertFalse(server.isHandleAttributeHeaders());
-        Assert.assertFalse(server.isHandleCookies());
-        Assert.assertEquals(server.getBinaryMediaTypes().size(), 6L);
+        assertNull(server.getConnector());
+        assertNull(server.getServletHandler());
+        assertNull(server.getSecurityHandler());
+        assertEquals(server.getConnectors().length, 0);
+        assertEquals(server.getFilters().size(), 0);
+        assertEquals(server.getFilterMappings().size(), 0);
+        assertEquals(server.getName(), "httpServer1");
+        assertEquals(server.getPort(), 8081);
+        assertEquals(server.getContextConfigLocation(), "classpath:org/citrusframework/http/citrus-servlet-context.xml");
+        assertEquals(server.getResourceBase(), "src/main/resources");
+        assertFalse(server.isAutoStart());
+        assertFalse(server.isDebugLogging());
+        assertFalse(server.isUseRootContextAsParent());
+        assertEquals(server.getDefaultStatusCode(), HttpStatus.OK.value());
+        assertEquals(server.getResponseCacheSize(), HttpServerSettings.responseCacheSize());
+        assertEquals(server.getContextPath(), "/");
+        assertEquals(server.getServletName(), "httpServer1-servlet");
+        assertEquals(server.getServletMappingPath(), "/*");
+        assertFalse(server.isHandleAttributeHeaders());
+        assertFalse(server.isHandleCookies());
+        assertEquals(server.getBinaryMediaTypes().size(), 6L);
 
         // 2nd message sender
         server = servers.get("httpServer2");
-        Assert.assertNotNull(server.getConnector());
-        Assert.assertEquals(server.getMessageConverter(), beanDefinitionContext.getBean("messageConverter"));
-        Assert.assertEquals(server.getConnector(), beanDefinitionContext.getBean("connector"));
-        Assert.assertEquals(server.getConnectors().length, 0);
-        Assert.assertEquals(server.getName(), "httpServer2");
-        Assert.assertEquals(server.getPort(), 8082);
-        Assert.assertEquals(server.getContextConfigLocation(), "classpath:org/citrusframework/http/servlet-context.xml");
-        Assert.assertEquals(server.getResourceBase(), "src/it/resources");
-        Assert.assertFalse(server.isAutoStart());
-        Assert.assertTrue(server.isDebugLogging());
-        Assert.assertTrue(server.isUseRootContextAsParent());
-        Assert.assertEquals(server.getDefaultStatusCode(), HttpStatus.NOT_FOUND.value());
-        Assert.assertEquals(server.getResponseCacheSize(), 1000);
-        Assert.assertEquals(server.getContextPath(), "/citrus");
-        Assert.assertEquals(server.getServletName(), "citrus-http");
-        Assert.assertEquals(server.getServletMappingPath(), "/foo");
-        Assert.assertTrue(server.isHandleAttributeHeaders());
-        Assert.assertTrue(server.isHandleCookies());
-        Assert.assertEquals(server.getBinaryMediaTypes().size(), 2L);
-        Assert.assertTrue(server.getBinaryMediaTypes().contains(MediaType.valueOf("application/custom")));
+        assertNotNull(server.getConnector());
+        assertEquals(server.getMessageConverter(), beanDefinitionContext.getBean("messageConverter"));
+        assertEquals(server.getConnector(), beanDefinitionContext.getBean("connector"));
+        assertEquals(server.getConnectors().length, 0);
+        assertEquals(server.getName(), "httpServer2");
+        assertEquals(server.getPort(), 8082);
+        assertEquals(server.getContextConfigLocation(), "classpath:org/citrusframework/http/servlet-context.xml");
+        assertEquals(server.getResourceBase(), "src/it/resources");
+        assertFalse(server.isAutoStart());
+        assertTrue(server.isDebugLogging());
+        assertTrue(server.isUseRootContextAsParent());
+        assertEquals(server.getDefaultStatusCode(), HttpStatus.NOT_FOUND.value());
+        assertEquals(server.getResponseCacheSize(), 1000);
+        assertEquals(server.getContextPath(), "/citrus");
+        assertEquals(server.getServletName(), "citrus-http");
+        assertEquals(server.getServletMappingPath(), "/foo");
+        assertTrue(server.isHandleAttributeHeaders());
+        assertTrue(server.isHandleCookies());
+        assertEquals(server.getBinaryMediaTypes().size(), 2L);
+        assertTrue(server.getBinaryMediaTypes().contains(MediaType.valueOf("application/custom")));
 
         // 3rd message sender
         server = servers.get("httpServer3");
-        Assert.assertNull(server.getConnector());
-        Assert.assertNotNull(server.getConnectors());
-        Assert.assertEquals(server.getConnectors().length, beanDefinitionContext.getBean("connectors", List.class).size());
-        Assert.assertNotNull(server.getFilters());
-        Assert.assertEquals(server.getFilters().size(), beanDefinitionContext.getBean("filters", Map.class).size());
-        Assert.assertNotNull(server.getFilterMappings());
-        Assert.assertEquals(server.getFilterMappings().size(), beanDefinitionContext.getBean("filterMappings", Map.class).size());
-        Assert.assertEquals(server.getName(), "httpServer3");
-        Assert.assertEquals(server.getPort(), 8083);
-        Assert.assertEquals(server.getContextConfigLocation(), "classpath:org/citrusframework/http/citrus-servlet-context.xml");
-        Assert.assertEquals(server.getResourceBase(), "src/main/resources");
-        Assert.assertFalse(server.isAutoStart());
-        Assert.assertFalse(server.isUseRootContextAsParent());
-        Assert.assertEquals(server.getServletName(), "httpServer3-servlet");
+        assertNull(server.getConnector());
+        assertNotNull(server.getConnectors());
+        assertEquals(server.getConnectors().length, beanDefinitionContext.getBean("connectors", List.class).size());
+        assertNotNull(server.getFilters());
+        assertEquals(server.getFilters().size(), beanDefinitionContext.getBean("filters", Map.class).size());
+        assertNotNull(server.getFilterMappings());
+        assertEquals(server.getFilterMappings().size(), beanDefinitionContext.getBean("filterMappings", Map.class).size());
+        assertEquals(server.getName(), "httpServer3");
+        assertEquals(server.getPort(), 8083);
+        assertEquals(server.getContextConfigLocation(), "classpath:org/citrusframework/http/citrus-servlet-context.xml");
+        assertEquals(server.getResourceBase(), "src/main/resources");
+        assertFalse(server.isAutoStart());
+        assertFalse(server.isUseRootContextAsParent());
+        assertEquals(server.getServletName(), "httpServer3-servlet");
 
         // 4th message sender
         server = servers.get("httpServer4");
-        Assert.assertNull(server.getConnector());
-        Assert.assertNotNull(server.getServletHandler());
-        Assert.assertEquals(server.getServletHandler(), beanDefinitionContext.getBean("servletHandler"));
-        Assert.assertEquals(server.getName(), "httpServer4");
-        Assert.assertEquals(server.getPort(), 8084);
-        Assert.assertEquals(server.getContextConfigLocation(), "classpath:org/citrusframework/http/citrus-servlet-context.xml");
-        Assert.assertEquals(server.getResourceBase(), "src/main/resources");
-        Assert.assertFalse(server.isAutoStart());
-        Assert.assertFalse(server.isUseRootContextAsParent());
-        Assert.assertEquals(server.getServletName(), "httpServer4-servlet");
-        Assert.assertNotNull(server.getInterceptors());
-        Assert.assertEquals(server.getInterceptors().size(), 0L);
+        assertNull(server.getConnector());
+        assertNotNull(server.getServletHandler());
+        assertEquals(server.getServletHandler(), beanDefinitionContext.getBean("servletHandler"));
+        assertEquals(server.getName(), "httpServer4");
+        assertEquals(server.getPort(), 8084);
+        assertEquals(server.getContextConfigLocation(), "classpath:org/citrusframework/http/citrus-servlet-context.xml");
+        assertEquals(server.getResourceBase(), "src/main/resources");
+        assertFalse(server.isAutoStart());
+        assertFalse(server.isUseRootContextAsParent());
+        assertEquals(server.getServletName(), "httpServer4-servlet");
+        assertNotNull(server.getInterceptors());
+        assertEquals(server.getInterceptors().size(), 0L);
 
         // 5th message sender
         server = servers.get("httpServer5");
-        Assert.assertNull(server.getConnector());
-        Assert.assertNotNull(server.getSecurityHandler());
-        Assert.assertEquals(server.getSecurityHandler(), beanDefinitionContext.getBean("securityHandler"));
-        Assert.assertEquals(server.getName(), "httpServer5");
-        Assert.assertEquals(server.getPort(), 8085);
-        Assert.assertEquals(server.getContextConfigLocation(), "classpath:org/citrusframework/http/citrus-servlet-context.xml");
-        Assert.assertEquals(server.getResourceBase(), "src/main/resources");
-        Assert.assertFalse(server.isAutoStart());
-        Assert.assertFalse(server.isUseRootContextAsParent());
-        Assert.assertEquals(server.getServletName(), "httpServer5-servlet");
-        Assert.assertNotNull(server.getInterceptors());
-        Assert.assertEquals(server.getInterceptors().size(), 2L);
+        assertNull(server.getConnector());
+        assertNotNull(server.getSecurityHandler());
+        assertEquals(server.getSecurityHandler(), beanDefinitionContext.getBean("securityHandler"));
+        assertEquals(server.getName(), "httpServer5");
+        assertEquals(server.getPort(), 8085);
+        assertEquals(server.getContextConfigLocation(), "classpath:org/citrusframework/http/citrus-servlet-context.xml");
+        assertEquals(server.getResourceBase(), "src/main/resources");
+        assertFalse(server.isAutoStart());
+        assertFalse(server.isUseRootContextAsParent());
+        assertEquals(server.getServletName(), "httpServer5-servlet");
+        assertNotNull(server.getInterceptors());
+        assertEquals(server.getInterceptors().size(), 2L);
     }
 
     @Test
@@ -149,57 +154,57 @@ public class HttpServerParserTest extends AbstractBeanDefinitionParserTest {
 
         Map<String, HttpServer> servers = beanDefinitionContext.getBeansOfType(HttpServer.class);
 
-        Assert.assertEquals(servers.size(), 6);
+        assertEquals(servers.size(), 6);
 
         // 1st message sender
         HttpServer server = servers.get("httpServer1");
-        Assert.assertEquals(server.getName(), "httpServer1");
-        Assert.assertEquals(server.getPort(), 8081);
-        Assert.assertNotNull(server.getEndpointAdapter());
-        Assert.assertEquals(server.getEndpointAdapter().getClass(), ChannelEndpointAdapter.class);
-        Assert.assertNotNull(server.getEndpointAdapter().getEndpoint());
-        Assert.assertEquals(server.getEndpointAdapter().getEndpoint().getEndpointConfiguration().getTimeout(), 10000L);
-        Assert.assertEquals(((ChannelEndpointConfiguration)server.getEndpointAdapter().getEndpoint().getEndpointConfiguration()).getChannelName(), "serverChannel");
+        assertEquals(server.getName(), "httpServer1");
+        assertEquals(server.getPort(), 8081);
+        assertNotNull(server.getEndpointAdapter());
+        assertEquals(server.getEndpointAdapter().getClass(), ChannelEndpointAdapter.class);
+        assertNotNull(server.getEndpointAdapter().getEndpoint());
+        assertEquals(server.getEndpointAdapter().getEndpoint().getEndpointConfiguration().getTimeout(), 10000L);
+        assertEquals(((ChannelEndpointConfiguration)server.getEndpointAdapter().getEndpoint().getEndpointConfiguration()).getChannelName(), "serverChannel");
 
         // 2nd message sender
         server = servers.get("httpServer2");
-        Assert.assertEquals(server.getName(), "httpServer2");
-        Assert.assertEquals(server.getPort(), 8082);
-        Assert.assertNotNull(server.getEndpointAdapter());
-        Assert.assertEquals(server.getEndpointAdapter().getClass(), JmsEndpointAdapter.class);
-        Assert.assertNotNull(server.getEndpointAdapter().getEndpoint());
-        Assert.assertEquals(server.getEndpointAdapter().getEndpoint().getEndpointConfiguration().getTimeout(), 2500);
-        Assert.assertEquals(((JmsEndpointConfiguration)server.getEndpointAdapter().getEndpoint().getEndpointConfiguration()).getDestinationName(), "serverQueue");
-        Assert.assertEquals(((JmsEndpointConfiguration)server.getEndpointAdapter().getEndpoint().getEndpointConfiguration()).getConnectionFactory(), beanDefinitionContext.getBean("connectionFactory", ConnectionFactory.class));
+        assertEquals(server.getName(), "httpServer2");
+        assertEquals(server.getPort(), 8082);
+        assertNotNull(server.getEndpointAdapter());
+        assertEquals(server.getEndpointAdapter().getClass(), JmsEndpointAdapter.class);
+        assertNotNull(server.getEndpointAdapter().getEndpoint());
+        assertEquals(server.getEndpointAdapter().getEndpoint().getEndpointConfiguration().getTimeout(), 2500);
+        assertEquals(((JmsEndpointConfiguration)server.getEndpointAdapter().getEndpoint().getEndpointConfiguration()).getDestinationName(), "serverQueue");
+        assertEquals(((JmsEndpointConfiguration)server.getEndpointAdapter().getEndpoint().getEndpointConfiguration()).getConnectionFactory(), beanDefinitionContext.getBean("connectionFactory", ConnectionFactory.class));
 
         // 3rd message sender
         server = servers.get("httpServer3");
-        Assert.assertEquals(server.getName(), "httpServer3");
-        Assert.assertEquals(server.getPort(), 8083);
-        Assert.assertNotNull(server.getEndpointAdapter());
-        Assert.assertEquals(server.getEndpointAdapter().getClass(), EmptyResponseEndpointAdapter.class);
+        assertEquals(server.getName(), "httpServer3");
+        assertEquals(server.getPort(), 8083);
+        assertNotNull(server.getEndpointAdapter());
+        assertEquals(server.getEndpointAdapter().getClass(), EmptyResponseEndpointAdapter.class);
 
         // 4th message sender
         server = servers.get("httpServer4");
-        Assert.assertEquals(server.getName(), "httpServer4");
-        Assert.assertEquals(server.getPort(), 8084);
-        Assert.assertNotNull(server.getEndpointAdapter());
-        Assert.assertEquals(server.getEndpointAdapter().getClass(), StaticResponseEndpointAdapter.class);
-        Assert.assertEquals(((StaticResponseEndpointAdapter) server.getEndpointAdapter()).getMessagePayload().replaceAll("\\s", ""), "<TestMessage><Text>Hello!</Text></TestMessage>");
-        Assert.assertEquals(((StaticResponseEndpointAdapter) server.getEndpointAdapter()).getMessageHeader().get("Operation"), "sayHello");
+        assertEquals(server.getName(), "httpServer4");
+        assertEquals(server.getPort(), 8084);
+        assertNotNull(server.getEndpointAdapter());
+        assertEquals(server.getEndpointAdapter().getClass(), StaticResponseEndpointAdapter.class);
+        assertEquals(((StaticResponseEndpointAdapter) server.getEndpointAdapter()).getMessagePayload().replaceAll("\\s", ""), "<TestMessage><Text>Hello!</Text></TestMessage>");
+        assertEquals(((StaticResponseEndpointAdapter) server.getEndpointAdapter()).getMessageHeader().get("Operation"), "sayHello");
 
         // 5th message sender
         server = servers.get("httpServer5");
-        Assert.assertEquals(server.getName(), "httpServer5");
-        Assert.assertEquals(server.getPort(), 8085);
-        Assert.assertNotNull(server.getEndpointAdapter());
-        Assert.assertEquals(server.getEndpointAdapter().getClass(), TimeoutProducingEndpointAdapter.class);
+        assertEquals(server.getName(), "httpServer5");
+        assertEquals(server.getPort(), 8085);
+        assertNotNull(server.getEndpointAdapter());
+        assertEquals(server.getEndpointAdapter().getClass(), TimeoutProducingEndpointAdapter.class);
 
         // 6th message sender
         server = servers.get("httpServer6");
-        Assert.assertEquals(server.getName(), "httpServer6");
-        Assert.assertEquals(server.getPort(), 8086);
-        Assert.assertNotNull(server.getEndpointAdapter());
-        Assert.assertEquals(server.getEndpointAdapter(), beanDefinitionContext.getBean("httpServerAdapter6", EndpointAdapter.class));
+        assertEquals(server.getName(), "httpServer6");
+        assertEquals(server.getPort(), 8086);
+        assertNotNull(server.getEndpointAdapter());
+        assertEquals(server.getEndpointAdapter(), beanDefinitionContext.getBean("httpServerAdapter6", EndpointAdapter.class));
     }
 }

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/integration/HttpBasicAuthJavaIT.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/integration/HttpBasicAuthJavaIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2023 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,16 +19,16 @@ package org.citrusframework.http.integration;
 import org.citrusframework.annotations.CitrusTest;
 import org.citrusframework.http.client.HttpClient;
 import org.citrusframework.http.client.HttpClientBuilder;
-import org.citrusframework.http.security.HttpAuthentication;
 import org.citrusframework.http.server.HttpServer;
 import org.citrusframework.http.server.HttpServerBuilder;
 import org.citrusframework.spi.BindToRegistry;
 import org.citrusframework.testng.spring.TestNGCitrusSpringSupport;
-import org.citrusframework.util.SocketUtils;
 import org.springframework.http.HttpStatus;
 import org.testng.annotations.Test;
 
 import static org.citrusframework.http.actions.HttpActionBuilder.http;
+import static org.citrusframework.http.security.HttpAuthentication.basic;
+import static org.citrusframework.util.SocketUtils.findAvailableTcpPort;
 
 /**
  * @author Christoph Deppisch
@@ -36,20 +36,20 @@ import static org.citrusframework.http.actions.HttpActionBuilder.http;
 @Test
 public class HttpBasicAuthJavaIT extends TestNGCitrusSpringSupport {
 
-    private final int port = SocketUtils.findAvailableTcpPort(8888);
+    private final int port = findAvailableTcpPort(8888);
 
     @BindToRegistry
     private final HttpServer basicAuthServer = new HttpServerBuilder()
             .port(port)
             .autoStart(true)
             .defaultStatus(HttpStatus.NO_CONTENT)
-            .authentication("/secured/*", HttpAuthentication.basic("citrus", "secr3t"))
+            .authentication("/secured/*", basic("citrus", "secr3t"))
             .build();
 
     @BindToRegistry
     private final HttpClient basicAuthClient = new HttpClientBuilder()
             .requestUrl("http://localhost:%d".formatted(port))
-            .authentication(HttpAuthentication.basic("citrus", "secr3t"))
+            .authentication(basic("citrus", "secr3t"))
             .build();
 
     @CitrusTest

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/message/CookieConverterTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/message/CookieConverterTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2018 the original author or authors
+ *    Copyright 2018-2024 the original author or authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,16 +16,17 @@
 
 package org.citrusframework.http.message;
 
+import jakarta.servlet.http.Cookie;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import jakarta.servlet.http.Cookie;
 import java.util.Collections;
 
 import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNull;
 import static org.testng.AssertJUnit.assertTrue;
 
 public class CookieConverterTest {
@@ -36,235 +37,219 @@ public class CookieConverterTest {
     private HttpHeaders cookieHeaders;
 
     @BeforeMethod
-    public void setUp(){
+    public void setUp() {
         cookie = new Cookie("foo", "bar");
         cookieHeaders = new HttpHeaders();
     }
 
     @Test
-    public void testCookiesAreParsedCorrectly(){
-
-        //GIVEN
+    public void testCookiesAreParsedCorrectly() {
+        // GIVEN
         cookieHeaders.put("Set-Cookie", Collections.singletonList("foo=bar"));
         final ResponseEntity<?> responseEntity = new ResponseEntity<>(cookieHeaders, HttpStatus.OK);
 
-        //WHEN
+        // WHEN
         final Cookie[] cookies = cookieConverter.convertCookies(responseEntity);
 
-        //THEN
+        // THEN
         assertEquals("foo", cookies[0].getName());
         assertEquals("bar", cookies[0].getValue());
     }
 
     @Test
-    public void testAdditionalCookieDirectivesAreDiscarded(){
-
-        //GIVEN
+    public void testAdditionalCookieDirectivesAreDiscarded() {
+        // GIVEN
         cookieHeaders.put("Set-Cookie", Collections.singletonList("foo=bar;HttpOnly"));
         final ResponseEntity<?> responseEntity = new ResponseEntity<>(cookieHeaders, HttpStatus.OK);
 
-        //WHEN
+        // WHEN
         final Cookie[] cookies = cookieConverter.convertCookies(responseEntity);
 
-        //THEN
+        // THEN
         assertEquals("foo", cookies[0].getName());
         assertEquals("bar", cookies[0].getValue());
     }
 
     @Test
-    public void testCookieCommentIsPreserved(){
-
-        //GIVEN
+    public void testCookieCommentIsNoLongerPreserved() {
+        // GIVEN
         cookieHeaders.put("Set-Cookie", Collections.singletonList("foo=bar;Comment=wtf"));
         final ResponseEntity<?> responseEntity = new ResponseEntity<>(cookieHeaders, HttpStatus.OK);
 
-        //WHEN
+        // WHEN
         final Cookie[] cookies = cookieConverter.convertCookies(responseEntity);
 
-        //THEN
-        assertEquals("wtf", cookies[0].getComment());
+        // THEN
+        assertNull(cookies[0].getComment());
     }
 
     @Test
-    public void testCookieDomainIsPreserved(){
-
-        //GIVEN
+    public void testCookieDomainIsPreserved() {
+        // GIVEN
         cookieHeaders.put("Set-Cookie", Collections.singletonList("foo=bar;Domain=whatever"));
         final ResponseEntity<?> responseEntity = new ResponseEntity<>(cookieHeaders, HttpStatus.OK);
 
-        //WHEN
+        // WHEN
         final Cookie[] cookies = cookieConverter.convertCookies(responseEntity);
 
-        //THEN
+        // THEN
         assertEquals("whatever", cookies[0].getDomain());
     }
 
     @Test
-    public void testCookieMaxAgeIsPreserved(){
-
-        //GIVEN
+    public void testCookieMaxAgeIsPreserved() {
+        // GIVEN
         cookieHeaders.put("Set-Cookie", Collections.singletonList("foo=bar;Max-Age=42"));
         final ResponseEntity<?> responseEntity = new ResponseEntity<>(cookieHeaders, HttpStatus.OK);
 
-        //WHEN
+        // WHEN
         final Cookie[] cookies = cookieConverter.convertCookies(responseEntity);
 
-        //THEN
+        // THEN
         assertEquals(42, cookies[0].getMaxAge());
     }
 
     @Test
-    public void testCookiePathIsPreserved(){
-
-        //GIVEN
+    public void testCookiePathIsPreserved() {
+        // GIVEN
         cookieHeaders.put("Set-Cookie", Collections.singletonList("foo=bar;Path=foobar"));
         final ResponseEntity<?> responseEntity = new ResponseEntity<>(cookieHeaders, HttpStatus.OK);
 
-        //WHEN
+        // WHEN
         final Cookie[] cookies = cookieConverter.convertCookies(responseEntity);
 
-        //THEN
+        // THEN
         assertEquals("foobar", cookies[0].getPath());
     }
 
 
     @Test
-    public void testCookieSecureIsPreserved(){
-
-        //GIVEN
+    public void testCookieSecureIsPreserved() {
+        // GIVEN
         cookieHeaders.put("Set-Cookie", Collections.singletonList("foo=bar;Secure"));
         final ResponseEntity<?> responseEntity = new ResponseEntity<>(cookieHeaders, HttpStatus.OK);
 
-        //WHEN
+        // WHEN
         final Cookie[] cookies = cookieConverter.convertCookies(responseEntity);
 
-        //THEN
+        // THEN
         assertTrue(cookies[0].getSecure());
     }
 
     @Test
-    public void testCookieVersionIsPreserved(){
-
-        //GIVEN
+    public void testCookieVersionIsNoLongerPreserved() {
+        // GIVEN
         cookieHeaders.put("Set-Cookie", Collections.singletonList("foo=bar;Version=1"));
         final ResponseEntity<?> responseEntity = new ResponseEntity<>(cookieHeaders, HttpStatus.OK);
 
-        //WHEN
+        // WHEN
         final Cookie[] cookies = cookieConverter.convertCookies(responseEntity);
 
-        //THEN
-        assertEquals(1, cookies[0].getVersion());
+        // THEN
+        assertEquals(0, cookies[0].getVersion());
     }
 
     @Test
-    public void testCookieHttpOnlyIsPreserved(){
-
-        //GIVEN
+    public void testCookieHttpOnlyIsPreserved() {
+        // GIVEN
         cookieHeaders.put("Set-Cookie", Collections.singletonList("foo=bar;HttpOnly"));
         final ResponseEntity<?> responseEntity = new ResponseEntity<>(cookieHeaders, HttpStatus.OK);
 
-        //WHEN
+        // WHEN
         final Cookie[] cookies = cookieConverter.convertCookies(responseEntity);
 
-        //THEN
+        // THEN
         assertTrue(cookies[0].isHttpOnly());
     }
 
     @Test
-    public void testCookieStringContainsVersion(){
-
-        //GIVEN
+    public void testCookieStringDoesNotContainVersion() {
+        // GIVEN
         cookie.setVersion(42);
-        String expectedCookieString = "foo=bar;Version=42";
+        String expectedCookieString = "foo=bar";
 
-        //WHEN
+        // WHEN
         final String cookieString = cookieConverter.getCookieString(cookie);
 
-        //THEN
-        assertEquals(cookieString, expectedCookieString);
+        // THEN
+        assertEquals(expectedCookieString, cookieString);
     }
 
     @Test
-    public void testCookieStringContainsPath(){
-
-        //GIVEN
+    public void testCookieStringContainsPath() {
+        // GIVEN
         cookie.setPath("/foo/bar");
         String expectedCookieString = "foo=bar;Path=/foo/bar";
 
-        //WHEN
+        // WHEN
         final String cookieString = cookieConverter.getCookieString(cookie);
 
-        //THEN
-        assertEquals(cookieString, expectedCookieString);
+        // THEN
+        assertEquals(expectedCookieString, cookieString);
     }
 
     @Test
-    public void testCookieStringContainsDomain(){
-
-        //GIVEN
+    public void testCookieStringContainsDomain() {
+        // GIVEN
         cookie.setDomain("localhost");
         String expectedCookieString = "foo=bar;Domain=localhost";
 
-        //WHEN
+        // WHEN
         final String cookieString = cookieConverter.getCookieString(cookie);
 
-        //THEN
-        assertEquals(cookieString, expectedCookieString);
+        // THEN
+        assertEquals(expectedCookieString, cookieString);
     }
 
     @Test
-    public void testCookieStringContainsMaxAge(){
-
-        //GIVEN
+    public void testCookieStringContainsMaxAge() {
+        // GIVEN
         cookie.setMaxAge(42);
         String expectedCookieString = "foo=bar;Max-Age=42";
 
-        //WHEN
+        // WHEN
         final String cookieString = cookieConverter.getCookieString(cookie);
 
-        //THEN
-        assertEquals(cookieString, expectedCookieString);
+        // THEN
+        assertEquals(expectedCookieString, cookieString);
     }
 
     @Test
-    public void testCookieStringContainsComment(){
-
-        //GIVEN
+    public void testCookieStringContainsComment() {
+        // GIVEN
         cookie.setComment("whatever");
-        String expectedCookieString = "foo=bar;Comment=whatever";
+        String expectedCookieString = "foo=bar";
 
-        //WHEN
+        // WHEN
         final String cookieString = cookieConverter.getCookieString(cookie);
 
-        //THEN
-        assertEquals(cookieString, expectedCookieString);
+        // THEN
+        assertEquals(expectedCookieString, cookieString);
     }
 
     @Test
-    public void testCookieStringContainsSecure(){
-
-        //GIVEN
+    public void testCookieStringContainsSecure() {
+        // GIVEN
         cookie.setSecure(true);
         String expectedCookieString = "foo=bar;Secure";
 
-        //WHEN
+        // WHEN
         final String cookieString = cookieConverter.getCookieString(cookie);
 
-        //THEN
-        assertEquals(cookieString, expectedCookieString);
+        // THEN
+        assertEquals(expectedCookieString, cookieString);
     }
 
     @Test
-    public void testCookieStringContainsHttpOnly(){
-
-        //GIVEN
+    public void testCookieStringContainsHttpOnly() {
+        // GIVEN
         cookie.setHttpOnly(true);
         String expectedCookieString = "foo=bar;HttpOnly";
 
-        //WHEN
+        // WHEN
         final String cookieString = cookieConverter.getCookieString(cookie);
 
-        //THEN
-        assertEquals(cookieString, expectedCookieString);
+        // THEN
+        assertEquals(expectedCookieString, cookieString);
     }
 }

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/message/CookieEnricherTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/message/CookieEnricherTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2018 the original author or authors
+ *    Copyright 2018-2024 the original author or authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,11 +16,11 @@
 
 package org.citrusframework.http.message;
 
+import jakarta.servlet.http.Cookie;
 import org.citrusframework.context.TestContext;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import jakarta.servlet.http.Cookie;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -36,113 +36,89 @@ public class CookieEnricherTest {
     private Cookie cookie;
 
     @BeforeMethod
-    public void setUp(){
+    public void setUp() {
         testContextMock = new TestContext();
         cookie = new Cookie("foo", "bar");
     }
 
     @Test
-    public void testCookiesArePreserved(){
-
-        //GIVEN
+    public void testCookiesArePreserved() {
+        // GIVEN
         cookie.setMaxAge(42);
-        cookie.setVersion(24);
         cookie.setHttpOnly(true);
         cookie.setSecure(true);
         final List<Cookie> cookies = Collections.singletonList(cookie);
 
-        //WHEN
+        // WHEN
         final List<Cookie> enrichedCookies = cookieEnricher.enrich(cookies, testContextMock);
 
-        //THEN
+        // THEN
         assertEquals(enrichedCookies.size(), 1);
 
         final Cookie enrichedCookie = enrichedCookies.get(0);
         assertEquals(enrichedCookie.getName(), "foo");
         assertEquals(enrichedCookie.getValue(), "bar");
         assertEquals(enrichedCookie.getMaxAge(), 42);
-        assertEquals(enrichedCookie.getVersion(), 24);
         assertTrue(enrichedCookie.isHttpOnly());
         assertTrue(enrichedCookie.getSecure());
     }
 
     @Test
-    public void testTwoCookiesArePreserved(){
-
-        //GIVEN
+    public void testTwoCookiesArePreserved() {
+        // GIVEN
         final List<Cookie> cookies = Arrays.asList(cookie, cookie);
 
-        //WHEN
+        // WHEN
         final List<Cookie> enrichedCookies = cookieEnricher.enrich(cookies, testContextMock);
 
-        //THEN
+        // THEN
         assertEquals(enrichedCookies.size(), 2);
     }
 
     @Test
-    public void testValueVariablesAreReplaced(){
-
-        //GIVEN
+    public void testValueVariablesAreReplaced() {
+        // GIVEN
         Cookie cookie = new Cookie("foo", "${foobar}");
         final List<Cookie> cookies = Collections.singletonList(cookie);
 
         testContextMock.setVariable("foobar", "bar");
 
-        //WHEN
+        // WHEN
         final List<Cookie> enrichedCookies = cookieEnricher.enrich(cookies, testContextMock);
 
-        //THEN
+        // THEN
         assertEquals(enrichedCookies.get(0).getName(), "foo");
         assertEquals(enrichedCookies.get(0).getValue(), "bar");
     }
 
     @Test
-    public void testCommentVariablesAreReplaced(){
-
-        //GIVEN
-        cookie.setComment("${variable}");
-        final List<Cookie> cookies = Collections.singletonList(cookie);
-
-        testContextMock.setVariable("variable", "foobar");
-
-        //WHEN
-        final List<Cookie> enrichedCookies = cookieEnricher.enrich(cookies, testContextMock);
-
-        //THEN
-        assertEquals(enrichedCookies.get(0).getName(), "foo");
-        assertEquals(enrichedCookies.get(0).getComment(), "foobar");
-    }
-
-    @Test
-    public void testPathVariablesAreReplaced(){
-
-        //GIVEN
+    public void testPathVariablesAreReplaced() {
+        // GIVEN
         cookie.setPath("/path/to/${variable}");
         final List<Cookie> cookies = Collections.singletonList(cookie);
 
         testContextMock.setVariable("variable", "foobar");
 
-        //WHEN
+        // WHEN
         final List<Cookie> enrichedCookies = cookieEnricher.enrich(cookies, testContextMock);
 
-        //THEN
+        // THEN
         assertEquals(enrichedCookies.get(0).getName(), "foo");
         assertEquals(enrichedCookies.get(0).getPath(), "/path/to/foobar");
     }
 
     @Test
-    public void testDomainVariablesAreReplaced(){
-
-        //GIVEN
+    public void testDomainVariablesAreReplaced() {
+        // GIVEN
         cookie.setDomain("${variable}");
         final List<Cookie> cookies = Collections.singletonList(cookie);
 
         testContextMock.setVariable("variable", "localhost");
 
-        //WHEN
+        // WHEN
         final List<Cookie> enrichedCookies = cookieEnricher.enrich(cookies, testContextMock);
 
-        //THEN
+        // THEN
         assertEquals(enrichedCookies.get(0).getName(), "foo");
         assertEquals(enrichedCookies.get(0).getDomain(), "localhost");
     }

--- a/endpoints/citrus-http/src/test/resources/org/citrusframework/http/config/xml/HttpServerParserTest-context.xml
+++ b/endpoints/citrus-http/src/test/resources/org/citrusframework/http/config/xml/HttpServerParserTest-context.xml
@@ -125,7 +125,7 @@
     </bean>
 
     <bean id ="servletHandler" class="org.mockito.Mockito" factory-method="mock">
-        <constructor-arg><value type="java.lang.Class">org.eclipse.jetty.servlet.ServletHandler</value></constructor-arg>
+        <constructor-arg><value type="java.lang.Class">org.eclipse.jetty.ee10.servlet.ServletHandler</value></constructor-arg>
         <constructor-arg value="servletHandler"/>
     </bean>
 </beans>

--- a/endpoints/citrus-websocket/pom.xml
+++ b/endpoints/citrus-websocket/pom.xml
@@ -70,29 +70,29 @@
     </dependency>
 
     <dependency>
-      <groupId>org.eclipse.jetty.websocket</groupId>
-      <artifactId>websocket-jetty-server</artifactId>
+      <groupId>org.eclipse.jetty.ee10.websocket</groupId>
+      <artifactId>jetty-ee10-websocket-jetty-server</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty.websocket</groupId>
-      <artifactId>websocket-jakarta-server</artifactId>
+      <groupId>org.eclipse.jetty.ee10.websocket</groupId>
+      <artifactId>jetty-ee10-websocket-jakarta-server</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty.websocket</groupId>
-      <artifactId>websocket-jakarta-common</artifactId>
+      <groupId>org.eclipse.jetty.ee10.websocket</groupId>
+      <artifactId>jetty-ee10-websocket-jakarta-common</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty.websocket</groupId>
-      <artifactId>websocket-jakarta-client</artifactId>
+      <groupId>org.eclipse.jetty.ee10.websocket</groupId>
+      <artifactId>jetty-ee10-websocket-jakarta-client</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-annotations</artifactId>
+      <groupId>org.eclipse.jetty.ee10</groupId>
+      <artifactId>jetty-ee10-annotations</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-webapp</artifactId>
+      <groupId>org.eclipse.jetty.ee10</groupId>
+      <artifactId>jetty-ee10-webapp</artifactId>
     </dependency>
     <dependency>
       <groupId>jakarta.servlet</groupId>

--- a/endpoints/citrus-websocket/src/main/java/org/citrusframework/websocket/config/annotation/WebSocketServerConfigParser.java
+++ b/endpoints/citrus-websocket/src/main/java/org/citrusframework/websocket/config/annotation/WebSocketServerConfigParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2016 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,24 +16,25 @@
 
 package org.citrusframework.websocket.config.annotation;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.citrusframework.TestActor;
 import org.citrusframework.config.annotation.AnnotationConfigParser;
 import org.citrusframework.endpoint.EndpointAdapter;
 import org.citrusframework.http.message.HttpMessageConverter;
 import org.citrusframework.spi.ReferenceResolver;
-import org.citrusframework.util.StringUtils;
 import org.citrusframework.websocket.endpoint.WebSocketEndpoint;
 import org.citrusframework.websocket.message.WebSocketMessageConverter;
 import org.citrusframework.websocket.server.WebSocketServer;
 import org.citrusframework.websocket.server.WebSocketServerBuilder;
 import org.citrusframework.websocket.server.WebSocketServerEndpointConfiguration;
+import org.eclipse.jetty.ee10.servlet.ServletHandler;
 import org.eclipse.jetty.security.SecurityHandler;
 import org.eclipse.jetty.server.Connector;
-import org.eclipse.jetty.servlet.ServletHandler;
 import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.citrusframework.util.StringUtils.hasText;
 
 /**
  * @author Christoph Deppisch
@@ -51,7 +52,7 @@ public class WebSocketServerConfigParser implements AnnotationConfigParser<WebSo
             WebSocketServerEndpointConfiguration webSocketConfiguration = new WebSocketServerEndpointConfiguration();
             webSocketConfiguration.setEndpointUri(webSocketConfig.path());
 
-            if (StringUtils.hasText(webSocketConfig.messageConverter())) {
+            if (hasText(webSocketConfig.messageConverter())) {
                 webSocketConfiguration.setMessageConverter(referenceResolver.resolve(webSocketConfig.messageConverter(), WebSocketMessageConverter.class));
             }
 
@@ -69,23 +70,23 @@ public class WebSocketServerConfigParser implements AnnotationConfigParser<WebSo
 
         builder.debugLogging(annotation.debugLogging());
 
-        if (StringUtils.hasText(annotation.endpointAdapter())) {
+        if (hasText(annotation.endpointAdapter())) {
             builder.endpointAdapter(referenceResolver.resolve(annotation.endpointAdapter(), EndpointAdapter.class));
         }
 
         builder.interceptors(referenceResolver.resolve(annotation.interceptors(), HandlerInterceptor.class));
 
-        if (StringUtils.hasText(annotation.actor())) {
+        if (hasText(annotation.actor())) {
             builder.actor(referenceResolver.resolve(annotation.actor(), TestActor.class));
         }
 
         builder.port(annotation.port());
 
-        if (StringUtils.hasText(annotation.contextConfigLocation())) {
+        if (hasText(annotation.contextConfigLocation())) {
             builder.contextConfigLocation(annotation.contextConfigLocation());
         }
 
-        if (StringUtils.hasText(annotation.resourceBase())) {
+        if (hasText(annotation.resourceBase())) {
             builder.resourceBase(annotation.resourceBase());
         }
 
@@ -93,35 +94,36 @@ public class WebSocketServerConfigParser implements AnnotationConfigParser<WebSo
 
         builder.connectors(referenceResolver.resolve(annotation.connectors(), Connector.class));
 
-        if (StringUtils.hasText(annotation.connector())) {
+        if (hasText(annotation.connector())) {
             builder.connector(referenceResolver.resolve(annotation.connector(), Connector.class));
         }
 
-        if (StringUtils.hasText(annotation.servletName())) {
+        if (hasText(annotation.servletName())) {
             builder.servletName(annotation.servletName());
         }
 
-        if (StringUtils.hasText(annotation.servletMappingPath())) {
+        if (hasText(annotation.servletMappingPath())) {
             builder.servletMappingPath(annotation.servletMappingPath());
         }
 
-        if (StringUtils.hasText(annotation.contextPath())) {
+        if (hasText(annotation.contextPath())) {
             builder.contextPath(annotation.contextPath());
         }
 
-        if (StringUtils.hasText(annotation.servletHandler())) {
+        if (hasText(annotation.servletHandler())) {
             builder.servletHandler(referenceResolver.resolve(annotation.servletHandler(), ServletHandler.class));
         }
 
-        if (StringUtils.hasText(annotation.securityHandler())) {
+        if (hasText(annotation.securityHandler())) {
             builder.securityHandler(referenceResolver.resolve(annotation.securityHandler(), SecurityHandler.class));
         }
 
-        if (StringUtils.hasText(annotation.messageConverter())) {
+        if (hasText(annotation.messageConverter())) {
             builder.messageConverter(referenceResolver.resolve(annotation.messageConverter(), HttpMessageConverter.class));
         }
 
         builder.initialize();
+
         return builder.build();
     }
 }

--- a/endpoints/citrus-websocket/src/main/java/org/citrusframework/websocket/server/WebSocketServer.java
+++ b/endpoints/citrus-websocket/src/main/java/org/citrusframework/websocket/server/WebSocketServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2015 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,15 @@
 
 package org.citrusframework.websocket.server;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.citrusframework.http.server.HttpServer;
 import org.citrusframework.websocket.endpoint.WebSocketEndpoint;
 import org.citrusframework.websocket.servlet.CitrusWebSocketDispatcherServlet;
-import org.eclipse.jetty.servlet.ServletContextHandler;
-import org.eclipse.jetty.websocket.server.config.JettyWebSocketServletContainerInitializer;
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee10.websocket.server.config.JettyWebSocketServletContainerInitializer;
 import org.springframework.web.servlet.DispatcherServlet;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Christoph Deppisch
@@ -72,6 +72,7 @@ public class WebSocketServer extends HttpServer {
 
     /**
      * Sets the WebSocket endpoints (id, uri)
+     *
      * @param webSockets
      */
     public void setWebSockets(List<WebSocketEndpoint> webSockets) {

--- a/endpoints/citrus-ws/pom.xml
+++ b/endpoints/citrus-ws/pom.xml
@@ -116,8 +116,8 @@
       <artifactId>jetty-server</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-servlet</artifactId>
+      <groupId>org.eclipse.jetty.ee10</groupId>
+      <artifactId>jetty-ee10-servlet</artifactId>
     </dependency>
     <dependency>
       <groupId>jakarta.servlet</groupId>

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/config/annotation/WebServiceServerConfigParser.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/config/annotation/WebServiceServerConfigParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2016 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,14 +20,15 @@ import org.citrusframework.TestActor;
 import org.citrusframework.config.annotation.AnnotationConfigParser;
 import org.citrusframework.endpoint.EndpointAdapter;
 import org.citrusframework.spi.ReferenceResolver;
-import org.citrusframework.util.StringUtils;
 import org.citrusframework.ws.message.converter.WebServiceMessageConverter;
 import org.citrusframework.ws.server.WebServiceServer;
 import org.citrusframework.ws.server.WebServiceServerBuilder;
+import org.eclipse.jetty.ee10.servlet.ServletHandler;
 import org.eclipse.jetty.security.SecurityHandler;
 import org.eclipse.jetty.server.Connector;
-import org.eclipse.jetty.servlet.ServletHandler;
 import org.springframework.ws.server.EndpointInterceptor;
+
+import static org.citrusframework.util.StringUtils.hasText;
 
 /**
  * @author Christoph Deppisch
@@ -43,15 +44,15 @@ public class WebServiceServerConfigParser implements AnnotationConfigParser<WebS
         builder.handleAttributeHeaders(annotation.handleAttributeHeaders());
         builder.keepSoapEnvelope(annotation.keepSoapEnvelope());
 
-        if (StringUtils.hasText(annotation.soapHeaderNamespace())) {
+        if (hasText(annotation.soapHeaderNamespace())) {
             builder.soapHeaderNamespace(annotation.soapHeaderNamespace());
         }
 
-        if (StringUtils.hasText(annotation.soapHeaderPrefix())) {
+        if (hasText(annotation.soapHeaderPrefix())) {
             builder.soapHeaderPrefix(annotation.soapHeaderPrefix());
         }
 
-        if (StringUtils.hasText(annotation.messageFactory())) {
+        if (hasText(annotation.messageFactory())) {
             builder.messageFactory(annotation.messageFactory());
         }
 
@@ -59,55 +60,55 @@ public class WebServiceServerConfigParser implements AnnotationConfigParser<WebS
         builder.port(annotation.port());
         builder.autoStart(annotation.autoStart());
 
-        if (StringUtils.hasText(annotation.resourceBase())) {
+        if (hasText(annotation.resourceBase())) {
             builder.resourceBase(annotation.resourceBase());
         }
 
-        if (StringUtils.hasText(annotation.contextConfigLocation())) {
+        if (hasText(annotation.contextConfigLocation())) {
             builder.contextConfigLocation(annotation.contextConfigLocation());
         }
 
         builder.connectors(referenceResolver.resolve(annotation.connectors(), Connector.class));
 
-        if (StringUtils.hasText(annotation.connector())) {
+        if (hasText(annotation.connector())) {
             builder.connector(referenceResolver.resolve(annotation.connector(), Connector.class));
         }
 
         builder.rootParentContext(annotation.rootParentContext());
 
-        if (StringUtils.hasText(annotation.servletName())) {
+        if (hasText(annotation.servletName())) {
             builder.servletName(annotation.servletName());
         }
 
-        if (StringUtils.hasText(annotation.servletMappingPath())) {
+        if (hasText(annotation.servletMappingPath())) {
             builder.servletMappingPath(annotation.servletMappingPath());
         }
 
-        if (StringUtils.hasText(annotation.contextPath())) {
+        if (hasText(annotation.contextPath())) {
             builder.contextPath(annotation.contextPath());
         }
 
-        if (StringUtils.hasText(annotation.servletHandler())) {
+        if (hasText(annotation.servletHandler())) {
             builder.servletHandler(referenceResolver.resolve(annotation.servletHandler(), ServletHandler.class));
         }
 
-        if (StringUtils.hasText(annotation.securityHandler())) {
+        if (hasText(annotation.securityHandler())) {
             builder.securityHandler(referenceResolver.resolve(annotation.securityHandler(), SecurityHandler.class));
         }
 
         builder.debugLogging(annotation.debugLogging());
 
-        if (StringUtils.hasText(annotation.endpointAdapter())) {
+        if (hasText(annotation.endpointAdapter())) {
             builder.endpointAdapter(referenceResolver.resolve(annotation.endpointAdapter(), EndpointAdapter.class));
         }
 
         builder.interceptors(referenceResolver.resolve(annotation.interceptors(), EndpointInterceptor.class));
 
-        if (StringUtils.hasText(annotation.actor())) {
+        if (hasText(annotation.actor())) {
             builder.actor(referenceResolver.resolve(annotation.actor(), TestActor.class));
         }
 
-        if (StringUtils.hasText(annotation.messageConverter())) {
+        if (hasText(annotation.messageConverter())) {
             builder.messageConverter(referenceResolver.resolve(annotation.messageConverter(), WebServiceMessageConverter.class));
         }
 

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/security/BasicAuthConstraint.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/security/BasicAuthConstraint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,25 +16,46 @@
 
 package org.citrusframework.ws.security;
 
-import org.eclipse.jetty.util.security.Constraint;
+import org.eclipse.jetty.security.Constraint;
+
+import java.util.Set;
+
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.toSet;
+import static org.eclipse.jetty.security.Authenticator.BASIC_AUTH;
+import static org.eclipse.jetty.security.Constraint.Transport.INHERIT;
 
 /**
  * Convenient constraint instantiation for basic authentication and multiple user roles.
- * 
+ *
  * @author Christoph Deppisch
  * @since 1.3
  */
-public class BasicAuthConstraint extends Constraint {
+public class BasicAuthConstraint implements Constraint {
 
-    /** Serialization thingy. */
-    private static final long serialVersionUID = -2295787554785979668L;
+    private final Set<String> userRoles;
 
-    /**
-     * Default constructor using fields.
-     */
-    public BasicAuthConstraint(String[] roles) {
-        setName(Constraint.__BASIC_AUTH);
-        setRoles(roles);
-        setAuthenticate(true);
+    public BasicAuthConstraint(String[] userRoles) {
+        this.userRoles = stream(userRoles).collect(toSet());
+    }
+
+    @Override
+    public String getName() {
+        return BASIC_AUTH;
+    }
+
+    @Override
+    public Transport getTransport() {
+        return INHERIT;
+    }
+
+    @Override
+    public Authorization getAuthorization() {
+        return Authorization.SPECIFIC_ROLE;
+    }
+
+    @Override
+    public Set<String> getRoles() {
+        return userRoles;
     }
 }

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/server/WebServiceServerBuilder.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/server/WebServiceServerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2016 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,15 @@
 
 package org.citrusframework.ws.server;
 
-import java.util.Arrays;
-import java.util.List;
-
 import org.citrusframework.server.AbstractServerBuilder;
 import org.citrusframework.ws.message.converter.WebServiceMessageConverter;
+import org.eclipse.jetty.ee10.servlet.ServletHandler;
 import org.eclipse.jetty.security.SecurityHandler;
 import org.eclipse.jetty.server.Connector;
-import org.eclipse.jetty.servlet.ServletHandler;
 import org.springframework.ws.server.EndpointInterceptor;
+
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * @author Christoph Deppisch
@@ -32,7 +32,9 @@ import org.springframework.ws.server.EndpointInterceptor;
  */
 public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceServer, WebServiceServerBuilder> {
 
-    /** Endpoint target */
+    /**
+     * Endpoint target
+     */
     private final WebServiceServer endpoint = new WebServiceServer();
 
     @Override
@@ -42,6 +44,7 @@ public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceSer
 
     /**
      * Sets the port property.
+     *
      * @param port
      * @return
      */
@@ -52,6 +55,7 @@ public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceSer
 
     /**
      * Sets the context config location.
+     *
      * @param configLocation
      * @return
      */
@@ -62,6 +66,7 @@ public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceSer
 
     /**
      * Sets the resource base.
+     *
      * @param resourceBase
      * @return
      */
@@ -72,6 +77,7 @@ public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceSer
 
     /**
      * Enables/disables the root parent context.
+     *
      * @param rootParentContext
      * @return
      */
@@ -82,6 +88,7 @@ public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceSer
 
     /**
      * Sets the connectors.
+     *
      * @param connectors
      * @return
      */
@@ -92,6 +99,7 @@ public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceSer
 
     /**
      * Sets the connector.
+     *
      * @param connector
      * @return
      */
@@ -102,6 +110,7 @@ public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceSer
 
     /**
      * Sets the servlet name.
+     *
      * @param servletName
      * @return
      */
@@ -112,6 +121,7 @@ public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceSer
 
     /**
      * Sets the servlet mapping path.
+     *
      * @param servletMappingPath
      * @return
      */
@@ -122,6 +132,7 @@ public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceSer
 
     /**
      * Sets the context path.
+     *
      * @param contextPath
      * @return
      */
@@ -132,6 +143,7 @@ public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceSer
 
     /**
      * Sets the servlet handler.
+     *
      * @param servletHandler
      * @return
      */
@@ -142,6 +154,7 @@ public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceSer
 
     /**
      * Sets the security handler.
+     *
      * @param securityHandler
      * @return
      */
@@ -152,6 +165,7 @@ public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceSer
 
     /**
      * Sets the message converter.
+     *
      * @param messageConverter
      * @return
      */
@@ -168,6 +182,7 @@ public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceSer
 
     /**
      * Sets the interceptors.
+     *
      * @param interceptors
      * @return
      */
@@ -178,16 +193,18 @@ public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceSer
 
     /**
      * Sets the interceptors.
+     *
      * @param interceptors
      * @return
      */
-    public WebServiceServerBuilder interceptors(EndpointInterceptor ... interceptors) {
+    public WebServiceServerBuilder interceptors(EndpointInterceptor... interceptors) {
         endpoint.setInterceptors(Arrays.asList(interceptors));
         return this;
     }
 
     /**
      * Sets the message factory.
+     *
      * @param messageFactory
      * @return
      */
@@ -198,6 +215,7 @@ public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceSer
 
     /**
      * Sets the keepSoapEnvelope property.
+     *
      * @param flag
      * @return
      */
@@ -208,6 +226,7 @@ public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceSer
 
     /**
      * Sets the handleMimeHeaders property.
+     *
      * @param flag
      * @return
      */
@@ -218,6 +237,7 @@ public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceSer
 
     /**
      * Sets the handleAttributeHeaders property.
+     *
      * @param flag
      * @return
      */
@@ -228,6 +248,7 @@ public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceSer
 
     /**
      * Sets the SOAP header namespace.
+     *
      * @param namespace
      * @return
      */
@@ -238,6 +259,7 @@ public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceSer
 
     /**
      * Sets the SOAP header prefix.
+     *
      * @param prefix
      * @return
      */

--- a/endpoints/citrus-ws/src/test/resources/org/citrusframework/ws/config/xml/WebServiceServerParserTest-context.xml
+++ b/endpoints/citrus-ws/src/test/resources/org/citrusframework/ws/config/xml/WebServiceServerParserTest-context.xml
@@ -75,7 +75,7 @@
     </bean>
 
     <bean id ="servletHandler" class="org.mockito.Mockito" factory-method="mock">
-        <constructor-arg><value type="java.lang.Class">org.eclipse.jetty.servlet.ServletHandler</value></constructor-arg>
+        <constructor-arg><value type="java.lang.Class">org.eclipse.jetty.ee10.servlet.ServletHandler</value></constructor-arg>
         <constructor-arg value="servletHandler"/>
     </bean>
 

--- a/pom.xml
+++ b/pom.xml
@@ -240,7 +240,7 @@
     <swagger.version>1.6.9</swagger.version>
     <swagger.parser.version>2.1.16</swagger.parser.version>
     <testng.version>7.8.0</testng.version>
-    <vertx.version>4.4.6</vertx.version>
+    <vertx.version>4.5.1</vertx.version>
     <wsdl4j.version>1.6.3</wsdl4j.version>
     <xbean-spring.version>4.24</xbean-spring.version>
     <xmlbeans.version>3.0.0</xmlbeans.version>

--- a/pom.xml
+++ b/pom.xml
@@ -238,7 +238,7 @@
     <spring.restdocs.version>3.0.1</spring.restdocs.version>
     <sshd.version>2.11.0</sshd.version>
     <swagger.version>1.6.9</swagger.version>
-    <swagger.parser.version>2.1.16</swagger.parser.version>
+    <swagger.parser.version>2.1.19</swagger.parser.version>
     <testng.version>7.8.0</testng.version>
     <vertx.version>4.5.1</vertx.version>
     <wsdl4j.version>1.6.3</wsdl4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -176,12 +176,12 @@
     <bouncycastle.version>1.77</bouncycastle.version>
     <byte.buddy.version>1.14.9</byte.buddy.version>
     <citrus.db.version>0.1.4</citrus.db.version>
-    <commons.dbcp2.version>2.10.0</commons.dbcp2.version>
-    <commons.cli.version>1.5.0</commons.cli.version>
+    <commons.dbcp2.version>2.11.0</commons.dbcp2.version>
+    <commons.cli.version>1.6.0</commons.cli.version>
     <commons.codec.version>1.16.0</commons.codec.version>
-    <commons.io.version>2.14.0</commons.io.version>
+    <commons.io.version>2.15.1</commons.io.version>
     <commons.lang.version>3.14.0</commons.lang.version>
-    <commons.logging.version>1.2</commons.logging.version>
+    <commons.logging.version>1.3.0</commons.logging.version>
     <commons.net.version>3.10.0</commons.net.version>
     <cucumber.version>7.15.0</cucumber.version>
     <docker-java.version>3.3.4</docker-java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@
     <junit.jupiter.version>5.10.1</junit.jupiter.version>
     <junit.platform.version>1.10.1</junit.platform.version>
     <junit.version>4.13.2</junit.version>
-    <junixsocket.version>2.8.1</junixsocket.version>
+    <junixsocket.version>2.8.3</junixsocket.version>
     <k8s.client.version>1.4.34</k8s.client.version>
     <k8s.model.version>1.0.65</k8s.model.version>
     <kafka.version>3.6.1</kafka.version>

--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
     <k8s.model.version>1.0.65</k8s.model.version>
     <kafka.version>3.6.0</kafka.version>
     <log4j2.version>2.21.0</log4j2.version>
-    <mockito.version>5.6.0</mockito.version>
+    <mockito.version>5.8.0</mockito.version>
     <mockftpserver.version>3.1.0</mockftpserver.version>
     <netty.version>4.1.100.Final</netty.version>
     <okhttp.version>4.12.0</okhttp.version>

--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,7 @@
     <jakarta.websocket-api.version>2.1.1</jakarta.websocket-api.version>
     <jakarta.xml.bind-api.version>4.0.1</jakarta.xml.bind-api.version>
     <jakarta.xml.soap-api.version>3.0.1</jakarta.xml.soap-api.version>
-    <jansi.version>2.4.0</jansi.version>
+    <jansi.version>2.4.1</jansi.version>
     <javapoet.version>1.13.0</javapoet.version>
     <jaxb.version>4.0.4</jaxb.version>
     <jetty.version>12.0.5</jetty.version>

--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
     <apache.camel.version>4.3.0</apache.camel.version>
     <apicurio.data-models.version>1.1.27</apicurio.data-models.version>
     <ascii-table-version>1.8.0</ascii-table-version>
-    <bouncycastle.version>1.76</bouncycastle.version>
+    <bouncycastle.version>1.77</bouncycastle.version>
     <byte.buddy.version>1.14.9</byte.buddy.version>
     <citrus.db.version>0.1.4</citrus.db.version>
     <commons.dbcp2.version>2.10.0</commons.dbcp2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@
     <jakarta.xml.soap-api.version>3.0.1</jakarta.xml.soap-api.version>
     <jansi.version>2.4.0</jansi.version>
     <javapoet.version>1.13.0</javapoet.version>
-    <jaxb.version>4.0.3</jaxb.version>
+    <jaxb.version>4.0.4</jaxb.version>
     <jetty.version>12.0.5</jetty.version>
     <jetty.websocket-api.version>2.0.0</jetty.websocket-api.version>
     <jsch.version>0.1.55</jsch.version>

--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
     <commons.net.version>3.10.0</commons.net.version>
     <cucumber.version>7.15.0</cucumber.version>
     <docker-java.version>3.3.4</docker-java.version>
-    <dropwizard.metrics.version>4.2.21</dropwizard.metrics.version>
+    <dropwizard.metrics.version>4.2.23</dropwizard.metrics.version>
     <ftpserver.version>1.2.0</ftpserver.version>
     <groovy.version>3.0.20</groovy.version>
     <greenmail.version>2.0.0</greenmail.version>

--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
     <commons.lang.version>3.14.0</commons.lang.version>
     <commons.logging.version>1.2</commons.logging.version>
     <commons.net.version>3.10.0</commons.net.version>
-    <cucumber.version>7.14.0</cucumber.version>
+    <cucumber.version>7.15.0</cucumber.version>
     <docker-java.version>3.3.3</docker-java.version>
     <dropwizard.metrics.version>4.2.21</dropwizard.metrics.version>
     <ftpserver.version>1.2.0</ftpserver.version>

--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,7 @@
     <junixsocket.version>2.8.1</junixsocket.version>
     <k8s.client.version>1.4.34</k8s.client.version>
     <k8s.model.version>1.0.65</k8s.model.version>
-    <kafka.version>3.6.0</kafka.version>
+    <kafka.version>3.6.1</kafka.version>
     <log4j2.version>2.21.0</log4j2.version>
     <mockito.version>5.8.0</mockito.version>
     <mockftpserver.version>3.1.0</mockftpserver.version>

--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@
     <jetty.websocket-api.version>2.0.0</jetty.websocket-api.version>
     <jsch.version>0.1.55</jsch.version>
     <json-path.version>2.8.0</json-path.version>
-    <json-schema-validator.version>1.0.87</json-schema-validator.version>
+    <json-schema-validator.version>1.1.0</json-schema-validator.version>
     <json-smart.version>2.5.0</json-smart.version>
     <jtidy.version>r938</jtidy.version>
     <junit.jupiter.version>5.10.1</junit.jupiter.version>

--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
     <activemq.artemis.version>2.31.0</activemq.artemis.version>
     <angus-mail.version>2.0.2</angus-mail.version>
     <apache.ant.version>1.10.14</apache.ant.version>
-    <apache.camel.version>4.1.0</apache.camel.version>
+    <apache.camel.version>4.3.0</apache.camel.version>
     <apicurio.data-models.version>1.1.27</apicurio.data-models.version>
     <ascii-table-version>1.8.0</ascii-table-version>
     <bouncycastle.version>1.76</bouncycastle.version>

--- a/pom.xml
+++ b/pom.xml
@@ -214,8 +214,8 @@
     <json-schema-validator.version>1.0.87</json-schema-validator.version>
     <json-smart.version>2.5.0</json-smart.version>
     <jtidy.version>r938</jtidy.version>
-    <junit.jupiter.version>5.10.0</junit.jupiter.version>
-    <junit.platform.version>1.10.0</junit.platform.version>
+    <junit.jupiter.version>5.10.1</junit.jupiter.version>
+    <junit.platform.version>1.10.1</junit.platform.version>
     <junit.version>4.13.2</junit.version>
     <junixsocket.version>2.8.1</junixsocket.version>
     <k8s.client.version>1.4.34</k8s.client.version>

--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
     <asciidoctor.maven.plugin.version>2.2.4</asciidoctor.maven.plugin.version>
     <jaxb.maven.plugin.version>3.1.0</jaxb.maven.plugin.version>
 
-    <activemq.artemis.version>2.31.0</activemq.artemis.version>
+    <activemq.artemis.version>2.31.2</activemq.artemis.version>
     <angus-mail.version>2.0.2</angus-mail.version>
     <apache.ant.version>1.10.14</apache.ant.version>
     <apache.camel.version>4.3.0</apache.camel.version>

--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
     <htmlunit.version>4.13.0</htmlunit.version>
     <httpclient.version>5.2.1</httpclient.version>
     <hsqldb.version>2.7.2</hsqldb.version>
-    <jackson.version>2.15.3</jackson.version>
+    <jackson.version>2.16.1</jackson.version>
     <jakarta.activation.api.version>2.1.2</jakarta.activation.api.version>
     <jakarta.activation.version>2.0.1</jakarta.activation.version>
     <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
@@ -207,7 +207,7 @@
     <jansi.version>2.4.0</jansi.version>
     <javapoet.version>1.13.0</javapoet.version>
     <jaxb.version>4.0.3</jaxb.version>
-    <jetty.version>11.0.17</jetty.version>
+    <jetty.version>12.0.5</jetty.version>
     <jetty.websocket-api.version>2.0.0</jetty.websocket-api.version>
     <jsch.version>0.1.55</jsch.version>
     <json-path.version>2.8.0</json-path.version>
@@ -232,11 +232,11 @@
     <slf4j.version>2.0.9</slf4j.version>
     <snappy.version>1.1.10.5</snappy.version>
     <snakeyaml.version>2.2</snakeyaml.version>
-    <spring.version>6.0.14</spring.version>
-    <spring.ws.version>4.0.7</spring.ws.version>
-    <spring.integration.version>6.1.4</spring.integration.version>
-    <spring.restdocs.version>3.0.0</spring.restdocs.version>
-    <sshd.version>2.10.0</sshd.version>
+    <spring.version>6.1.2</spring.version>
+    <spring.ws.version>4.0.9</spring.ws.version>
+    <spring.integration.version>6.2.1</spring.integration.version>
+    <spring.restdocs.version>3.0.1</spring.restdocs.version>
+    <sshd.version>2.11.0</sshd.version>
     <swagger.version>1.6.9</swagger.version>
     <swagger.parser.version>2.1.16</swagger.parser.version>
     <testng.version>7.8.0</testng.version>
@@ -568,8 +568,8 @@
         <version>${jetty.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-servlet</artifactId>
+        <groupId>org.eclipse.jetty.ee10</groupId>
+        <artifactId>jetty-ee10-servlet</artifactId>
         <version>${jetty.version}</version>
       </dependency>
       <dependency>
@@ -578,33 +578,28 @@
         <version>${jetty.websocket-api.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.eclipse.jetty.websocket</groupId>
-        <artifactId>websocket-servlet</artifactId>
+        <groupId>org.eclipse.jetty.ee10.websocket</groupId>
+        <artifactId>jetty-ee10-websocket-jetty-server</artifactId>
         <version>${jetty.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.eclipse.jetty.websocket</groupId>
-        <artifactId>websocket-jetty-server</artifactId>
+        <groupId>org.eclipse.jetty.ee10.websocket</groupId>
+        <artifactId>jetty-ee10-websocket-jakarta-server</artifactId>
         <version>${jetty.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.eclipse.jetty.websocket</groupId>
-        <artifactId>websocket-jakarta-server</artifactId>
+        <groupId>org.eclipse.jetty.ee10.websocket</groupId>
+        <artifactId>jetty-ee10-websocket-jakarta-common</artifactId>
         <version>${jetty.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.eclipse.jetty.websocket</groupId>
-        <artifactId>websocket-jakarta-common</artifactId>
+        <groupId>org.eclipse.jetty.ee10.websocket</groupId>
+        <artifactId>jetty-ee10-websocket-jakarta-client</artifactId>
         <version>${jetty.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.eclipse.jetty.websocket</groupId>
-        <artifactId>websocket-jakarta-client</artifactId>
-        <version>${jetty.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-annotations</artifactId>
+        <groupId>org.eclipse.jetty.ee10</groupId>
+        <artifactId>jetty-ee10-annotations</artifactId>
         <version>${jetty.version}</version>
       </dependency>
       <dependency>
@@ -618,8 +613,8 @@
         <version>${jetty.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-webapp</artifactId>
+        <groupId>org.eclipse.jetty.ee10</groupId>
+        <artifactId>jetty-ee10-webapp</artifactId>
         <version>${jetty.version}</version>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
     <docker-java.version>3.3.3</docker-java.version>
     <dropwizard.metrics.version>4.2.21</dropwizard.metrics.version>
     <ftpserver.version>1.2.0</ftpserver.version>
-    <groovy.version>3.0.19</groovy.version>
+    <groovy.version>3.0.20</groovy.version>
     <greenmail.version>2.0.0</greenmail.version>
     <hamcrest.version>2.2</hamcrest.version>
     <htmlunit.version>4.13.0</htmlunit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
     <apicurio.data-models.version>1.1.27</apicurio.data-models.version>
     <ascii-table-version>1.8.0</ascii-table-version>
     <bouncycastle.version>1.77</bouncycastle.version>
-    <byte.buddy.version>1.14.9</byte.buddy.version>
+    <byte.buddy.version>1.14.11</byte.buddy.version>
     <citrus.db.version>0.1.4</citrus.db.version>
     <commons.dbcp2.version>2.11.0</commons.dbcp2.version>
     <commons.cli.version>1.6.0</commons.cli.version>

--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
     <commons.logging.version>1.2</commons.logging.version>
     <commons.net.version>3.10.0</commons.net.version>
     <cucumber.version>7.15.0</cucumber.version>
-    <docker-java.version>3.3.3</docker-java.version>
+    <docker-java.version>3.3.4</docker-java.version>
     <dropwizard.metrics.version>4.2.21</dropwizard.metrics.version>
     <ftpserver.version>1.2.0</ftpserver.version>
     <groovy.version>3.0.20</groovy.version>

--- a/pom.xml
+++ b/pom.xml
@@ -228,7 +228,7 @@
     <okhttp.version>4.12.0</okhttp.version>
     <picoli-version>4.7.5</picoli-version>
     <saaj.version>3.0.3</saaj.version>
-    <selenium.version>4.14.1</selenium.version>
+    <selenium.version>4.16.1</selenium.version>
     <slf4j.version>2.0.9</slf4j.version>
     <snappy.version>1.1.10.5</snappy.version>
     <snakeyaml.version>2.2</snakeyaml.version>

--- a/runtime/citrus-quarkus/pom.xml
+++ b/runtime/citrus-quarkus/pom.xml
@@ -15,7 +15,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <quarkus.platform.version>3.4.2</quarkus.platform.version>
+    <quarkus.platform.version>3.6.4</quarkus.platform.version>
   </properties>
 
   <dependencyManagement>

--- a/tools/restdocs/src/main/java/org/citrusframework/restdocs/http/CachedBodyHttpRequest.java
+++ b/tools/restdocs/src/main/java/org/citrusframework/restdocs/http/CachedBodyHttpRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2016 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,9 @@
 
 package org.citrusframework.restdocs.http;
 
-import org.springframework.http.*;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpRequest;
 
 import java.net.URI;
 
@@ -44,11 +46,6 @@ public class CachedBodyHttpRequest implements HttpRequest {
     @Override
     public HttpMethod getMethod() {
         return delegate.getMethod();
-    }
-
-    @Override
-    public String getMethodValue() {
-        return delegate.getMethodValue();
     }
 
     @Override

--- a/tools/restdocs/src/main/java/org/citrusframework/restdocs/http/RestDocConfiguredHttpRequest.java
+++ b/tools/restdocs/src/main/java/org/citrusframework/restdocs/http/RestDocConfiguredHttpRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2016 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,9 @@
 
 package org.citrusframework.restdocs.http;
 
-import org.springframework.http.*;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpRequest;
 import org.springframework.restdocs.RestDocumentationContext;
 
 import java.net.URI;
@@ -71,11 +73,6 @@ public class RestDocConfiguredHttpRequest implements HttpRequest {
     @Override
     public HttpMethod getMethod() {
         return delegate.getMethod();
-    }
-
-    @Override
-    public String getMethodValue() {
-        return delegate.getMethodValue();
     }
 
     @Override


### PR DESCRIPTION
both dependency updates are "breaking", because the underlying frameworks have migrated to the [jakarta ee 10 release](https://jakarta.ee/release/10/). this is tightly coupled to a follow-up pull-request in citrusframework/citrus-simulator that should update to spring-boot >= 3.2 ([release notes](https://github.com/spring-projects/spring-boot/releases/tag/v3.2.0)).

contains updates of:
* [Spring >= 6.1.0](https://github.com/spring-projects/spring-framework/releases/tag/v6.1.0)
* [Jetty >= 12.0.0](eclipse.dev/jetty/documentation/jetty-12/programming-guide/index.html#pg-migration-11-to-12)

closes https://github.com/citrusframework/citrus/issues/1010.