### PR TITLE
allow configuration of xml validator via constructor

### DIFF
--- a/validation/citrus-validation-xml/src/main/java/org/citrusframework/validation/xml/DomXmlMessageValidator.java
+++ b/validation/citrus-validation-xml/src/main/java/org/citrusframework/validation/xml/DomXmlMessageValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import javax.xml.XMLConstants;
 import javax.xml.namespace.NamespaceContext;
-
 import org.citrusframework.CitrusSettings;
 import org.citrusframework.XmlValidationHelper;
 import org.citrusframework.context.TestContext;
@@ -64,7 +63,15 @@ public class DomXmlMessageValidator extends AbstractMessageValidator<XmlMessageV
     private NamespaceContextBuilder namespaceContextBuilder;
 
     /** Default schema validator */
-    private final XmlSchemaValidation schemaValidator = new XmlSchemaValidation();
+    private final XmlSchemaValidation schemaValidator;
+
+    public DomXmlMessageValidator() {
+        this(new XmlSchemaValidation());
+    }
+
+    public DomXmlMessageValidator(XmlSchemaValidation schemaValidator) {
+        this.schemaValidator = schemaValidator;
+    }
 
     @Override
     public void validateMessage(Message receivedMessage, Message controlMessage,

--- a/validation/citrus-validation-xml/src/main/java/org/citrusframework/validation/xml/schema/XmlSchemaValidation.java
+++ b/validation/citrus-validation-xml/src/main/java/org/citrusframework/validation/xml/schema/XmlSchemaValidation.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.citrusframework.validation.xml.schema;
 
 import org.citrusframework.XmlValidationHelper;

--- a/validation/citrus-validation-xml/src/test/java/org/citrusframework/validation/xml/DomXmlMessageValidatorTest.java
+++ b/validation/citrus-validation-xml/src/test/java/org/citrusframework/validation/xml/DomXmlMessageValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,6 +49,12 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.xml.sax.SAXException;
 
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertTrue;
+
 /**
  * @author Christoph Deppisch
  */
@@ -94,6 +100,26 @@ public class DomXmlMessageValidatorTest extends UnitTestSupport {
         factory.getReferenceResolver().bind("testSchema2", testSchema2);
         factory.getReferenceResolver().bind("testSchema3", testSchema3);
         return factory;
+    }
+
+    @Test
+    public void constructorWithoutArguments() {
+        Object xmlSchemaValidation = getField(validator, DomXmlMessageValidator.class, "schemaValidator");
+
+        assertTrue(xmlSchemaValidation instanceof XmlSchemaValidation);
+        assertNotNull(xmlSchemaValidation);
+    }
+
+    @Test
+    public void allArgsConstructor() {
+        XmlSchemaValidation xmlSchemaValidationMock = mock(XmlSchemaValidation.class);
+        DomXmlMessageValidator domXmlMessageValidator = new DomXmlMessageValidator(xmlSchemaValidationMock);
+
+        Object xmlSchemaValidation = getField(domXmlMessageValidator, DomXmlMessageValidator.class, "schemaValidator");
+
+        assertTrue(xmlSchemaValidation instanceof XmlSchemaValidation);
+        assertNotNull(xmlSchemaValidation);
+        assertEquals(xmlSchemaValidationMock, xmlSchemaValidation);
     }
 
     @Test


### PR DESCRIPTION
in addition to https://github.com/citrusframework/citrus/pull/1093, so it's possible to override the validation style from children/callees.