### PR TITLE
fix: nested jar loading with relative URL

### DIFF
--- a/core/citrus-api/src/main/java/org/citrusframework/spi/ClasspathResourceResolver.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/spi/ClasspathResourceResolver.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2023 the original author or authors.
+ *  Copyright 2023-2024 the original author or authors.
  *
  *  Licensed to the Apache Software Foundation (ASF) under one or more
  *  contributor license agreements. See the NOTICE file distributed with
@@ -149,7 +149,7 @@ public class ClasspathResourceResolver {
     private static void loadFromNestedJar(ClassLoader classLoader, String path, String urlPath,
         Set<Path> resources, Predicate<String> filter, String baseJar, String nestedJar) throws IOException {
         try (JarFile jarFile = new JarFile(baseJar)) {
-            JarEntry jarEntry = jarFile.getJarEntry(nestedJar.substring(1));
+            JarEntry jarEntry = jarFile.getJarEntry(nestedJar.startsWith("/") ? nestedJar.substring(1) : nestedJar);
             readFromJarStream(classLoader, path, urlPath, resources, filter, jarFile.getInputStream(jarEntry));
         }
     }


### PR DESCRIPTION
turns out we have jars that use relative URLs instead of absolute ones @tschlat. the `substring`-invocation then fails, respectively returns a `null`-value for `JarEntry jarEntry` which makes the subsequent call to `jarFile.getInputStream(jarEntry)` fail.