### PR TITLE
Remove scm information from quarkus-extension.yaml

### DIFF
--- a/runtime/citrus-quarkus/citrus-quarkus-runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/runtime/citrus-quarkus/citrus-quarkus-runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -17,6 +17,4 @@ metadata:
     - "testing"
     - "messaging"
     - "integration"
-  scm:
-    url: "https://github.com/citrusframework/citrus"
   status: "preview"


### PR DESCRIPTION
It's usually not necessary to add scm information to the quarkus-extension.yaml. Although https://quarkus.io/version/main/guides/extension-metadata#quarkus-extension-yaml does show an scm entry, it's in the 'this is what gets generated after the tooling enriches the data' section. Because the citrus pom.xml has scm information, we can be DRY and omit it from the metadata.

(I've also realised the example format in the docs is wrong, so the `scm:` information here is being ignored anyway, but that's a separate issue!)