### PR TITLE
fix(#1116): Fix CitrusLifecycleHooks to not break Cucumber API

### DIFF
--- a/runtime/citrus-cucumber/src/main/java/org/citrusframework/cucumber/CitrusLifecycleHooks.java
+++ b/runtime/citrus-cucumber/src/main/java/org/citrusframework/cucumber/CitrusLifecycleHooks.java
@@ -25,8 +25,6 @@ import org.citrusframework.annotations.CitrusResource;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.cucumber.backend.Scenario;
 import org.citrusframework.exceptions.CitrusRuntimeException;
-import io.cucumber.java.After;
-import io.cucumber.java.Before;
 
 /**
  * @author Christoph Deppisch
@@ -43,7 +41,6 @@ public class CitrusLifecycleHooks {
     @CitrusResource
     private TestContext context;
 
-    @Before
     public void before(Scenario scenario) {
         if (runner != null) {
             runner.name(scenario.getName());
@@ -52,7 +49,6 @@ public class CitrusLifecycleHooks {
         }
     }
 
-    @After
     public void after(Scenario scenario) {
         if (runner != null) {
             if (context != null && scenario.isFailed()) {

--- a/runtime/citrus-cucumber/src/main/java/org/citrusframework/cucumber/backend/CitrusBackend.java
+++ b/runtime/citrus-cucumber/src/main/java/org/citrusframework/cucumber/backend/CitrusBackend.java
@@ -20,18 +20,15 @@ import java.lang.reflect.Method;
 import java.net.URI;
 import java.util.List;
 
-import org.citrusframework.CitrusInstanceManager;
-import org.citrusframework.cucumber.CitrusLifecycleHooks;
-import org.citrusframework.cucumber.CitrusReporter;
 import io.cucumber.core.backend.Backend;
 import io.cucumber.core.backend.Container;
 import io.cucumber.core.backend.Glue;
 import io.cucumber.core.backend.Lookup;
 import io.cucumber.core.backend.Snippet;
 import io.cucumber.core.exception.CucumberException;
-import io.cucumber.core.resource.ClasspathSupport;
-import io.cucumber.java.After;
-import io.cucumber.java.Before;
+import org.citrusframework.CitrusInstanceManager;
+import org.citrusframework.cucumber.CitrusLifecycleHooks;
+import org.citrusframework.cucumber.CitrusReporter;
 
 /**
  * @author Christoph Deppisch
@@ -58,27 +55,16 @@ public class CitrusBackend implements Backend {
     @Override
     public void loadGlue(Glue glue, List<URI> gluePaths) {
         try {
-            if (!gluePaths.contains(getLifecycleHooksGluePath()) && container.addClass(CitrusLifecycleHooks.class)) {
+            if (container.addClass(CitrusLifecycleHooks.class)) {
                 Method beforeMethod = CitrusLifecycleHooks.class.getMethod("before", Scenario.class);
-                Before beforeAnnotation = beforeMethod.getAnnotation(Before.class);
-                glue.addBeforeHook(new CitrusHookDefinition(beforeMethod, beforeAnnotation.value(), beforeAnnotation.order(), lookup));
+                glue.addBeforeHook(new CitrusHookDefinition(beforeMethod, "", 10000, lookup));
 
                 Method afterMethod = CitrusLifecycleHooks.class.getMethod("after", Scenario.class);
-                After afterAnnotation = afterMethod.getAnnotation(After.class);
-                glue.addAfterHook(new CitrusHookDefinition(afterMethod, afterAnnotation.value(), afterAnnotation.order(), lookup));
+                glue.addAfterHook(new CitrusHookDefinition(afterMethod, "", 10000, lookup));
             }
         } catch (NoSuchMethodException e) {
             throw new CucumberException("Unable to add Citrus lifecycle hooks");
         }
-    }
-
-    /**
-     * Helper to create proper URI pointing to {@link CitrusLifecycleHooks}.
-     * @return
-     */
-    private static URI getLifecycleHooksGluePath() {
-        return URI.create(ClasspathSupport.CLASSPATH_SCHEME_PREFIX +
-                ClasspathSupport.resourceNameOfPackageName(CitrusLifecycleHooks.class.getPackage().getName()));
     }
 
     @Override


### PR DESCRIPTION
- Do not use Cucumber before/after annotations as part of CitrusLifecycleHooks as this may lead to errors when loading the class with normal glue code API
- CitrusLifecycleHooks are only supposed to be loaded by the special Citrus backend implementation

Fixes #1116 
Fixes #1047 