### PR TITLE
chore: language migrations

### DIFF
--- a/connectors/citrus-docker/src/main/java/org/citrusframework/docker/command/AbstractDockerCommand.java
+++ b/connectors/citrus-docker/src/main/java/org/citrusframework/docker/command/AbstractDockerCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2015 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ package org.citrusframework.docker.command;
 import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Arrays;
 
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;

--- a/connectors/citrus-docker/src/main/java/org/citrusframework/docker/command/ContainerCreate.java
+++ b/connectors/citrus-docker/src/main/java/org/citrusframework/docker/command/ContainerCreate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2015 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,6 @@
 package org.citrusframework.docker.command;
 
 import java.util.stream.Stream;
-import java.util.stream.Collectors;
-import java.util.Arrays;
-import java.util.List;
 
 import org.citrusframework.context.TestContext;
 import org.citrusframework.docker.actions.DockerExecuteAction;
@@ -34,6 +31,10 @@ import com.github.dockerjava.api.model.ExposedPort;
 import com.github.dockerjava.api.model.PortBinding;
 import com.github.dockerjava.api.model.Ports;
 import com.github.dockerjava.api.model.Volume;
+
+import static com.github.dockerjava.api.model.ExposedPort.tcp;
+import static com.github.dockerjava.api.model.ExposedPort.udp;
+import static java.lang.Integer.parseInt;
 
 /**
  * @author Christoph Deppisch
@@ -215,11 +216,11 @@ public class ContainerCreate extends AbstractDockerCommand<CreateContainerRespon
             String portSpec = context.replaceDynamicContentInString(ports[i]);
 
             if (portSpec.startsWith("udp:")) {
-                exposedPorts[i] = ExposedPort.udp(Integer.valueOf(portSpec.substring("udp:".length())));
+                exposedPorts[i] = udp(parseInt(portSpec.substring("udp:".length())));
             } else if (portSpec.startsWith("tcp:")) {
-                exposedPorts[i] = ExposedPort.tcp(Integer.valueOf(portSpec.substring("tcp:".length())));
+                exposedPorts[i] = tcp(parseInt(portSpec.substring("tcp:".length())));
             } else {
-                exposedPorts[i] = ExposedPort.tcp(Integer.valueOf(portSpec));
+                exposedPorts[i] = tcp(parseInt(portSpec));
             }
         }
 
@@ -243,7 +244,7 @@ public class ContainerCreate extends AbstractDockerCommand<CreateContainerRespon
                 Integer hostPort = Integer.valueOf(binding[0]);
                 Integer port = Integer.valueOf(binding[1]);
 
-                portsBindings.bind(Stream.of(exposedPorts).filter(exposed -> port.equals(exposed.getPort())).findAny().orElseGet(() -> ExposedPort.tcp(port)), Ports.Binding.bindPort(hostPort));
+                portsBindings.bind(Stream.of(exposedPorts).filter(exposed -> port.equals(exposed.getPort())).findAny().orElseGet(() -> tcp(port)), Ports.Binding.bindPort(hostPort));
             }
         }
 

--- a/connectors/citrus-docker/src/test/java/org/citrusframework/docker/actions/DockerExecuteActionTest.java
+++ b/connectors/citrus-docker/src/test/java/org/citrusframework/docker/actions/DockerExecuteActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2015 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ package org.citrusframework.docker.actions;
 import java.io.File;
 import java.util.Collections;
 import java.util.UUID;
-import java.util.List;
 
 import org.citrusframework.docker.client.DockerClient;
 import org.citrusframework.docker.command.ContainerCreate;
@@ -58,8 +57,6 @@ import com.github.dockerjava.api.command.VersionCmd;
 import com.github.dockerjava.api.command.WaitContainerCmd;
 import com.github.dockerjava.api.command.WaitContainerResultCallback;
 import com.github.dockerjava.api.model.BuildResponseItem;
-import com.github.dockerjava.api.model.Capability;
-import com.github.dockerjava.api.model.ContainerConfig;
 import com.github.dockerjava.api.model.PullResponseItem;
 import com.github.dockerjava.api.model.ResponseItem;
 import com.github.dockerjava.api.model.Volume;

--- a/connectors/citrus-docker/src/test/java/org/citrusframework/docker/actions/dsl/DockerTestActionBuilderTest.java
+++ b/connectors/citrus-docker/src/test/java/org/citrusframework/docker/actions/dsl/DockerTestActionBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2015 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,9 +90,7 @@ public class DockerTestActionBuilderTest extends UnitTestSupport {
 
         builder.$(docker().client(client)
                     .version()
-                    .validateCommandResult((result, context) -> {
-                        Assert.assertNotNull(result);
-                    }));
+                    .validateCommandResult((result, context) -> Assert.assertNotNull(result)));
 
         builder.$(docker().client(client)
                     .create("new_image")

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/config/xml/KubernetesExecuteActionParser.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/config/xml/KubernetesExecuteActionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2016 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package org.citrusframework.kubernetes.config.xml;
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -85,8 +84,8 @@ public class KubernetesExecuteActionParser<T extends KubernetesCommand> implemen
 
             Map<String, Object> pathExpressions = new HashMap<>();
             List<?> pathElements = DomUtils.getChildElementsByTagName(controlCmdResult, "element");
-            for (Iterator<?> iter = pathElements.iterator(); iter.hasNext();) {
-                Element messageValue = (Element) iter.next();
+            for (Object pathElement : pathElements) {
+                Element messageValue = (Element) pathElement;
                 pathExpressions.put(messageValue.getAttribute("path"), messageValue.getAttribute("value"));
             }
 

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/message/KubernetesMessageConverter.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/message/KubernetesMessageConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2016 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,19 +16,40 @@
 
 package org.citrusframework.kubernetes.message;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;
-import org.citrusframework.kubernetes.command.*;
+import org.citrusframework.kubernetes.command.CommandResult;
+import org.citrusframework.kubernetes.command.CreatePod;
+import org.citrusframework.kubernetes.command.CreateService;
+import org.citrusframework.kubernetes.command.DeletePod;
+import org.citrusframework.kubernetes.command.DeleteService;
+import org.citrusframework.kubernetes.command.GetPod;
+import org.citrusframework.kubernetes.command.GetService;
+import org.citrusframework.kubernetes.command.Info;
+import org.citrusframework.kubernetes.command.KubernetesCommand;
+import org.citrusframework.kubernetes.command.ListEndpoints;
+import org.citrusframework.kubernetes.command.ListEvents;
+import org.citrusframework.kubernetes.command.ListNamespaces;
+import org.citrusframework.kubernetes.command.ListNodes;
+import org.citrusframework.kubernetes.command.ListPods;
+import org.citrusframework.kubernetes.command.ListReplicationControllers;
+import org.citrusframework.kubernetes.command.ListServices;
+import org.citrusframework.kubernetes.command.WatchEventResult;
+import org.citrusframework.kubernetes.command.WatchNamespaces;
+import org.citrusframework.kubernetes.command.WatchNodes;
+import org.citrusframework.kubernetes.command.WatchPods;
+import org.citrusframework.kubernetes.command.WatchReplicationControllers;
+import org.citrusframework.kubernetes.command.WatchServices;
 import org.citrusframework.kubernetes.endpoint.KubernetesEndpointConfiguration;
 import org.citrusframework.kubernetes.model.KubernetesRequest;
 import org.citrusframework.kubernetes.model.KubernetesResponse;
 import org.citrusframework.message.Message;
 import org.citrusframework.message.MessageConverter;
 import org.citrusframework.util.StringUtils;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * @author Christoph Deppisch
@@ -89,48 +110,28 @@ public class KubernetesMessageConverter implements MessageConverter<KubernetesCo
             throw new CitrusRuntimeException("Missing command name property");
         }
 
-        switch (commandName) {
-            case "info":
-                return new Info();
-            case "list-events":
-                return new ListEvents();
-            case "list-endpoints":
-                return new ListEndpoints();
-            case "create-pod":
-                return new CreatePod();
-            case "get-pod":
-                return new GetPod();
-            case "delete-pod":
-                return new DeletePod();
-            case "list-pods":
-                return new ListPods();
-            case "watch-pods":
-                return new WatchPods();
-            case "list-namespaces":
-                return new ListNamespaces();
-            case "watch-namespaces":
-                return new WatchNamespaces();
-            case "list-nodes":
-                return new ListNodes();
-            case "watch-nodes":
-                return new WatchNodes();
-            case "list-replication-controllers":
-                return new ListReplicationControllers();
-            case "watch-replication-controllers":
-                return new WatchReplicationControllers();
-            case "create-service":
-                return new CreateService();
-            case "get-service":
-                return new GetService();
-            case "delete-service":
-                return new DeleteService();
-            case "list-services":
-                return new ListServices();
-            case "watch-services":
-                return new WatchServices();
-            default:
-                throw new CitrusRuntimeException("Unknown kubernetes command: " + commandName);
-        }
+        return switch (commandName) {
+            case "info" -> new Info();
+            case "list-events" -> new ListEvents();
+            case "list-endpoints" -> new ListEndpoints();
+            case "create-pod" -> new CreatePod();
+            case "get-pod" -> new GetPod();
+            case "delete-pod" -> new DeletePod();
+            case "list-pods" -> new ListPods();
+            case "watch-pods" -> new WatchPods();
+            case "list-namespaces" -> new ListNamespaces();
+            case "watch-namespaces" -> new WatchNamespaces();
+            case "list-nodes" -> new ListNodes();
+            case "watch-nodes" -> new WatchNodes();
+            case "list-replication-controllers" -> new ListReplicationControllers();
+            case "watch-replication-controllers" -> new WatchReplicationControllers();
+            case "create-service" -> new CreateService();
+            case "get-service" -> new GetService();
+            case "delete-service" -> new DeleteService();
+            case "list-services" -> new ListServices();
+            case "watch-services" -> new WatchServices();
+            default -> throw new CitrusRuntimeException("Unknown kubernetes command: " + commandName);
+        };
     }
 
     /**
@@ -139,7 +140,7 @@ public class KubernetesMessageConverter implements MessageConverter<KubernetesCo
      * @return
      */
     private Map<String,Object> createMessageHeaders(KubernetesCommand<?> command) {
-        Map<String, Object> headers = new HashMap<String, Object>();
+        Map<String, Object> headers = new HashMap<>();
 
         headers.put(KubernetesMessageHeaders.COMMAND, command.getName());
 

--- a/connectors/citrus-kubernetes/src/test/java/org/citrusframework/kubernetes/actions/KubernetesExecuteActionTest.java
+++ b/connectors/citrus-kubernetes/src/test/java/org/citrusframework/kubernetes/actions/KubernetesExecuteActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2015 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,8 +26,6 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.client.dsl.ClientMixedOperation;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -49,7 +47,7 @@ public class KubernetesExecuteActionTest extends AbstractTestNGUnitTest {
     }
 
     @Test
-    public void testListPods() throws Exception {
+    public void testListPods() {
         final ClientMixedOperation clientOperation = Mockito.mock(ClientMixedOperation.class);
         PodList response = new PodList();
         response.getItems().add(new Pod());
@@ -74,7 +72,7 @@ public class KubernetesExecuteActionTest extends AbstractTestNGUnitTest {
     }
 
     @Test
-    public void testListPodsInNamespace() throws Exception {
+    public void testListPodsInNamespace() {
         final ClientMixedOperation clientOperation = Mockito.mock(ClientMixedOperation.class);
         PodList response = new PodList();
         response.getItems().add(new Pod());
@@ -99,7 +97,7 @@ public class KubernetesExecuteActionTest extends AbstractTestNGUnitTest {
     }
 
     @Test
-    public void testListPodsInDefaultClientNamespace() throws Exception {
+    public void testListPodsInDefaultClientNamespace() {
         final ClientMixedOperation clientOperation = Mockito.mock(ClientMixedOperation.class);
         PodList response = new PodList();
         response.getItems().add(new Pod());
@@ -125,7 +123,7 @@ public class KubernetesExecuteActionTest extends AbstractTestNGUnitTest {
     }
 
     @Test
-    public void testListPodsWithLabels() throws Exception {
+    public void testListPodsWithLabels() {
         final ClientMixedOperation clientOperation = Mockito.mock(ClientMixedOperation.class);
         PodList response = new PodList();
         response.getItems().add(new Pod());
@@ -134,16 +132,13 @@ public class KubernetesExecuteActionTest extends AbstractTestNGUnitTest {
 
         when(kubernetesClient.pods()).thenReturn(clientOperation);
         when(clientOperation.inAnyNamespace()).thenReturn(clientOperation);
-        when(clientOperation.withLabels(anyMap())).thenAnswer(new Answer<Object>() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                Map<String, String> labels = (Map<String, String>) invocation.getArguments()[0];
-                Assert.assertEquals(labels.size(), 2);
-                Assert.assertEquals(labels.get("app"), null);
-                Assert.assertEquals(labels.get("pod_label"), "active");
+        when(clientOperation.withLabels(anyMap())).thenAnswer(invocation -> {
+            Map<String, String> labels = (Map<String, String>) invocation.getArguments()[0];
+            Assert.assertEquals(labels.size(), 2);
+            Assert.assertEquals(labels.get("app"), null);
+            Assert.assertEquals(labels.get("pod_label"), "active");
 
-                return clientOperation;
-            }
+            return clientOperation;
         });
         when(clientOperation.list()).thenReturn(response);
 
@@ -161,7 +156,7 @@ public class KubernetesExecuteActionTest extends AbstractTestNGUnitTest {
     }
 
     @Test
-    public void testListPodsWithoutLabels() throws Exception {
+    public void testListPodsWithoutLabels() {
         final ClientMixedOperation clientOperation = Mockito.mock(ClientMixedOperation.class);
         PodList response = new PodList();
         response.getItems().add(new Pod());
@@ -170,16 +165,13 @@ public class KubernetesExecuteActionTest extends AbstractTestNGUnitTest {
 
         when(kubernetesClient.pods()).thenReturn(clientOperation);
         when(clientOperation.inAnyNamespace()).thenReturn(clientOperation);
-        when(clientOperation.withoutLabels(anyMap())).thenAnswer(new Answer<Object>() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                Map<String, String> labels = (Map<String, String>) invocation.getArguments()[0];
-                Assert.assertEquals(labels.size(), 2);
-                Assert.assertEquals(labels.get("app"), null);
-                Assert.assertEquals(labels.get("pod_label"), "inactive");
+        when(clientOperation.withoutLabels(anyMap())).thenAnswer(invocation -> {
+            Map<String, String> labels = (Map<String, String>) invocation.getArguments()[0];
+            Assert.assertEquals(labels.size(), 2);
+            Assert.assertEquals(labels.get("app"), null);
+            Assert.assertEquals(labels.get("pod_label"), "inactive");
 
-                return clientOperation;
-            }
+            return clientOperation;
         });
         when(clientOperation.list()).thenReturn(response);
 
@@ -197,7 +189,7 @@ public class KubernetesExecuteActionTest extends AbstractTestNGUnitTest {
     }
 
     @Test
-    public void testListPodsMixedLabels() throws Exception {
+    public void testListPodsMixedLabels() {
         final ClientMixedOperation clientOperation = Mockito.mock(ClientMixedOperation.class);
         PodList response = new PodList();
         response.getItems().add(new Pod());
@@ -206,27 +198,21 @@ public class KubernetesExecuteActionTest extends AbstractTestNGUnitTest {
 
         when(kubernetesClient.pods()).thenReturn(clientOperation);
         when(clientOperation.inAnyNamespace()).thenReturn(clientOperation);
-        when(clientOperation.withLabels(anyMap())).thenAnswer(new Answer<Object>() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                Map<String, String> labels = (Map<String, String>) invocation.getArguments()[0];
-                Assert.assertEquals(labels.size(), 2);
-                Assert.assertEquals(labels.get("app"), null);
-                Assert.assertEquals(labels.get("with"), "active");
+        when(clientOperation.withLabels(anyMap())).thenAnswer(invocation -> {
+            Map<String, String> labels = (Map<String, String>) invocation.getArguments()[0];
+            Assert.assertEquals(labels.size(), 2);
+            Assert.assertEquals(labels.get("app"), null);
+            Assert.assertEquals(labels.get("with"), "active");
 
-                return clientOperation;
-            }
+            return clientOperation;
         });
-        when(clientOperation.withoutLabels(anyMap())).thenAnswer(new Answer<Object>() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                Map<String, String> labels = (Map<String, String>) invocation.getArguments()[0];
-                Assert.assertEquals(labels.size(), 2);
-                Assert.assertEquals(labels.get("running"), null);
-                Assert.assertEquals(labels.get("without"), "inactive");
+        when(clientOperation.withoutLabels(anyMap())).thenAnswer(invocation -> {
+            Map<String, String> labels = (Map<String, String>) invocation.getArguments()[0];
+            Assert.assertEquals(labels.size(), 2);
+            Assert.assertEquals(labels.get("running"), null);
+            Assert.assertEquals(labels.get("without"), "inactive");
 
-                return clientOperation;
-            }
+            return clientOperation;
         });
         when(clientOperation.list()).thenReturn(response);
 

--- a/connectors/citrus-kubernetes/src/test/java/org/citrusframework/kubernetes/actions/dsl/KubernetesTestActionBuilderTest.java
+++ b/connectors/citrus-kubernetes/src/test/java/org/citrusframework/kubernetes/actions/dsl/KubernetesTestActionBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2016 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -122,16 +122,12 @@ public class KubernetesTestActionBuilderTest extends UnitTestSupport {
         builder.$(kubernetes().client(client)
             .nodes()
             .list()
-            .validate((nodes, context) -> {
-                Assert.assertNotNull(nodes.getResult());
-            }));
+            .validate((nodes, context) -> Assert.assertNotNull(nodes.getResult())));
 
         builder.$(kubernetes().client(client)
             .namespaces()
             .list()
-            .validate((namespaces, context) -> {
-                Assert.assertNotNull(namespaces.getResult());
-            }));
+            .validate((namespaces, context) -> Assert.assertNotNull(namespaces.getResult())));
 
         builder.$(kubernetes().client(client)
             .nodes()

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/actions/FillFormAction.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/actions/FillFormAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2016 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,13 +51,11 @@ public class FillFormAction extends AbstractSeleniumAction {
 
     @Override
     public void execute(SeleniumBrowser browser, TestContext context) {
-        formFields.forEach((by, value) -> {
-            new SetInputAction.Builder()
-                    .element(by)
-                    .value(value)
-                    .build()
-                    .execute(browser, context);
-        });
+        formFields.forEach((by, value) -> new SetInputAction.Builder()
+                .element(by)
+                .value(value)
+                .build()
+                .execute(browser, context));
 
         if (submitButton != null) {
             new ClickAction.Builder()

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/actions/FindElementAction.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/actions/FindElementAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2016 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,6 @@
 
 package org.citrusframework.selenium.actions;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.exceptions.ValidationException;
@@ -28,6 +24,10 @@ import org.citrusframework.util.StringUtils;
 import org.citrusframework.validation.matcher.ValidationMatcherUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Finds element in DOM tree on current page and validates its properties and settings.
@@ -164,24 +164,16 @@ public class FindElementAction extends AbstractSeleniumAction {
             return by;
         }
 
-        switch (property) {
-            case "id":
-                return By.id(context.replaceDynamicContentInString(propertyValue));
-            case "class-name":
-                return By.className(context.replaceDynamicContentInString(propertyValue));
-            case "link-text":
-                return By.linkText(context.replaceDynamicContentInString(propertyValue));
-            case "css-selector":
-                return By.cssSelector(context.replaceDynamicContentInString(propertyValue));
-            case "name":
-                return By.name(context.replaceDynamicContentInString(propertyValue));
-            case "tag-name":
-                return By.tagName(context.replaceDynamicContentInString(propertyValue));
-            case "xpath":
-                return By.xpath(context.replaceDynamicContentInString(propertyValue));
-        }
-
-        throw new CitrusRuntimeException("Unknown selector type: " + property);
+        return switch (property) {
+            case "id" -> By.id(context.replaceDynamicContentInString(propertyValue));
+            case "class-name" -> By.className(context.replaceDynamicContentInString(propertyValue));
+            case "link-text" -> By.linkText(context.replaceDynamicContentInString(propertyValue));
+            case "css-selector" -> By.cssSelector(context.replaceDynamicContentInString(propertyValue));
+            case "name" -> By.name(context.replaceDynamicContentInString(propertyValue));
+            case "tag-name" -> By.tagName(context.replaceDynamicContentInString(propertyValue));
+            case "xpath" -> By.xpath(context.replaceDynamicContentInString(propertyValue));
+            default -> throw new CitrusRuntimeException("Unknown selector type: " + property);
+        };
     }
 
     /**

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/actions/JavaScriptAction.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/actions/JavaScriptAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2016 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,8 +64,7 @@ public class JavaScriptAction extends AbstractSeleniumAction {
     @Override
     protected void execute(SeleniumBrowser browser, TestContext context) {
         try {
-            if (browser.getWebDriver() instanceof JavascriptExecutor) {
-                JavascriptExecutor jsEngine = ((JavascriptExecutor) browser.getWebDriver());
+            if (browser.getWebDriver() instanceof JavascriptExecutor jsEngine) {
                 jsEngine.executeScript(context.replaceDynamicContentInString(script), context.resolveDynamicValuesInArray(arguments.toArray()));
 
                 List<String> errors = new ArrayList<>();

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/actions/NavigateAction.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/actions/NavigateAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2016 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,37 +50,36 @@ public class NavigateAction extends AbstractSeleniumAction {
 
     @Override
     protected void execute(SeleniumBrowser browser, TestContext context) {
-        if (page.equals("back")) {
-            browser.getWebDriver().navigate().back();
-        } else if (page.equals("forward")) {
-            browser.getWebDriver().navigate().forward();
-        } else if (page.equals("refresh")) {
-            browser.getWebDriver().navigate().refresh();
-        } else {
-            try {
-                if (Browser.IE.is(browser.getEndpointConfiguration().getBrowserType())) {
-                    String cachingSafeUrl = BrowserUtils.makeIECachingSafeUrl(context.replaceDynamicContentInString(page), new Date().getTime());
-                    browser.getWebDriver().navigate().to(new URL(cachingSafeUrl));
-                } else {
-                    browser.getWebDriver().navigate().to(new URL(context.replaceDynamicContentInString(page)));
-                }
-            } catch (MalformedURLException ex) {
-                String baseUrl = browser.getWebDriver().getCurrentUrl();
+        switch (page) {
+            case "back" -> browser.getWebDriver().navigate().back();
+            case "forward" -> browser.getWebDriver().navigate().forward();
+            case "refresh" -> browser.getWebDriver().navigate().refresh();
+            default -> {
                 try {
-                    new URL(baseUrl);
-                } catch (MalformedURLException e) {
-                    if (StringUtils.hasText(browser.getEndpointConfiguration().getStartPageUrl())) {
-                        baseUrl = browser.getEndpointConfiguration().getStartPageUrl();
+                    if (Browser.IE.is(browser.getEndpointConfiguration().getBrowserType())) {
+                        String cachingSafeUrl = BrowserUtils.makeIECachingSafeUrl(context.replaceDynamicContentInString(page), new Date().getTime());
+                        browser.getWebDriver().navigate().to(new URL(cachingSafeUrl));
                     } else {
-                        throw new CitrusRuntimeException("Failed to create relative page URL - must set start page on browser", ex);
+                        browser.getWebDriver().navigate().to(new URL(context.replaceDynamicContentInString(page)));
                     }
-                }
-                String lastChar = baseUrl.substring(baseUrl.length() - 1);
-                if (!lastChar.equals("/")) {
-                    baseUrl = baseUrl + "/";
-                }
+                } catch (MalformedURLException ex) {
+                    String baseUrl = browser.getWebDriver().getCurrentUrl();
+                    try {
+                        new URL(baseUrl);
+                    } catch (MalformedURLException e) {
+                        if (StringUtils.hasText(browser.getEndpointConfiguration().getStartPageUrl())) {
+                            baseUrl = browser.getEndpointConfiguration().getStartPageUrl();
+                        } else {
+                            throw new CitrusRuntimeException("Failed to create relative page URL - must set start page on browser", ex);
+                        }
+                    }
+                    String lastChar = baseUrl.substring(baseUrl.length() - 1);
+                    if (!lastChar.equals("/")) {
+                        baseUrl = baseUrl + "/";
+                    }
 
-                browser.getWebDriver().navigate().to(baseUrl + context.replaceDynamicContentInString(page));
+                    browser.getWebDriver().navigate().to(baseUrl + context.replaceDynamicContentInString(page));
+                }
             }
         }
     }

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/endpoint/SeleniumBrowser.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/endpoint/SeleniumBrowser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2016 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,6 @@
  */
 
 package org.citrusframework.selenium.endpoint;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Path;
 
 import com.gargoylesoftware.htmlunit.BrowserVersion;
 import org.citrusframework.context.TestContext;
@@ -57,6 +50,18 @@ import org.openqa.selenium.support.events.EventFiringDecorator;
 import org.openqa.selenium.support.events.WebDriverListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static com.gargoylesoftware.htmlunit.BrowserVersion.CHROME;
+import static com.gargoylesoftware.htmlunit.BrowserVersion.FIREFOX;
+import static com.gargoylesoftware.htmlunit.BrowserVersion.FIREFOX_ESR;
+import static com.gargoylesoftware.htmlunit.BrowserVersion.INTERNET_EXPLORER;
 
 /**
  * Selenium browser provides access to web driver and initializes Selenium environment from endpoint configuration.
@@ -220,33 +225,30 @@ public class SeleniumBrowser extends AbstractEndpoint implements Producer {
         } else if (Browser.CHROME.is(browserType)) {
             return new ChromeDriver();
         } else if (Browser.HTMLUNIT.is(browserType)) {
-            BrowserVersion browserVersion = null;
-            switch (getEndpointConfiguration().getVersion()) {
-                case "FIREFOX":
-                    browserVersion = BrowserVersion.FIREFOX;
-                    break;
-                case "FIREFOX_78":
-                case "FIREFOX_ESR":
-                    browserVersion = BrowserVersion.FIREFOX_ESR;
-                    break;
-                case "INTERNET_EXPLORER":
-                    browserVersion = BrowserVersion.INTERNET_EXPLORER;
-                    break;
-                case "CHROME":
-                    browserVersion = BrowserVersion.CHROME;
-                    break;
-            }
-
-            HtmlUnitDriver htmlUnitDriver;
-            if (browserVersion != null) {
-                htmlUnitDriver = new HtmlUnitDriver(browserVersion, getEndpointConfiguration().isJavaScript());
-            } else {
-                htmlUnitDriver = new HtmlUnitDriver(getEndpointConfiguration().isJavaScript());
-            }
+            HtmlUnitDriver htmlUnitDriver = getHtmlUnitDriver();
             return htmlUnitDriver;
         }
 
         throw new CitrusRuntimeException("Unsupported local browser type: " + browserType);
+    }
+
+    private HtmlUnitDriver getHtmlUnitDriver() {
+        BrowserVersion browserVersion = switch (getEndpointConfiguration().getVersion()) {
+            case "FIREFOX" -> FIREFOX;
+            case "FIREFOX_78", "FIREFOX_ESR" -> FIREFOX_ESR;
+            case "INTERNET_EXPLORER" -> INTERNET_EXPLORER;
+            case "CHROME" -> CHROME;
+            default -> null;
+        };
+
+        HtmlUnitDriver htmlUnitDriver;
+        if (browserVersion != null) {
+            htmlUnitDriver = new HtmlUnitDriver(browserVersion, getEndpointConfiguration().isJavaScript());
+        } else {
+            htmlUnitDriver = new HtmlUnitDriver(getEndpointConfiguration().isJavaScript());
+        }
+
+        return htmlUnitDriver;
     }
 
     /**

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/ClickActionTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/ClickActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2017 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.selenium.endpoint.SeleniumBrowser;
 import org.citrusframework.testng.AbstractTestNGUnitTest;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.openqa.selenium.*;
 import org.testng.Assert;
@@ -51,16 +50,13 @@ public class ClickActionTest extends AbstractTestNGUnitTest {
     }
 
     @Test
-    public void testExecute() throws Exception {
-        when(webDriver.findElement(any(By.class))).thenAnswer(new Answer<WebElement>() {
-            @Override
-            public WebElement answer(InvocationOnMock invocation) throws Throwable {
-                By select = (By) invocation.getArguments()[0];
+    public void testExecute() {
+        when(webDriver.findElement(any(By.class))).thenAnswer((Answer<WebElement>) invocation -> {
+            By select = (By) invocation.getArguments()[0];
 
-                Assert.assertEquals(select.getClass(), By.ById.class);
-                Assert.assertEquals(select.toString(), "By.id: myButton");
-                return element;
-            }
+            Assert.assertEquals(select.getClass(), By.ById.class);
+            Assert.assertEquals(select.toString(), "By.id: myButton");
+            return element;
         });
 
         ClickAction action =  new ClickAction.Builder()
@@ -82,5 +78,4 @@ public class ClickActionTest extends AbstractTestNGUnitTest {
                 .build();
         action.execute(context);
     }
-
 }

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/FindElementActionTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/FindElementActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2017 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.selenium.endpoint.SeleniumBrowser;
 import org.citrusframework.testng.AbstractTestNGUnitTest;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
@@ -56,16 +55,13 @@ public class FindElementActionTest extends AbstractTestNGUnitTest {
     }
 
     @Test(dataProvider = "findByProvider")
-    public void testExecuteFindBy(String property, String value, final By by) throws Exception {
-        when(webDriver.findElement(any(By.class))).thenAnswer(new Answer<WebElement>() {
-            @Override
-            public WebElement answer(InvocationOnMock invocation) throws Throwable {
-                By select = (By) invocation.getArguments()[0];
+    public void testExecuteFindBy(String property, String value, final By by) {
+        when(webDriver.findElement(any(By.class))).thenAnswer((Answer<WebElement>) invocation -> {
+            By select = (By) invocation.getArguments()[0];
 
-                Assert.assertEquals(select.getClass(), by.getClass());
-                Assert.assertEquals(select.toString(), by.toString());
-                return element;
-            }
+            Assert.assertEquals(select.getClass(), by.getClass());
+            Assert.assertEquals(select.toString(), by.toString());
+            return element;
         });
 
         FindElementAction action =  new FindElementAction.Builder()
@@ -91,16 +87,13 @@ public class FindElementActionTest extends AbstractTestNGUnitTest {
     }
 
     @Test
-    public void testExecuteFindByVariableSupport() throws Exception {
-        when(webDriver.findElement(any(By.class))).thenAnswer(new Answer<WebElement>() {
-            @Override
-            public WebElement answer(InvocationOnMock invocation) throws Throwable {
-                By select = (By) invocation.getArguments()[0];
+    public void testExecuteFindByVariableSupport() {
+        when(webDriver.findElement(any(By.class))).thenAnswer((Answer<WebElement>) invocation -> {
+            By select = (By) invocation.getArguments()[0];
 
-                Assert.assertEquals(select.getClass(), By.ById.class);
-                Assert.assertEquals(select.toString(), By.id("clickMe").toString());
-                return element;
-            }
+            Assert.assertEquals(select.getClass(), By.ById.class);
+            Assert.assertEquals(select.toString(), By.id("clickMe").toString());
+            return element;
         });
 
         context.setVariable("myId", "clickMe");
@@ -115,20 +108,17 @@ public class FindElementActionTest extends AbstractTestNGUnitTest {
     }
 
     @Test
-    public void testExecuteFindByValidation() throws Exception {
+    public void testExecuteFindByValidation() {
         when(element.getText()).thenReturn("Click Me!");
         when(element.getAttribute("type")).thenReturn("submit");
         when(element.getCssValue("color")).thenReturn("red");
 
-        when(webDriver.findElement(any(By.class))).thenAnswer(new Answer<WebElement>() {
-            @Override
-            public WebElement answer(InvocationOnMock invocation) throws Throwable {
-                By select = (By) invocation.getArguments()[0];
+        when(webDriver.findElement(any(By.class))).thenAnswer((Answer<WebElement>) invocation -> {
+            By select = (By) invocation.getArguments()[0];
 
-                Assert.assertEquals(select.getClass(), By.ByName.class);
-                Assert.assertEquals(select.toString(), By.name("clickMe").toString());
-                return element;
-            }
+            Assert.assertEquals(select.getClass(), By.ByName.class);
+            Assert.assertEquals(select.toString(), By.name("clickMe").toString());
+            return element;
         });
 
         FindElementAction action =  new FindElementAction.Builder()
@@ -145,21 +135,18 @@ public class FindElementActionTest extends AbstractTestNGUnitTest {
     }
 
     @Test(dataProvider = "validationErrorProvider")
-    public void testExecuteFindByValidationFailed(String tagName, String text, String attribute, String cssStyle, boolean displayed, boolean enabled, String errorMsg) throws Exception {
+    public void testExecuteFindByValidationFailed(String tagName, String text, String attribute, String cssStyle, boolean displayed, boolean enabled, String errorMsg) {
         when(element.getTagName()).thenReturn("button");
         when(element.getText()).thenReturn("Click Me!");
         when(element.getAttribute("type")).thenReturn("submit");
         when(element.getCssValue("color")).thenReturn("red");
 
-        when(webDriver.findElement(any(By.class))).thenAnswer(new Answer<WebElement>() {
-            @Override
-            public WebElement answer(InvocationOnMock invocation) throws Throwable {
-                By select = (By) invocation.getArguments()[0];
+        when(webDriver.findElement(any(By.class))).thenAnswer((Answer<WebElement>) invocation -> {
+            By select = (By) invocation.getArguments()[0];
 
-                Assert.assertEquals(select.getClass(), By.ByName.class);
-                Assert.assertEquals(select.toString(), By.name("clickMe").toString());
-                return element;
-            }
+            Assert.assertEquals(select.getClass(), By.ByName.class);
+            Assert.assertEquals(select.toString(), By.name("clickMe").toString());
+            return element;
         });
 
         FindElementAction action =  new FindElementAction.Builder()

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/NavigateActionTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/NavigateActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2017 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import java.net.URL;
 import org.citrusframework.selenium.endpoint.SeleniumBrowser;
 import org.citrusframework.testng.AbstractTestNGUnitTest;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.Browser;
@@ -52,14 +51,11 @@ public class NavigateActionTest extends AbstractTestNGUnitTest {
     }
 
     @Test
-    public void testNavigatePageUrl() throws Exception {
+    public void testNavigatePageUrl() {
         seleniumBrowser.getEndpointConfiguration().setBrowserType(Browser.CHROME.browserName());
-        doAnswer(new Answer<Object>() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                Assert.assertEquals(invocation.getArguments()[0].toString(), "http://localhost:8080");
-                return null;
-            }
+        doAnswer((Answer<Object>) invocation -> {
+            Assert.assertEquals(invocation.getArguments()[0].toString(), "http://localhost:8080");
+            return null;
         }).when(navigation).to(any(URL.class));
 
         NavigateAction action =  new NavigateAction.Builder()
@@ -72,14 +68,11 @@ public class NavigateActionTest extends AbstractTestNGUnitTest {
     }
 
     @Test
-    public void testNavigatePageUrlInternetExplorer() throws Exception {
+    public void testNavigatePageUrlInternetExplorer() {
         seleniumBrowser.getEndpointConfiguration().setBrowserType(Browser.IE.browserName());
-        doAnswer(new Answer<Object>() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                Assert.assertTrue(invocation.getArguments()[0].toString().startsWith("http://localhost:8080?timestamp="));
-                return null;
-            }
+        doAnswer((Answer<Object>) invocation -> {
+            Assert.assertTrue(invocation.getArguments()[0].toString().startsWith("http://localhost:8080?timestamp="));
+            return null;
         }).when(navigation).to(any(URL.class));
 
         NavigateAction action =  new NavigateAction.Builder()
@@ -92,7 +85,7 @@ public class NavigateActionTest extends AbstractTestNGUnitTest {
     }
 
     @Test
-    public void testNavigateRelativePageUrl() throws Exception {
+    public void testNavigateRelativePageUrl(){
         seleniumBrowser.getEndpointConfiguration().setBrowserType(Browser.IE.browserName());
         seleniumBrowser.getEndpointConfiguration().setStartPageUrl("http://localhost:8080");
 
@@ -106,7 +99,7 @@ public class NavigateActionTest extends AbstractTestNGUnitTest {
     }
 
     @Test
-    public void testExecuteBack() throws Exception {
+    public void testExecuteBack(){
         NavigateAction action =  new NavigateAction.Builder()
                 .browser(seleniumBrowser)
                 .page("back")
@@ -117,7 +110,7 @@ public class NavigateActionTest extends AbstractTestNGUnitTest {
     }
 
     @Test
-    public void testExecuteForward() throws Exception {
+    public void testExecuteForward(){
         NavigateAction action =  new NavigateAction.Builder()
                 .browser(seleniumBrowser)
                 .page("forward")
@@ -128,7 +121,7 @@ public class NavigateActionTest extends AbstractTestNGUnitTest {
     }
 
     @Test
-    public void testExecuteRefresh() throws Exception {
+    public void testExecuteRefresh(){
         NavigateAction action =  new NavigateAction.Builder()
                 .browser(seleniumBrowser)
                 .page("refresh")

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/StartBrowserActionTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/StartBrowserActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2017 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ import org.citrusframework.selenium.endpoint.SeleniumBrowserConfiguration;
 import org.citrusframework.selenium.endpoint.SeleniumHeaders;
 import org.citrusframework.testng.AbstractTestNGUnitTest;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.Browser;
@@ -74,12 +73,9 @@ public class StartBrowserActionTest extends AbstractTestNGUnitTest {
         when(seleniumBrowser.isStarted()).thenReturn(false);
         when(seleniumBrowserConfiguration.getStartPageUrl()).thenReturn("http://localhost:8080");
 
-        doAnswer(new Answer<Object>() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                Assert.assertEquals(invocation.getArguments()[0].toString(), "http://localhost:8080");
-                return null;
-            }
+        doAnswer((Answer<Object>) invocation -> {
+            Assert.assertEquals(invocation.getArguments()[0].toString(), "http://localhost:8080");
+            return null;
         }).when(navigation).to(any(URL.class));
 
         StartBrowserAction action =  new StartBrowserAction.Builder()

--- a/connectors/citrus-sql/src/main/java/org/citrusframework/actions/ExecuteSQLQueryAction.java
+++ b/connectors/citrus-sql/src/main/java/org/citrusframework/actions/ExecuteSQLQueryAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataAccessException;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.util.CollectionUtils;
+
+import static java.lang.Integer.parseInt;
 
 /**
  * Action executes SQL queries and offers result set validation.
@@ -98,9 +100,9 @@ public class ExecuteSQLQueryAction extends AbstractDatabaseConnectingTestAction 
 
         try {
             //for control result set validation
-            final Map<String, List<String>> columnValuesMap = new HashMap<String, List<String>>();
+            final Map<String, List<String>> columnValuesMap = new HashMap<>();
             //for groovy script validation
-            final List<Map<String, Object>> allResultRows = new ArrayList<Map<String, Object>>();
+            final List<Map<String, Object>> allResultRows = new ArrayList<>();
 
             if (getTransactionManager() != null) {
                 if (logger.isDebugEnabled()) {
@@ -108,7 +110,7 @@ public class ExecuteSQLQueryAction extends AbstractDatabaseConnectingTestAction 
                 }
 
                 TransactionTemplate transactionTemplate = new TransactionTemplate(getTransactionManager());
-                transactionTemplate.setTimeout(Integer.valueOf(context.replaceDynamicContentInString(getTransactionTimeout())));
+                transactionTemplate.setTimeout(parseInt(context.replaceDynamicContentInString(getTransactionTimeout())));
                 transactionTemplate.setIsolationLevelName(context.replaceDynamicContentInString(getTransactionIsolationLevel()));
                 transactionTemplate.execute(status -> {
                     executeStatements(statementsToUse, allResultRows, columnValuesMap, context);
@@ -197,7 +199,7 @@ public class ExecuteSQLQueryAction extends AbstractDatabaseConnectingTestAction 
                 String columnValue;
                 String columnName = column.getKey();
                 if (!columnValuesMap.containsKey(columnName)) {
-                    columnValuesMap.put(columnName, new ArrayList<String>());
+                    columnValuesMap.put(columnName, new ArrayList<>());
                 }
 
                 if (column.getValue() instanceof byte[]) {

--- a/connectors/citrus-sql/src/main/java/org/citrusframework/config/xml/SQLActionParser.java
+++ b/connectors/citrus-sql/src/main/java/org/citrusframework/config/xml/SQLActionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,7 +73,7 @@ public class SQLActionParser implements BeanDefinitionParser {
 
         DescriptionElementParser.doParse(element, beanDefinition);
 
-        List<String> statements = new ArrayList<String>();
+        List<String> statements = new ArrayList<>();
         List<Element> stmtElements = DomUtils.getChildElementsByTagName(element, "statement");
         for (Element stmt : stmtElements) {
             statements.add(DomUtils.getTextValue(stmt));

--- a/connectors/citrus-sql/src/main/java/org/citrusframework/util/SqlUtils.java
+++ b/connectors/citrus-sql/src/main/java/org/citrusframework/util/SqlUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2015 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,7 +70,7 @@ public abstract class SqlUtils {
      */
     public static List<String> createStatementsFromFileResource(Resource sqlResource, LastScriptLineDecorator lineDecorator) {
         BufferedReader reader = null;
-        StringBuffer buffer;
+        StringBuilder buffer;
 
         List<String> stmts = new ArrayList<>();
 
@@ -80,13 +80,13 @@ public abstract class SqlUtils {
             }
 
             reader = new BufferedReader(new InputStreamReader(sqlResource.getInputStream()));
-            buffer = new StringBuffer();
+            buffer = new StringBuilder();
 
             String line;
             while (reader.ready()) {
                 line = reader.readLine();
 
-                if (line != null && !line.trim().startsWith(SQL_COMMENT) && line.trim().length() > 0) {
+                if (line != null && !line.trim().startsWith(SQL_COMMENT) && !line.trim().isEmpty()) {
                     if (line.trim().endsWith(getStatementEndingCharacter(lineDecorator))) {
                         if (lineDecorator != null) {
                             buffer.append(lineDecorator.decorate(line));
@@ -102,7 +102,7 @@ public abstract class SqlUtils {
 
                         stmts.add(stmt);
                         buffer.setLength(0);
-                        buffer = new StringBuffer();
+                        buffer = new StringBuilder();
                     } else {
                         buffer.append(line);
 

--- a/connectors/citrus-sql/src/test/java/org/citrusframework/actions/ExecutePLSQLActionTest.java
+++ b/connectors/citrus-sql/src/test/java/org/citrusframework/actions/ExecutePLSQLActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -128,13 +128,14 @@ public class ExecutePLSQLActionTest extends AbstractTestNGUnitTest {
     public void testPLSQLExecutionWithFileResource() {
         executePLSQLActionBuilder.sqlResource("classpath:org/citrusframework/actions/test-plsql.sql");
 
-        String controlStatement = "DECLARE\n" +
-                "    Zahl1 number(2);\n" +
-                "    Text varchar(20) := 'Hello World!';\n" +
-                "BEGIN\n" +
-                "    EXECUTE IMMEDIATE \"\n" +
-                "        select number_of_greetings into Zahl1 from Greetings where text='Hello World!';\"\n" +
-                "END;";
+        String controlStatement = """
+                DECLARE
+                    Zahl1 number(2);
+                    Text varchar(20) := 'Hello World!';
+                BEGIN
+                    EXECUTE IMMEDIATE "
+                        select number_of_greetings into Zahl1 from Greetings where text='Hello World!';"
+                END;""";
 
         reset(jdbcTemplate);
 
@@ -178,13 +179,14 @@ public class ExecutePLSQLActionTest extends AbstractTestNGUnitTest {
 
         executePLSQLActionBuilder.sqlResource("classpath:org/citrusframework/actions/test-plsql-with-variables.sql");
 
-        String controlStatement = "DECLARE\n" +
-                "    Zahl1 number(2);\n" +
-                "    Text varchar(20) := 'Hello World!';\n" +
-                "BEGIN\n" +
-                "    EXECUTE IMMEDIATE \"\n" +
-                "        select number_of_greetings into Zahl1 from Greetings where text='Hello World!';\"\n" +
-                "END;";
+        String controlStatement = """
+                DECLARE
+                    Zahl1 number(2);
+                    Text varchar(20) := 'Hello World!';
+                BEGIN
+                    EXECUTE IMMEDIATE "
+                        select number_of_greetings into Zahl1 from Greetings where text='Hello World!';"
+                END;""";
 
         reset(jdbcTemplate);
         executePLSQLActionBuilder.build().execute(context);
@@ -229,13 +231,14 @@ public class ExecutePLSQLActionTest extends AbstractTestNGUnitTest {
     public void testPLSQLExecutionWithFileResourceMultipleStmts() {
         executePLSQLActionBuilder.sqlResource("classpath:org/citrusframework/actions/test-plsql-multiple-stmts.sql");
 
-        String controlStatement = "DECLARE\n" +
-                "    Zahl1 number(2);\n" +
-                "    Text varchar(20) := 'Hello World!';\n" +
-                "BEGIN\n" +
-                "    EXECUTE IMMEDIATE \"\n" +
-                "        select number_of_greetings into Zahl1 from Greetings where text='Hello World!';\"\n" +
-                "END;";
+        String controlStatement = """
+                DECLARE
+                    Zahl1 number(2);
+                    Text varchar(20) := 'Hello World!';
+                BEGIN
+                    EXECUTE IMMEDIATE "
+                        select number_of_greetings into Zahl1 from Greetings where text='Hello World!';"
+                END;""";
 
         reset(jdbcTemplate);
         executePLSQLActionBuilder.build().execute(context);

--- a/connectors/citrus-sql/src/test/java/org/citrusframework/actions/ExecuteSQLQueryActionTest.java
+++ b/connectors/citrus-sql/src/test/java/org/citrusframework/actions/ExecuteSQLQueryActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -485,7 +485,7 @@ public class ExecuteSQLQueryActionTest extends UnitTestSupport {
 
         when(jdbcTemplate.queryForList(sql2)).thenReturn(Collections.singletonList(resultMap2));
 
-        List<String> statements = new ArrayList<String>();
+        List<String> statements = new ArrayList<>();
         statements.add(sql1);
         statements.add(sql2);
 
@@ -557,9 +557,10 @@ public class ExecuteSQLQueryActionTest extends UnitTestSupport {
 
         executeSQLQueryAction.statements(Collections.singletonList(sql));
 
-        String validationScript = "assert rows.size() == 1\n" +
-                "assert rows[0].ORDERTYPE == 'small'\n" +
-                "assert rows[0] == [ORDERTYPE:'small', STATUS:'in_progress']";
+        String validationScript = """
+                assert rows.size() == 1
+                assert rows[0].ORDERTYPE == 'small'
+                assert rows[0] == [ORDERTYPE:'small', STATUS:'in_progress']""";
         executeSQLQueryAction.validateScript(validationScript, ScriptTypes.GROOVY);
         executeSQLQueryAction.build().execute(context);
 
@@ -588,16 +589,18 @@ public class ExecuteSQLQueryActionTest extends UnitTestSupport {
         when(jdbcTemplate.queryForList(sql1)).thenReturn(Collections.singletonList(resultMap));
         when(jdbcTemplate.queryForList(sql2)).thenReturn(results);
 
-        List<String> statements = new ArrayList<String>();
+        List<String> statements = new ArrayList<>();
         statements.add(sql1);
         statements.add(sql2);
         executeSQLQueryAction.statements(statements);
 
-        String validationScript = "assert rows.size() == 4\n" +
-                "assert rows[0].ORDERTYPE == 'small'\n" +
-                "assert rows[0] == [ORDERTYPE:'small', STATUS:'in_progress']\n" +
-                "assert rows[1].ID == '1'\n" +
-                "assert rows[3].NAME == 'error3'\n";
+        String validationScript = """
+                assert rows.size() == 4
+                assert rows[0].ORDERTYPE == 'small'
+                assert rows[0] == [ORDERTYPE:'small', STATUS:'in_progress']
+                assert rows[1].ID == '1'
+                assert rows[3].NAME == 'error3'
+                """;
         executeSQLQueryAction.validateScript(validationScript, ScriptTypes.GROOVY);
         executeSQLQueryAction.build().execute(context);
 
@@ -649,9 +652,10 @@ public class ExecuteSQLQueryActionTest extends UnitTestSupport {
         executeSQLQueryAction.validate("ORDERTYPE", "small");
         executeSQLQueryAction.validate("STATUS", "in_progress");
 
-        String validationScript = "assert rows.size() == 1\n" +
-                "assert rows[0].ORDERTYPE == 'small'\n" +
-                "assert rows[0] == [ORDERTYPE:'small', STATUS:'in_progress']";
+        String validationScript = """
+                assert rows.size() == 1
+                assert rows[0].ORDERTYPE == 'small'
+                assert rows[0] == [ORDERTYPE:'small', STATUS:'in_progress']""";
         executeSQLQueryAction.validateScript(validationScript, ScriptTypes.GROOVY);
         executeSQLQueryAction.build().execute(context);
 

--- a/connectors/citrus-sql/src/test/java/org/citrusframework/actions/dsl/ExecutePLSQLTestActionBuilderTest.java
+++ b/connectors/citrus-sql/src/test/java/org/citrusframework/actions/dsl/ExecutePLSQLTestActionBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2015 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -108,12 +108,13 @@ public class ExecutePLSQLTestActionBuilderTest extends UnitTestSupport {
     public void testExecutePLSQLBuilderWithSQLResource() throws IOException {
         reset(jdbcTemplate, sqlResource);
         when(sqlResource.exists()).thenReturn(true);
-        when(sqlResource.getInputStream()).thenReturn(new ByteArrayInputStream(("TEST_STMT_1\n" +
-                "/\n" +
-                "TEST_STMT_2\n" +
-                "/\n" +
-                "TEST_STMT_3\n" +
-                "/").getBytes()));
+        when(sqlResource.getInputStream()).thenReturn(new ByteArrayInputStream(("""
+                TEST_STMT_1
+                /
+                TEST_STMT_2
+                /
+                TEST_STMT_3
+                /""").getBytes()));
 
         DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
         builder.$(plsql().jdbcTemplate(jdbcTemplate)
@@ -128,12 +129,13 @@ public class ExecutePLSQLTestActionBuilderTest extends UnitTestSupport {
         Assert.assertEquals(action.getName(), "plsql");
         Assert.assertFalse(action.isIgnoreErrors());
         Assert.assertEquals(action.getStatements().size(), 0L);
-        Assert.assertEquals(action.getScript(), ("TEST_STMT_1\n" +
-                "/\n" +
-                "TEST_STMT_2\n" +
-                "/\n" +
-                "TEST_STMT_3\n" +
-                "/"));
+        Assert.assertEquals(action.getScript(), ("""
+                TEST_STMT_1
+                /
+                TEST_STMT_2
+                /
+                TEST_STMT_3
+                /"""));
         Assert.assertEquals(action.getJdbcTemplate(), jdbcTemplate);
 
         verify(jdbcTemplate).execute("TEST_STMT_1");
@@ -172,10 +174,11 @@ public class ExecutePLSQLTestActionBuilderTest extends UnitTestSupport {
         DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
         builder.$(plsql().jdbcTemplate(jdbcTemplate)
                         .ignoreErrors(true)
-                        .sqlScript(("TEST_STMT_1\n" +
-                                "/\n" +
-                                "TEST_STMT_2\n" +
-                                "/")));
+                        .sqlScript(("""
+                                TEST_STMT_1
+                                /
+                                TEST_STMT_2
+                                /""")));
 
         TestCase test = builder.getTestCase();
         Assert.assertEquals(test.getActionCount(), 1);
@@ -187,10 +190,11 @@ public class ExecutePLSQLTestActionBuilderTest extends UnitTestSupport {
         Assert.assertTrue(action.isIgnoreErrors());
         Assert.assertEquals(action.getStatements().size(), 0L);
         Assert.assertNull(action.getSqlResourcePath());
-        Assert.assertEquals(action.getScript(), ("TEST_STMT_1\n" +
-                "/\n" +
-                "TEST_STMT_2\n" +
-                "/"));
+        Assert.assertEquals(action.getScript(), ("""
+                TEST_STMT_1
+                /
+                TEST_STMT_2
+                /"""));
         Assert.assertEquals(action.getJdbcTemplate(), jdbcTemplate);
 
         verify(jdbcTemplate).execute("TEST_STMT_1");

--- a/connectors/citrus-sql/src/test/java/org/citrusframework/integration/actions/ExecutePLSQLJavaIT.java
+++ b/connectors/citrus-sql/src/test/java/org/citrusframework/integration/actions/ExecutePLSQLJavaIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,16 +43,18 @@ public class ExecutePLSQLJavaIT extends TestNGCitrusSpringSupport {
             .ignoreErrors(true));
 
         run(plsql(dataSource)
-            .sqlScript("BEGIN\n" +
-                            "EXECUTE IMMEDIATE 'create or replace function test (v_id in number) return number is\n" +
-                              "begin\n" +
-                               "if v_id  is null then\n" +
-                                "return 0;\n" +
-                                "end if;\n" +
-                                "return v_id;\n" +
-                              "end;';\n" +
-                        "END;\n" +
-                        "/")
+            .sqlScript("""
+                    BEGIN
+                    EXECUTE IMMEDIATE 'create or replace function test(v_id in number)
+                        return number is
+                        begin
+                        if v_id  is null then
+                                            return 0;
+                        end if;
+                        return v_id;
+                        end;';
+                    END;
+                    /""")
             .ignoreErrors(true));
     }
 }

--- a/core/citrus-api/src/main/java/org/citrusframework/CitrusSettings.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/CitrusSettings.java
@@ -1,9 +1,28 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.citrusframework;
+
+import org.citrusframework.message.MessageType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.InputStream;
 import java.nio.charset.Charset;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -11,10 +30,11 @@ import java.util.logging.LogManager;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.citrusframework.common.TestLoader;
-import org.citrusframework.message.MessageType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static java.util.Collections.emptySet;
+import static org.citrusframework.common.TestLoader.GROOVY;
+import static org.citrusframework.common.TestLoader.SPRING;
+import static org.citrusframework.common.TestLoader.XML;
+import static org.citrusframework.common.TestLoader.YAML;
 
 /**
  * @author Christoph Deppisch
@@ -287,16 +307,11 @@ public final class CitrusSettings {
      * @return
      */
     public static Set<String> getTestFileNamePattern(String type) {
-        switch (type) {
-            case TestLoader.XML:
-            case TestLoader.SPRING:
-                return CitrusSettings.getXmlTestFileNamePattern();
-            case TestLoader.GROOVY:
-                return CitrusSettings.getGroovyTestFileNamePattern();
-            case TestLoader.YAML:
-                return CitrusSettings.getYamlTestFileNamePattern();
-            default:
-                return Collections.emptySet();
-        }
+        return switch (type) {
+            case XML, SPRING -> getXmlTestFileNamePattern();
+            case GROOVY -> getGroovyTestFileNamePattern();
+            case YAML -> getYamlTestFileNamePattern();
+            default -> emptySet();
+        };
     }
 }

--- a/core/citrus-api/src/main/java/org/citrusframework/TestResult.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/TestResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,9 @@ package org.citrusframework;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
+import static java.lang.Math.max;
+import static java.util.stream.Collectors.joining;
 
 /**
  * Class representing test results (failed, successful, skipped)
@@ -207,20 +208,18 @@ public final class TestResult {
     public String toString() {
         StringBuilder builder = new StringBuilder();
 
-        if (parameters != null && parameters.size() > 0) {
+        if (parameters != null && !parameters.isEmpty()) {
             builder.append(" ")
                     .append(testName)
                     .append("(")
-                    .append(parameters.values().stream().map(Object::toString).collect(Collectors.joining(",")))
+                    .append(parameters.values().stream().map(Object::toString).collect(joining(",")))
                     .append(") ");
         } else {
             builder.append(" ").append(testName).append(" ");
         }
 
         int spaces = 65 - builder.length();
-        for (int i = 0; i < spaces; i++) {
-            builder.append(".");
-        }
+        builder.append(".".repeat(max(0, spaces)));
 
         switch (result) {
             case SUCCESS:

--- a/core/citrus-api/src/main/java/org/citrusframework/exceptions/CitrusRuntimeException.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/exceptions/CitrusRuntimeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,7 +97,7 @@ public class CitrusRuntimeException extends RuntimeException {
      * @return the failureStack
      */
     public Stack<FailureStackElement> getFailureStack() {
-        Stack<FailureStackElement> stack = new Stack<FailureStackElement>();
+        Stack<FailureStackElement> stack = new Stack<>();
 
         for (FailureStackElement failureStackElement : failureStack) {
             stack.push(failureStackElement);

--- a/core/citrus-api/src/main/java/org/citrusframework/exceptions/ParallelContainerException.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/exceptions/ParallelContainerException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package org.citrusframework.exceptions;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -30,7 +29,7 @@ public class ParallelContainerException extends CitrusRuntimeException {
 
     private static final long serialVersionUID = 1L;
 
-    private List<CitrusRuntimeException> exceptions = new ArrayList<CitrusRuntimeException>();
+    private List<CitrusRuntimeException> exceptions;
     
     public ParallelContainerException(List<CitrusRuntimeException> nestedExceptions) {
         super();
@@ -44,7 +43,7 @@ public class ParallelContainerException extends CitrusRuntimeException {
         
         builder.append("Several actions failed in parallel container");
         for (CitrusRuntimeException exception : exceptions) {
-            builder.append("\n\t+ " + exception.getClass().getName() + ": " + exception.getLocalizedMessage());
+            builder.append("\n\t+ ").append(exception.getClass().getName()).append(": ").append(exception.getLocalizedMessage());
         }
         
         return builder.toString();

--- a/core/citrus-api/src/main/java/org/citrusframework/functions/FunctionLibrary.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/functions/FunctionLibrary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import java.util.Map;
  */
 public class FunctionLibrary {
     /** Map of functions in this library */
-    private Map<String, Function> members = new HashMap<String, Function>();
+    private Map<String, Function> members = new HashMap<>();
 
     /** Default function prefix */
     private static final String DEFAULT_PREFIX = "citrus:";

--- a/core/citrus-api/src/main/java/org/citrusframework/functions/FunctionUtils.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/functions/FunctionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ package org.citrusframework.functions;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.InvalidFunctionUsageException;
 import org.citrusframework.variable.VariableUtils;
+
+import static java.util.Objects.requireNonNullElse;
 
 /**
  * Utility class for functions.
@@ -57,12 +59,12 @@ public final class FunctionUtils {
         }
 
         String newString = stringValue;
-        StringBuffer strBuffer = new StringBuffer();
+        var strBuffer = new StringBuilder();
 
-        boolean isVarComplete = false;
-        StringBuffer variableNameBuf = new StringBuffer();
+        boolean isVarComplete;
+        var variableNameBuf = new StringBuilder();
 
-        int startIndex = 0;
+        int startIndex;
         int curIndex;
         int searchIndex;
 
@@ -104,14 +106,13 @@ public final class FunctionUtils {
 
                 startIndex = curIndex;
 
-                variableNameBuf = new StringBuffer();
-                isVarComplete = false;
+                variableNameBuf = new StringBuilder();
             }
 
             strBuffer.append(newString.substring(startIndex));
             newString = strBuffer.toString();
 
-            strBuffer = new StringBuffer();
+            strBuffer = new StringBuilder();
         }
 
         return newString;
@@ -141,10 +142,6 @@ public final class FunctionUtils {
 
         String value = library.getFunction(function).execute(FunctionParameterHelper.getParameterList(parameterString), context);
 
-        if (value == null) {
-            return "";
-        } else {
-            return value;
-        }
+        return requireNonNullElse(value, "");
     }
 }

--- a/core/citrus-api/src/main/java/org/citrusframework/message/Message.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/message/Message.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,8 +62,7 @@ public interface Message extends Serializable {
             return print();
         }
 
-        if (context.getLogModifier() instanceof LogMessageModifier) {
-            LogMessageModifier modifier = ((LogMessageModifier) context.getLogModifier());
+        if (context.getLogModifier() instanceof LogMessageModifier modifier) {
             return print(modifier.maskBody(this), modifier.maskHeaders(this), modifier.maskHeaderData(this));
         }
 

--- a/core/citrus-api/src/main/java/org/citrusframework/message/MessageHeaderUtils.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/message/MessageHeaderUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,11 +73,9 @@ public final class MessageHeaderUtils {
             return true;
         } else if (headerName.equals("expirationDate")) {
             return true;
-        } else if (headerName.startsWith("jms_")) {
-            return true;
+        } else {
+            return headerName.startsWith("jms_");
         }
-
-        return false;
     }
 
     /**
@@ -88,14 +86,11 @@ public final class MessageHeaderUtils {
      * @param value
      */
     public static void setHeader(Message message, String name, String value) {
-        if (name.equals(SEQUENCE_NUMBER)) {
-            message.setHeader(SEQUENCE_NUMBER, Integer.valueOf(value));
-        } else if (name.equals(SEQUENCE_SIZE)) {
-            message.setHeader(SEQUENCE_SIZE, Integer.valueOf(value));
-        } else if (name.equals(PRIORITY)) {
-            message.setHeader(PRIORITY, Integer.valueOf(value));
-        } else {
-            message.setHeader(name, value);
+        switch (name) {
+            case SEQUENCE_NUMBER -> message.setHeader(SEQUENCE_NUMBER, Integer.valueOf(value));
+            case SEQUENCE_SIZE -> message.setHeader(SEQUENCE_SIZE, Integer.valueOf(value));
+            case PRIORITY -> message.setHeader(PRIORITY, Integer.valueOf(value));
+            default -> message.setHeader(name, value);
         }
     }
 

--- a/core/citrus-api/src/main/java/org/citrusframework/report/FailureStackElement.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/report/FailureStackElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2011 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ public class FailureStackElement {
      * @return the stack trace message.
      */
     public String getStackMessage() {
-        if (lineNumberEnd.longValue() > 0 && !lineNumberStart.equals(lineNumberEnd)) {
+        if (lineNumberEnd > 0 && !lineNumberStart.equals(lineNumberEnd)) {
             return "at " + testFilePath + "(" + actionName + ":" + lineNumberStart + "-" + lineNumberEnd + ")";
         } else {
             return "at " + testFilePath + "(" + actionName + ":" + lineNumberStart + ")";

--- a/core/citrus-api/src/main/java/org/citrusframework/validation/SchemaValidator.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/validation/SchemaValidator.java
@@ -1,19 +1,31 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.citrusframework.validation;
 
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.message.Message;
-import org.citrusframework.message.MessageType;
-import org.citrusframework.spi.ReferenceResolver;
 import org.citrusframework.spi.ResourcePathTypeResolver;
 import org.citrusframework.spi.TypeResolver;
 import org.citrusframework.validation.context.SchemaValidationContext;
-import org.citrusframework.validation.context.ValidationContext;
 import org.citrusframework.validation.matcher.ValidationMatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 

--- a/core/citrus-api/src/main/java/org/citrusframework/variable/SegmentVariableExtractor.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/variable/SegmentVariableExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,15 +17,6 @@
 package org.citrusframework.variable;
 
 import org.citrusframework.context.TestContext;
-import org.citrusframework.exceptions.CitrusRuntimeException;
-import org.citrusframework.spi.ResourcePathTypeResolver;
-import org.citrusframework.spi.TypeResolver;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Map;
 
 /**
  * Class extracting values of segments of VariableExpressions.

--- a/core/citrus-api/src/main/java/org/citrusframework/variable/VariableUtils.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/variable/VariableUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -141,10 +141,10 @@ public final class VariableUtils {
     * @return
     */
    public static String replaceVariablesInString(final String str, TestContext context, boolean enableQuoting) {
-       StringBuffer newStr = new StringBuffer();
+       var newStr = new StringBuilder();
 
        boolean isVarComplete;
-       StringBuffer variableNameBuf = new StringBuffer();
+       var variableNameBuf = new StringBuilder();
 
        int startIndex = 0;
        int curIndex;
@@ -180,18 +180,17 @@ public final class VariableUtils {
                throw new NoSuchVariableException("Variable: " + variableNameBuf.toString() + " could not be found");
            }
 
-           newStr.append(str.substring(startIndex, searchIndex));
+           newStr.append(str, startIndex, searchIndex);
 
            if (enableQuoting) {
-               newStr.append("'" + value + "'");
+               newStr.append("'").append(value).append("'");
            } else {
                newStr.append(value);
            }
 
            startIndex = curIndex;
 
-           variableNameBuf = new StringBuffer();
-           isVarComplete = false;
+           variableNameBuf = new StringBuilder();
        }
 
        newStr.append(str.substring(startIndex));

--- a/core/citrus-api/src/test/java/org/citrusframework/variable/VariableExpressionSegmentMatcherTest.java
+++ b/core/citrus-api/src/test/java/org/citrusframework/variable/VariableExpressionSegmentMatcherTest.java
@@ -1,6 +1,21 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.citrusframework.variable;
 
-import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 

--- a/core/citrus-base/src/main/java/org/citrusframework/AbstractTestContainerBuilder.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/AbstractTestContainerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2015 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,7 +101,7 @@ public abstract class AbstractTestContainerBuilder<T extends TestActionContainer
      * @return
      */
     public static <T extends TestActionContainer, B extends TestActionContainerBuilder<T, B>> TestActionContainerBuilder<T, B> container(T container)  {
-        return new AbstractTestContainerBuilder<T, B>() {
+        return new AbstractTestContainerBuilder<>() {
             @Override
             public T doBuild() {
                 return container;

--- a/core/citrus-base/src/main/java/org/citrusframework/actions/AntRunAction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/actions/AntRunAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2012 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -149,7 +149,7 @@ public class AntRunAction extends AbstractTestAction {
      * @return
      */
     private Stack<String> parseTargets() {
-        Stack<String> stack = new Stack<String>();
+        Stack<String> stack = new Stack<>();
         String[] targetTokens = targets.split(",");
 
         for (String targetToken : targetTokens) {

--- a/core/citrus-base/src/main/java/org/citrusframework/endpoint/adapter/mapping/SimpleMappingStrategy.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/endpoint/adapter/mapping/SimpleMappingStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ import org.citrusframework.exceptions.CitrusRuntimeException;
 public class SimpleMappingStrategy implements EndpointAdapterMappingStrategy {
 
     /** Simple map holds mapping key and endpoint adapters */
-    private Map<String, EndpointAdapter> adapterMappings = new HashMap<String, EndpointAdapter>();
+    private Map<String, EndpointAdapter> adapterMappings = new HashMap<>();
 
     @Override
     public EndpointAdapter getEndpointAdapter(String mappingKey) {

--- a/core/citrus-base/src/main/java/org/citrusframework/functions/core/AbsoluteFunction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/functions/core/AbsoluteFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,10 @@ import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.InvalidFunctionUsageException;
 import org.citrusframework.functions.Function;
 
+import static java.lang.Double.parseDouble;
+import static java.lang.Integer.parseInt;
+import static java.lang.Math.abs;
+
 /**
  * Function returning the absolute value of a decimal number.
  *
@@ -41,10 +45,9 @@ public class AbsoluteFunction implements Function {
         String param = parameterList.get(0);
 
         if (param.contains(".")) {
-            return String.valueOf(Math.abs(Double.valueOf(param)));
+            return String.valueOf(abs(parseDouble(param)));
         } else {
-            return String.valueOf(Math.abs(Integer.valueOf(param)));
+            return String.valueOf(abs(parseInt(param)));
         }
     }
-
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/functions/core/AbstractDateFunction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/functions/core/AbstractDateFunction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@ import org.citrusframework.functions.Function;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
+
+import static java.lang.Integer.parseInt;
 
 /**
  * Abstract date value handling function provides base date value manipulation helpers.
@@ -54,7 +56,7 @@ public abstract class AbstractDateFunction implements Function {
      * @return
      */
     protected int getDateValueOffset(String offsetString, char c) {
-        ArrayList<Character> charList = new ArrayList<Character>();
+        ArrayList<Character> charList = new ArrayList<>();
 
         int index = offsetString.indexOf(c);
         if (index != -1) {
@@ -62,17 +64,16 @@ public abstract class AbstractDateFunction implements Function {
                 if (Character.isDigit(offsetString.charAt(i))) {
                     charList.add(0, offsetString.charAt(i));
                 } else {
-
-                    StringBuffer offsetValue = new StringBuffer();
+                    StringBuilder offsetValue = new StringBuilder();
                     offsetValue.append("0");
-                    for (int j = 0; j < charList.size(); j++) {
-                        offsetValue.append(charList.get(j));
+                    for (var character : charList) {
+                        offsetValue.append(character);
                     }
 
                     if (offsetString.charAt(i) == '-') {
-                        return Integer.valueOf("-" + offsetValue.toString());
+                        return parseInt("-" + offsetValue);
                     } else {
-                        return Integer.valueOf(offsetValue.toString());
+                        return parseInt(offsetValue.toString());
                     }
                 }
             }

--- a/core/citrus-base/src/main/java/org/citrusframework/functions/core/AvgFunction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/functions/core/AvgFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@ import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.InvalidFunctionUsageException;
 import org.citrusframework.functions.Function;
 
+import static java.lang.Double.parseDouble;
+
 /**
  * Function returning the average of a set of numeric values.
  *
@@ -41,10 +43,9 @@ public class AvgFunction implements Function {
         double result = 0.0;
 
         for (String token : parameterList) {
-            result += Double.valueOf(token);
+            result += parseDouble(token);
         }
 
         return Double.valueOf(result / parameterList.size()).toString();
     }
-
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/functions/core/CeilingFunction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/functions/core/CeilingFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,9 @@ import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.InvalidFunctionUsageException;
 import org.citrusframework.functions.Function;
 
+import static java.lang.Double.parseDouble;
+import static java.lang.Math.ceil;
+
 /**
  * Returns the smallest (closest to negative infinity) double value
  * according to the numeric argument.
@@ -39,7 +42,7 @@ public class CeilingFunction implements Function {
             throw new InvalidFunctionUsageException("Function parameters must not be empty");
         }
 
-        return String.valueOf(Math.ceil(Double.valueOf(parameterList.get(0))));
+        return String.valueOf(ceil(parseDouble(parameterList.get(0))));
     }
 
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/functions/core/ConcatFunction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/functions/core/ConcatFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,13 +39,12 @@ public class ConcatFunction implements Function {
             throw new InvalidFunctionUsageException("Function parameters must not be empty");
         }
 
-        StringBuffer resultString = new StringBuffer();
+        StringBuilder resultString = new StringBuilder();
 
-        for (int i = 0; i < parameterList.size(); i++) {
-            resultString.append(parameterList.get(i));
+        for (var parameter : parameterList) {
+            resultString.append(parameter);
         }
 
         return resultString.toString();
     }
-
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/functions/core/FloorFunction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/functions/core/FloorFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,9 @@ import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.InvalidFunctionUsageException;
 import org.citrusframework.functions.Function;
 
+import static java.lang.Double.parseDouble;
+import static java.lang.Math.floor;
+
 /**
  * Returns the largest (closest to positive infinity) double value according to numeric argument
  * value.
@@ -39,7 +42,6 @@ public class FloorFunction implements Function {
             throw new InvalidFunctionUsageException("Function parameters must not be empty");
         }
 
-        return String.valueOf(Math.floor(Double.valueOf(parameterList.get(0))));
+        return String.valueOf(floor(parseDouble(parameterList.get(0))));
     }
-
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/functions/core/MaxFunction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/functions/core/MaxFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@ import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.InvalidFunctionUsageException;
 import org.citrusframework.functions.Function;
 
+import static java.lang.Double.parseDouble;
+
 /**
  * Function returns the maximum numeric value in a set of numeric arguments.
  *
@@ -41,13 +43,12 @@ public class MaxFunction implements Function {
         double result = 0.0;
 
         for (int i = 0; i < parameterList.size(); i++) {
-            String token = (String) parameterList.get(i);
-            if (i==0 || Double.valueOf(token) > result) {
-                result = Double.valueOf(token);
+            String token = parameterList.get(i);
+            if (i==0 || parseDouble(token) > result) {
+                result = parseDouble(token);
             }
         }
 
         return Double.valueOf(result).toString();
     }
-
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/functions/core/MinFunction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/functions/core/MinFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@ import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.InvalidFunctionUsageException;
 import org.citrusframework.functions.Function;
 
+import static java.lang.Double.parseDouble;
+
 /**
  * Returns the minimum value in a set of numeric arguments.
  *
@@ -41,13 +43,12 @@ public class MinFunction implements Function {
         double result = 0.0;
 
         for (int i = 0; i < parameterList.size(); i++) {
-            String token = (String) parameterList.get(i);
-            if (i==0 || Double.valueOf(token) < result) {
-                result = Double.valueOf(token);
+            String token = parameterList.get(i);
+            if (i==0 || parseDouble(token) < result) {
+                result = parseDouble(token);
             }
         }
 
         return Double.valueOf(result).toString();
     }
-
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/functions/core/RandomNumberFunction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/functions/core/RandomNumberFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,9 @@ import java.util.Random;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.InvalidFunctionUsageException;
 import org.citrusframework.functions.Function;
+
+import static java.lang.Boolean.parseBoolean;
+import static java.lang.Integer.parseInt;
 
 /**
  * Function returning a random numeric value. Argument specifies the number of digits and
@@ -49,13 +52,13 @@ public class RandomNumberFunction implements Function {
             throw new InvalidFunctionUsageException("Too many parameters for function");
         }
 
-        numberLength = Integer.valueOf(parameterList.get(0));
+        numberLength = parseInt(parameterList.get(0));
         if (numberLength < 0) {
             throw new InvalidFunctionUsageException("Invalid parameter definition. Number of letters must not be positive non-zero integer value");
         }
 
         if (parameterList.size() > 1) {
-            paddingOn = Boolean.valueOf(parameterList.get(1));
+            paddingOn = parseBoolean(parameterList.get(1));
         }
 
         return getRandomNumber(numberLength, paddingOn);

--- a/core/citrus-base/src/main/java/org/citrusframework/functions/core/RandomStringFunction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/functions/core/RandomStringFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,9 @@ import java.util.Random;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.InvalidFunctionUsageException;
 import org.citrusframework.functions.Function;
+
+import static java.lang.Boolean.parseBoolean;
+import static java.lang.Integer.parseInt;
 
 /**
  * Function generating a random string containing alphabetic characters. Arguments specify
@@ -74,7 +77,7 @@ public class RandomStringFunction implements Function {
             throw new InvalidFunctionUsageException("Too many parameters for function");
         }
 
-        numberOfLetters = Integer.valueOf(parameterList.get(0));
+        numberOfLetters = parseInt(parameterList.get(0));
         if (numberOfLetters < 0) {
             throw new InvalidFunctionUsageException("Invalid parameter definition. Number of letters must not be positive non-zero integer value");
         }
@@ -84,7 +87,7 @@ public class RandomStringFunction implements Function {
         }
 
         if (parameterList.size() > 2) {
-            includeNumbers = Boolean.valueOf(parameterList.get(2));
+            includeNumbers = parseBoolean(parameterList.get(2));
         }
 
         if (notationMethod.equals(UPPERCASE)) {

--- a/core/citrus-base/src/main/java/org/citrusframework/functions/core/RoundFunction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/functions/core/RoundFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@ import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.InvalidFunctionUsageException;
 import org.citrusframework.functions.Function;
 
+import static java.lang.Double.parseDouble;
+
 /**
  * Function returns the closest integer value to a decimal argument.
  *
@@ -38,7 +40,6 @@ public class RoundFunction implements Function {
             throw new InvalidFunctionUsageException("Function parameters must not be empty");
         }
 
-        return Long.valueOf(Math.round(Double.valueOf((parameterList.get(0))))).toString();
+        return Long.valueOf(Math.round(parseDouble(parameterList.get(0)))).toString();
     }
-
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/functions/core/SubstringFunction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/functions/core/SubstringFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,9 @@ import java.util.List;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.InvalidFunctionUsageException;
 import org.citrusframework.functions.Function;
-import org.citrusframework.util.StringUtils;
+
+import static java.lang.Integer.parseInt;
+import static org.citrusframework.util.StringUtils.hasText;
 
 /**
  * Function implements simple substring functionality.
@@ -48,7 +50,7 @@ public class SubstringFunction implements Function {
         String beginIndex = parameterList.get(1);
         String endIndex = null;
 
-        if (!StringUtils.hasText(beginIndex)) {
+        if (!hasText(beginIndex)) {
             throw new InvalidFunctionUsageException("Invalid beginIndex - please check function parameters");
         }
 
@@ -56,13 +58,12 @@ public class SubstringFunction implements Function {
             endIndex = parameterList.get(2);
         }
 
-        if (StringUtils.hasText(endIndex)) {
-            targetString = targetString.substring(Integer.valueOf(beginIndex), Integer.valueOf(endIndex));
+        if (hasText(endIndex)) {
+            targetString = targetString.substring(parseInt(beginIndex), parseInt(endIndex));
         } else {
-            targetString = targetString.substring(Integer.valueOf(beginIndex));
+            targetString = targetString.substring(parseInt(beginIndex));
         }
 
         return targetString;
     }
-
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/message/MessageSelectorBuilder.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/message/MessageSelectorBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,7 +76,7 @@ public class MessageSelectorBuilder {
      * @return
      */
     public static MessageSelectorBuilder fromKeyValueMap(Map<String, Object> valueMap) {
-        StringBuffer buf = new StringBuffer();
+        var buf = new StringBuilder();
 
         Iterator<Entry<String, Object>> iter = valueMap.entrySet().iterator();
 
@@ -85,7 +85,7 @@ public class MessageSelectorBuilder {
             String key = entry.getKey();
             String value = entry.getValue().toString();
 
-            buf.append(key + " = '" + value + "'");
+            buf.append(key).append(" = '").append(value).append("'");
         }
 
         while (iter.hasNext()) {
@@ -93,7 +93,7 @@ public class MessageSelectorBuilder {
         	String key = entry.getKey();
             String value = entry.getValue().toString();
 
-            buf.append(" AND " + key + " = '" + value + "'");
+            buf.append(" AND ").append(key).append(" = '").append(value).append("'");
         }
 
         return new MessageSelectorBuilder(buf.toString());
@@ -104,7 +104,7 @@ public class MessageSelectorBuilder {
      * @return
      */
     public Map<String, String> toKeyValueMap() {
-        Map<String, String> valueMap = new HashMap<String, String>();
+        Map<String, String> valueMap = new HashMap<>();
         String[] tokens;
 
         if (selectorString.contains(" AND")) {

--- a/core/citrus-base/src/main/java/org/citrusframework/message/correlation/DefaultCorrelationManager.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/message/correlation/DefaultCorrelationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ public class DefaultCorrelationManager<T> implements CorrelationManager<T> {
     private static final Logger logger = LoggerFactory.getLogger(DefaultCorrelationManager.class);
 
     /** Map of managed objects */
-    private ObjectStore<T> objectStore = new DefaultObjectStore<T>();
+    private ObjectStore<T> objectStore = new DefaultObjectStore<>();
 
     @Override
     public void saveCorrelationKey(String correlationKeyName, String correlationKey, TestContext context) {

--- a/core/citrus-base/src/main/java/org/citrusframework/report/FailureStackTestListener.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/report/FailureStackTestListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -209,8 +209,7 @@ public class FailureStackTestListener extends AbstractTestListener {
              * in startElement event.
              */
             if (eventElement.equals(action.getName())) {
-                if (action instanceof TestActionContainer && !actionStack.isEmpty()) {
-                    TestActionContainer container = (TestActionContainer)action;
+                if (action instanceof TestActionContainer container && !actionStack.isEmpty()) {
                     for (int i = container.getActions().size()-1; i >= 0; i--) {
                         actionStack.add(container.getActions().get(i));
                     }

--- a/core/citrus-base/src/main/java/org/citrusframework/report/HtmlReporter.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/report/HtmlReporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2011 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -166,15 +166,16 @@ public class HtmlReporter extends AbstractOutputFileReporter implements TestList
         BufferedReader reader = null;
 
         try {
-            if (cause instanceof CitrusRuntimeException) {
-                CitrusRuntimeException ex = (CitrusRuntimeException) cause;
+            if (cause instanceof CitrusRuntimeException ex) {
                 if (!ex.getFailureStack().isEmpty()) {
                     FailureStackElement stackElement = ex.getFailureStack().pop();
                     if (stackElement.getLineNumberStart() > 0) {
                         reader = new BufferedReader(Resources.fromClasspath(stackElement.getTestFilePath() + FileUtils.FILE_EXTENSION_XML).getReader());
 
-                        codeSnippet.append("<div class=\"code-snippet\">");
-                        codeSnippet.append("<h2 class=\"code-title\">" + stackElement.getTestFilePath() + ".xml</h2>");
+                        codeSnippet.append("<div class=\"code-snippet\">")
+                                .append("<h2 class=\"code-title\">")
+                                .append(stackElement.getTestFilePath())
+                                .append(".xml</h2>");
 
                         String line;
                         String codeStyle;
@@ -194,8 +195,13 @@ public class HtmlReporter extends AbstractOutputFileReporter implements TestList
                             }
 
                             if (StringUtils.hasText(codeStyle)) {
-                                codeSnippet.append("<pre class=\"" + codeStyle +"\"><span class=\"line-number\">" + lineIndex + ":</span>" +
-                                        line.replaceAll(">", "&gt;").replaceAll("<", "&lt;") + "</pre>");
+                                codeSnippet.append("<pre class=\"")
+                                        .append(codeStyle)
+                                        .append("\"><span class=\"line-number\">")
+                                        .append(lineIndex)
+                                        .append(":</span>")
+                                        .append(line.replaceAll(">", "&gt;").replaceAll("<", "&lt;"))
+                                        .append("</pre>");
                             }
 
                             lineIndex++;

--- a/core/citrus-base/src/main/java/org/citrusframework/util/BooleanExpressionParser.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/util/BooleanExpressionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,19 +16,21 @@
 
 package org.citrusframework.util;
 
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Deque;
-import java.util.List;
-import java.util.NoSuchElementException;
-
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.NoSuchElementException;
+
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
+import static java.lang.Boolean.parseBoolean;
+import static java.lang.Integer.parseInt;
+import static java.util.Arrays.asList;
 
 /**
  * Parses boolean expression strings and evaluates to boolean result.
@@ -38,18 +40,17 @@ public final class BooleanExpressionParser {
     /**
      * List of known non-boolean operators
      */
-    private static final List<String> OPERATORS = new ArrayList<>(Arrays.asList("lt", "lt=", "gt", "gt=", "<", "<=", ">", ">="));
+    private static final List<String> OPERATORS = new ArrayList<>(asList("lt", "lt=", "gt", "gt=", "<", "<=", ">", ">="));
 
     /**
      * List of known boolean operators
      */
-    private static final List<String> BOOLEAN_OPERATORS = new ArrayList<>(Arrays.asList("=", "and", "or"));
+    private static final List<String> BOOLEAN_OPERATORS = new ArrayList<>(asList("=", "and", "or"));
 
     /**
      * List of known boolean values
      */
-    private static final List<String> BOOLEAN_VALUES = new ArrayList<>(
-            Arrays.asList(TRUE.toString(), FALSE.toString()));
+    private static final List<String> BOOLEAN_VALUES = new ArrayList<>(asList(TRUE.toString(), FALSE.toString()));
 
     /**
      * SeparatorToken is an explicit type to identify different kinds of separators.
@@ -124,7 +125,7 @@ public final class BooleanExpressionParser {
                 }
             }
 
-            result = Boolean.valueOf(evaluateExpressionStack(operators, values));
+            result = parseBoolean(evaluateExpressionStack(operators, values));
 
             if (logger.isDebugEnabled()) {
                 logger.debug("Boolean expression {} evaluates to {}", expression, result);
@@ -315,27 +316,15 @@ public final class BooleanExpressionParser {
      * @return true/false as String
      */
     private static String getBooleanResultAsString(final String operator, final String rightOperand, final String leftOperand) {
-        switch (operator) {
-            case "lt":
-            case "<":
-                return Boolean.toString(Integer.valueOf(leftOperand) < Integer.valueOf(rightOperand));
-            case "lt=":
-            case "<=":
-                return Boolean.toString(Integer.valueOf(leftOperand) <= Integer.valueOf(rightOperand));
-            case "gt":
-            case ">":
-                return Boolean.toString(Integer.valueOf(leftOperand) > Integer.valueOf(rightOperand));
-            case "gt=":
-            case ">=":
-                return Boolean.toString(Integer.valueOf(leftOperand) >= Integer.valueOf(rightOperand));
-            case "=":
-                return Boolean.toString(Integer.parseInt(leftOperand) == Integer.parseInt(rightOperand));
-            case "and":
-                return Boolean.toString(Boolean.valueOf(leftOperand) && Boolean.valueOf(rightOperand));
-            case "or":
-                return Boolean.toString(Boolean.valueOf(leftOperand) || Boolean.valueOf(rightOperand));
-            default:
-                throw new CitrusRuntimeException("Unknown operator '" + operator + "'");
-        }
+        return switch (operator) {
+            case "lt", "<" -> Boolean.toString(parseInt(leftOperand) < parseInt(rightOperand));
+            case "lt=", "<=" -> Boolean.toString(parseInt(leftOperand) <= parseInt(rightOperand));
+            case "gt", ">" -> Boolean.toString(parseInt(leftOperand) > parseInt(rightOperand));
+            case "gt=", ">=" -> Boolean.toString(parseInt(leftOperand) >= parseInt(rightOperand));
+            case "=" -> Boolean.toString(parseInt(leftOperand) == parseInt(rightOperand));
+            case "and" -> Boolean.toString(parseBoolean(leftOperand) && parseBoolean(rightOperand));
+            case "or" -> Boolean.toString(parseBoolean(leftOperand) || parseBoolean(rightOperand));
+            default -> throw new CitrusRuntimeException("Unknown operator '" + operator + "'");
+        };
     }
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/util/PropertyUtils.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/util/PropertyUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,11 +67,11 @@ public final class PropertyUtils {
      * @return
      */
     public static String replacePropertiesInString(final String line, Properties properties) {
-        StringBuffer newStr = new StringBuffer();
+        StringBuilder newStr = new StringBuilder();
 
         boolean isVarComplete = false;
 
-        StringBuffer propertyName = new StringBuffer();
+        StringBuilder propertyName = new StringBuilder();
 
         int startIndex = 0;
         int curIndex;
@@ -79,13 +79,11 @@ public final class PropertyUtils {
         while ((searchIndex = line.indexOf(PROPERTY_MARKER, startIndex)) != -1) {
             //first check if property Marker is escaped by '\' character
             if (searchIndex != 0 && line.charAt((searchIndex-1)) == '\\') {
-                newStr.append(line.substring(startIndex, searchIndex-1));
+                newStr.append(line, startIndex, searchIndex-1);
                 newStr.append(PROPERTY_MARKER);
                 startIndex = searchIndex + 1;
                 continue;
             }
-
-            isVarComplete = false;
 
             curIndex = searchIndex + 1;
 
@@ -105,12 +103,12 @@ public final class PropertyUtils {
                         + PROPERTY_MARKER + propertyName.toString() + PROPERTY_MARKER + "'");
             }
 
-            newStr.append(line.substring(startIndex, searchIndex));
+            newStr.append(line, startIndex, searchIndex);
             newStr.append(properties.getProperty(propertyName.toString(), "")); // property value
 
             startIndex = curIndex;
 
-            propertyName = new StringBuffer();
+            propertyName = new StringBuilder();
             isVarComplete = false;
         }
 

--- a/core/citrus-base/src/test/java/org/citrusframework/TestCaseTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/TestCaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -170,9 +170,7 @@ public class TestCaseTest extends UnitTestSupport {
         final TestCase testcase = new DefaultTestCase();
         testcase.setName("MyTestCase");
 
-        testcase.addTestAction(action(context -> {
-                context.addException(new CitrusRuntimeException("This failed in forked action"));
-        }).build());
+        testcase.addTestAction(action(context -> context.addException(new CitrusRuntimeException("This failed in forked action"))).build());
 
         testcase.addTestAction(new EchoAction.Builder().message("Everything is fine!").build());
 

--- a/core/citrus-base/src/test/java/org/citrusframework/actions/AntRunActionTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/actions/AntRunActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,8 +59,8 @@ public class AntRunActionTest extends UnitTestSupport {
 
 	@Test
     public void testRunTargets() {
-        final List<String> executedTargets = new ArrayList<String>();
-        final List<String> echoMessages = new ArrayList<String>();
+        final List<String> executedTargets = new ArrayList<>();
+        final List<String> echoMessages = new ArrayList<>();
 
         AntRunAction ant = new AntRunAction.Builder()
                 .buildFilePath("classpath:org/citrusframework/actions/build.xml")

--- a/core/citrus-base/src/test/java/org/citrusframework/actions/JavaActionTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/actions/JavaActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ public class JavaActionTest extends UnitTestSupport {
 
 	@Test
 	public void testJavaCallSingleMethodParameter() {
-		List<Object> args = new ArrayList<Object>();
+		List<Object> args = new ArrayList<>();
 		args.add("Test");
 
 		JavaAction action = new JavaAction.Builder()
@@ -53,7 +53,7 @@ public class JavaActionTest extends UnitTestSupport {
 
 	@Test
 	public void testJavaCallMethodParameters() {
-		List<Object> args = new ArrayList<Object>();
+		List<Object> args = new ArrayList<>();
 		args.add(4);
 		args.add("Test");
 		args.add(true);
@@ -78,7 +78,7 @@ public class JavaActionTest extends UnitTestSupport {
 
 	@Test
 	public void testJavaCallSingleConstructorArg() {
-		List<Object> args = new ArrayList<Object>();
+		List<Object> args = new ArrayList<>();
         args.add("Test");
 
 		JavaAction action = new JavaAction.Builder()
@@ -91,7 +91,7 @@ public class JavaActionTest extends UnitTestSupport {
 
 	@Test
 	public void testJavaCallConstructorArgs() {
-		List<Object> args = new ArrayList<Object>();
+		List<Object> args = new ArrayList<>();
 		args.add(4);
 		args.add("Test");
 		args.add(true);
@@ -108,7 +108,7 @@ public class JavaActionTest extends UnitTestSupport {
     public void testJavaCallConstructorArgsVariableSupport() {
         context.setVariable("text", "Test");
 
-        List<Object> args = new ArrayList<Object>();
+        List<Object> args = new ArrayList<>();
         args.add(4);
         args.add("${text}");
         args.add(true);
@@ -123,7 +123,7 @@ public class JavaActionTest extends UnitTestSupport {
 
 	@Test
 	public void testJavaCall() {
-		List<Object> args = new ArrayList<Object>();
+		List<Object> args = new ArrayList<>();
 		args.add(4);
 		args.add("Test");
 		args.add(true);
@@ -141,7 +141,7 @@ public class JavaActionTest extends UnitTestSupport {
     public void testJavaCallVariableSupport() {
         context.setVariable("text", "Test");
 
-        List<Object> args = new ArrayList<Object>();
+        List<Object> args = new ArrayList<>();
         args.add(4);
         args.add("${text}");
         args.add(true);
@@ -157,7 +157,7 @@ public class JavaActionTest extends UnitTestSupport {
 
 	@Test(expectedExceptions = {CitrusRuntimeException.class})
 	public void testJavaCallWrongConstructorArgs() {
-		List<Object> args = new ArrayList<Object>();
+		List<Object> args = new ArrayList<>();
 		args.add("Wrong");
 		args.add(4);
 		args.add(true);
@@ -172,7 +172,7 @@ public class JavaActionTest extends UnitTestSupport {
 
 	@Test(expectedExceptions = {CitrusRuntimeException.class})
 	public void testJavaCallWrongMethodParameters() {
-		List<Object> args = new ArrayList<Object>();
+		List<Object> args = new ArrayList<>();
 		args.add("Wrong");
 		args.add(4);
 		args.add(true);

--- a/core/citrus-base/src/test/java/org/citrusframework/actions/PurgeEndpointActionTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/actions/PurgeEndpointActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2015 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ package org.citrusframework.actions;
 import java.util.Collections;
 
 import org.citrusframework.UnitTestSupport;
-import org.citrusframework.spi.SimpleReferenceResolver;
 import org.citrusframework.context.TestContextFactory;
 import org.citrusframework.endpoint.Endpoint;
 import org.citrusframework.exceptions.ActionTimeoutException;

--- a/core/citrus-base/src/test/java/org/citrusframework/actions/ReceiveMessageActionTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/actions/ReceiveMessageActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@ import org.citrusframework.endpoint.Endpoint;
 import org.citrusframework.endpoint.EndpointConfiguration;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.exceptions.UnknownElementException;
-import org.citrusframework.exceptions.ValidationException;
 import org.citrusframework.message.DefaultMessage;
 import org.citrusframework.message.Message;
 import org.citrusframework.message.MessageDirection;
@@ -207,10 +206,11 @@ public class ReceiveMessageActionTest extends UnitTestSupport {
         DefaultMessageBuilder controlMessageBuilder = new DefaultMessageBuilder();
         controlMessageBuilder.setPayloadBuilder(new FileResourcePayloadBuilder("classpath:org/citrusframework/actions/test-request-payload.xml"));
 
-        final Message controlMessage = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<TestRequest>\n" +
-                "    <Message>Hello World!</Message>\n" +
-                "</TestRequest>");
+        final Message controlMessage = new DefaultMessage("""
+                <?xml version="1.0" encoding="UTF-8"?>
+                <TestRequest>
+                    <Message>Hello World!</Message>
+                </TestRequest>""");
 
         reset(endpoint, consumer, endpointConfiguration);
         when(endpoint.createConsumer()).thenReturn(consumer);
@@ -278,10 +278,11 @@ public class ReceiveMessageActionTest extends UnitTestSupport {
 
         context.setVariable("myText", "Hello World!");
 
-        final Message controlMessage = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<TestRequest>\n" +
-                "    <Message>Hello World!</Message>\n" +
-                "</TestRequest>");
+        final Message controlMessage = new DefaultMessage("""
+                <?xml version="1.0" encoding="UTF-8"?>
+                <TestRequest>
+                    <Message>Hello World!</Message>
+                </TestRequest>""");
 
         reset(endpoint, consumer, endpointConfiguration);
         when(endpoint.createConsumer()).thenReturn(consumer);
@@ -313,10 +314,11 @@ public class ReceiveMessageActionTest extends UnitTestSupport {
         DefaultMessageBuilder controlMessageBuilder = new DefaultMessageBuilder();
         controlMessageBuilder.setPayloadBuilder(new FileResourcePayloadBuilder("classpath:org/citrusframework/actions/test-request-payload-with-functions.xml"));
 
-        final Message controlMessage = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<TestRequest>\n" +
-                "    <Message>Hello World!</Message>\n" +
-                "</TestRequest>");
+        final Message controlMessage = new DefaultMessage("""
+                <?xml version="1.0" encoding="UTF-8"?>
+                <TestRequest>
+                    <Message>Hello World!</Message>
+                </TestRequest>""");
 
         reset(endpoint, consumer, endpointConfiguration);
         when(endpoint.createConsumer()).thenReturn(consumer);

--- a/core/citrus-base/src/test/java/org/citrusframework/actions/SendMessageActionTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/actions/SendMessageActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,10 +100,11 @@ public class SendMessageActionTest extends UnitTestSupport {
         DefaultMessageBuilder messageBuilder = new DefaultMessageBuilder();
         messageBuilder.setPayloadBuilder(new FileResourcePayloadBuilder("classpath:org/citrusframework/actions/test-request-payload.xml"));
 
-        final Message controlMessage = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<TestRequest>\n" +
-                "    <Message>Hello World!</Message>\n" +
-                "</TestRequest>");
+        final Message controlMessage = new DefaultMessage("""
+                <?xml version="1.0" encoding="UTF-8"?>
+                <TestRequest>
+                    <Message>Hello World!</Message>
+                </TestRequest>""");
 
         reset(endpoint, producer, endpointConfiguration);
         when(endpoint.createProducer()).thenReturn(producer);
@@ -157,10 +158,11 @@ public class SendMessageActionTest extends UnitTestSupport {
 
         context.setVariable("myText", "Hello World!");
 
-        final Message controlMessage = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<TestRequest>\n" +
-                "    <Message>Hello World!</Message>\n" +
-                "</TestRequest>");
+        final Message controlMessage = new DefaultMessage("""
+                <?xml version="1.0" encoding="UTF-8"?>
+                <TestRequest>
+                    <Message>Hello World!</Message>
+                </TestRequest>""");
 
         reset(endpoint, producer, endpointConfiguration);
         when(endpoint.createProducer()).thenReturn(producer);
@@ -185,10 +187,11 @@ public class SendMessageActionTest extends UnitTestSupport {
         DefaultMessageBuilder messageBuilder = new DefaultMessageBuilder();
         messageBuilder.setPayloadBuilder(new FileResourcePayloadBuilder("classpath:org/citrusframework/actions/test-request-payload-with-functions.xml"));
 
-        final Message controlMessage = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<TestRequest>\n" +
-                "    <Message>Hello World!</Message>\n" +
-                "</TestRequest>");
+        final Message controlMessage = new DefaultMessage("""
+                <?xml version="1.0" encoding="UTF-8"?>
+                <TestRequest>
+                    <Message>Hello World!</Message>
+                </TestRequest>""");
 
         reset(endpoint, producer, endpointConfiguration);
         when(endpoint.createProducer()).thenReturn(producer);
@@ -213,9 +216,7 @@ public class SendMessageActionTest extends UnitTestSupport {
         DefaultMessageBuilder messageBuilder = new DefaultMessageBuilder();
         messageBuilder.setPayloadBuilder(new DefaultPayloadBuilder("<TestRequest><Message>?</Message></TestRequest>"));
 
-        MessageProcessor processor = (message, context) -> {
-            message.setPayload(message.getPayload(String.class).replaceAll("\\?", "Hello World!"));
-        };
+        MessageProcessor processor = (message, context) -> message.setPayload(message.getPayload(String.class).replaceAll("\\?", "Hello World!"));
 
         final Message controlMessage = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>");
 
@@ -243,11 +244,11 @@ public class SendMessageActionTest extends UnitTestSupport {
         DefaultMessageBuilder messageBuilder = new DefaultMessageBuilder();
         messageBuilder.setPayloadBuilder(new DefaultPayloadBuilder("<TestRequest><Message>Hello World!</Message></TestRequest>"));
 
-        final Map<String, Object> controlHeaders = new HashMap<String, Object>();
+        final Map<String, Object> controlHeaders = new HashMap<>();
         controlHeaders.put("Operation", "sayHello");
         final Message controlMessage = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>", controlHeaders);
 
-        final Map<String, Object> headers = new HashMap<String, Object>();
+        final Map<String, Object> headers = new HashMap<>();
         headers.put("Operation", "sayHello");
         messageBuilder.addHeaderBuilder(new DefaultHeaderBuilder(headers));
 
@@ -276,11 +277,11 @@ public class SendMessageActionTest extends UnitTestSupport {
 
         context.setVariable("myOperation", "sayHello");
 
-        final Map<String, Object> controlHeaders = new HashMap<String, Object>();
+        final Map<String, Object> controlHeaders = new HashMap<>();
         controlHeaders.put("Operation", "sayHello");
         final Message controlMessage = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>", controlHeaders);
 
-        final Map<String, Object> headers = new HashMap<String, Object>();
+        final Map<String, Object> headers = new HashMap<>();
         headers.put("Operation", "${myOperation}");
         messageBuilder.addHeaderBuilder(new DefaultHeaderBuilder(headers));
 
@@ -331,7 +332,7 @@ public class SendMessageActionTest extends UnitTestSupport {
         DefaultMessageBuilder messageBuilder = new DefaultMessageBuilder();
         messageBuilder.setPayloadBuilder(new DefaultPayloadBuilder("<TestRequest><Message>Hello World!</Message></TestRequest>"));
 
-        final Map<String, Object> headers = new HashMap<String, Object>();
+        final Map<String, Object> headers = new HashMap<>();
         headers.put("Operation", "${myOperation}");
         messageBuilder.addHeaderBuilder(new DefaultHeaderBuilder(headers));
 
@@ -359,15 +360,15 @@ public class SendMessageActionTest extends UnitTestSupport {
         DefaultMessageBuilder messageBuilder = new DefaultMessageBuilder();
         messageBuilder.setPayloadBuilder(new DefaultPayloadBuilder("<TestRequest><Message>Hello World!</Message></TestRequest>"));
 
-        final Map<String, Object> controlHeaders = new HashMap<String, Object>();
+        final Map<String, Object> controlHeaders = new HashMap<>();
         controlHeaders.put("Operation", "sayHello");
         final Message controlMessage = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>", controlHeaders);
 
-        final Map<String, Object> headers = new HashMap<String, Object>();
+        final Map<String, Object> headers = new HashMap<>();
         headers.put("Operation", "sayHello");
         messageBuilder.addHeaderBuilder(new DefaultHeaderBuilder(headers));
 
-        Map<String, String> extractVars = new HashMap<String, String>();
+        Map<String, String> extractVars = new HashMap<>();
         extractVars.put("Operation", "myOperation");
         extractVars.put(MessageHeaders.ID, "correlationId");
 
@@ -495,10 +496,11 @@ public class SendMessageActionTest extends UnitTestSupport {
         DefaultMessageBuilder messageBuilder = new DefaultMessageBuilder();
         messageBuilder.setPayloadBuilder(new FileResourcePayloadBuilder("classpath:org/citrusframework/actions/test-request-iso-encoding.xml"));
 
-        final Message controlMessage = new DefaultMessage("<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n" +
-                "<TestRequest>\n" +
-                "    <Message>Hello World!</Message>\n" +
-                "</TestRequest>");
+        final Message controlMessage = new DefaultMessage("""
+                <?xml version="1.0" encoding="ISO-8859-1"?>
+                <TestRequest>
+                    <Message>Hello World!</Message>
+                </TestRequest>""");
 
         reset(endpoint, producer, endpointConfiguration);
         when(endpoint.createProducer()).thenReturn(producer);

--- a/core/citrus-base/src/test/java/org/citrusframework/actions/StopServerActionTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/actions/StopServerActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,7 +81,7 @@ public class StopServerActionTest extends UnitTestSupport {
         when(server1.getName()).thenReturn("MyServer1");
         when(server2.getName()).thenReturn("MyServer2");
 
-        List<Server> serverList = new ArrayList<Server>();
+        List<Server> serverList = new ArrayList<>();
         serverList.add(server1);
         serverList.add(server2);
 

--- a/core/citrus-base/src/test/java/org/citrusframework/container/ParallelTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/container/ParallelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ public class ParallelTest extends UnitTestSupport {
 
         reset(action);
 
-        List<TestAction> actionList = new ArrayList<TestAction>();
+        List<TestAction> actionList = new ArrayList<>();
         actionList.add(action);
 
         parallelAction.setActions(actionList);
@@ -61,7 +61,7 @@ public class ParallelTest extends UnitTestSupport {
 
         reset(action);
 
-        List<TestAction> actionList = new ArrayList<TestAction>();
+        List<TestAction> actionList = new ArrayList<>();
         actionList.add(new EchoAction.Builder().build());
         actionList.add(action);
         actionList.add(new EchoAction.Builder().build());
@@ -77,7 +77,7 @@ public class ParallelTest extends UnitTestSupport {
     public void testParallelActions() {
         Parallel parallelAction = new Parallel.Builder().build();
 
-        List<TestAction> actionList = new ArrayList<TestAction>();
+        List<TestAction> actionList = new ArrayList<>();
         actionList.add(new EchoAction.Builder().build());
         actionList.add(new EchoAction.Builder().build());
         actionList.add(new EchoAction.Builder().build());
@@ -96,7 +96,7 @@ public class ParallelTest extends UnitTestSupport {
     public void testOneActionThatIsFailing() {
         Parallel parallelAction = new Parallel.Builder().build();
 
-        List<TestAction> actionList = new ArrayList<TestAction>();
+        List<TestAction> actionList = new ArrayList<>();
         actionList.add(new FailAction.Builder().build());
 
         parallelAction.setActions(actionList);
@@ -108,7 +108,7 @@ public class ParallelTest extends UnitTestSupport {
     public void testOnlyActionFailingActions() {
         Parallel parallelAction = new Parallel.Builder().build();
 
-        List<TestAction> actionList = new ArrayList<TestAction>();
+        List<TestAction> actionList = new ArrayList<>();
         actionList.add(new FailAction.Builder().build());
         actionList.add(new FailAction.Builder().build());
         actionList.add(new FailAction.Builder().build());
@@ -122,7 +122,7 @@ public class ParallelTest extends UnitTestSupport {
     public void testSingleFailingAction() {
         Parallel parallelAction = new Parallel.Builder().build();
 
-        List<TestAction> actionList = new ArrayList<TestAction>();
+        List<TestAction> actionList = new ArrayList<>();
         actionList.add(new EchoAction.Builder().build());
         actionList.add(new FailAction.Builder().build());
         actionList.add(new EchoAction.Builder().build());
@@ -138,7 +138,7 @@ public class ParallelTest extends UnitTestSupport {
 
         reset(action);
 
-        List<TestAction> actionList = new ArrayList<TestAction>();
+        List<TestAction> actionList = new ArrayList<>();
         actionList.add(new EchoAction.Builder().build());
         actionList.add(new FailAction.Builder().build());
         actionList.add(action);

--- a/core/citrus-base/src/test/java/org/citrusframework/container/TemplateTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/container/TemplateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@ public class TemplateTest extends UnitTestSupport {
 
         EchoAction echo = new EchoAction.Builder().message("${myText}").build();
 
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         parameters.put("param", "Parameter was set");
         parameters.put("myText", "${text}");
 

--- a/core/citrus-base/src/test/java/org/citrusframework/context/TestContextTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/context/TestContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,6 @@ import org.citrusframework.message.DefaultMessage;
 import org.citrusframework.message.Message;
 import org.citrusframework.report.MessageListeners;
 import org.citrusframework.variable.GlobalVariables;
-import org.citrusframework.variable.VariableExpressionSegmentMatcher;
 import org.citrusframework.variable.SegmentVariableExtractor;
 import org.mockito.Mockito;
 import org.testng.Assert;

--- a/core/citrus-base/src/test/java/org/citrusframework/endpoint/DefaultEndpointFactoryTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/endpoint/DefaultEndpointFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ public class DefaultEndpointFactoryTest {
     private ReferenceResolver referenceResolver = Mockito.mock(ReferenceResolver.class);
 
     @Test
-    public void testResolveDirectEndpoint() throws Exception {
+    public void testResolveDirectEndpoint() {
         reset(referenceResolver);
         when(referenceResolver.resolve("myEndpoint", Endpoint.class)).thenReturn(Mockito.mock(Endpoint.class));
         TestContext context = new TestContext();
@@ -53,8 +53,8 @@ public class DefaultEndpointFactoryTest {
     }
 
     @Test
-    public void testResolveCustomEndpoint() throws Exception {
-        Map<String, EndpointComponent> components = new HashMap<String, EndpointComponent>();
+    public void testResolveCustomEndpoint() {
+        Map<String, EndpointComponent> components = new HashMap<>();
         components.put("custom", new DirectEndpointComponent());
 
         reset(referenceResolver);
@@ -70,8 +70,8 @@ public class DefaultEndpointFactoryTest {
     }
 
     @Test
-    public void testOverwriteEndpointComponent() throws Exception {
-        Map<String, EndpointComponent> components = new HashMap<String, EndpointComponent>();
+    public void testOverwriteEndpointComponent() {
+        Map<String, EndpointComponent> components = new HashMap<>();
         components.put("jms", new DirectEndpointComponent());
 
         reset(referenceResolver);
@@ -87,7 +87,7 @@ public class DefaultEndpointFactoryTest {
     }
 
     @Test
-    public void testResolveUnknownEndpointComponent() throws Exception {
+    public void testResolveUnknownEndpointComponent() {
         reset(referenceResolver);
         when(referenceResolver.resolveAll(EndpointComponent.class)).thenReturn(Collections.emptyMap());
         TestContext context = new TestContext();
@@ -103,7 +103,7 @@ public class DefaultEndpointFactoryTest {
     }
 
     @Test
-    public void testResolveInvalidEndpointUri() throws Exception {
+    public void testResolveInvalidEndpointUri() {
         reset(referenceResolver);
         TestContext context = new TestContext();
         context.setReferenceResolver(referenceResolver);

--- a/core/citrus-base/src/test/java/org/citrusframework/endpoint/adapter/RequestDispatchingEndpointAdapterTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/endpoint/adapter/RequestDispatchingEndpointAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,13 @@
 
 package org.citrusframework.endpoint.adapter;
 
-import org.citrusframework.endpoint.EndpointAdapter;
-import org.citrusframework.endpoint.adapter.mapping.MappingKeyExtractor;
 import org.citrusframework.endpoint.adapter.mapping.SimpleMappingStrategy;
 import org.citrusframework.message.DefaultMessage;
 import org.citrusframework.message.Message;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.util.Collections;
+import static java.util.Collections.singletonMap;
 
 /**
  * @author Christoph Deppisch
@@ -35,19 +33,13 @@ public class RequestDispatchingEndpointAdapterTest {
     public void testDispatchRequest() {
         RequestDispatchingEndpointAdapter endpointAdapter = new RequestDispatchingEndpointAdapter();
 
-        endpointAdapter.setMappingKeyExtractor(new MappingKeyExtractor() {
-            @Override
-            public String extractMappingKey(Message request) {
-                return "foo";
-            }
-        });
+        endpointAdapter.setMappingKeyExtractor(request -> "foo");
 
         SimpleMappingStrategy mappingStrategy = new SimpleMappingStrategy();
-        mappingStrategy.setAdapterMappings(Collections.<String, EndpointAdapter>singletonMap("foo", new EmptyResponseEndpointAdapter()));
+        mappingStrategy.setAdapterMappings(singletonMap("foo", new EmptyResponseEndpointAdapter()));
         endpointAdapter.setMappingStrategy(mappingStrategy);
 
-        Message response = endpointAdapter.handleMessage(
-                new DefaultMessage("<TestMessage>Hello World!</TestMessage>"));
+        Message response = endpointAdapter.handleMessage(new DefaultMessage("<TestMessage>Hello World!</TestMessage>"));
 
         Assert.assertEquals(response.getPayload(), "");
     }

--- a/core/citrus-base/src/test/java/org/citrusframework/endpoint/adapter/mapping/SimpleMappingStrategyTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/endpoint/adapter/mapping/SimpleMappingStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,10 +35,10 @@ public class SimpleMappingStrategyTest {
     private EndpointAdapter barEndpointAdapter = Mockito.mock(EndpointAdapter.class);
 
     @Test
-    public void testGetEndpointAdapter() throws Exception {
+    public void testGetEndpointAdapter() {
         SimpleMappingStrategy mappingStrategy = new SimpleMappingStrategy();
 
-        Map<String, EndpointAdapter> mappings = new HashMap<String, EndpointAdapter>();
+        Map<String, EndpointAdapter> mappings = new HashMap<>();
         mappings.put("foo", fooEndpointAdapter);
         mappings.put("bar", barEndpointAdapter);
         mappingStrategy.setAdapterMappings(mappings);

--- a/core/citrus-base/src/test/java/org/citrusframework/functions/FunctionsTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/functions/FunctionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import java.text.SimpleDateFormat;
 
 import org.citrusframework.UnitTestSupport;
 import org.citrusframework.functions.core.RandomStringFunction;
-import org.citrusframework.functions.core.UnixTimestampFunction;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 

--- a/core/citrus-base/src/test/java/org/citrusframework/functions/core/AvgFunctionTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/functions/core/AvgFunctionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ public class AvgFunctionTest extends UnitTestSupport {
 
     @Test
     public void testFunction() {
-        List<String> params = new ArrayList<String>();
+        List<String> params = new ArrayList<>();
         params.add("3");
         params.add("3");
         params.add("3");

--- a/core/citrus-base/src/test/java/org/citrusframework/functions/core/ConcatFunctionTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/functions/core/ConcatFunctionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ public class ConcatFunctionTest extends UnitTestSupport {
 
     @Test
     public void testFunction() {
-        List<String> params = new ArrayList<String>();
+        List<String> params = new ArrayList<>();
         params.add("Hallo ");
         params.add("TestFramework");
         params.add("!");

--- a/core/citrus-base/src/test/java/org/citrusframework/functions/core/MaxFunctionTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/functions/core/MaxFunctionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ public class MaxFunctionTest extends UnitTestSupport {
 
     @Test
     public void testFunction() {
-        List<String> params = new ArrayList<String>();
+        List<String> params = new ArrayList<>();
         params.add("3");
         params.add("5.2");
         params.add("4.7");

--- a/core/citrus-base/src/test/java/org/citrusframework/functions/core/MinFunctionTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/functions/core/MinFunctionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ public class MinFunctionTest extends UnitTestSupport {
 
     @Test
     public void testFunction() {
-        List<String> params = new ArrayList<String>();
+        List<String> params = new ArrayList<>();
         params.add("3");
         params.add("5.2");
         params.add("4.7");

--- a/core/citrus-base/src/test/java/org/citrusframework/functions/core/RandomEnumValueFunctionTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/functions/core/RandomEnumValueFunctionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ public class RandomEnumValueFunctionTest extends UnitTestSupport {
 
 	private List<String> generateRandomValues() {
 		final int valueCount = random.nextInt(15) + 5;
-		final List<String> values = new ArrayList<String>(valueCount);
+		final List<String> values = new ArrayList<>(valueCount);
 		for (int i=0; i<valueCount; i++) {
 			values.add("value" + i);
 		}

--- a/core/citrus-base/src/test/java/org/citrusframework/functions/core/RandomNumberFunctionTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/functions/core/RandomNumberFunctionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,16 @@
 package org.citrusframework.functions.core;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.citrusframework.UnitTestSupport;
 import org.citrusframework.exceptions.InvalidFunctionUsageException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import static java.lang.Integer.parseInt;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 
 /**
  * @author Christoph Deppisch
@@ -33,41 +36,41 @@ public class RandomNumberFunctionTest extends UnitTestSupport {
 
     @Test
     public void testFunction() {
-        List<String> params = new ArrayList<String>();
+        List<String> params = new ArrayList<>();
         params.add("3");
 
-        Assert.assertTrue(Integer.valueOf(function.execute(params, context)) < 1000);
+        Assert.assertTrue(parseInt(function.execute(params, context)) < 1000);
 
-        params = new ArrayList<String>();
+        params = new ArrayList<>();
         params.add("3");
         params.add("false");
 
         String generated = function.execute(params, context);
         Assert.assertTrue(generated.length() <= 3);
-        Assert.assertTrue(generated.length() > 0);
+        Assert.assertTrue(!generated.isEmpty());
     }
 
     @Test
     public void testLeadingZeroNumbers() {
         String generated = RandomNumberFunction.checkLeadingZeros("0001", true);
-        Assert.assertTrue(Integer.valueOf(generated.substring(0, 1)) > 0);
+        Assert.assertTrue(parseInt(generated.substring(0, 1)) > 0);
 
         generated = RandomNumberFunction.checkLeadingZeros("0009", true);
         Assert.assertEquals(generated.length(), 4);
 
         generated = RandomNumberFunction.checkLeadingZeros("00000", true);
         Assert.assertEquals(generated.length(), 5);
-        Assert.assertTrue(Integer.valueOf(generated.substring(0, 1)) > 0);
+        Assert.assertTrue(parseInt(generated.substring(0, 1)) > 0);
         Assert.assertTrue(generated.endsWith("0000"));
 
         generated = RandomNumberFunction.checkLeadingZeros("009809", true);
         Assert.assertEquals(generated.length(), 6);
-        Assert.assertTrue(Integer.valueOf(generated.substring(0, 1)) > 0);
+        Assert.assertTrue(parseInt(generated.substring(0, 1)) > 0);
         Assert.assertTrue(generated.endsWith("09809"));
 
         generated = RandomNumberFunction.checkLeadingZeros("01209", true);
         Assert.assertEquals(generated.length(), 5);
-        Assert.assertTrue(Integer.valueOf(generated.substring(0, 1)) > 0);
+        Assert.assertTrue(parseInt(generated.substring(0, 1)) > 0);
         Assert.assertTrue(generated.endsWith("1209"));
 
         generated = RandomNumberFunction.checkLeadingZeros("1209", true);
@@ -93,17 +96,17 @@ public class RandomNumberFunctionTest extends UnitTestSupport {
 
     @Test(expectedExceptions = {InvalidFunctionUsageException.class})
     public void testWrongParameterUsage() {
-        function.execute(Collections.singletonList("-1"), context);
+        function.execute(singletonList("-1"), context);
     }
 
     @Test(expectedExceptions = {InvalidFunctionUsageException.class})
     public void testNoParameters() {
-        function.execute(Collections.<String>emptyList(), context);
+        function.execute(emptyList(), context);
     }
 
     @Test(expectedExceptions = {InvalidFunctionUsageException.class})
     public void testTooManyParameters() {
-        List<String> params = new ArrayList<String>();
+        List<String> params = new ArrayList<>();
         params.add("3");
         params.add("true");
         params.add("too much");

--- a/core/citrus-base/src/test/java/org/citrusframework/functions/core/RandomStringFunctionTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/functions/core/RandomStringFunctionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,15 @@
 package org.citrusframework.functions.core;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.citrusframework.UnitTestSupport;
 import org.citrusframework.exceptions.InvalidFunctionUsageException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 
 /**
  * @author Christoph Deppisch
@@ -33,81 +35,81 @@ public class RandomStringFunctionTest extends UnitTestSupport {
 
     @Test
     public void testFunction() {
-        List<String> params = new ArrayList<String>();
+        List<String> params = new ArrayList<>();
         params.add("3");
 
-        Assert.assertTrue(function.execute(params, context).length() == 3);
+        Assert.assertEquals(function.execute(params, context).length(), 3);
 
-        params = new ArrayList<String>();
+        params = new ArrayList<>();
         params.add("3");
         params.add("UPPERCASE");
 
-        Assert.assertTrue(function.execute(params, context).length() == 3);
+        Assert.assertEquals(function.execute(params, context).length(), 3);
 
-        params = new ArrayList<String>();
+        params = new ArrayList<>();
         params.add("3");
         params.add("LOWERCASE");
 
-        Assert.assertTrue(function.execute(params, context).length() == 3);
+        Assert.assertEquals(function.execute(params, context).length(), 3);
 
-        params = new ArrayList<String>();
+        params = new ArrayList<>();
         params.add("3");
         params.add("MIXED");
 
-        Assert.assertTrue(function.execute(params, context).length() == 3);
+        Assert.assertEquals(function.execute(params, context).length(), 3);
 
-        params = new ArrayList<String>();
+        params = new ArrayList<>();
         params.add("3");
         params.add("UNKNOWN");
 
-        Assert.assertTrue(function.execute(params, context).length() == 3);
+        Assert.assertEquals(function.execute(params, context).length(), 3);
     }
 
     @Test
     public void testWithNumbers() {
-        List<String> params = new ArrayList<String>();
-        params = new ArrayList<String>();
+        List<String> params;
+        params = new ArrayList<>();
         params.add("10");
         params.add("UPPERCASE");
         params.add("true");
 
-        Assert.assertTrue(function.execute(params, context).length() == 10);
+        Assert.assertEquals(function.execute(params, context).length(), 10);
 
-        params = new ArrayList<String>();
+        params = new ArrayList<>();
         params.add("10");
         params.add("LOWERCASE");
         params.add("true");
 
-        Assert.assertTrue(function.execute(params, context).length() == 10);
+        Assert.assertEquals(function.execute(params, context).length(), 10);
 
-        params = new ArrayList<String>();
+        params = new ArrayList<>();
         params.add("10");
         params.add("MIXED");
         params.add("true");
 
-        Assert.assertTrue(function.execute(params, context).length() == 10);
+        Assert.assertEquals(function.execute(params, context).length(), 10);
 
-        params = new ArrayList<String>();
+        params = new ArrayList<>();
         params.add("10");
         params.add("UNKNOWN");
         params.add("true");
 
-        Assert.assertTrue(function.execute(params, context).length() == 10);
+        Assert.assertEquals(function.execute(params, context).length(), 10);
     }
 
     @Test(expectedExceptions = {InvalidFunctionUsageException.class})
     public void testWrongParameterUsage() {
-        function.execute(Collections.singletonList("-1"), context);
+        function.execute(singletonList("-1"), context);
     }
 
     @Test(expectedExceptions = {InvalidFunctionUsageException.class})
     public void testNoParameters() {
-        function.execute(Collections.<String>emptyList(), context);
+        function.execute(emptyList(), context);
     }
 
     @Test(expectedExceptions = {InvalidFunctionUsageException.class})
     public void testTooManyParameters() {
-        List<String> params = new ArrayList<String>();
+        List<String> params = new ArrayList<>();
         params.add("3");
         params.add("UPPERCASE");
         params.add("true");

--- a/core/citrus-base/src/test/java/org/citrusframework/functions/core/ReadFileResourceFunctionTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/functions/core/ReadFileResourceFunctionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2015 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package org.citrusframework.functions.core;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 

--- a/core/citrus-base/src/test/java/org/citrusframework/functions/core/SubstringAfterFunctionTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/functions/core/SubstringAfterFunctionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,14 @@
 package org.citrusframework.functions.core;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.citrusframework.UnitTestSupport;
 import org.citrusframework.exceptions.InvalidFunctionUsageException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import static java.util.Collections.emptyList;
 
 /**
  * @author Christoph Deppisch
@@ -33,7 +34,7 @@ public class SubstringAfterFunctionTest extends UnitTestSupport {
 
     @Test
     public void testFunction() {
-        List<String> params = new ArrayList<String>();
+        List<String> params = new ArrayList<>();
         params.add("Hallo,TestFramework");
         params.add(",");
         Assert.assertEquals(function.execute(params, context), "TestFramework");
@@ -46,6 +47,6 @@ public class SubstringAfterFunctionTest extends UnitTestSupport {
 
     @Test(expectedExceptions = {InvalidFunctionUsageException.class})
     public void testNoParameters() {
-        function.execute(Collections.<String>emptyList(), context);
+        function.execute(emptyList(), context);
     }
 }

--- a/core/citrus-base/src/test/java/org/citrusframework/functions/core/SubstringBeforeFunctionTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/functions/core/SubstringBeforeFunctionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,14 @@
 package org.citrusframework.functions.core;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.citrusframework.UnitTestSupport;
 import org.citrusframework.exceptions.InvalidFunctionUsageException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import static java.util.Collections.emptyList;
 
 /**
  * @author Christoph Deppisch
@@ -33,7 +34,7 @@ public class SubstringBeforeFunctionTest extends UnitTestSupport {
 
     @Test
     public void testFunction() {
-        List<String> params = new ArrayList<String>();
+        List<String> params = new ArrayList<>();
         params.add("Hallo,TestFramework");
         params.add(",");
         Assert.assertEquals(function.execute(params, context), "Hallo");
@@ -46,6 +47,6 @@ public class SubstringBeforeFunctionTest extends UnitTestSupport {
 
     @Test(expectedExceptions = {InvalidFunctionUsageException.class})
     public void testNoParameters() {
-        function.execute(Collections.<String>emptyList(), context);
+        function.execute(emptyList(), context);
     }
 }

--- a/core/citrus-base/src/test/java/org/citrusframework/functions/core/SubstringFunctionTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/functions/core/SubstringFunctionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,15 @@
 package org.citrusframework.functions.core;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.citrusframework.UnitTestSupport;
 import org.citrusframework.exceptions.InvalidFunctionUsageException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 
 /**
  * @author Christoph Deppisch
@@ -33,7 +35,7 @@ public class SubstringFunctionTest extends UnitTestSupport {
 
     @Test
     public void testFunction() {
-        List<String> params = new ArrayList<String>();
+        List<String> params = new ArrayList<>();
         params.add("Hallo,TestFramework");
         params.add("6");
         Assert.assertEquals(function.execute(params, context), "TestFramework");
@@ -46,7 +48,7 @@ public class SubstringFunctionTest extends UnitTestSupport {
 
     @Test
     public void testEndIndex() {
-        List<String> params = new ArrayList<String>();
+        List<String> params = new ArrayList<>();
         params.add("Hallo,TestFramework");
         params.add("6");
         params.add("10");
@@ -61,7 +63,7 @@ public class SubstringFunctionTest extends UnitTestSupport {
 
     @Test(expectedExceptions = {StringIndexOutOfBoundsException.class})
     public void testIndexOutOfBounds() {
-        List<String> params = new ArrayList<String>();
+        List<String> params = new ArrayList<>();
         params.add("Test");
         params.add("-1");
         function.execute(params, context);
@@ -69,12 +71,12 @@ public class SubstringFunctionTest extends UnitTestSupport {
 
     @Test(expectedExceptions = {InvalidFunctionUsageException.class})
     public void testMissingBeginIndex() {
-        function.execute(Collections.singletonList("This is a test"), context);
+        function.execute(singletonList("This is a test"), context);
     }
 
     @Test(expectedExceptions = {NumberFormatException.class})
     public void testNotANumber() {
-        List<String> params = new ArrayList<String>();
+        List<String> params = new ArrayList<>();
         params.add("Hallo,TestFramework");
         params.add("one");
         function.execute(params, context);
@@ -82,6 +84,6 @@ public class SubstringFunctionTest extends UnitTestSupport {
 
     @Test(expectedExceptions = {InvalidFunctionUsageException.class})
     public void testNoParameters() {
-        function.execute(Collections.<String>emptyList(), context);
+        function.execute(emptyList(), context);
     }
 }

--- a/core/citrus-base/src/test/java/org/citrusframework/functions/core/SumFunctionTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/functions/core/SumFunctionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,15 @@
 package org.citrusframework.functions.core;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.citrusframework.UnitTestSupport;
 import org.citrusframework.exceptions.InvalidFunctionUsageException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 
 /**
  * @author Christoph Deppisch
@@ -33,7 +35,7 @@ public class SumFunctionTest extends UnitTestSupport {
 
     @Test
     public void testFunction() {
-        List<String> params = new ArrayList<String>();
+        List<String> params = new ArrayList<>();
         params.add("3");
         params.add("5.3");
         params.add("4.7");
@@ -44,11 +46,11 @@ public class SumFunctionTest extends UnitTestSupport {
 
     @Test(expectedExceptions = {NumberFormatException.class})
     public void testWrongParameterUsage() {
-        function.execute(Collections.singletonList("no digit"), context);
+        function.execute(singletonList("no digit"), context);
     }
 
     @Test(expectedExceptions = {InvalidFunctionUsageException.class})
     public void testNoParameters() {
-        function.execute(Collections.<String>emptyList(), context);
+        function.execute(emptyList(), context);
     }
 }

--- a/core/citrus-base/src/test/java/org/citrusframework/functions/core/TranslateFunctionTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/functions/core/TranslateFunctionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ public class TranslateFunctionTest extends UnitTestSupport {
 
     @Test
     public void testFunction() {
-        List<String> params = new ArrayList<String>();
+        List<String> params = new ArrayList<>();
         params.add("H.llo TestFr.mework");
         params.add("\\.");
         params.add("a");
@@ -43,7 +43,7 @@ public class TranslateFunctionTest extends UnitTestSupport {
 
     @Test(expectedExceptions = {InvalidFunctionUsageException.class})
     public void testMissingParameter() {
-        List<String> params = new ArrayList<String>();
+        List<String> params = new ArrayList<>();
         params.add("H.llo TestFr.mework");
         params.add("\\.");
         function.execute(params, context);

--- a/core/citrus-base/src/test/java/org/citrusframework/report/JUnitReporterTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/report/JUnitReporterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2018 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,10 +43,11 @@ public class JUnitReporterTest {
         String reportFile = FileUtils.readToString(new File(reporter.getReportDirectory() + File.separator + reporter.getOutputDirectory() + File.separator + String.format(reporter.getReportFileNamePattern(), JUnitReporterTest.class.getName())));
         String testSuiteFile = FileUtils.readToString(new File(reporter.getReportDirectory() + File.separator + String.format(reporter.getReportFileNamePattern(), reporter.getSuiteName())));
 
-        Assert.assertEquals(TestUtils.normalizeLineEndings(reportFile), "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                        "<testsuite name=\"org.citrusframework.report.JUnitReporterTest\" time=\"0.0\" tests=\"1\" errors=\"0\" skipped=\"0\" failures=\"0\">\n" +
-                        "    <testcase name=\"fooTest\" classname=\"org.citrusframework.report.JUnitReporterTest\" time=\"0.0\"/>\n" +
-                        "</testsuite>"
+        Assert.assertEquals(TestUtils.normalizeLineEndings(reportFile), """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <testsuite name="org.citrusframework.report.JUnitReporterTest" time="0.0" tests="1" errors="0" skipped="0" failures="0">
+                    <testcase name="fooTest" classname="org.citrusframework.report.JUnitReporterTest" time="0.0"/>
+                </testsuite>"""
         );
 
         Assert.assertEquals(TestUtils.normalizeLineEndings(testSuiteFile), "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
@@ -65,11 +66,12 @@ public class JUnitReporterTest {
 
         String reportFile = FileUtils.readToString(new File(reporter.getReportDirectory() + File.separator + reporter.getOutputDirectory() + File.separator + String.format(reporter.getReportFileNamePattern(), JUnitReporterTest.class.getName())));
 
-        Assert.assertEquals(TestUtils.normalizeLineEndings(reportFile), "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<testsuite name=\"org.citrusframework.report.JUnitReporterTest\" time=\"0.0\" tests=\"2\" errors=\"0\" skipped=\"0\" failures=\"0\">\n" +
-                "    <testcase name=\"fooTest\" classname=\"org.citrusframework.report.JUnitReporterTest\" time=\"0.0\"/>\n" +
-                "    <testcase name=\"barTest\" classname=\"org.citrusframework.report.JUnitReporterTest\" time=\"0.0\"/>\n" +
-                "</testsuite>");
+        Assert.assertEquals(TestUtils.normalizeLineEndings(reportFile), """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <testsuite name="org.citrusframework.report.JUnitReporterTest" time="0.0" tests="2" errors="0" skipped="0" failures="0">
+                    <testcase name="fooTest" classname="org.citrusframework.report.JUnitReporterTest" time="0.0"/>
+                    <testcase name="barTest" classname="org.citrusframework.report.JUnitReporterTest" time="0.0"/>
+                </testsuite>""");
     }
 
     @Test
@@ -85,13 +87,14 @@ public class JUnitReporterTest {
         Assert.assertTrue(
                 TestUtils.normalizeLineEndings(reportFile)
                         .startsWith(
-                                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                                        "<testsuite name=\"org.citrusframework.report.JUnitReporterTest\" time=\"0.0\" tests=\"2\" errors=\"0\" skipped=\"0\" failures=\"1\">\n" +
-                                        "    <testcase name=\"fooTest\" classname=\"org.citrusframework.report.JUnitReporterTest\" time=\"0.0\"/>\n" +
-                                        "    <testcase name=\"barTest\" classname=\"org.citrusframework.report.JUnitReporterTest\" time=\"0.0\">\n" +
-                                        "      <failure type=\"java.lang.NullPointerException\" message=\"Something went wrong!\">\n" +
-                                        "        <![CDATA[\n" +
-                                        "        java.lang.NullPointerException: Something went wrong!"
+                                """
+                                        <?xml version="1.0" encoding="UTF-8"?>
+                                        <testsuite name="org.citrusframework.report.JUnitReporterTest" time="0.0" tests="2" errors="0" skipped="0" failures="1">
+                                            <testcase name="fooTest" classname="org.citrusframework.report.JUnitReporterTest" time="0.0"/>
+                                            <testcase name="barTest" classname="org.citrusframework.report.JUnitReporterTest" time="0.0">
+                                              <failure type="java.lang.NullPointerException" message="Something went wrong!">
+                                                <![CDATA[
+                                                java.lang.NullPointerException: Something went wrong!"""
                         )
         );
 
@@ -109,11 +112,12 @@ public class JUnitReporterTest {
 
         String reportFile = FileUtils.readToString(new File(reporter.getReportDirectory() + File.separator + reporter.getOutputDirectory() + File.separator + String.format(reporter.getReportFileNamePattern(), JUnitReporterTest.class.getName())));
 
-        Assert.assertEquals(TestUtils.normalizeLineEndings(reportFile), "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<testsuite name=\"org.citrusframework.report.JUnitReporterTest\" time=\"0.0\" tests=\"2\" errors=\"0\" skipped=\"1\" failures=\"0\">\n" +
-                "    <testcase name=\"fooTest\" classname=\"org.citrusframework.report.JUnitReporterTest\" time=\"0.0\"/>\n" +
-                "    <testcase name=\"barTest\" classname=\"org.citrusframework.report.JUnitReporterTest\" time=\"0.0\"/>\n" +
-                "</testsuite>");
+        Assert.assertEquals(TestUtils.normalizeLineEndings(reportFile), """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <testsuite name="org.citrusframework.report.JUnitReporterTest" time="0.0" tests="2" errors="0" skipped="1" failures="0">
+                    <testcase name="fooTest" classname="org.citrusframework.report.JUnitReporterTest" time="0.0"/>
+                    <testcase name="barTest" classname="org.citrusframework.report.JUnitReporterTest" time="0.0"/>
+                </testsuite>""");
     }
 
     @Test
@@ -129,13 +133,14 @@ public class JUnitReporterTest {
         Assert.assertTrue(
                 TestUtils.normalizeLineEndings(reportFile)
                         .startsWith(
-                                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                                        "<testsuite name=\"org.citrusframework.report.JUnitReporterTest\" time=\"0.0\" tests=\"2\" errors=\"0\" skipped=\"0\" failures=\"1\">\n" +
-                                        "    <testcase name=\"foo&quot;Test\" classname=\"org.citrusframework.report.JUnitReporterTest\" time=\"0.0\"/>\n" +
-                                        "    <testcase name=\"bar&quot;Test\" classname=\"org.citrusframework.report.JUnitReporterTest\" time=\"0.0\">\n" +
-                                        "      <failure type=\"java.lang.NullPointerException\" message=\"Something &quot;went wrong!\">\n" +
-                                        "        <![CDATA[\n" +
-                                        "        java.lang.NullPointerException: Something \"went wrong!"
+                                """
+                                        <?xml version="1.0" encoding="UTF-8"?>
+                                        <testsuite name="org.citrusframework.report.JUnitReporterTest" time="0.0" tests="2" errors="0" skipped="0" failures="1">
+                                            <testcase name="foo&quot;Test" classname="org.citrusframework.report.JUnitReporterTest" time="0.0"/>
+                                            <testcase name="bar&quot;Test" classname="org.citrusframework.report.JUnitReporterTest" time="0.0">
+                                              <failure type="java.lang.NullPointerException" message="Something &quot;went wrong!">
+                                                <![CDATA[
+                                                java.lang.NullPointerException: Something "went wrong!"""
                         )
         );
 
@@ -157,11 +162,12 @@ public class JUnitReporterTest {
         assertTrue(
                 TestUtils.normalizeLineEndings(reportFile)
                         .startsWith(
-                                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                                        "<testsuite name=\"org.citrusframework.report.JUnitReporterTest\" time=\"0.0\" tests=\"2\" errors=\"0\" skipped=\"0\" failures=\"1\">\n" +
-                                        "    <testcase name=\"fooTest\" classname=\"org.citrusframework.report.JUnitReporterTest\" time=\"0.0\"/>\n" +
-                                        "    <testcase name=\"barTest\" classname=\"org.citrusframework.report.JUnitReporterTest\" time=\"0.0\">\n" +
-                                        "      <failure type=\"\" message=\"Something went wrong!\">"
+                                """
+                                        <?xml version="1.0" encoding="UTF-8"?>
+                                        <testsuite name="org.citrusframework.report.JUnitReporterTest" time="0.0" tests="2" errors="0" skipped="0" failures="1">
+                                            <testcase name="fooTest" classname="org.citrusframework.report.JUnitReporterTest" time="0.0"/>
+                                            <testcase name="barTest" classname="org.citrusframework.report.JUnitReporterTest" time="0.0">
+                                              <failure type="" message="Something went wrong!">"""
                         )
         );
 

--- a/core/citrus-base/src/test/java/org/citrusframework/util/InvocationDummy.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/util/InvocationDummy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,9 +65,9 @@ public class InvocationDummy {
     }
     
     public void invoke(String[] args) {
-        for (int i = 0; i < args.length; i++) {
+        for (var arg : args) {
             if (logger.isDebugEnabled()) {
-                logger.debug("Methode invoke with argument: " + args[i]);
+                logger.debug("Methode invoke with argument: " + arg);
             }
         }
     }

--- a/core/citrus-base/src/test/java/org/citrusframework/validation/matcher/core/ContainsValidationMatcherTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/validation/matcher/core/ContainsValidationMatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,8 @@ import org.citrusframework.UnitTestSupport;
 import org.citrusframework.exceptions.ValidationException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import static java.util.Objects.requireNonNullElse;
 
 public class ContainsValidationMatcherTest extends UnitTestSupport {
 
@@ -51,11 +53,7 @@ public class ContainsValidationMatcherTest extends UnitTestSupport {
 			Assert.assertTrue(e.getMessage().contains(fieldName));
 			Assert.assertTrue(e.getMessage().contains(control.get(0)));
 
-            if (value != null) {
-			    Assert.assertTrue(e.getMessage().contains(value));
-            } else {
-                Assert.assertTrue(e.getMessage().contains("null"));
-            }
+            Assert.assertTrue(e.getMessage().contains(requireNonNullElse(value, "null")));
 		}
     }
 }

--- a/core/citrus-base/src/test/java/org/citrusframework/validation/matcher/core/DateRangeValidationMatcherTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/validation/matcher/core/DateRangeValidationMatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2015 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ public class DateRangeValidationMatcherTest {
             if (expectedErrorMessage == null) {
                 fail("Was not expecting exception but got one", e);
             }
-            Assert.assertTrue(e.getMessage().indexOf(expectedErrorMessage) > -1, String.format("Expected error '%s' not found in '%s'", expectedErrorMessage, e.getMessage()));
+            Assert.assertTrue(e.getMessage().contains(expectedErrorMessage), String.format("Expected error '%s' not found in '%s'", expectedErrorMessage, e.getMessage()));
         }
     }
 

--- a/core/citrus-base/src/test/java/org/citrusframework/validation/script/TemplateBasedScriptBuilderTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/validation/script/TemplateBasedScriptBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,13 +54,22 @@ public class TemplateBasedScriptBuilderTest {
 
     @Test
     public void testCustomImports() {
-        Assert.assertEquals(TemplateBasedScriptBuilder.fromTemplateScript("+++HEAD+++@SCRIPTBODY@+++TAIL+++")
-                .withCode("import org.citrusframework.MyClass;\n" +
-                		"import org.citrusframework.SomeOtherClass;\n" +
-                		"importedBODYimported\n" +
-                		"this is also script body\n\n" +
-                		"END")
-                .build(), "import org.citrusframework.MyClass;\nimport org.citrusframework.SomeOtherClass;\n" +
-                		"+++HEAD+++importedBODYimported\nthis is also script body\n\nEND+++TAIL+++");
+        Assert.assertEquals(
+                TemplateBasedScriptBuilder.fromTemplateScript("+++HEAD+++@SCRIPTBODY@+++TAIL+++")
+                        .withCode("""
+                                import org.citrusframework.MyClass;
+                                import org.citrusframework.SomeOtherClass;
+                                importedBODYimported
+                                this is also script body
+
+                                END""")
+                        .build(),
+                """
+                        import org.citrusframework.MyClass;
+                        import org.citrusframework.SomeOtherClass;
+                        +++HEAD+++importedBODYimported
+                        this is also script body
+
+                        END+++TAIL+++""");
     }
 }

--- a/core/citrus-spring/src/main/java/org/citrusframework/config/CitrusSpringConfig.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/config/CitrusSpringConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2023 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,6 @@ import org.citrusframework.validation.interceptor.MessageProcessorsFactory;
 import org.citrusframework.validation.matcher.ValidationMatcherConfig;
 import org.citrusframework.variable.SegmentVariableExtractorRegistry;
 import org.springframework.beans.factory.config.CustomEditorConfigurer;
-import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;

--- a/core/citrus-spring/src/main/java/org/citrusframework/config/util/ValidateMessageParserUtil.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/config/util/ValidateMessageParserUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2016 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package org.citrusframework.config.util;
 
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -39,9 +38,9 @@ public class ValidateMessageParserUtil {
      */
     public static void parseJsonPathElements(Element validateElement, Map<String, Object> validateJsonPathExpressions) {
         List<?> jsonPathElements = DomUtils.getChildElementsByTagName(validateElement, "json-path");
-        if (jsonPathElements.size() > 0) {
-            for (Iterator<?> jsonPathIterator = jsonPathElements.iterator(); jsonPathIterator.hasNext();) {
-                Element jsonPathElement = (Element) jsonPathIterator.next();
+        if (!jsonPathElements.isEmpty()) {
+            for (Object pathElement : jsonPathElements) {
+                Element jsonPathElement = (Element) pathElement;
                 String expression = jsonPathElement.getAttribute("expression");
                 if (StringUtils.hasText(expression)) {
                     validateJsonPathExpressions.put(expression, jsonPathElement.getAttribute("value"));

--- a/core/citrus-spring/src/main/java/org/citrusframework/config/xml/AbstractDataDictionaryParser.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/config/xml/AbstractDataDictionaryParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ public abstract class AbstractDataDictionaryParser implements BeanDefinitionPars
      * @param element the source element.
      */
     private void parseMappingDefinitions(BeanDefinitionBuilder builder, Element element) {
-        HashMap<String, String> mappings = new HashMap<String, String>();
+        HashMap<String, String> mappings = new HashMap<>();
         for (Element matcher : DomUtils.getChildElementsByTagName(element, "mapping")) {
             mappings.put(matcher.getAttribute("path"), matcher.getAttribute("value"));
         }

--- a/core/citrus-spring/src/main/java/org/citrusframework/config/xml/AntRunActionParser.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/config/xml/AntRunActionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package org.citrusframework.config.xml;
 
-import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
 
@@ -56,9 +55,9 @@ public class AntRunActionParser implements BeanDefinitionParser {
             BeanDefinitionParserUtils.setPropertyValue(beanDefinition, propertiesElement.getAttribute("file"), "propertyFilePath");
 
             List<?> propertyElements = DomUtils.getChildElementsByTagName(propertiesElement, "property");
-            if (propertyElements.size() > 0) {
-                for (Iterator<?> iter = propertyElements.iterator(); iter.hasNext();) {
-                    Element propertyElement = (Element) iter.next();
+            if (!propertyElements.isEmpty()) {
+                for (Object o : propertyElements) {
+                    Element propertyElement = (Element) o;
                     properties.put(propertyElement.getAttribute("name"), propertyElement.getAttribute("value"));
                 }
 

--- a/core/citrus-spring/src/main/java/org/citrusframework/config/xml/BaseTestCaseMetaInfoParser.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/config/xml/BaseTestCaseMetaInfoParser.java
@@ -1,8 +1,22 @@
+/*
+ * Copyright 024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.citrusframework.config.xml;
 
 import org.citrusframework.TestCaseMetaInfo;
-import org.citrusframework.config.TestCaseFactory;
-import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
@@ -11,7 +25,6 @@ import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.util.xml.DomUtils;
 import org.w3c.dom.Element;
 
-import java.lang.reflect.InvocationTargetException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 
@@ -54,14 +67,11 @@ public abstract class BaseTestCaseMetaInfoParser<T extends TestCaseMetaInfo> imp
 
         String status = DomUtils.getTextValue(statusElement);
 
-        if (status.equals("DRAFT")) {
-            metaInfoBuilder.addPropertyValue("status", Status.DRAFT);
-        } else if (status.equals("READY_FOR_REVIEW")) {
-            metaInfoBuilder.addPropertyValue("status", Status.READY_FOR_REVIEW);
-        } else if (status.equals("FINAL")) {
-            metaInfoBuilder.addPropertyValue("status", Status.FINAL);
-        } else if (status.equals("DISABLED")) {
-            metaInfoBuilder.addPropertyValue("status", Status.DISABLED);
+        switch (status) {
+            case "DRAFT" -> metaInfoBuilder.addPropertyValue("status", Status.DRAFT);
+            case "READY_FOR_REVIEW" -> metaInfoBuilder.addPropertyValue("status", Status.READY_FOR_REVIEW);
+            case "FINAL" -> metaInfoBuilder.addPropertyValue("status", Status.FINAL);
+            case "DISABLED" -> metaInfoBuilder.addPropertyValue("status", Status.DISABLED);
         }
 
         if (lastUpdatedByElement != null) {

--- a/core/citrus-spring/src/main/java/org/citrusframework/config/xml/BaseTestCaseParser.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/config/xml/BaseTestCaseParser.java
@@ -1,6 +1,21 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.citrusframework.config.xml;
 
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -82,7 +97,7 @@ public class BaseTestCaseParser<T extends TestCase> implements BeanDefinitionPar
      * @return
      */
     private ManagedList<BeanDefinition> parseActions(Element actionsContainerElement, ParserContext parserContext) {
-        ManagedList<BeanDefinition> actions = new ManagedList<BeanDefinition>();
+        ManagedList<BeanDefinition> actions = new ManagedList<>();
 
         if (actionsContainerElement != null) {
             List<Element> actionList = DomUtils.getChildElements(actionsContainerElement);
@@ -113,10 +128,10 @@ public class BaseTestCaseParser<T extends TestCase> implements BeanDefinitionPar
     private void parseVariableDefinitions(BeanDefinitionBuilder testCase, Element element) {
         Element variablesElement = DomUtils.getChildElementByTagName(element, "variables");
         if (variablesElement != null) {
-            Map<String, String> testVariables = new LinkedHashMap<String, String>();
+            Map<String, String> testVariables = new LinkedHashMap<>();
             List<?> variableElements = DomUtils.getChildElementsByTagName(variablesElement, "variable");
-            for (Iterator<?> iter = variableElements.iterator(); iter.hasNext(); ) {
-                Element variableDefinition = (Element) iter.next();
+            for (Object variableElement : variableElements) {
+                Element variableDefinition = (Element) variableElement;
                 Element variableValueElement = DomUtils.getChildElementByTagName(variableDefinition, "value");
                 if (variableValueElement == null) {
                     testVariables.put(variableDefinition.getAttribute("name"), variableDefinition.getAttribute("value"));

--- a/core/citrus-spring/src/main/java/org/citrusframework/config/xml/CallTemplateParser.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/config/xml/CallTemplateParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
 
 package org.citrusframework.config.xml;
 
-import java.util.*;
-
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
@@ -25,6 +23,12 @@ import org.springframework.beans.factory.xml.BeanDefinitionParser;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.util.xml.DomUtils;
 import org.w3c.dom.Element;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.springframework.util.CollectionUtils.isEmpty;
 
 /**
  * Bean definition parser for call template action in test case.
@@ -46,25 +50,25 @@ public class CallTemplateParser implements BeanDefinitionParser {
 
         List<?> parameterElements = DomUtils.getChildElementsByTagName(element, "parameter");
 
-        if (parameterElements != null && parameterElements.size() > 0) {
-            Map<String, String> parameters = new LinkedHashMap<String, String>();
+        if (!isEmpty(parameterElements)) {
+            Map<String, String> parameters = new LinkedHashMap<>();
 
-            for (Iterator<?> iter = parameterElements.iterator(); iter.hasNext();) {
-                Element parameterElement = (Element) iter.next();
+            for (Object o : parameterElements) {
+                Element parameterElement = (Element) o;
                 final String name = parameterElement.getAttribute("name");
                 String value = null;
                 if (parameterElement.hasAttribute("value")) {
-                	value = parameterElement.getAttribute("value");
+                    value = parameterElement.getAttribute("value");
                 } else {
-                	Element valueElement = DomUtils.getChildElementByTagName(parameterElement, "value");
-                	if (valueElement != null) {
-                		value = valueElement.getTextContent();
-                	}
+                    Element valueElement = DomUtils.getChildElementByTagName(parameterElement, "value");
+                    if (valueElement != null) {
+                        value = valueElement.getTextContent();
+                    }
                 }
                 if (value != null) {
-                	parameters.put(name, value);
+                    parameters.put(name, value);
                 } else {
-                	throw new BeanCreationException("Please provide either value attribute or value element for parameter");
+                    throw new BeanCreationException("Please provide either value attribute or value element for parameter");
                 }
             }
 

--- a/core/citrus-spring/src/main/java/org/citrusframework/config/xml/CreateVariablesActionParser.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/config/xml/CreateVariablesActionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ public class CreateVariablesActionParser implements BeanDefinitionParser {
 
         DescriptionElementParser.doParse(element, beanDefinition);
 
-        Map<String, String> variables = new LinkedHashMap<String, String>();
+        Map<String, String> variables = new LinkedHashMap<>();
         List<Element> variableElements = DomUtils.getChildElementsByTagName(element, "variable");
         for (Element variable : variableElements) {
             Element variableValueElement = DomUtils.getChildElementByTagName(variable, "value");

--- a/core/citrus-spring/src/main/java/org/citrusframework/config/xml/FunctionLibraryParser.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/config/xml/FunctionLibraryParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ public class FunctionLibraryParser implements BeanDefinitionParser {
      * @param element the source element.
      */
     private void parseFunctionDefinitions(BeanDefinitionBuilder builder, Element element) {
-        ManagedMap<String, Object> functions = new ManagedMap<String, Object>();
+        ManagedMap<String, Object> functions = new ManagedMap<>();
         for (Element function : DomUtils.getChildElementsByTagName(element, "function")) {
             if (function.hasAttribute("ref")) {
                 functions.put(function.getAttribute("name"), new RuntimeBeanReference(function.getAttribute("ref")));

--- a/core/citrus-spring/src/main/java/org/citrusframework/config/xml/JavaActionParser.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/config/xml/JavaActionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,11 @@ import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.util.xml.DomUtils;
 import org.w3c.dom.Element;
 
+import static java.lang.Boolean.parseBoolean;
+import static java.lang.Double.parseDouble;
+import static java.lang.Integer.parseInt;
+import static java.lang.Long.parseLong;
+
 /**
  * Bean definition parser for java action in test case.
  *
@@ -47,7 +52,7 @@ public class JavaActionParser implements BeanDefinitionParser {
         BeanDefinitionParserUtils.setPropertyReference(beanDefinition, element.getAttribute("ref"), "instance");
 
         Element constructorElement = DomUtils.getChildElementByTagName(element, "constructor");
-        List<Object> arguments = new ArrayList<Object>();
+        List<Object> arguments = new ArrayList<>();
         if (constructorElement != null) {
             List<Element> argumentList = DomUtils.getChildElementsByTagName(constructorElement, "argument");
             for (Element arg : argumentList) {
@@ -57,7 +62,7 @@ public class JavaActionParser implements BeanDefinitionParser {
         }
 
         Element methodElement = DomUtils.getChildElementByTagName(element, "method");
-        arguments = new ArrayList<Object>();
+        arguments = new ArrayList<>();
         if (methodElement != null) {
             String methodName = methodElement.getAttribute("name");
             beanDefinition.addPropertyValue("methodName", methodName);
@@ -78,13 +83,13 @@ public class JavaActionParser implements BeanDefinitionParser {
         } else if (type.equals("String[]")) {
             return value.split(",");
         } else if (type.equals("boolean")) {
-            return Boolean.valueOf(value).booleanValue();
+            return parseBoolean(value);
         }  else if (type.equals("int")) {
-            return Integer.valueOf(value).intValue();
+            return parseInt(value);
         } else if (type.equals("long")) {
-            return Long.valueOf(value);
+            return parseLong(value);
         } else if (type.equals("double")) {
-            return Double.valueOf(value);
+            return parseDouble(value);
         }
 
         throw new BeanCreationException("Found unsupported method argument type: '" + type + "'");

--- a/core/citrus-spring/src/main/java/org/citrusframework/config/xml/MessageSelectorParser.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/config/xml/MessageSelectorParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2017 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,8 +50,8 @@ public abstract class MessageSelectorParser {
 
             Map<String, String> messageSelectorMap = new HashMap<>();
             List<?> messageSelectorElements = DomUtils.getChildElementsByTagName(messageSelectorElement, "element");
-            for (Iterator<?> iter = messageSelectorElements.iterator(); iter.hasNext();) {
-                Element selectorElement = (Element) iter.next();
+            for (Object o : messageSelectorElements) {
+                Element selectorElement = (Element) o;
                 messageSelectorMap.put(selectorElement.getAttribute("name"), selectorElement.getAttribute("value"));
             }
             builder.addPropertyValue("messageSelectorMap", messageSelectorMap);

--- a/core/citrus-spring/src/main/java/org/citrusframework/config/xml/NamespaceContextParser.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/config/xml/NamespaceContextParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ public class NamespaceContextParser implements BeanDefinitionParser {
      * @param element the source element.
      */
     private void parseNamespaceDefinitions(BeanDefinitionBuilder builder, Element element) {
-        Map<String, String> namespaces = new LinkedHashMap<String, String>();
+        Map<String, String> namespaces = new LinkedHashMap<>();
         for (Element namespace : DomUtils.getChildElementsByTagName(element, "namespace")) {
             namespaces.put(namespace.getAttribute("prefix"), namespace.getAttribute("uri"));
         }

--- a/core/citrus-spring/src/main/java/org/citrusframework/config/xml/TestCaseParser.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/config/xml/TestCaseParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package org.citrusframework.config.xml;
 
 import org.citrusframework.DefaultTestCase;
-import org.citrusframework.TestCaseMetaInfo;
 
 /**
  * Bean definition parser for test case.

--- a/core/citrus-spring/src/main/java/org/citrusframework/config/xml/TraceVariablesActionParser.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/config/xml/TraceVariablesActionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package org.citrusframework.config.xml;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 import org.citrusframework.actions.TraceVariablesAction;
@@ -41,10 +40,10 @@ public class TraceVariablesActionParser implements BeanDefinitionParser {
 
         DescriptionElementParser.doParse(element, beanDefinition);
 
-        List<String> variableNames = new ArrayList<String>();
+        List<String> variableNames = new ArrayList<>();
         List<?> variableElements = DomUtils.getChildElementsByTagName(element, "variable");
-        for (Iterator<?> iter = variableElements.iterator(); iter.hasNext();) {
-            Element variable = (Element) iter.next();
+        for (Object variableElement : variableElements) {
+            Element variable = (Element) variableElement;
             variableNames.add(variable.getAttribute("name"));
         }
         beanDefinition.addPropertyValue("variableNames", variableNames);

--- a/core/citrus-spring/src/main/java/org/citrusframework/config/xml/ValidationMatcherLibraryParser.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/config/xml/ValidationMatcherLibraryParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ public class ValidationMatcherLibraryParser implements BeanDefinitionParser {
      * @param element the source element.
      */
     private void parseMatcherDefinitions(BeanDefinitionBuilder builder, Element element) {
-        ManagedMap<String, Object> matchers = new ManagedMap<String, Object>();
+        ManagedMap<String, Object> matchers = new ManagedMap<>();
         for (Element matcher : DomUtils.getChildElementsByTagName(element, "matcher")) {
             if (matcher.hasAttribute("ref")) {
                 matchers.put(matcher.getAttribute("name"), new RuntimeBeanReference(matcher.getAttribute("ref")));

--- a/core/citrus-spring/src/main/java/org/citrusframework/context/TestContextFactoryBean.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/context/TestContextFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,6 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
-import org.springframework.lang.NonNullApi;
 import org.springframework.util.CollectionUtils;
 
 /**

--- a/core/citrus-spring/src/main/java/org/citrusframework/endpoint/adapter/XmlTestExecutingEndpointAdapter.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/endpoint/adapter/XmlTestExecutingEndpointAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,11 +77,9 @@ public class XmlTestExecutingEndpointAdapter extends RequestDispatchingEndpointA
                     mappingName + "' in Spring bean context", e);
         }
 
-        taskExecutor.execute(new Runnable() {
-            public void run() {
-                prepareExecution(request, test);
-                test.execute(testContext);
-            }
+        taskExecutor.execute(() -> {
+            prepareExecution(request, test);
+            test.execute(testContext);
         });
 
         return endpointAdapterDelegate.handleMessage(request);

--- a/core/citrus-spring/src/main/java/org/citrusframework/functions/core/EnvironmentPropertyFunction.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/functions/core/EnvironmentPropertyFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with
@@ -28,7 +28,6 @@ import org.citrusframework.exceptions.InvalidFunctionUsageException;
 import org.citrusframework.functions.Function;
 import org.springframework.context.EnvironmentAware;
 import org.springframework.core.env.Environment;
-import org.springframework.util.CollectionUtils;
 
 /**
  * Function to get environment variable settings.

--- a/core/citrus-spring/src/test/java/org/citrusframework/config/xml/SendMessageActionParserTest.java
+++ b/core/citrus-spring/src/test/java/org/citrusframework/config/xml/SendMessageActionParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,23 +16,17 @@
 
 package org.citrusframework.config.xml;
 
-import java.io.IOException;
-
 import org.citrusframework.actions.SendMessageAction;
 import org.citrusframework.endpoint.Endpoint;
 import org.citrusframework.message.DelegatingPathExpressionProcessor;
 import org.citrusframework.testng.AbstractActionParserTest;
 import org.citrusframework.util.FileUtils;
 import org.citrusframework.validation.builder.DefaultMessageBuilder;
-import org.citrusframework.validation.context.ValidationContext;
-import org.citrusframework.validation.json.JsonMessageValidationContext;
-import org.citrusframework.validation.xml.XmlMessageValidationContext;
 import org.citrusframework.variable.MessageHeaderVariableExtractor;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
-import java.util.List;
 
 /**
  * @author Christoph Deppisch

--- a/core/citrus-spring/src/test/java/org/citrusframework/util/InvocationDummy.java
+++ b/core/citrus-spring/src/test/java/org/citrusframework/util/InvocationDummy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,9 +65,9 @@ public class InvocationDummy {
     }
     
     public void invoke(String[] args) {
-        for (int i = 0; i < args.length; i++) {
+        for (var arg : args) {
             if (logger.isDebugEnabled()) {
-                logger.debug("Methode invoke with argument: " + args[i]);
+                logger.debug("Methode invoke with argument: " + arg);
             }
         }
     }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CreateCamelRouteAction.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CreateCamelRouteAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2015 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,8 +64,7 @@ public class CreateCamelRouteAction extends AbstractCamelRouteAction {
             // now let's parse the routes with JAXB
             try {
                 Object value = CamelUtils.getJaxbContext().createUnmarshaller().unmarshal(new StringSource(context.replaceDynamicContentInString(routeContext)));
-                if (value instanceof CamelRouteContextFactoryBean) {
-                    CamelRouteContextFactoryBean factoryBean = (CamelRouteContextFactoryBean) value;
+                if (value instanceof CamelRouteContextFactoryBean factoryBean) {
                     routesToUse = factoryBean.getRoutes();
                 } else {
                     throw new CitrusRuntimeException(String.format("Failed to parse routes from given route context - expected %s but found %s",

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/config/xml/RemoveCamelRouteActionParser.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/config/xml/RemoveCamelRouteActionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2015 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package org.citrusframework.camel.config.xml;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 import org.citrusframework.camel.actions.RemoveCamelRouteAction;
@@ -38,9 +37,9 @@ public class RemoveCamelRouteActionParser extends AbstractCamelRouteActionParser
     public void parse(BeanDefinitionBuilder beanDefinition, Element element, ParserContext parserContext) {
         List<String> routeIds = new ArrayList<>();
         List<?> routeElements = DomUtils.getChildElementsByTagName(element, "route");
-        if (routeElements.size() > 0) {
-            for (Iterator<?> iter = routeElements.iterator(); iter.hasNext();) {
-                Element routeElement = (Element) iter.next();
+        if (!routeElements.isEmpty()) {
+            for (Object o : routeElements) {
+                Element routeElement = (Element) o;
                 routeIds.add(routeElement.getAttribute("id"));
             }
 

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/config/xml/StartCamelRouteActionParser.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/config/xml/StartCamelRouteActionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2015 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package org.citrusframework.camel.config.xml;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 import org.citrusframework.camel.actions.StartCamelRouteAction;
@@ -38,9 +37,9 @@ public class StartCamelRouteActionParser extends AbstractCamelRouteActionParser 
     public void parse(BeanDefinitionBuilder beanDefinition, Element element, ParserContext parserContext) {
         List<String> routeIds = new ArrayList<>();
         List<?> routeElements = DomUtils.getChildElementsByTagName(element, "route");
-        if (routeElements.size() > 0) {
-            for (Iterator<?> iter = routeElements.iterator(); iter.hasNext();) {
-                Element routeElement = (Element) iter.next();
+        if (!routeElements.isEmpty()) {
+            for (Object o : routeElements) {
+                Element routeElement = (Element) o;
                 routeIds.add(routeElement.getAttribute("id"));
             }
 

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/config/xml/StopCamelRouteActionParser.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/config/xml/StopCamelRouteActionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2015 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package org.citrusframework.camel.config.xml;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 import org.citrusframework.camel.actions.StopCamelRouteAction;
@@ -38,9 +37,9 @@ public class StopCamelRouteActionParser extends AbstractCamelRouteActionParser {
     public void parse(BeanDefinitionBuilder beanDefinition, Element element, ParserContext parserContext) {
         List<String> routeIds = new ArrayList<>();
         List<?> routeElements = DomUtils.getChildElementsByTagName(element, "route");
-        if (routeElements.size() > 0) {
-            for (Iterator<?> iter = routeElements.iterator(); iter.hasNext();) {
-                Element routeElement = (Element) iter.next();
+        if (!routeElements.isEmpty()) {
+            for (Object o : routeElements) {
+                Element routeElement = (Element) o;
                 routeIds.add(routeElement.getAttribute("id"));
             }
 

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/endpoint/CamelSyncProducer.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/endpoint/CamelSyncProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import org.citrusframework.message.correlation.CorrelationManager;
 import org.citrusframework.message.correlation.PollingCorrelationManager;
 import org.citrusframework.messaging.ReplyConsumer;
 import org.apache.camel.Exchange;
-import org.apache.camel.Processor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,14 +81,10 @@ public class CamelSyncProducer extends CamelProducer implements ReplyConsumer {
         context.onOutboundMessage(message);
 
         Exchange response = getProducerTemplate(context)
-                .request(endpointUri, new Processor() {
-                    @Override
-                    public void process(Exchange exchange) throws Exception {
-                        endpointConfiguration.getMessageConverter().convertOutbound(exchange, message, endpointConfiguration, context);
-                        logger.info("Message was sent to camel endpoint: '" + endpointUri + "'");
-                    }
+                .request(endpointUri, exchange -> {
+                    endpointConfiguration.getMessageConverter().convertOutbound(exchange, message, endpointConfiguration, context);
+                    logger.info("Message was sent to camel endpoint: '" + endpointUri + "'");
                 });
-
 
         logger.info("Received synchronous reply message on camel endpoint: '" + endpointUri + "'");
         Message replyMessage = endpointConfiguration.getMessageConverter().convertInbound(response, endpointConfiguration, context);

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/actions/CreateCamelRouteActionTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/actions/CreateCamelRouteActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2015 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,16 +58,17 @@ public class CreateCamelRouteActionTest extends AbstractTestNGUnitTest {
 
         CreateCamelRouteAction action = new CreateCamelRouteAction.Builder()
                 .context(camelContext)
-                .routeContext("<routeContext xmlns=\"http://camel.apache.org/schema/spring\">\n" +
-                        "<route id=\"route_1\">\n" +
-                        "<from uri=\"direct:test1\"/>\n" +
-                        "<to uri=\"mock:test1\"/>\n" +
-                        "</route>\n" +
-                        "<route id=\"route_2\">\n" +
-                        "<from uri=\"direct:test2\"/>\n" +
-                        "<to uri=\"mock:test2\"/>\n" +
-                        "</route>\n" +
-                        "</routeContext>")
+                .routeContext("""
+                        <routeContext xmlns="http://camel.apache.org/schema/spring">
+                            <route id="route_1">
+                                <from uri="direct:test1"/>
+                                <to uri="mock:test1"/>
+                            </route>
+                            <route id="route_2">
+                                <from uri="direct:test2"/>
+                                <to uri="mock:test2"/>
+                            </route>
+                        </routeContext>""")
                 .build();
         action.execute(context);
 
@@ -93,12 +94,13 @@ public class CreateCamelRouteActionTest extends AbstractTestNGUnitTest {
 
         CreateCamelRouteAction action = new CreateCamelRouteAction.Builder()
                 .context(camelContext)
-                .routeContext("<routeContext xmlns=\"http://camel.apache.org/schema/spring\">\n" +
-                    "<route id=\"${routeId}\">\n" +
-                        "<from uri=\"direct:${endpointUri}\"/>\n" +
-                        "<to uri=\"mock:${endpointUri}\"/>\n" +
-                    "</route>\n" +
-                "</routeContext>")
+                .routeContext("""
+                        <routeContext xmlns="http://camel.apache.org/schema/spring">
+                            <route id="${routeId}">
+                                <from uri="direct:${endpointUri}"/>
+                                <to uri="mock:${endpointUri}"/>
+                            </route>
+                        </routeContext>""")
                 .build();
 
         action.execute(context);

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/endpoint/CamelEndpointComponentTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/endpoint/CamelEndpointComponentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -104,7 +104,7 @@ public class CamelEndpointComponentTest {
     public void testCreateEndpointWithParameters() throws Exception {
         CamelEndpointComponent component = new CamelEndpointComponent();
 
-        Map<String, CamelContext> camelContextMap = new HashMap<String, CamelContext>();
+        Map<String, CamelContext> camelContextMap = new HashMap<>();
         camelContextMap.put("someCamelContext", Mockito.mock(CamelContext.class));
         camelContextMap.put("myCamelContext", camelContext);
 
@@ -127,7 +127,7 @@ public class CamelEndpointComponentTest {
     public void testCreateEndpointWithCamelParameters() throws Exception {
         CamelEndpointComponent component = new CamelEndpointComponent();
 
-        Map<String, CamelContext> camelContextMap = new HashMap<String, CamelContext>();
+        Map<String, CamelContext> camelContextMap = new HashMap<>();
         camelContextMap.put("someCamelContext", Mockito.mock(CamelContext.class));
         camelContextMap.put("myCamelContext", camelContext);
 

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/endpoint/CamelSyncEndpointTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/endpoint/CamelSyncEndpointTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,8 +31,6 @@ import org.apache.camel.support.DefaultExchange;
 import org.apache.camel.support.DefaultMessage;
 import org.apache.camel.support.SimpleUuidGenerator;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -157,13 +155,10 @@ public class CamelSyncEndpointTest extends AbstractTestNGUnitTest {
         when(producerTemplate.request(eq(endpointUri), any(Processor.class))).thenReturn(exchange);
 
         when(messageListeners.isEmpty()).thenReturn(false);
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                Message inboundMessage = (Message) invocation.getArguments()[0];
-                Assert.assertTrue(inboundMessage.getPayload(String.class).contains("Hello from Camel!"));
-                return null;
-            }
+        doAnswer(invocation -> {
+            Message inboundMessage = (Message) invocation.getArguments()[0];
+            Assert.assertTrue(inboundMessage.getPayload(String.class).contains("Hello from Camel!"));
+            return null;
         }).when(messageListeners).onInboundMessage(any(Message.class), eq(context));
 
         camelEndpoint.createProducer().send(requestMessage, context);

--- a/endpoints/citrus-ftp/src/main/java/org/citrusframework/ftp/client/SftpClient.java
+++ b/endpoints/citrus-ftp/src/main/java/org/citrusframework/ftp/client/SftpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2018 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -201,7 +201,7 @@ public class SftpClient extends FtpClient {
             String localFilePath = context.replaceDynamicContentInString(command.getFile().getPath());
             String remoteFilePath = addFileNameToTargetPath(localFilePath, context.replaceDynamicContentInString(command.getTarget().getPath()));
 
-            String dataType = context.replaceDynamicContentInString(Optional.ofNullable(command.getFile().getType()).orElseGet(() -> DataType.BINARY.name()));
+            String dataType = context.replaceDynamicContentInString(Optional.ofNullable(command.getFile().getType()).orElseGet(DataType.BINARY::name));
             try (InputStream localFileInputStream = getLocalFileInputStream(command.getFile().getPath(), dataType, context)) {
                 sftp.put(localFileInputStream, remoteFilePath);
             }

--- a/endpoints/citrus-ftp/src/main/java/org/citrusframework/ftp/server/FtpServer.java
+++ b/endpoints/citrus-ftp/src/main/java/org/citrusframework/ftp/server/FtpServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,7 +85,7 @@ public class FtpServer extends AbstractServer {
                 fileSystemFactory.setCreateHome(true);
                 serverFactory.setFileSystem(fileSystemFactory);
 
-                Map<String, Ftplet> ftpLets = new HashMap<String, Ftplet>();
+                Map<String, Ftplet> ftpLets = new HashMap<>();
                 ftpLets.put("citrusFtpLet", new FtpServerFtpLet(getEndpointConfiguration(), getEndpointAdapter()));
                 serverFactory.setFtplets(ftpLets);
 

--- a/endpoints/citrus-ftp/src/main/java/org/citrusframework/ftp/server/FtpServerFtpLet.java
+++ b/endpoints/citrus-ftp/src/main/java/org/citrusframework/ftp/server/FtpServerFtpLet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,8 @@ import org.apache.ftpserver.ftplet.FtpletResult;
 import org.apache.ftpserver.ftplet.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static java.lang.Integer.parseInt;
 
 /**
  * Ftp servlet implementation that logs incoming connections and commands forwarding those to
@@ -178,7 +180,7 @@ public class FtpServerFtpLet implements Ftplet {
     private void writeFtpReply(FtpSession session, FtpMessage response) {
         try {
             CommandResultType commandResult = response.getPayload(CommandResultType.class);
-            FtpReply reply = new DefaultFtpReply(Integer.valueOf(commandResult.getReplyCode()), commandResult.getReplyString());
+            FtpReply reply = new DefaultFtpReply(parseInt(commandResult.getReplyCode()), commandResult.getReplyString());
 
             session.write(reply);
         } catch (FtpException e) {

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/config/xml/HttpReceiveRequestActionParser.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/config/xml/HttpReceiveRequestActionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2015 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,8 @@ import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.http.HttpMethod;
 import org.springframework.util.xml.DomUtils;
 import org.w3c.dom.Element;
+
+import static java.lang.Boolean.parseBoolean;
 
 /**
  * @author Christoph Deppisch
@@ -113,7 +115,7 @@ public class HttpReceiveRequestActionParser extends ReceiveMessageActionParser {
                 httpMessage.cookie(new Cookie(cookie.getAttribute("name"), cookie.getAttribute("value")));
             }
 
-            boolean ignoreCase = headers.hasAttribute("ignore-case") ? Boolean.valueOf(headers.getAttribute("ignore-case")) : true;
+            boolean ignoreCase = !headers.hasAttribute("ignore-case") || parseBoolean(headers.getAttribute("ignore-case"));
             validationContexts.stream().filter(context -> context instanceof HeaderValidationContext)
                     .map(context -> (HeaderValidationContext) context)
                     .forEach(context -> context.setHeaderNameIgnoreCase(ignoreCase));

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/config/xml/HttpSendRequestActionParser.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/config/xml/HttpSendRequestActionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2015 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -151,7 +151,7 @@ public class HttpSendRequestActionParser extends SendMessageActionParser {
 
         builder.addPropertyValue("messageBuilder", httpMessageBuilder);
 
-        List<VariableExtractor> variableExtractors = new ArrayList<VariableExtractor>();
+        List<VariableExtractor> variableExtractors = new ArrayList<>();
         parseExtractHeaderElements(element, variableExtractors);
 
         if (!variableExtractors.isEmpty()) {

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/interceptor/LoggingHandlerInterceptor.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/interceptor/LoggingHandlerInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2012 the original author or authors.
+ * Copyright 2006-20242 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,8 @@ import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.ModelAndView;
 
+import static java.lang.System.lineSeparator;
+
 /**
  * Logging interceptor called by Spring MVC for each controller handling a RESTful Http request
  * as a server.
@@ -46,7 +48,7 @@ import org.springframework.web.servlet.ModelAndView;
 public class LoggingHandlerInterceptor implements HandlerInterceptor {
 
     /** New line characters in logger files */
-    private static final String NEWLINE = System.getProperty("line.separator");
+    private static final String NEWLINE = lineSeparator();
 
     /** Logger */
     private static final Logger logger = LoggerFactory.getLogger(LoggingHandlerInterceptor.class);
@@ -56,21 +58,18 @@ public class LoggingHandlerInterceptor implements HandlerInterceptor {
     private final TestContextFactory contextFactory = TestContextFactory.newInstance();
 
     @Override
-    public boolean preHandle(HttpServletRequest request,
-            HttpServletResponse response, Object handler) throws Exception {
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
         handleRequest(getRequestContent(request));
         return true;
     }
 
     @Override
-    public void postHandle(HttpServletRequest request,
-            HttpServletResponse response, Object handler, ModelAndView modelAndView) throws Exception {
+    public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, ModelAndView modelAndView) {
         handleResponse(getResponseContent(request, response, handler));
     }
 
     @Override
-    public void afterCompletion(HttpServletRequest request,
-            HttpServletResponse response, Object handler, Exception ex) throws Exception {
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) throws Exception {
     }
 
     /**
@@ -118,7 +117,7 @@ public class LoggingHandlerInterceptor implements HandlerInterceptor {
      * @throws IOException
      */
     private String getRequestContent(HttpServletRequest request) throws IOException {
-        StringBuilder builder = new StringBuilder();
+        var builder = new StringBuilder();
 
         builder.append(request.getProtocol());
         builder.append(" ");
@@ -165,14 +164,13 @@ public class LoggingHandlerInterceptor implements HandlerInterceptor {
      * @return the complete response data with headers and body content as String
      */
     private String getResponseContent(HttpServletRequest request, HttpServletResponse response, Object handler) {
-        StringBuilder builder = new StringBuilder();
+        var builder = new StringBuilder();
 
         builder.append(response);
 
-        if (handler instanceof HandlerMethod) {
-            HandlerMethod handlerMethod = (HandlerMethod) handler;
-            if (handlerMethod.getBean() instanceof HttpMessageController) {
-                ResponseEntity<?> responseEntity = ((HttpMessageController) handlerMethod.getBean()).getResponseCache(request);
+        if (handler instanceof HandlerMethod handlerMethod) {
+            if (handlerMethod.getBean() instanceof HttpMessageController httpMessageController) {
+                ResponseEntity<?> responseEntity = httpMessageController.getResponseCache(request);
                 if (responseEntity != null) {
                     builder.append(NEWLINE);
                     builder.append(responseEntity.getBody());

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/message/HttpMessage.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/message/HttpMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,8 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.web.bind.annotation.RequestMethod;
+
+import static java.lang.Integer.parseInt;
 
 /**
  * @author Christoph Deppisch
@@ -394,12 +396,12 @@ public class HttpMessage extends DefaultMessage {
         final Object statusCode = getHeader(HttpMessageHeaders.HTTP_STATUS_CODE);
 
         if (statusCode != null) {
-            if (statusCode instanceof HttpStatusCode) {
-                return (HttpStatusCode) statusCode;
-            } else if (statusCode instanceof Integer) {
-                return HttpStatusCode.valueOf((Integer) statusCode);
+            if (statusCode instanceof HttpStatusCode httpStatusCode) {
+                return httpStatusCode;
+            } else if (statusCode instanceof Integer integer) {
+                return HttpStatusCode.valueOf(integer);
             } else {
-                return HttpStatusCode.valueOf(Integer.valueOf(statusCode.toString()));
+                return HttpStatusCode.valueOf(parseInt(statusCode.toString()));
             }
         }
         return null;
@@ -543,7 +545,7 @@ public class HttpMessage extends DefaultMessage {
             }
 
             if (statusLine.length > 1) {
-                response.status(HttpStatusCode.valueOf(Integer.valueOf(statusLine[1])));
+                response.status(HttpStatusCode.valueOf(parseInt(statusLine[1])));
             }
 
             return parseHttpMessage(reader, response);

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/message/HttpMessageConverter.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/message/HttpMessageConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import jakarta.servlet.http.Cookie;
 import org.citrusframework.context.TestContext;
@@ -36,6 +35,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMethod;
+
+import static java.util.stream.Collectors.joining;
 
 /**
  * Message converter implementation able to convert HTTP request and response entities to internal message
@@ -151,9 +152,8 @@ public class HttpMessageConverter implements MessageConverter<HttpEntity<?>, Htt
         Map<String, Object> convertedHeaders = new HashMap<>();
 
         for (Map.Entry<String, Object> header : headers.entrySet()) {
-            if (header.getValue() instanceof Collection<?>) {
-                Collection<?> value = (Collection<?>)header.getValue();
-                convertedHeaders.put(header.getKey(), value.stream().map(String::valueOf).collect(Collectors.joining(",")));
+            if (header.getValue() instanceof Collection<?> value) {
+                convertedHeaders.put(header.getKey(), value.stream().map(String::valueOf).collect(joining(",")));
             } else if (header.getValue() instanceof MediaType) {
                 convertedHeaders.put(header.getKey(), header.getValue().toString());
             } else {

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/model/FormData.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/model/FormData.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2006-2016 the original author or authors.
+ *  Copyright 2006-2024 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -116,7 +116,7 @@ public class FormData {
     })
     public static class Controls {
         @XmlElement(name = "control", required = true)
-        protected List<Control> controls = new ArrayList<Control>();
+        protected List<Control> controls = new ArrayList<>();
 
         public List<Control> getControls() {
             return this.controls;

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/client/HttpClientTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/client/HttpClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package org.citrusframework.http.client;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
 import java.util.Random;
 
 import org.citrusframework.endpoint.resolver.EndpointUriResolver;
@@ -40,7 +39,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.client.HttpClientErrorException;
@@ -49,6 +47,7 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import static java.util.Collections.singletonList;
 import static org.mockito.Mockito.*;
 
 /**
@@ -157,7 +156,7 @@ public class HttpClientTest extends AbstractTestNGUnitTest {
         endpointConfiguration.setRestTemplate(restTemplate);
 
         StringHttpMessageConverter messageConverter = Mockito.mock(StringHttpMessageConverter.class);
-        when(restTemplate.getMessageConverters()).thenReturn(Collections.<HttpMessageConverter<?>>singletonList(messageConverter));
+        when(restTemplate.getMessageConverters()).thenReturn(singletonList(messageConverter));
 
         doAnswer((Answer<ResponseEntity>) invocation -> {
             HttpEntity<?> httpRequest = (HttpEntity<?>)invocation.getArguments()[2];

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/message/DelegatingHttpEntityMessageConverterTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/message/DelegatingHttpEntityMessageConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2018 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -99,30 +99,14 @@ public class DelegatingHttpEntityMessageConverterTest {
     @DataProvider
     public Object[][] writeProvider() {
         return new Object[][] {
-                new Object[] { "Hello Citrus!", (Consumer<ByteArrayOutputStream>) outStream -> {
-                    Assert.assertEquals(new String(outStream.toByteArray()), "Hello Citrus!");
-                }, MediaType.TEXT_PLAIN },
-                new Object[] { "{ \"message\": \"Hello Citrus!\" }", (Consumer<ByteArrayOutputStream>) outStream -> {
-                    Assert.assertEquals(new String(outStream.toByteArray()), "{ \"message\": \"Hello Citrus!\" }");
-                }, MediaType.APPLICATION_JSON },
-                new Object[] { "{ \"message\": \"Hello Citrus!\" }", (Consumer<ByteArrayOutputStream>) outStream -> {
-                    Assert.assertEquals(new String(outStream.toByteArray()), "{ \"message\": \"Hello Citrus!\" }");
-                }, MediaType.APPLICATION_JSON_UTF8 },
-                new Object[] { "<message>Hello Citrus!</message>", (Consumer<ByteArrayOutputStream>) outStream -> {
-                    Assert.assertEquals(new String(outStream.toByteArray()), "<message>Hello Citrus!</message>");
-                }, MediaType.APPLICATION_XML },
-                new Object[] { formData, (Consumer<ByteArrayOutputStream>) outStream -> {
-                    Assert.assertEquals(new String(outStream.toByteArray()), "message=Hello+Citrus%21&user=Leonard");
-                }, MediaType.APPLICATION_FORM_URLENCODED },
-                new Object[] { pdfData, (Consumer<ByteArrayOutputStream>) outStream -> {
-                    Assert.assertEquals(outStream.toByteArray(), pdfData);
-                }, MediaType.APPLICATION_PDF },
-                new Object[] { imageData, (Consumer<ByteArrayOutputStream>) outStream -> {
-                    Assert.assertEquals(outStream.toByteArray(), imageData);
-                }, MediaType.APPLICATION_OCTET_STREAM },
-                new Object[] { imageData, (Consumer<ByteArrayOutputStream>) outStream -> {
-                    Assert.assertEquals(outStream.toByteArray(), imageData);
-                }, MediaType.IMAGE_PNG }
+                new Object[] { "Hello Citrus!", (Consumer<ByteArrayOutputStream>) outStream -> Assert.assertEquals(new String(outStream.toByteArray()), "Hello Citrus!"), MediaType.TEXT_PLAIN },
+                new Object[] { "{ \"message\": \"Hello Citrus!\" }", (Consumer<ByteArrayOutputStream>) outStream -> Assert.assertEquals(new String(outStream.toByteArray()), "{ \"message\": \"Hello Citrus!\" }"), MediaType.APPLICATION_JSON },
+                new Object[] { "{ \"message\": \"Hello Citrus!\" }", (Consumer<ByteArrayOutputStream>) outStream -> Assert.assertEquals(new String(outStream.toByteArray()), "{ \"message\": \"Hello Citrus!\" }"), MediaType.APPLICATION_JSON_UTF8 },
+                new Object[] { "<message>Hello Citrus!</message>", (Consumer<ByteArrayOutputStream>) outStream -> Assert.assertEquals(new String(outStream.toByteArray()), "<message>Hello Citrus!</message>"), MediaType.APPLICATION_XML },
+                new Object[] { formData, (Consumer<ByteArrayOutputStream>) outStream -> Assert.assertEquals(new String(outStream.toByteArray()), "message=Hello+Citrus%21&user=Leonard"), MediaType.APPLICATION_FORM_URLENCODED },
+                new Object[] { pdfData, (Consumer<ByteArrayOutputStream>) outStream -> Assert.assertEquals(outStream.toByteArray(), pdfData), MediaType.APPLICATION_PDF },
+                new Object[] { imageData, (Consumer<ByteArrayOutputStream>) outStream -> Assert.assertEquals(outStream.toByteArray(), imageData), MediaType.APPLICATION_OCTET_STREAM },
+                new Object[] { imageData, (Consumer<ByteArrayOutputStream>) outStream -> Assert.assertEquals(outStream.toByteArray(), imageData), MediaType.IMAGE_PNG }
         };
     }
 }

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/validation/FormUrlEncodedMessageValidatorTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/validation/FormUrlEncodedMessageValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2006-2016 the original author or authors.
+ *  Copyright 2006-2024 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -45,18 +45,19 @@ public class FormUrlEncodedMessageValidatorTest extends AbstractTestNGUnitTest {
         return factory;
     }
 
-    private String expectedFormData = "<form-data xmlns=\"http://www.citrusframework.org/schema/http/message\">\n" +
-                "<content-type>application/x-www-form-urlencoded</content-type>\n" +
-                "<action>/form-test</action>\n" +
-                "<controls>\n" +
-                    "<control name=\"password\">\n" +
-                        "<value>s!cr!t</value>\n" +
-                    "</control>\n" +
-                    "<control name=\"username\">\n" +
-                        "<value>test</value>\n" +
-                    "</control>\n" +
-                "</controls>\n" +
-            "</form-data>";
+    private String expectedFormData = """
+            <form-data xmlns="http://www.citrusframework.org/schema/http/message">
+                <content-type>application/x-www-form-urlencoded</content-type>
+                <action>/form-test</action>
+                <controls>
+                    <control name="password">
+                        <value>s!cr!t</value>
+                    </control>
+                    <control name="username">
+                        <value>test</value>
+                    </control>
+                </controls>
+            </form-data>""";
 
     @Test
     public void testValidateMessagePayload() throws Exception {

--- a/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/config/xml/PurgeJmsQueuesActionParser.java
+++ b/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/config/xml/PurgeJmsQueuesActionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,8 +64,8 @@ public class PurgeJmsQueuesActionParser implements BeanDefinitionParser {
         BeanDefinitionParserUtils.setPropertyValue(beanDefinition, element.getAttribute("timeout"), "receiveTimeout");
         BeanDefinitionParserUtils.setPropertyValue(beanDefinition, element.getAttribute("sleep"), "sleepTime");
 
-        List<String> queueNames = new ArrayList<String>();
-        ManagedList<BeanDefinition> queueRefs = new ManagedList<BeanDefinition>();
+        List<String> queueNames = new ArrayList<>();
+        ManagedList<BeanDefinition> queueRefs = new ManagedList<>();
         List<Element> queueElements = DomUtils.getChildElementsByTagName(element, "queue");
         for (Element queue : queueElements) {
             String queueName = queue.getAttribute("name");

--- a/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/message/JmsMessageConverter.java
+++ b/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/message/JmsMessageConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2011 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,7 +88,7 @@ public class JmsMessageConverter implements MessageConverter<jakarta.jms.Message
                 ((BytesMessage) jmsMessage).readBytes(bytes);
                 payload = bytes;
             } else if (jmsMessage instanceof MapMessage) {
-                Map<String, Object> map = new HashMap<String, Object>();
+                Map<String, Object> map = new HashMap<>();
                 Enumeration en = ((MapMessage) jmsMessage).getMapNames();
                 while (en.hasMoreElements()) {
                     String key = (String) en.nextElement();
@@ -101,8 +101,7 @@ public class JmsMessageConverter implements MessageConverter<jakarta.jms.Message
                 payload = jmsMessage;
             }
 
-            if (payload instanceof Message) {
-                Message nestedMessage = (Message) payload;
+            if (payload instanceof Message nestedMessage) {
                 for (Map.Entry<String, Object> headerEntry : headers.entrySet()) {
                     if (!headerEntry.getKey().startsWith(org.citrusframework.message.MessageHeaders.MESSAGE_PREFIX)) {
                         nestedMessage.setHeader(headerEntry.getKey(), headerEntry.getValue());
@@ -152,7 +151,7 @@ public class JmsMessageConverter implements MessageConverter<jakarta.jms.Message
             } else if (payload instanceof Map) {
                 jmsMessage = session.createMapMessage();
                 Map<?, ?> map = ((Map) payload);
-                for (Map.Entry entry : map.entrySet()) {
+                for (var entry : map.entrySet()) {
                     if (!(entry.getKey() instanceof String)) {
                         throw new CitrusRuntimeException("Cannot convert non-String key of type [" + entry.getKey() + "] to JMS MapMessage entry");
                     }

--- a/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/actions/PurgeJmsQueuesActionTest.java
+++ b/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/actions/PurgeJmsQueuesActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -193,7 +193,7 @@ public class PurgeJmsQueuesActionTest extends AbstractTestNGUnitTest {
         List<String> queueNames = new ArrayList<>();
         queueNames.add("${variableQueueName}");
 
-        Map<String, Object> requestHeaders = new HashMap<String, Object>();
+        Map<String, Object> requestHeaders = new HashMap<>();
         TextMessage jmsRequest = new TextMessageImpl("<TestRequest>Hello World!</TestRequest>", requestHeaders);
 
         reset(connectionFactory, connection, session, messageConsumer);

--- a/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/endpoint/JmsEndpointAdapterTest.java
+++ b/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/endpoint/JmsEndpointAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,7 +72,7 @@ public class JmsEndpointAdapterTest extends AbstractTestNGUnitTest {
 
     @Test
     public void testEndpointAdapter() throws JMSException {
-        TextMessage jmsResponse = new TextMessageImpl("<TestResponse>Hello World!</TestResponse>", new HashMap<String, Object>());
+        TextMessage jmsResponse = new TextMessageImpl("<TestResponse>Hello World!</TestResponse>", new HashMap<>());
 
         reset(connectionFactory, connection, session, messageConsumer, messageProducer, tempReplyQueue);
 
@@ -87,14 +87,14 @@ public class JmsEndpointAdapterTest extends AbstractTestNGUnitTest {
         when(session.createProducer(destination)).thenReturn(messageProducer);
 
         when(session.createTextMessage("<TestMessage><text>Hi!</text></TestMessage>")).thenReturn(
-                new TextMessageImpl("<TestMessage><text>Hi!</text></TestMessage>", new HashMap<String, Object>()));
+                new TextMessageImpl("<TestMessage><text>Hi!</text></TestMessage>", new HashMap<>()));
 
 
         Message response = endpointAdapter.handleMessage(new DefaultMessage("<TestMessage><text>Hi!</text></TestMessage>"));
         Assert.assertNotNull(response);
         Assert.assertEquals(response.getPayload(String.class), "<TestResponse>Hello World!</TestResponse>");
 
-        verify(messageProducer).send((TextMessage)any());
+        verify(messageProducer).send(any());
         verify(connection).start();
         verify(tempReplyQueue).delete();
 
@@ -115,12 +115,12 @@ public class JmsEndpointAdapterTest extends AbstractTestNGUnitTest {
         when(session.createProducer(destination)).thenReturn(messageProducer);
 
         when(session.createTextMessage("<TestMessage><text>Hi!</text></TestMessage>")).thenReturn(
-                new TextMessageImpl("<TestMessage><text>Hi!</text></TestMessage>", new HashMap<String, Object>()));
+                new TextMessageImpl("<TestMessage><text>Hi!</text></TestMessage>", new HashMap<>()));
 
 
         Assert.assertNull(endpointAdapter.handleMessage(new DefaultMessage("<TestMessage><text>Hi!</text></TestMessage>")));
 
-        verify(messageProducer).send((TextMessage)any());
+        verify(messageProducer).send(any());
         verify(connection).start();
         verify(tempReplyQueue).delete();
     }

--- a/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/endpoint/JmsEndpointConsumerTest.java
+++ b/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/endpoint/JmsEndpointConsumerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ public class JmsEndpointConsumerTest extends AbstractTestNGUnitTest {
         JmsEndpoint endpoint = new JmsEndpoint();
         endpoint.getEndpointConfiguration().setJmsTemplate(jmsTemplate);
 
-        Map<String, Object> controlHeaders = new HashMap<String, Object>();
+        Map<String, Object> controlHeaders = new HashMap<>();
         final Message controlMessage = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>");
 
         reset(jmsTemplate, connectionFactory, destination);
@@ -84,7 +84,7 @@ public class JmsEndpointConsumerTest extends AbstractTestNGUnitTest {
 
         final Message controlMessage = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>");
 
-        Map<String, Object> headers = new HashMap<String, Object>();
+        Map<String, Object> headers = new HashMap<>();
 
         reset(jmsTemplate, connectionFactory, destination, connection, session, messageConsumer);
 
@@ -111,7 +111,7 @@ public class JmsEndpointConsumerTest extends AbstractTestNGUnitTest {
 
         final Message controlMessage = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>");
 
-        Map<String, Object> headers = new HashMap<String, Object>();
+        Map<String, Object> headers = new HashMap<>();
 
         reset(jmsTemplate, connectionFactory, destination, connection, session, messageConsumer);
 
@@ -168,7 +168,7 @@ public class JmsEndpointConsumerTest extends AbstractTestNGUnitTest {
 
         final Message controlMessage = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>");
 
-        Map<String, Object> headers = new HashMap<String, Object>();
+        Map<String, Object> headers = new HashMap<>();
 
         reset(jmsTemplate, connectionFactory, destination, connection, session, messageConsumer);
 
@@ -193,11 +193,11 @@ public class JmsEndpointConsumerTest extends AbstractTestNGUnitTest {
 
         endpoint.getEndpointConfiguration().setDestination(destination);
 
-        Map<String, Object> controlHeaders = new HashMap<String, Object>();
+        Map<String, Object> controlHeaders = new HashMap<>();
         controlHeaders.put("Operation", "sayHello");
         final Message controlMessage = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>", controlHeaders);
 
-        Map<String, Object> headers = new HashMap<String, Object>();
+        Map<String, Object> headers = new HashMap<>();
         headers.put("Operation", "sayHello");
 
         reset(jmsTemplate, connectionFactory, destination, connection, session, messageConsumer);
@@ -227,7 +227,7 @@ public class JmsEndpointConsumerTest extends AbstractTestNGUnitTest {
 
         final Message controlMessage = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>");
 
-        Map<String, Object> headers = new HashMap<String, Object>();
+        Map<String, Object> headers = new HashMap<>();
 
         reset(jmsTemplate, connectionFactory, destination, connection, session, messageConsumer);
 
@@ -255,7 +255,7 @@ public class JmsEndpointConsumerTest extends AbstractTestNGUnitTest {
 
         final Message controlMessage = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>");
 
-        Map<String, Object> headers = new HashMap<String, Object>();
+        Map<String, Object> headers = new HashMap<>();
 
         reset(jmsTemplate, connectionFactory, destination, connection, session, messageConsumer);
 

--- a/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/endpoint/JmsEndpointProducerTest.java
+++ b/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/endpoint/JmsEndpointProducerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,7 +84,7 @@ public class JmsEndpointProducerTest extends AbstractTestNGUnitTest {
         when(session.createProducer(destination)).thenReturn(messageProducer);
 
         when(session.createTextMessage("<TestRequest><Message>Hello World!</Message></TestRequest>")).thenReturn(
-                new TextMessageImpl("<TestRequest><Message>Hello World!</Message></TestRequest>", new HashMap<String, Object>()));
+                new TextMessageImpl("<TestRequest><Message>Hello World!</Message></TestRequest>", new HashMap<>()));
 
         when(session.getTransacted()).thenReturn(false);
 
@@ -110,7 +110,7 @@ public class JmsEndpointProducerTest extends AbstractTestNGUnitTest {
         when(session.createProducer(destinationQueue)).thenReturn(messageProducer);
 
         when(session.createTextMessage("<TestRequest><Message>Hello World!</Message></TestRequest>")).thenReturn(
-                new TextMessageImpl("<TestRequest><Message>Hello World!</Message></TestRequest>", new HashMap<String, Object>()));
+                new TextMessageImpl("<TestRequest><Message>Hello World!</Message></TestRequest>", new HashMap<>()));
 
         when(session.getTransacted()).thenReturn(false);
 
@@ -122,7 +122,7 @@ public class JmsEndpointProducerTest extends AbstractTestNGUnitTest {
     }
 
     @Test(expectedExceptions = CitrusRuntimeException.class, expectedExceptionsMessageRegExp = "Message is empty - unable to send empty message")
-    public void testSendEmptyMessage() throws JMSException {
+    public void testSendEmptyMessage() {
         JmsEndpoint endpoint = new JmsEndpoint();
         endpoint.getEndpointConfiguration().setConnectionFactory(connectionFactory);
 

--- a/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/endpoint/JmsEndpointSyncConsumerTest.java
+++ b/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/endpoint/JmsEndpointSyncConsumerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,7 +66,7 @@ public class JmsEndpointSyncConsumerTest extends AbstractTestNGUnitTest {
 
         final Message controlMessage = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>");
 
-        Map<String, Object> headers = new HashMap<String, Object>();
+        Map<String, Object> headers = new HashMap<>();
 
         reset(connectionFactory, destination, connection, session, messageConsumer);
 
@@ -105,7 +105,7 @@ public class JmsEndpointSyncConsumerTest extends AbstractTestNGUnitTest {
 
         final Message controlMessage = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>");
 
-        Map<String, Object> headers = new HashMap<String, Object>();
+        Map<String, Object> headers = new HashMap<>();
 
         reset(connectionFactory, destination, connection, session, messageConsumer);
 
@@ -165,7 +165,7 @@ public class JmsEndpointSyncConsumerTest extends AbstractTestNGUnitTest {
         when(session.createProducer(replyDestination)).thenReturn(messageProducer);
 
         when(session.createTextMessage("<TestRequest><Message>Hello World!</Message></TestRequest>")).thenReturn(
-                new TextMessageImpl("<TestRequest><Message>Hello World!</Message></TestRequest>", new HashMap<String, Object>()));
+                new TextMessageImpl("<TestRequest><Message>Hello World!</Message></TestRequest>", new HashMap<>()));
 
         when(session.getTransacted()).thenReturn(false);
 
@@ -191,7 +191,7 @@ public class JmsEndpointSyncConsumerTest extends AbstractTestNGUnitTest {
                 endpoint.getEndpointConfiguration().getCorrelator().getCorrelationKeyName(endpoint.createConsumer().getName()),
                 requestMessage.getId(), context);
 
-        Map<String, Object> headers = new HashMap<String, Object>();
+        Map<String, Object> headers = new HashMap<>();
         final Message message = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>", headers);
 
         reset(jmsTemplate, connectionFactory, messageProducer, connection, session);
@@ -202,7 +202,7 @@ public class JmsEndpointSyncConsumerTest extends AbstractTestNGUnitTest {
         when(session.createProducer(replyDestination)).thenReturn(messageProducer);
 
         when(session.createTextMessage("<TestRequest><Message>Hello World!</Message></TestRequest>")).thenReturn(
-                new TextMessageImpl("<TestRequest><Message>Hello World!</Message></TestRequest>", new HashMap<String, Object>()));
+                new TextMessageImpl("<TestRequest><Message>Hello World!</Message></TestRequest>", new HashMap<>()));
 
         when(session.getTransacted()).thenReturn(false);
 
@@ -229,7 +229,7 @@ public class JmsEndpointSyncConsumerTest extends AbstractTestNGUnitTest {
                 dummyEndpoint.getEndpointConfiguration().getCorrelator().getCorrelationKeyName(dummyEndpoint.createConsumer().getName()),
                 "123456789", context);
 
-        Map<String, Object> headers = new HashMap<String, Object>();
+        Map<String, Object> headers = new HashMap<>();
         final Message message = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>", headers);
 
         try {
@@ -279,7 +279,7 @@ public class JmsEndpointSyncConsumerTest extends AbstractTestNGUnitTest {
                 endpoint.getEndpointConfiguration().getCorrelator().getCorrelationKeyName(endpoint.createConsumer().getName()),
                 "123456789", context);
 
-        Map<String, Object> headers = new HashMap<String, Object>();
+        Map<String, Object> headers = new HashMap<>();
         final Message message = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>", headers);
 
         JmsSyncConsumer jmsSyncConsumer = (JmsSyncConsumer)endpoint.createConsumer();

--- a/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/endpoint/JmsEndpointSyncProducerTest.java
+++ b/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/endpoint/JmsEndpointSyncProducerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,7 +70,7 @@ public class JmsEndpointSyncProducerTest extends AbstractTestNGUnitTest {
 
         final Message message = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>");
 
-        Map<String, Object> responseHeaders = new HashMap<String, Object>();
+        Map<String, Object> responseHeaders = new HashMap<>();
         TextMessage jmsResponse = new TextMessageImpl("<TestResponse>Hello World!</TestResponse>", responseHeaders);
 
         reset(connectionFactory, destination, connection, session, messageConsumer, messageProducer);
@@ -84,7 +84,7 @@ public class JmsEndpointSyncProducerTest extends AbstractTestNGUnitTest {
         when(session.createProducer(destination)).thenReturn(messageProducer);
 
         when(session.createTextMessage("<TestRequest><Message>Hello World!</Message></TestRequest>")).thenReturn(
-                new TextMessageImpl("<TestRequest><Message>Hello World!</Message></TestRequest>", new HashMap<String, Object>()));
+                new TextMessageImpl("<TestRequest><Message>Hello World!</Message></TestRequest>", new HashMap<>()));
 
         endpoint.createProducer().send(message, context);
 
@@ -102,7 +102,7 @@ public class JmsEndpointSyncProducerTest extends AbstractTestNGUnitTest {
 
         final Message message = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>");
 
-        Map<String, Object> responseHeaders = new HashMap<String, Object>();
+        Map<String, Object> responseHeaders = new HashMap<>();
         TextMessage jmsResponse = new TextMessageImpl("<TestResponse>Hello World!</TestResponse>", responseHeaders);
 
         reset(connectionFactory, destination, connection, session, messageConsumer, messageProducer);
@@ -118,7 +118,7 @@ public class JmsEndpointSyncProducerTest extends AbstractTestNGUnitTest {
         when(session.createProducer(destinationQueue)).thenReturn(messageProducer);
 
         when(session.createTextMessage("<TestRequest><Message>Hello World!</Message></TestRequest>")).thenReturn(
-                new TextMessageImpl("<TestRequest><Message>Hello World!</Message></TestRequest>", new HashMap<String, Object>()));
+                new TextMessageImpl("<TestRequest><Message>Hello World!</Message></TestRequest>", new HashMap<>()));
 
         when(session.createQueue("myDestination")).thenReturn(destinationQueue);
 
@@ -137,7 +137,7 @@ public class JmsEndpointSyncProducerTest extends AbstractTestNGUnitTest {
 
         final Message message = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>");
 
-        Map<String, Object> responseHeaders = new HashMap<String, Object>();
+        Map<String, Object> responseHeaders = new HashMap<>();
         TextMessage jmsResponse = new TextMessageImpl("<TestResponse>Hello World!</TestResponse>", responseHeaders);
 
         reset(connectionFactory, destination, connection, session, messageConsumer, messageProducer, tempReplyQueue);
@@ -153,7 +153,7 @@ public class JmsEndpointSyncProducerTest extends AbstractTestNGUnitTest {
         when(session.createProducer(destination)).thenReturn(messageProducer);
 
         when(session.createTextMessage("<TestRequest><Message>Hello World!</Message></TestRequest>")).thenReturn(
-                new TextMessageImpl("<TestRequest><Message>Hello World!</Message></TestRequest>", new HashMap<String, Object>()));
+                new TextMessageImpl("<TestRequest><Message>Hello World!</Message></TestRequest>", new HashMap<>()));
 
         endpoint.createProducer().send(message, context);
 
@@ -173,7 +173,7 @@ public class JmsEndpointSyncProducerTest extends AbstractTestNGUnitTest {
 
         final Message message = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>");
 
-        Map<String, Object> responseHeaders = new HashMap<String, Object>();
+        Map<String, Object> responseHeaders = new HashMap<>();
         TextMessage jmsResponse = new TextMessageImpl("<TestResponse>Hello World!</TestResponse>", responseHeaders);
 
         reset(connectionFactory, destination, connection, session, messageConsumer, messageProducer);
@@ -187,7 +187,7 @@ public class JmsEndpointSyncProducerTest extends AbstractTestNGUnitTest {
         when(session.createProducer(destination)).thenReturn(messageProducer);
 
         when(session.createTextMessage("<TestRequest><Message>Hello World!</Message></TestRequest>")).thenReturn(
-                new TextMessageImpl("<TestRequest><Message>Hello World!</Message></TestRequest>", new HashMap<String, Object>()));
+                new TextMessageImpl("<TestRequest><Message>Hello World!</Message></TestRequest>", new HashMap<>()));
 
         endpoint.createProducer().send(message, context);
 
@@ -209,7 +209,7 @@ public class JmsEndpointSyncProducerTest extends AbstractTestNGUnitTest {
 
         final Message message = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>");
 
-        Map<String, Object> responseHeaders = new HashMap<String, Object>();
+        Map<String, Object> responseHeaders = new HashMap<>();
         TextMessage jmsResponse = new TextMessageImpl("<TestResponse>Hello World!</TestResponse>", responseHeaders);
 
         reset(connectionFactory, destination, connection, session, messageConsumer, messageProducer);
@@ -223,7 +223,7 @@ public class JmsEndpointSyncProducerTest extends AbstractTestNGUnitTest {
         when(session.createProducer(destination)).thenReturn(messageProducer);
 
         when(session.createTextMessage("<TestRequest><Message>Hello World!</Message></TestRequest>")).thenReturn(
-                new TextMessageImpl("<TestRequest><Message>Hello World!</Message></TestRequest>", new HashMap<String, Object>()));
+                new TextMessageImpl("<TestRequest><Message>Hello World!</Message></TestRequest>", new HashMap<>()));
 
         endpoint.createProducer().send(message, context);
 
@@ -275,7 +275,7 @@ public class JmsEndpointSyncProducerTest extends AbstractTestNGUnitTest {
 
         JmsSyncEndpoint endpoint = new JmsSyncEndpoint();
 
-        ((JmsSyncProducer)endpoint.createProducer()).getCorrelationManager().setObjectStore(new ObjectStore<Message>() {
+        ((JmsSyncProducer) endpoint.createProducer()).getCorrelationManager().setObjectStore(new ObjectStore<>() {
             @Override
             public void add(String correlationKey, Message object) {
             }
@@ -308,7 +308,7 @@ public class JmsEndpointSyncProducerTest extends AbstractTestNGUnitTest {
         JmsSyncEndpoint endpoint = new JmsSyncEndpoint();
         endpoint.getEndpointConfiguration().setPollingInterval(300L);
 
-        ((JmsSyncProducer)endpoint.createProducer()).getCorrelationManager().setObjectStore(new ObjectStore<Message>() {
+        ((JmsSyncProducer) endpoint.createProducer()).getCorrelationManager().setObjectStore(new ObjectStore<>() {
             @Override
             public void add(String correlationKey, Message object) {
             }
@@ -342,7 +342,7 @@ public class JmsEndpointSyncProducerTest extends AbstractTestNGUnitTest {
         JmsSyncEndpoint endpoint = new JmsSyncEndpoint();
         endpoint.getEndpointConfiguration().setPollingInterval(1000L);
 
-        ((JmsSyncProducer)endpoint.createProducer()).getCorrelationManager().setObjectStore(new ObjectStore<Message>() {
+        ((JmsSyncProducer) endpoint.createProducer()).getCorrelationManager().setObjectStore(new ObjectStore<>() {
             @Override
             public void add(String correlationKey, Message object) {
             }
@@ -375,7 +375,7 @@ public class JmsEndpointSyncProducerTest extends AbstractTestNGUnitTest {
         JmsSyncEndpoint endpoint = new JmsSyncEndpoint();
         endpoint.getEndpointConfiguration().setPollingInterval(1000L);
 
-        ((JmsSyncProducer)endpoint.createProducer()).getCorrelationManager().setObjectStore(new ObjectStore<Message>() {
+        ((JmsSyncProducer) endpoint.createProducer()).getCorrelationManager().setObjectStore(new ObjectStore<>() {
             @Override
             public void add(String correlationKey, Message object) {
             }

--- a/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/endpoint/TextMessageImpl.java
+++ b/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/endpoint/TextMessageImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,74 +16,208 @@
 
 package org.citrusframework.jms.endpoint;
 
-import jakarta.jms.*;
-import java.util.*;
+import jakarta.jms.Destination;
+import jakarta.jms.TextMessage;
+
+import java.util.Enumeration;
+import java.util.Map;
+import java.util.Vector;
 
 /**
  * @author Christoph Deppisch
  */
 public class TextMessageImpl implements TextMessage {
     private String payload;
-    
+
     private Destination replyDestination = null;
-    
-    private Map<String, Object> headers;
-    
+
+    private final Map<String, Object> headers;
+
     public TextMessageImpl(String payload, Map<String, Object> headers) {
         this.payload = payload;
         this.headers = headers;
     }
-    
-    public void setStringProperty(String name, String value) throws JMSException {headers.put(name, value);}
-    public void setShortProperty(String name, short value) throws JMSException {}
-    public void setObjectProperty(String name, Object value) throws JMSException {}
-    public void setLongProperty(String name, long value) throws JMSException {}
-    public void setJMSType(String type) throws JMSException {}
-    public void setJMSTimestamp(long timestamp) throws JMSException {}
-    public void setJMSReplyTo(Destination replyTo) throws JMSException {this.replyDestination=replyTo;}
-    public void setJMSRedelivered(boolean redelivered) throws JMSException {}
-    public void setJMSPriority(int priority) throws JMSException {}
-    public void setJMSMessageID(String id) throws JMSException {}
-    public void setJMSExpiration(long expiration) throws JMSException {}
-    public long getJMSDeliveryTime() throws JMSException { return 0; }
-    public void setJMSDeliveryTime(long deliveryTime) throws JMSException {}
-    public void setJMSDestination(Destination destination) throws JMSException {}
-    public void setJMSDeliveryMode(int deliveryMode) throws JMSException {}
-    public void setJMSCorrelationIDAsBytes(byte[] correlationID) throws JMSException {}
-    public void setJMSCorrelationID(String correlationID) throws JMSException {}
-    public void setIntProperty(String name, int value) throws JMSException {}
-    public void setFloatProperty(String name, float value) throws JMSException {}
-    public void setDoubleProperty(String name, double value) throws JMSException {}
-    public void setByteProperty(String name, byte value) throws JMSException {}
-    public void setBooleanProperty(String name, boolean value) throws JMSException {}
-    public boolean propertyExists(String name) throws JMSException {return false;}
-    public String getStringProperty(String name) throws JMSException {return headers.get(name).toString();}
-    public short getShortProperty(String name) throws JMSException {return 0;}
+
+    public void setStringProperty(String name, String value) {
+        headers.put(name, value);
+    }
+
+    public void setShortProperty(String name, short value) {
+    }
+
+    public void setObjectProperty(String name, Object value) {
+    }
+
+    public void setLongProperty(String name, long value) {
+    }
+
+    public long getJMSDeliveryTime() {
+        return 0;
+    }
+
+    public void setJMSDeliveryTime(long deliveryTime) {
+    }
+
+    public void setIntProperty(String name, int value) {
+    }
+
+    public void setFloatProperty(String name, float value) {
+    }
+
+    public void setDoubleProperty(String name, double value) {
+    }
+
+    public void setByteProperty(String name, byte value) {
+    }
+
+    public void setBooleanProperty(String name, boolean value) {
+    }
+
+    public boolean propertyExists(String name) {
+        return false;
+    }
+
+    public String getStringProperty(String name) {
+        return headers.get(name).toString();
+    }
+
+    public short getShortProperty(String name) {
+        return 0;
+    }
+
     @SuppressWarnings("rawtypes")
-    public Enumeration getPropertyNames() throws JMSException {return new Vector<String>(headers.keySet()).elements();}
-    public Object getObjectProperty(String name) throws JMSException {return headers.get(name);}
-    public long getLongProperty(String name) throws JMSException {return 0;}
-    public String getJMSType() throws JMSException {return null;}
-    public long getJMSTimestamp() throws JMSException {return 0;}
-    public Destination getJMSReplyTo() throws JMSException {return replyDestination;}
-    public boolean getJMSRedelivered() throws JMSException {return false;}
-    public int getJMSPriority() throws JMSException {return 0;}
-    public String getJMSMessageID() throws JMSException {return "123456789";}
-    public long getJMSExpiration() throws JMSException {return 0;}
-    public Destination getJMSDestination() throws JMSException {return null;}
-    public int getJMSDeliveryMode() throws JMSException {return 0;}
-    public byte[] getJMSCorrelationIDAsBytes() throws JMSException {return null;}
-    public String getJMSCorrelationID() throws JMSException {return null;}
-    public int getIntProperty(String name) throws JMSException {return 0;}
-    public float getFloatProperty(String name) throws JMSException {return 0;}
-    public double getDoubleProperty(String name) throws JMSException {return 0;}
-    public byte getByteProperty(String name) throws JMSException {return 0;}
-    public boolean getBooleanProperty(String name) throws JMSException {return false;}
-    public void clearProperties() throws JMSException {}
-    public void clearBody() throws JMSException {}
-    public <T> T getBody(Class<T> c) throws JMSException { return (T) payload; }
-    public boolean isBodyAssignableTo(Class c) throws JMSException { return true; }
-    public void acknowledge() throws JMSException {}
-    public void setText(String string) throws JMSException {this.payload = string;}
-    public String getText() throws JMSException {return payload;}
+    public Enumeration getPropertyNames() {
+        return new Vector<>(headers.keySet()).elements();
+    }
+
+    public Object getObjectProperty(String name) {
+        return headers.get(name);
+    }
+
+    public long getLongProperty(String name) {
+        return 0;
+    }
+
+    public String getJMSType() {
+        return null;
+    }
+
+    public void setJMSType(String type) {
+    }
+
+    public long getJMSTimestamp() {
+        return 0;
+    }
+
+    public void setJMSTimestamp(long timestamp) {
+    }
+
+    public Destination getJMSReplyTo() {
+        return replyDestination;
+    }
+
+    public void setJMSReplyTo(Destination replyTo) {
+        this.replyDestination = replyTo;
+    }
+
+    public boolean getJMSRedelivered() {
+        return false;
+    }
+
+    public void setJMSRedelivered(boolean redelivered) {
+    }
+
+    public int getJMSPriority() {
+        return 0;
+    }
+
+    public void setJMSPriority(int priority) {
+    }
+
+    public String getJMSMessageID() {
+        return "123456789";
+    }
+
+    public void setJMSMessageID(String id) {
+    }
+
+    public long getJMSExpiration() {
+        return 0;
+    }
+
+    public void setJMSExpiration(long expiration) {
+    }
+
+    public Destination getJMSDestination() {
+        return null;
+    }
+
+    public void setJMSDestination(Destination destination) {
+    }
+
+    public int getJMSDeliveryMode() {
+        return 0;
+    }
+
+    public void setJMSDeliveryMode(int deliveryMode) {
+    }
+
+    public byte[] getJMSCorrelationIDAsBytes() {
+        return null;
+    }
+
+    public void setJMSCorrelationIDAsBytes(byte[] correlationID) {
+    }
+
+    public String getJMSCorrelationID() {
+        return null;
+    }
+
+    public void setJMSCorrelationID(String correlationID) {
+    }
+
+    public int getIntProperty(String name) {
+        return 0;
+    }
+
+    public float getFloatProperty(String name) {
+        return 0;
+    }
+
+    public double getDoubleProperty(String name) {
+        return 0;
+    }
+
+    public byte getByteProperty(String name) {
+        return 0;
+    }
+
+    public boolean getBooleanProperty(String name) {
+        return false;
+    }
+
+    public void clearProperties() {
+    }
+
+    public void clearBody() {
+    }
+
+    public <T> T getBody(Class<T> c) {
+        return (T) payload;
+    }
+
+    public boolean isBodyAssignableTo(Class c) {
+        return true;
+    }
+
+    public void acknowledge() {
+    }
+
+    public String getText() {
+        return payload;
+    }
+
+    public void setText(String string) {
+        this.payload = string;
+    }
 }

--- a/endpoints/citrus-jmx/src/main/java/org/citrusframework/jmx/model/ManagedBeanInvocation.java
+++ b/endpoints/citrus-jmx/src/main/java/org/citrusframework/jmx/model/ManagedBeanInvocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2016 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -553,7 +553,7 @@ public class ManagedBeanInvocation {
 
         public List<OperationParam> getParameter() {
             if (parameter == null) {
-                parameter = new ArrayList<OperationParam>();
+                parameter = new ArrayList<>();
             }
             return this.parameter;
         }

--- a/endpoints/citrus-mail/src/main/java/org/citrusframework/mail/client/MailEndpointComponent.java
+++ b/endpoints/citrus-mail/src/main/java/org/citrusframework/mail/client/MailEndpointComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@ import java.util.StringTokenizer;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.endpoint.AbstractEndpointComponent;
 import org.citrusframework.endpoint.Endpoint;
+
+import static java.lang.Integer.parseInt;
 
 /**
  * Component creates proper mail client from endpoint uri resource and parameters.
@@ -48,7 +50,7 @@ public class MailEndpointComponent extends AbstractEndpointComponent {
             client.getEndpointConfiguration().setHost(tok.nextToken());
 
             if (tok.hasMoreTokens()) {
-                client.getEndpointConfiguration().setPort(Integer.valueOf(tok.nextToken()));
+                client.getEndpointConfiguration().setPort(parseInt(tok.nextToken()));
             }
         } else {
             client.getEndpointConfiguration().setHost(resourcePath);

--- a/endpoints/citrus-rmi/src/main/java/org/citrusframework/rmi/model/RmiServiceInvocation.java
+++ b/endpoints/citrus-rmi/src/main/java/org/citrusframework/rmi/model/RmiServiceInvocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2015 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -248,7 +248,7 @@ public class RmiServiceInvocation {
 
         public List<MethodArg> getArgs() {
             if (args == null) {
-                args = new ArrayList<MethodArg>();
+                args = new ArrayList<>();
             }
             return this.args;
         }

--- a/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/channel/ChannelConsumer.java
+++ b/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/channel/ChannelConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,13 +71,11 @@ public class ChannelConsumer extends AbstractSelectiveMessageConsumer {
 
         Message message;
         if (StringUtils.hasText(selector)) {
-            if (!(destinationChannel instanceof MessageSelectingQueueChannel)) {
-                throw new CitrusRuntimeException("Message channel type '" + endpointConfiguration.getChannel().getClass() +
-                        "' does not support selective receive operations.");
+            if (!(destinationChannel instanceof MessageSelectingQueueChannel queueChannel)) {
+                throw new CitrusRuntimeException("Message channel type '" + endpointConfiguration.getChannel().getClass() + "' does not support selective receive operations.");
             }
 
             MessageSelector messageSelector = new DispatchingMessageSelector(selector, endpointConfiguration.getBeanFactory(), context);
-            MessageSelectingQueueChannel queueChannel = ((MessageSelectingQueueChannel) destinationChannel);
 
             if (timeout <= 0) {
                 message = endpointConfiguration.getMessageConverter().convertInbound(queueChannel.receive(messageSelector), endpointConfiguration, context);

--- a/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/channel/ChannelMessageConverter.java
+++ b/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/channel/ChannelMessageConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,16 +41,14 @@ public class ChannelMessageConverter implements MessageConverter<org.springframe
         }
 
         Map<String, Object> headers = new LinkedHashMap<>();
-        for (Map.Entry<String, Object> headerEntry: internalMessage.getHeaders().entrySet()) {
+        for (var headerEntry : internalMessage.getHeaders().entrySet()) {
             if (endpointConfiguration.isFilterInternalHeaders()) {
                 if (!headerEntry.getKey().startsWith(MessageHeaders.PREFIX)) {
                     headers.put(headerEntry.getKey(), headerEntry.getValue());
                 }
-            } else {
-                if (!headerEntry.getKey().equals(org.citrusframework.message.MessageHeaders.ID)
-                        && !headerEntry.getKey().equals(org.citrusframework.message.MessageHeaders.TIMESTAMP)) {
-                    headers.put(headerEntry.getKey(), headerEntry.getValue());
-                }
+            } else if (!headerEntry.getKey().equals(org.citrusframework.message.MessageHeaders.ID)
+                    && !headerEntry.getKey().equals(org.citrusframework.message.MessageHeaders.TIMESTAMP)) {
+                headers.put(headerEntry.getKey(), headerEntry.getValue());
             }
         }
 
@@ -68,10 +66,8 @@ public class ChannelMessageConverter implements MessageConverter<org.springframe
         Map<String, Object> messageHeaders = new LinkedHashMap<>(externalMessage.getHeaders());
 
         Object payload = externalMessage.getPayload();
-        if (payload instanceof Message) {
-            Message nestedMessage = (Message) payload;
-
-            for (Map.Entry<String, Object> headerEntry : messageHeaders.entrySet()) {
+        if (payload instanceof Message nestedMessage) {
+            for (var headerEntry : messageHeaders.entrySet()) {
                 if (endpointConfiguration.isFilterInternalHeaders()) {
                     if (!headerEntry.getKey().startsWith(MessageHeaders.PREFIX)) {
                         nestedMessage.setHeader(headerEntry.getKey(), headerEntry.getValue());

--- a/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/config/xml/PurgeMessageChannelActionParser.java
+++ b/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/config/xml/PurgeMessageChannelActionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2012 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,8 +55,8 @@ public class PurgeMessageChannelActionParser implements BeanDefinitionParser {
             BeanDefinitionParserUtils.setPropertyReference(beanDefinition, element.getAttribute("message-selector"), "messageSelector");
         }
 
-        List<String> channelNames = new ArrayList<String>();
-        ManagedList<BeanDefinition> channelRefs = new ManagedList<BeanDefinition>();
+        List<String> channelNames = new ArrayList<>();
+        ManagedList<BeanDefinition> channelRefs = new ManagedList<>();
         List<Element> channelElements = DomUtils.getChildElementsByTagName(element, "channel");
         for (Element channel : channelElements) {
             String channelName = channel.getAttribute("name");

--- a/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/channel/ChannelEndpointConsumerTest.java
+++ b/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/channel/ChannelEndpointConsumerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ public class ChannelEndpointConsumerTest extends AbstractTestNGUnitTest {
 
         endpoint.getEndpointConfiguration().setChannel(channel);
 
-        Map<String, Object> headers = new HashMap<String, Object>();
+        Map<String, Object> headers = new HashMap<>();
         final org.springframework.messaging.Message message = MessageBuilder.withPayload("<TestRequest><Message>Hello World!</Message></TestRequest>")
                                 .copyHeaders(headers)
                                 .build();
@@ -85,7 +85,7 @@ public class ChannelEndpointConsumerTest extends AbstractTestNGUnitTest {
 
         endpoint.getEndpointConfiguration().setChannelResolver(channelResolver);
 
-        Map<String, Object> headers = new HashMap<String, Object>();
+        Map<String, Object> headers = new HashMap<>();
         final org.springframework.messaging.Message message = MessageBuilder.withPayload("<TestRequest><Message>Hello World!</Message></TestRequest>")
                                 .copyHeaders(headers)
                                 .build();
@@ -113,7 +113,7 @@ public class ChannelEndpointConsumerTest extends AbstractTestNGUnitTest {
         endpoint.getEndpointConfiguration().setChannel(channel);
         endpoint.getEndpointConfiguration().setTimeout(10000L);
 
-        Map<String, Object> headers = new HashMap<String, Object>();
+        Map<String, Object> headers = new HashMap<>();
         final org.springframework.messaging.Message message = MessageBuilder.withPayload("<TestRequest><Message>Hello World!</Message></TestRequest>")
                                 .copyHeaders(headers)
                                 .build();
@@ -138,7 +138,7 @@ public class ChannelEndpointConsumerTest extends AbstractTestNGUnitTest {
         endpoint.getEndpointConfiguration().setChannel(channel);
         endpoint.getEndpointConfiguration().setTimeout(10000L);
 
-        Map<String, Object> headers = new HashMap<String, Object>();
+        Map<String, Object> headers = new HashMap<>();
         final org.springframework.messaging.Message message = MessageBuilder.withPayload("<TestRequest><Message>Hello World!</Message></TestRequest>")
                                 .copyHeaders(headers)
                                 .build();

--- a/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/channel/ChannelEndpointSyncConsumerTest.java
+++ b/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/channel/ChannelEndpointSyncConsumerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,8 +29,6 @@ import org.citrusframework.message.MessageCorrelator;
 import org.citrusframework.message.MessageHeaders;
 import org.citrusframework.testng.AbstractTestNGUnitTest;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.springframework.integration.core.MessagingTemplate;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.MessageChannel;
@@ -70,7 +68,7 @@ public class ChannelEndpointSyncConsumerTest extends AbstractTestNGUnitTest {
         endpoint.getEndpointConfiguration().setMessagingTemplate(messagingTemplate);
         endpoint.getEndpointConfiguration().setChannel(channel);
 
-        Map<String, Object> headers = new HashMap<String, Object>();
+        Map<String, Object> headers = new HashMap<>();
         final org.springframework.messaging.Message message = MessageBuilder.withPayload("<TestResponse>Hello World!</TestResponse>")
                                 .copyHeaders(headers)
                                 .setReplyChannel(replyChannel)
@@ -104,7 +102,7 @@ public class ChannelEndpointSyncConsumerTest extends AbstractTestNGUnitTest {
 
         endpoint.getEndpointConfiguration().setChannelResolver(channelResolver);
 
-        Map<String, Object> headers = new HashMap<String, Object>();
+        Map<String, Object> headers = new HashMap<>();
         final org.springframework.messaging.Message message = MessageBuilder.withPayload("<TestResponse>Hello World!</TestResponse>")
                                 .copyHeaders(headers)
                                 .setReplyChannel(replyChannel)
@@ -175,7 +173,7 @@ public class ChannelEndpointSyncConsumerTest extends AbstractTestNGUnitTest {
 
         endpoint.getEndpointConfiguration().setTimeout(10000L);
 
-        Map<String, Object> headers = new HashMap<String, Object>();
+        Map<String, Object> headers = new HashMap<>();
         final org.springframework.messaging.Message message = MessageBuilder.withPayload("<TestResponse>Hello World!</TestResponse>")
                                 .copyHeaders(headers)
                                 .setReplyChannel(replyChannel)
@@ -211,7 +209,7 @@ public class ChannelEndpointSyncConsumerTest extends AbstractTestNGUnitTest {
         endpoint.getEndpointConfiguration().setTimeout(500L);
         endpoint.getEndpointConfiguration().setPollingInterval(100);
 
-        Map<String, Object> headers = new HashMap<String, Object>();
+        Map<String, Object> headers = new HashMap<>();
         final org.springframework.messaging.Message message = MessageBuilder.withPayload("<TestResponse>Hello World!</TestResponse>")
                                 .copyHeaders(headers)
                                 .setReplyChannel(replyChannel)
@@ -275,7 +273,7 @@ public class ChannelEndpointSyncConsumerTest extends AbstractTestNGUnitTest {
         endpoint.getEndpointConfiguration().setTimeout(500L);
         endpoint.getEndpointConfiguration().setPollingInterval(150L);
 
-        Map<String, Object> headers = new HashMap<String, Object>();
+        Map<String, Object> headers = new HashMap<>();
         final org.springframework.messaging.Message message = MessageBuilder.withPayload("<TestResponse>Hello World!</TestResponse>")
                                 .copyHeaders(headers)
                                 .build();
@@ -326,17 +324,14 @@ public class ChannelEndpointSyncConsumerTest extends AbstractTestNGUnitTest {
                 endpoint.getEndpointConfiguration().getCorrelator().getCorrelationKeyName(endpoint.createConsumer().getName()),
                 request.getId(), context);
 
-        Map<String, Object> headers = new HashMap<String, Object>();
+        Map<String, Object> headers = new HashMap<>();
         final Message message = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>", headers);
 
         reset(messagingTemplate, replyChannel);
 
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                Assert.assertEquals(((GenericMessage)invocation.getArguments()[1]).getPayload(), message.getPayload());
-                return null;
-            }
+        doAnswer(invocation -> {
+            Assert.assertEquals(((GenericMessage)invocation.getArguments()[1]).getPayload(), message.getPayload());
+            return null;
         }).when(messagingTemplate).send(eq(replyChannel), any(org.springframework.messaging.Message.class));
 
         ChannelSyncConsumer channelSyncConsumer = (ChannelSyncConsumer) endpoint.createConsumer();
@@ -380,7 +375,7 @@ public class ChannelEndpointSyncConsumerTest extends AbstractTestNGUnitTest {
                 dummyEndpoint.getEndpointConfiguration().getCorrelator().getCorrelationKeyName(dummyEndpoint.createConsumer().getName()),
                 "123456789", context);
 
-        Map<String, Object> headers = new HashMap<String, Object>();
+        Map<String, Object> headers = new HashMap<>();
         final Message message = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>", headers);
 
         try {
@@ -408,7 +403,7 @@ public class ChannelEndpointSyncConsumerTest extends AbstractTestNGUnitTest {
                 endpoint.getEndpointConfiguration().getCorrelator().getCorrelationKeyName(endpoint.createConsumer().getName()),
                 "123456789", context);
 
-        Map<String, Object> headers = new HashMap<String, Object>();
+        Map<String, Object> headers = new HashMap<>();
         final Message message = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>", headers);
 
         ChannelSyncConsumer channelSyncConsumer = (ChannelSyncConsumer) endpoint.createConsumer();

--- a/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/channel/ChannelEndpointSyncProducerTest.java
+++ b/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/channel/ChannelEndpointSyncProducerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ public class ChannelEndpointSyncProducerTest extends AbstractTestNGUnitTest {
 
         final Message message = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>");
 
-        Map<String, Object> responseHeaders = new HashMap<String, Object>();
+        Map<String, Object> responseHeaders = new HashMap<>();
         final org.springframework.messaging.Message response = MessageBuilder.withPayload("<TestResponse>Hello World!</TestResponse>")
                                 .copyHeaders(responseHeaders)
                                 .build();
@@ -84,7 +84,7 @@ public class ChannelEndpointSyncProducerTest extends AbstractTestNGUnitTest {
 
         final Message message = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>");
 
-        Map<String, Object> responseHeaders = new HashMap<String, Object>();
+        Map<String, Object> responseHeaders = new HashMap<>();
         final org.springframework.messaging.Message response = MessageBuilder.withPayload("<TestResponse>Hello World!</TestResponse>")
                                 .copyHeaders(responseHeaders)
                                 .build();
@@ -108,7 +108,7 @@ public class ChannelEndpointSyncProducerTest extends AbstractTestNGUnitTest {
 
         final Message message = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>");
 
-        Map<String, Object> responseHeaders = new HashMap<String, Object>();
+        Map<String, Object> responseHeaders = new HashMap<>();
         final org.springframework.messaging.Message response = MessageBuilder.withPayload("<TestResponse>Hello World!</TestResponse>")
                                 .copyHeaders(responseHeaders)
                                 .build();
@@ -139,7 +139,7 @@ public class ChannelEndpointSyncProducerTest extends AbstractTestNGUnitTest {
 
         final Message message = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>");
 
-        Map<String, Object> responseHeaders = new HashMap<String, Object>();
+        Map<String, Object> responseHeaders = new HashMap<>();
         final org.springframework.messaging.Message response = MessageBuilder.withPayload("<TestResponse>Hello World!</TestResponse>")
                                 .copyHeaders(responseHeaders)
                                 .build();
@@ -168,7 +168,7 @@ public class ChannelEndpointSyncProducerTest extends AbstractTestNGUnitTest {
 
         final Message message = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>");
 
-        Map<String, Object> responseHeaders = new HashMap<String, Object>();
+        Map<String, Object> responseHeaders = new HashMap<>();
         final org.springframework.messaging.Message response = MessageBuilder.withPayload("<TestResponse>Hello World!</TestResponse>")
                                 .copyHeaders(responseHeaders)
                                 .build();

--- a/endpoints/citrus-ssh/src/main/java/org/citrusframework/ssh/client/SshClient.java
+++ b/endpoints/citrus-ssh/src/main/java/org/citrusframework/ssh/client/SshClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 
 import com.jcraft.jsch.ChannelExec;
 import com.jcraft.jsch.JSch;
@@ -229,20 +228,10 @@ public class SshClient extends AbstractEndpoint implements Producer, ReplyConsum
     }
 
     private void sendStandardInput(ChannelExec pCh, String pInput) {
-        OutputStream os = null;
-        try {
-            os = pCh.getOutputStream();
+        try (var os = pCh.getOutputStream()) {
             os.write(pInput.getBytes());
         } catch (IOException e) {
-            throw new CitrusRuntimeException("Cannot write to standard input of SSH channel: " + e,e);
-        } finally {
-            if (os != null) {
-                try {
-                    os.close();
-                } catch (IOException e) {
-                    // best try
-                }
-            }
+            throw new CitrusRuntimeException("Cannot write to standard input of SSH channel: " + e, e);
         }
     }
 

--- a/endpoints/citrus-ssh/src/main/java/org/citrusframework/ssh/client/SshEndpointComponent.java
+++ b/endpoints/citrus-ssh/src/main/java/org/citrusframework/ssh/client/SshEndpointComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@ import java.util.StringTokenizer;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.endpoint.AbstractEndpointComponent;
 import org.citrusframework.endpoint.Endpoint;
+
+import static java.lang.Integer.parseInt;
 
 /**
  * Component creates proper ssh client from endpoint uri resource and parameters.
@@ -48,7 +50,7 @@ public class SshEndpointComponent extends AbstractEndpointComponent {
             client.getEndpointConfiguration().setHost(tok.nextToken());
 
             if (tok.hasMoreTokens()) {
-                client.getEndpointConfiguration().setPort(Integer.valueOf(tok.nextToken()));
+                client.getEndpointConfiguration().setPort(parseInt(tok.nextToken()));
             }
         } else {
             client.getEndpointConfiguration().setHost(resourcePath);

--- a/endpoints/citrus-ssh/src/main/java/org/citrusframework/ssh/server/SinglePublicKeyAuthenticator.java
+++ b/endpoints/citrus-ssh/src/main/java/org/citrusframework/ssh/server/SinglePublicKeyAuthenticator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2012 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,17 +83,15 @@ class SinglePublicKeyAuthenticator implements PublickeyAuthenticator {
      * @return
      */
     private PublicKey readKey(InputStream is) {
-        try (InputStreamReader isr = new InputStreamReader(is);
-             PEMParser r = new PEMParser(isr)) {
-            Object o = r.readObject();
-            if (o instanceof PEMKeyPair) {
-                PEMKeyPair keyPair = (PEMKeyPair) o;
-                if (keyPair.getPublicKeyInfo() != null &&
-                        keyPair.getPublicKeyInfo().getEncoded().length > 0) {
+        try (InputStreamReader inputStreamReader = new InputStreamReader(is); PEMParser pemParser = new PEMParser(inputStreamReader)) {
+            Object o = pemParser.readObject();
+            if (o instanceof PEMKeyPair keyPair) {
+                if (keyPair.getPublicKeyInfo() != null
+                        && keyPair.getPublicKeyInfo().getEncoded().length > 0) {
                     return BouncyCastleProvider.getPublicKey(keyPair.getPublicKeyInfo());
                 }
-            } else if (o instanceof SubjectPublicKeyInfo) {
-                return BouncyCastleProvider.getPublicKey((SubjectPublicKeyInfo) o);
+            } else if (o instanceof SubjectPublicKeyInfo subjectPublicKeyInfo) {
+                return BouncyCastleProvider.getPublicKey(subjectPublicKeyInfo);
             }
         } catch (IOException e) {
             // Ignoring, returning null
@@ -102,5 +100,4 @@ class SinglePublicKeyAuthenticator implements PublickeyAuthenticator {
 
         return null;
     }
-
 }

--- a/endpoints/citrus-ssh/src/test/java/org/citrusframework/ssh/server/SshServerTest.java
+++ b/endpoints/citrus-ssh/src/test/java/org/citrusframework/ssh/server/SshServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2012 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -140,12 +140,8 @@ public class SshServerTest {
     @Test(expectedExceptions = CitrusRuntimeException.class,expectedExceptionsMessageRegExp = ".*Address already in use.*")
     public void doubleStart() throws IOException {
         prepareServer(true);
-        ServerSocket s = null;
-        try {
-            s = new ServerSocket(port);
+        try (var ignored = new ServerSocket(port)) {
             server.start();
-        } finally {
-            if (s != null) s.close();
         }
     }
 

--- a/endpoints/citrus-vertx/src/main/java/org/citrusframework/vertx/endpoint/VertxSyncProducer.java
+++ b/endpoints/citrus-vertx/src/main/java/org/citrusframework/vertx/endpoint/VertxSyncProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,6 @@ import org.citrusframework.message.Message;
 import org.citrusframework.message.correlation.CorrelationManager;
 import org.citrusframework.message.correlation.PollingCorrelationManager;
 import org.citrusframework.messaging.ReplyConsumer;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.DeliveryOptions;
 import org.slf4j.Logger;

--- a/endpoints/citrus-vertx/src/main/java/org/citrusframework/vertx/message/VertxMessageConverter.java
+++ b/endpoints/citrus-vertx/src/main/java/org/citrusframework/vertx/message/VertxMessageConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package org.citrusframework.vertx.message;
 
 import org.citrusframework.context.TestContext;
 import org.citrusframework.message.*;
-import org.citrusframework.message.Message;
 import org.citrusframework.vertx.endpoint.VertxEndpointConfiguration;
 
 /**

--- a/endpoints/citrus-vertx/src/test/java/org/citrusframework/vertx/endpoint/VertxEndpointTest.java
+++ b/endpoints/citrus-vertx/src/test/java/org/citrusframework/vertx/endpoint/VertxEndpointTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ import org.citrusframework.testng.AbstractTestNGUnitTest;
 import org.citrusframework.vertx.factory.SingleVertxInstanceFactory;
 import org.citrusframework.vertx.message.CitrusVertxMessageHeaders;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
@@ -111,14 +110,11 @@ public class VertxEndpointTest extends AbstractTestNGUnitTest {
         when(messageMock.replyAddress()).thenReturn("replyAddress");
 
         when(vertx.eventBus()).thenReturn(eventBus);
-        doAnswer(new Answer<MessageConsumer>() {
-            @Override
-            public MessageConsumer answer(InvocationOnMock invocation) throws Throwable {
-                Handler handler = (Handler) invocation.getArguments()[1];
-                handler.handle(messageMock);
+        doAnswer((Answer<MessageConsumer>) invocation -> {
+            Handler handler = (Handler) invocation.getArguments()[1];
+            handler.handle(messageMock);
 
-                return messageConsumer;
-            }
+            return messageConsumer;
         }).when(eventBus).consumer(eq(eventBusAddress), any(Handler.class));
 
         Message receivedMessage = vertxEndpoint.createConsumer().receive(context, endpointConfiguration.getTimeout());

--- a/endpoints/citrus-vertx/src/test/java/org/citrusframework/vertx/endpoint/VertxSyncEndpointTest.java
+++ b/endpoints/citrus-vertx/src/test/java/org/citrusframework/vertx/endpoint/VertxSyncEndpointTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ import org.citrusframework.vertx.message.CitrusVertxMessageHeaders;
 import io.vertx.core.*;
 import io.vertx.core.eventbus.DeliveryOptions;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
@@ -71,13 +70,10 @@ public class VertxSyncEndpointTest extends AbstractTestNGUnitTest {
         when(asyncResult.result()).thenReturn(messageMock);
 
         when(vertx.eventBus()).thenReturn(eventBus);
-        doAnswer(new Answer<EventBus>() {
-            @Override
-            public EventBus answer(InvocationOnMock invocation) throws Throwable {
-                Handler<AsyncResult> handler = (Handler<AsyncResult>) invocation.getArguments()[3];
-                handler.handle(asyncResult);
-                return eventBus;
-            }
+        doAnswer((Answer<EventBus>) invocation -> {
+            Handler<AsyncResult> handler = (Handler<AsyncResult>) invocation.getArguments()[3];
+            handler.handle(asyncResult);
+            return eventBus;
         }).when(eventBus).request(eq(eventBusAddress), eq(requestMessage.getPayload()), any(DeliveryOptions.class), any(Handler.class));
 
         when(messageMock.body()).thenReturn("Hello from Vertx!");

--- a/endpoints/citrus-websocket/src/main/java/org/citrusframework/websocket/message/WebSocketMessage.java
+++ b/endpoints/citrus-websocket/src/main/java/org/citrusframework/websocket/message/WebSocketMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2015 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@ import org.citrusframework.message.DefaultMessage;
 import org.citrusframework.message.Message;
 
 import java.util.Map;
+
+import static java.lang.Boolean.parseBoolean;
 
 /**
  * Message representing web socket message data.
@@ -79,8 +81,8 @@ public class WebSocketMessage extends DefaultMessage {
         Object isLast = getHeader(WebSocketMessageHeaders.WEB_SOCKET_IS_LAST);
 
         if (isLast != null) {
-            if (isLast instanceof String) {
-                return Boolean.valueOf(isLast.toString());
+            if (isLast instanceof String string) {
+                return parseBoolean(string);
             } else {
                 return (Boolean) isLast;
             }
@@ -88,5 +90,4 @@ public class WebSocketMessage extends DefaultMessage {
 
         return true;
     }
-
 }

--- a/endpoints/citrus-websocket/src/test/java/org/citrusframework/websocket/endpoint/WebSocketEndpointTest.java
+++ b/endpoints/citrus-websocket/src/test/java/org/citrusframework/websocket/endpoint/WebSocketEndpointTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2015 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,6 @@ import org.citrusframework.websocket.handler.CitrusWebSocketHandler;
 import org.citrusframework.websocket.message.WebSocketMessage;
 import org.citrusframework.websocket.server.WebSocketServerEndpointConfiguration;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.springframework.web.socket.*;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -58,16 +56,13 @@ public class WebSocketEndpointTest extends AbstractTestNGUnitTest {
         when(session.getId()).thenReturn("test-socket-1");
         when(session.isOpen()).thenReturn(true);
 
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                org.springframework.web.socket.WebSocketMessage request = (org.springframework.web.socket.WebSocketMessage) invocation.getArguments()[0];
+        doAnswer(invocation -> {
+            org.springframework.web.socket.WebSocketMessage request = (org.springframework.web.socket.WebSocketMessage) invocation.getArguments()[0];
 
-                Assert.assertTrue(TextMessage.class.isInstance(request));
-                Assert.assertEquals(((TextMessage)request).getPayload(), responseMessage.getPayload(String.class));
-                Assert.assertTrue(request.isLast());
-                return null;
-            }
+            Assert.assertTrue(TextMessage.class.isInstance(request));
+            Assert.assertEquals(((TextMessage)request).getPayload(), responseMessage.getPayload(String.class));
+            Assert.assertTrue(request.isLast());
+            return null;
         }).when(session).sendMessage(any(org.springframework.web.socket.WebSocketMessage.class));
 
         handler.afterConnectionEstablished(session);
@@ -104,28 +99,22 @@ public class WebSocketEndpointTest extends AbstractTestNGUnitTest {
         when(session.isOpen()).thenReturn(true);
         when(session2.isOpen()).thenReturn(true);
 
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                org.springframework.web.socket.WebSocketMessage request = (org.springframework.web.socket.WebSocketMessage) invocation.getArguments()[0];
+        doAnswer(invocation -> {
+            org.springframework.web.socket.WebSocketMessage request = (org.springframework.web.socket.WebSocketMessage) invocation.getArguments()[0];
 
-                Assert.assertTrue(TextMessage.class.isInstance(request));
-                Assert.assertEquals(((TextMessage)request).getPayload(), responseMessage.getPayload(String.class));
-                Assert.assertTrue(request.isLast());
-                return null;
-            }
+            Assert.assertTrue(TextMessage.class.isInstance(request));
+            Assert.assertEquals(((TextMessage)request).getPayload(), responseMessage.getPayload(String.class));
+            Assert.assertTrue(request.isLast());
+            return null;
         }).when(session).sendMessage(any(org.springframework.web.socket.WebSocketMessage.class));
 
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                org.springframework.web.socket.WebSocketMessage request = (org.springframework.web.socket.WebSocketMessage) invocation.getArguments()[0];
+        doAnswer(invocation -> {
+            org.springframework.web.socket.WebSocketMessage request = (org.springframework.web.socket.WebSocketMessage) invocation.getArguments()[0];
 
-                Assert.assertTrue(TextMessage.class.isInstance(request));
-                Assert.assertEquals(((TextMessage)request).getPayload(), responseMessage.getPayload(String.class));
-                Assert.assertTrue(request.isLast());
-                return null;
-            }
+            Assert.assertTrue(TextMessage.class.isInstance(request));
+            Assert.assertEquals(((TextMessage)request).getPayload(), responseMessage.getPayload(String.class));
+            Assert.assertTrue(request.isLast());
+            return null;
         }).when(session2).sendMessage(any(org.springframework.web.socket.WebSocketMessage.class));
 
         handler.afterConnectionEstablished(session);

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/config/xml/ReceiveSoapMessageActionParser.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/config/xml/ReceiveSoapMessageActionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ public class ReceiveSoapMessageActionParser extends ReceiveMessageActionParser {
         BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(ReceiveSoapMessageActionFactoryBean.class);
 
         List<Element> attachmentElements = DomUtils.getChildElementsByTagName(element, "attachment");
-        List<SoapAttachment> attachments = new ArrayList<SoapAttachment>();
+        List<SoapAttachment> attachments = new ArrayList<>();
         for (Element attachment : attachmentElements) {
             attachments.add(SoapAttachmentParser.parseAttachment(attachment));
         }

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/config/xml/SendSoapFaultActionParser.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/config/xml/SendSoapFaultActionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,8 +80,8 @@ public class SendSoapFaultActionParser extends SendSoapMessageActionParser {
      */
     private void parseFaultDetail(BeanDefinitionBuilder builder, Element faultElement) {
         List<Element> faultDetailElements = DomUtils.getChildElementsByTagName(faultElement, "fault-detail");
-        List<String> faultDetails = new ArrayList<String>();
-        List<String> faultDetailResourcePaths = new ArrayList<String>();
+        List<String> faultDetails = new ArrayList<>();
+        List<String> faultDetailResourcePaths = new ArrayList<>();
 
         for (Element faultDetailElement : faultDetailElements) {
             if (faultDetailElement.hasAttribute("file")) {

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/config/xml/SendSoapMessageActionParser.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/config/xml/SendSoapMessageActionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ public class SendSoapMessageActionParser extends SendMessageActionParser {
         BeanDefinitionBuilder builder = super.parseComponent(element, parserContext);
 
         List<Element> attachmentElements = DomUtils.getChildElementsByTagName(element, "attachment");
-        List<SoapAttachment> attachments = new ArrayList<SoapAttachment>();
+        List<SoapAttachment> attachments = new ArrayList<>();
         for (Element attachment : attachmentElements) {
             attachments.add(SoapAttachmentParser.parseAttachment(attachment));
         }

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/interceptor/DelegatingEndpointInterceptor.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/interceptor/DelegatingEndpointInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ import java.util.List;
 public class DelegatingEndpointInterceptor implements SmartEndpointInterceptor, SoapEndpointInterceptor {
 
     /** List of interceptors to delegate to when this interceptor is invoked */
-    private List<EndpointInterceptor> interceptors = new ArrayList<EndpointInterceptor>();
+    private List<EndpointInterceptor> interceptors = new ArrayList<>();
 
     @Override
     public boolean shouldIntercept(MessageContext messageContext, Object endpoint) {

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/interceptor/SoapMustUnderstandEndpointInterceptor.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/interceptor/SoapMustUnderstandEndpointInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import org.springframework.ws.soap.server.SoapEndpointInterceptor;
  */
 public class SoapMustUnderstandEndpointInterceptor implements SoapEndpointInterceptor {
 
-    private List<String> acceptedHeaders = new ArrayList<String>();
+    private List<String> acceptedHeaders = new ArrayList<>();
     
     /**
      * (non-Javadoc)
@@ -39,19 +39,14 @@ public class SoapMustUnderstandEndpointInterceptor implements SoapEndpointInterc
      */
     public boolean understands(SoapHeaderElement header) {
         //see if header is accepted
-        if (header.getName() != null && acceptedHeaders.contains(header.getName().toString())) {
-            return true;
-        }
-        
-        return false;
+        return header.getName() != null && acceptedHeaders.contains(header.getName().toString());
     }
     
     /**
      * (non-Javadoc)
      * @see org.springframework.ws.server.EndpointInterceptor#handleFault(org.springframework.ws.context.MessageContext, java.lang.Object)
      */
-    public boolean handleFault(MessageContext messageContext, Object endpoint)
-            throws Exception {
+    public boolean handleFault(MessageContext messageContext, Object endpoint) {
         return true;
     }
 
@@ -59,8 +54,7 @@ public class SoapMustUnderstandEndpointInterceptor implements SoapEndpointInterc
      * (non-Javadoc)
      * @see org.springframework.ws.server.EndpointInterceptor#handleRequest(org.springframework.ws.context.MessageContext, java.lang.Object)
      */
-    public boolean handleRequest(MessageContext messageContext, Object endpoint)
-            throws Exception {
+    public boolean handleRequest(MessageContext messageContext, Object endpoint) {
         return true;
     }
 
@@ -68,16 +62,14 @@ public class SoapMustUnderstandEndpointInterceptor implements SoapEndpointInterc
      * (non-Javadoc)
      * @see org.springframework.ws.server.EndpointInterceptor#handleResponse(org.springframework.ws.context.MessageContext, java.lang.Object)
      */
-    public boolean handleResponse(MessageContext messageContext, Object endpoint)
-            throws Exception {
+    public boolean handleResponse(MessageContext messageContext, Object endpoint) {
         return true;
     }
     
     /**
      * {@inheritDoc}
      */
-    public void afterCompletion(MessageContext messageContext, Object endpoint, Exception ex) 
-            throws Exception {
+    public void afterCompletion(MessageContext messageContext, Object endpoint, Exception ex) {
     }
     
     /**
@@ -86,5 +78,4 @@ public class SoapMustUnderstandEndpointInterceptor implements SoapEndpointInterc
     public void setAcceptedHeaders(List<String> acceptedHeaders) {
         this.acceptedHeaders = acceptedHeaders;
     }
-    
 }

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/message/SoapFault.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/message/SoapFault.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@ public class SoapFault extends SoapMessage {
     private Locale locale = Locale.ENGLISH;
 
     /** List of fault detail elements */
-    private List<String> faultDetails = new ArrayList<String>();
+    private List<String> faultDetails = new ArrayList<>();
 
     /**
      * Default constructor.

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/servlet/CitrusMessageDispatcherServlet.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/servlet/CitrusMessageDispatcherServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -111,7 +111,7 @@ public class CitrusMessageDispatcherServlet extends MessageDispatcherServlet {
      * @return
      */
     private List<EndpointInterceptor> adaptInterceptors(List<Object> interceptors) {
-        List<EndpointInterceptor> endpointInterceptors = new ArrayList<EndpointInterceptor>();
+        List<EndpointInterceptor> endpointInterceptors = new ArrayList<>();
 
         if (interceptors != null) {
             for (Object interceptor : interceptors) {

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/WebServiceEndpointTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/WebServiceEndpointTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,6 @@ import jakarta.activation.DataHandler;
 import jakarta.xml.soap.MimeHeaders;
 import jakarta.xml.soap.SOAPMessage;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.springframework.ws.context.MessageContext;
 import org.springframework.ws.mime.Attachment;
@@ -137,7 +136,7 @@ public class WebServiceEndpointTest {
     public void testMessageProcessingWithSoapAction() throws Exception {
         WebServiceEndpoint endpoint = new WebServiceEndpoint();
 
-        Map<String, Object> requestHeaders = new HashMap<String, Object>();
+        Map<String, Object> requestHeaders = new HashMap<>();
         requestHeaders.put(SoapMessageHeaders.SOAP_ACTION, "sayHello");
         final Message requestMessage = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?><TestRequest><Message>Hello World!</Message></TestRequest>", requestHeaders);
 
@@ -194,7 +193,7 @@ public class WebServiceEndpointTest {
     public void testMessageProcessingWithSoapRequestHeaders() throws Exception {
         WebServiceEndpoint endpoint = new WebServiceEndpoint();
 
-        Map<String, Object> requestHeaders = new HashMap<String, Object>();
+        Map<String, Object> requestHeaders = new HashMap<>();
         requestHeaders.put(SoapMessageHeaders.SOAP_ACTION, "sayHello");
         requestHeaders.put("Operation", "sayHello");
         final Message requestMessage = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?><TestRequest><Message>Hello World!</Message></TestRequest>", requestHeaders);
@@ -214,7 +213,7 @@ public class WebServiceEndpointTest {
             }
         });
 
-        Set<SoapHeaderElement> soapRequestHeaders = new HashSet<SoapHeaderElement>();
+        Set<SoapHeaderElement> soapRequestHeaders = new HashSet<>();
         soapRequestHeaders.add(soapRequestHeaderEntry);
 
         StringResult soapResponsePayload = new StringResult();
@@ -342,11 +341,11 @@ public class WebServiceEndpointTest {
     public void testMessageProcessingWithSoapResponseHeaders() throws Exception {
         WebServiceEndpoint endpoint = new WebServiceEndpoint();
 
-        Map<String, Object> requestHeaders = new HashMap<String, Object>();
+        Map<String, Object> requestHeaders = new HashMap<>();
         requestHeaders.put(SoapMessageHeaders.SOAP_ACTION, "sayHello");
         final Message requestMessage = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?><TestRequest><Message>Hello World!</Message></TestRequest>", requestHeaders);
 
-        Map<String, Object> responseHeaders = new HashMap<String, Object>();
+        Map<String, Object> responseHeaders = new HashMap<>();
         responseHeaders.put("{http://citrusframework.org/citrus}citrus:Operation", "sayHello");
         final Message responseMessage = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?><TestResponse><Message>Hello World!</Message></TestResponse>", responseHeaders);
 
@@ -392,16 +391,13 @@ public class WebServiceEndpointTest {
 
         when(soapResponse.getSoapHeader()).thenReturn(soapResponseHeader);
 
-        doAnswer(new Answer<SoapHeaderElement>() {
-            @Override
-            public SoapHeaderElement answer(InvocationOnMock invocation) throws Throwable {
-                QName headerQName = (QName)invocation.getArguments()[0];
+        doAnswer((Answer<SoapHeaderElement>) invocation -> {
+            QName headerQName = (QName)invocation.getArguments()[0];
 
-                Assert.assertEquals(headerQName.getLocalPart(), "Operation");
-                Assert.assertEquals(headerQName.getPrefix(), "citrus");
-                Assert.assertEquals(headerQName.getNamespaceURI(), "http://citrusframework.org/citrus");
-                return soapRequestHeaderEntry;
-            }
+            Assert.assertEquals(headerQName.getLocalPart(), "Operation");
+            Assert.assertEquals(headerQName.getPrefix(), "citrus");
+            Assert.assertEquals(headerQName.getNamespaceURI(), "http://citrusframework.org/citrus");
+            return soapRequestHeaderEntry;
         }).when(soapResponseHeader).addHeaderElement((QName)any());
 
         endpoint.invoke(messageContext);
@@ -415,11 +411,11 @@ public class WebServiceEndpointTest {
     public void testMessageProcessingWithDefaultHeaderQName() throws Exception {
         WebServiceEndpoint endpoint = new WebServiceEndpoint();
 
-        Map<String, Object> requestHeaders = new HashMap<String, Object>();
+        Map<String, Object> requestHeaders = new HashMap<>();
         requestHeaders.put(SoapMessageHeaders.SOAP_ACTION, "sayHello");
         final Message requestMessage = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?><TestRequest><Message>Hello World!</Message></TestRequest>", requestHeaders);
 
-        Map<String, Object> responseHeaders = new HashMap<String, Object>();
+        Map<String, Object> responseHeaders = new HashMap<>();
         responseHeaders.put("Operation", "sayHello");
         final Message responseMessage = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?><TestResponse><Message>Hello World!</Message></TestResponse>", responseHeaders);
 
@@ -467,16 +463,13 @@ public class WebServiceEndpointTest {
 
         when(soapResponse.getSoapHeader()).thenReturn(soapResponseHeader);
 
-        doAnswer(new Answer<SoapHeaderElement>() {
-            @Override
-            public SoapHeaderElement answer(InvocationOnMock invocation) throws Throwable {
-                QName headerQName = (QName)invocation.getArguments()[0];
+        doAnswer((Answer<SoapHeaderElement>) invocation -> {
+            QName headerQName = (QName)invocation.getArguments()[0];
 
-                Assert.assertEquals(headerQName.getLocalPart(), "Operation");
-                Assert.assertEquals(headerQName.getPrefix(), "citrus");
-                Assert.assertEquals(headerQName.getNamespaceURI(), "http://citrusframework.org/citrus");
-                return soapRequestHeaderEntry;
-            }
+            Assert.assertEquals(headerQName.getLocalPart(), "Operation");
+            Assert.assertEquals(headerQName.getPrefix(), "citrus");
+            Assert.assertEquals(headerQName.getNamespaceURI(), "http://citrusframework.org/citrus");
+            return soapRequestHeaderEntry;
         }).when(soapResponseHeader).addHeaderElement((QName)any());
 
         endpoint.invoke(messageContext);
@@ -490,11 +483,11 @@ public class WebServiceEndpointTest {
     public void testMessageProcessingWithDefaultHeaderQNameNoPrefix() throws Exception {
         WebServiceEndpoint endpoint = new WebServiceEndpoint();
 
-        Map<String, Object> requestHeaders = new HashMap<String, Object>();
+        Map<String, Object> requestHeaders = new HashMap<>();
         requestHeaders.put(SoapMessageHeaders.SOAP_ACTION, "sayHello");
         final Message requestMessage = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?><TestRequest><Message>Hello World!</Message></TestRequest>", requestHeaders);
 
-        Map<String, Object> responseHeaders = new HashMap<String, Object>();
+        Map<String, Object> responseHeaders = new HashMap<>();
         responseHeaders.put("Operation", "sayHello");
         final Message responseMessage = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?><TestResponse><Message>Hello World!</Message></TestResponse>", responseHeaders);
 
@@ -542,16 +535,13 @@ public class WebServiceEndpointTest {
 
         when(soapResponse.getSoapHeader()).thenReturn(soapResponseHeader);
 
-        doAnswer(new Answer<SoapHeaderElement>() {
-            @Override
-            public SoapHeaderElement answer(InvocationOnMock invocation) throws Throwable {
-                QName headerQName = (QName)invocation.getArguments()[0];
+        doAnswer((Answer<SoapHeaderElement>) invocation -> {
+            QName headerQName = (QName)invocation.getArguments()[0];
 
-                Assert.assertEquals(headerQName.getLocalPart(), "Operation");
-                Assert.assertEquals(headerQName.getPrefix(), "");
-                Assert.assertEquals(headerQName.getNamespaceURI(), "http://citrusframework.org/citrus");
-                return soapRequestHeaderEntry;
-            }
+            Assert.assertEquals(headerQName.getLocalPart(), "Operation");
+            Assert.assertEquals(headerQName.getPrefix(), "");
+            Assert.assertEquals(headerQName.getNamespaceURI(), "http://citrusframework.org/citrus");
+            return soapRequestHeaderEntry;
         }).when(soapResponseHeader).addHeaderElement((QName)any());
 
         endpoint.invoke(messageContext);
@@ -565,11 +555,11 @@ public class WebServiceEndpointTest {
     public void testMessageProcessingMissingNamespaceUri() throws Exception {
         WebServiceEndpoint endpoint = new WebServiceEndpoint();
 
-        Map<String, Object> requestHeaders = new HashMap<String, Object>();
+        Map<String, Object> requestHeaders = new HashMap<>();
         requestHeaders.put(SoapMessageHeaders.SOAP_ACTION, "sayHello");
         final Message requestMessage = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?><TestRequest><Message>Hello World!</Message></TestRequest>", requestHeaders);
 
-        Map<String, Object> responseHeaders = new HashMap<String, Object>();
+        Map<String, Object> responseHeaders = new HashMap<>();
         responseHeaders.put("Operation", "sayHello");
         final Message responseMessage = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?><TestResponse><Message>Hello World!</Message></TestResponse>", responseHeaders);
 
@@ -615,16 +605,13 @@ public class WebServiceEndpointTest {
 
         when(soapResponse.getSoapHeader()).thenReturn(soapResponseHeader);
 
-        doAnswer(new Answer<SoapHeaderElement>() {
-            @Override
-            public SoapHeaderElement answer(InvocationOnMock invocation) throws Throwable {
-                QName headerQName = (QName)invocation.getArguments()[0];
+        doAnswer((Answer<SoapHeaderElement>) invocation -> {
+            QName headerQName = (QName)invocation.getArguments()[0];
 
-                Assert.assertEquals(headerQName.getLocalPart(), "Operation");
-                Assert.assertEquals(headerQName.getPrefix(), "");
-                Assert.assertEquals(headerQName.getNamespaceURI(), "");
-                return soapRequestHeaderEntry;
-            }
+            Assert.assertEquals(headerQName.getLocalPart(), "Operation");
+            Assert.assertEquals(headerQName.getPrefix(), "");
+            Assert.assertEquals(headerQName.getNamespaceURI(), "");
+            return soapRequestHeaderEntry;
         }).when(soapResponseHeader).addHeaderElement((QName)any());
 
         endpoint.invoke(messageContext);
@@ -667,7 +654,7 @@ public class WebServiceEndpointTest {
 
         StringResult soapResponsePayload = new StringResult();
 
-        Set<Attachment> attachments = new HashSet<Attachment>();
+        Set<Attachment> attachments = new HashSet<>();
         Attachment attachment = Mockito.mock(Attachment.class);
         attachments.add(attachment);
 
@@ -721,7 +708,7 @@ public class WebServiceEndpointTest {
 
         StringResult soapResponsePayload = new StringResult();
 
-        Set<Attachment> attachments = new HashSet<Attachment>();
+        Set<Attachment> attachments = new HashSet<>();
         Attachment attachment = Mockito.mock(Attachment.class);
         attachments.add(attachment);
 
@@ -767,7 +754,7 @@ public class WebServiceEndpointTest {
     public void testMessageProcessingWithServerSoapFaultInResponse() throws Exception {
         WebServiceEndpoint endpoint = new WebServiceEndpoint();
 
-        Map<String, Object> requestHeaders = new HashMap<String, Object>();
+        Map<String, Object> requestHeaders = new HashMap<>();
         requestHeaders.put(SoapMessageHeaders.SOAP_ACTION, "sayHello");
         final Message requestMessage = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?><TestRequest><Message>Hello World!</Message></TestRequest>", requestHeaders);
 
@@ -817,13 +804,10 @@ public class WebServiceEndpointTest {
 
         when(soapResponse.getSoapBody()).thenReturn(soapBody);
 
-        doAnswer(new Answer<org.springframework.ws.soap.SoapFault>() {
-            @Override
-            public org.springframework.ws.soap.SoapFault answer(InvocationOnMock invocation) throws Throwable {
-                Assert.assertEquals(invocation.getArguments()[0], "Invalid request, because of unknown error");
+        doAnswer((Answer<org.springframework.ws.soap.SoapFault>) invocation -> {
+            Assert.assertEquals(invocation.getArguments()[0], "Invalid request, because of unknown error");
 
-                return soapFault;
-            }
+            return soapFault;
         }).when(soapBody).addServerOrReceiverFault((String)any(), (Locale)any());
 
 
@@ -837,7 +821,7 @@ public class WebServiceEndpointTest {
     public void testMessageProcessingWithClientSoapFaultInResponse() throws Exception {
         WebServiceEndpoint endpoint = new WebServiceEndpoint();
 
-        Map<String, Object> requestHeaders = new HashMap<String, Object>();
+        Map<String, Object> requestHeaders = new HashMap<>();
         requestHeaders.put(SoapMessageHeaders.SOAP_ACTION, "sayHello");
         final Message requestMessage = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?><TestRequest><Message>Hello World!</Message></TestRequest>", requestHeaders);
 
@@ -887,12 +871,9 @@ public class WebServiceEndpointTest {
 
         when(soapResponse.getSoapBody()).thenReturn(soapBody);
 
-        doAnswer(new Answer<org.springframework.ws.soap.SoapFault>() {
-            @Override
-            public org.springframework.ws.soap.SoapFault answer(InvocationOnMock invocation) throws Throwable {
-                Assert.assertEquals(invocation.getArguments()[0], "Invalid request");
-                return soapFault;
-            }
+        doAnswer((Answer<org.springframework.ws.soap.SoapFault>) invocation -> {
+            Assert.assertEquals(invocation.getArguments()[0], "Invalid request");
+            return soapFault;
         }).when(soapBody).addClientOrSenderFault((String)any(), (Locale)any());
 
 
@@ -906,7 +887,7 @@ public class WebServiceEndpointTest {
     public void testMessageProcessingWithSoapFaultDetail() throws Exception {
         WebServiceEndpoint endpoint = new WebServiceEndpoint();
 
-        Map<String, Object> requestHeaders = new HashMap<String, Object>();
+        Map<String, Object> requestHeaders = new HashMap<>();
         requestHeaders.put(SoapMessageHeaders.SOAP_ACTION, "sayHello");
         final Message requestMessage = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?><TestRequest><Message>Hello World!</Message></TestRequest>", requestHeaders);
 
@@ -958,13 +939,10 @@ public class WebServiceEndpointTest {
 
         when(soapResponse.getSoapBody()).thenReturn(soapBody);
 
-        doAnswer(new Answer<org.springframework.ws.soap.SoapFault>() {
-            @Override
-            public org.springframework.ws.soap.SoapFault answer(InvocationOnMock invocation) throws Throwable {
-                Assert.assertEquals(invocation.getArguments()[0], "Invalid request");
+        doAnswer((Answer<org.springframework.ws.soap.SoapFault>) invocation -> {
+            Assert.assertEquals(invocation.getArguments()[0], "Invalid request");
 
-                return soapFault;
-            }
+            return soapFault;
         }).when(soapBody).addServerOrReceiverFault((String)any(), (Locale)any());
 
         when(soapFault.addFaultDetail()).thenReturn(soapFaultDetail);
@@ -982,7 +960,7 @@ public class WebServiceEndpointTest {
     public void testMessageProcessingWithMultipleSoapFaultDetails() throws Exception {
         WebServiceEndpoint endpoint = new WebServiceEndpoint();
 
-        Map<String, Object> requestHeaders = new HashMap<String, Object>();
+        Map<String, Object> requestHeaders = new HashMap<>();
         requestHeaders.put(SoapMessageHeaders.SOAP_ACTION, "sayHello");
         final Message requestMessage = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?><TestRequest><Message>Hello World!</Message></TestRequest>", requestHeaders);
 
@@ -1035,13 +1013,10 @@ public class WebServiceEndpointTest {
 
         when(soapResponse.getSoapBody()).thenReturn(soapBody);
 
-        doAnswer(new Answer<org.springframework.ws.soap.SoapFault>() {
-            @Override
-            public org.springframework.ws.soap.SoapFault answer(InvocationOnMock invocation) throws Throwable {
-                Assert.assertEquals(invocation.getArguments()[0], "Invalid request");
+        doAnswer((Answer<org.springframework.ws.soap.SoapFault>) invocation -> {
+            Assert.assertEquals(invocation.getArguments()[0], "Invalid request");
 
-                return soapFault;
-            }
+            return soapFault;
         }).when(soapBody).addServerOrReceiverFault((String)any(), (Locale)any());
 
         when(soapFault.addFaultDetail()).thenReturn(soapFaultDetail);
@@ -1059,11 +1034,11 @@ public class WebServiceEndpointTest {
     public void testMessageProcessingWithSoapActionInResponse() throws Exception {
         WebServiceEndpoint endpoint = new WebServiceEndpoint();
 
-        Map<String, Object> requestHeaders = new HashMap<String, Object>();
+        Map<String, Object> requestHeaders = new HashMap<>();
         requestHeaders.put(SoapMessageHeaders.SOAP_ACTION, "sayHello");
         final Message requestMessage = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?><TestRequest><Message>Hello World!</Message></TestRequest>", requestHeaders);
 
-        Map<String, Object> responseHeaders = new HashMap<String, Object>();
+        Map<String, Object> responseHeaders = new HashMap<>();
         responseHeaders.put(SoapMessageHeaders.SOAP_ACTION, "answerHello");
         final Message responseMessage = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?><TestResponse><Message>Hello World!</Message></TestResponse>", responseHeaders);
 
@@ -1119,7 +1094,7 @@ public class WebServiceEndpointTest {
     public void testMessageProcessingWithSoap11FaultInResponse() throws Exception {
         WebServiceEndpoint endpoint = new WebServiceEndpoint();
 
-        Map<String, Object> requestHeaders = new HashMap<String, Object>();
+        Map<String, Object> requestHeaders = new HashMap<>();
         requestHeaders.put(SoapMessageHeaders.SOAP_ACTION, "sayHello");
         final Message requestMessage = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?><TestRequest><Message>Hello World!</Message></TestRequest>", requestHeaders);
 
@@ -1172,18 +1147,15 @@ public class WebServiceEndpointTest {
 
         when(soapResponse.getSoapBody()).thenReturn(soapResponseBody);
 
-        doAnswer(new Answer<org.springframework.ws.soap.SoapFault>() {
-            @Override
-            public org.springframework.ws.soap.SoapFault answer(InvocationOnMock invocation) throws Throwable {
-                QName faultQName = (QName)invocation.getArguments()[0];
+        doAnswer((Answer<org.springframework.ws.soap.SoapFault>) invocation -> {
+            QName faultQName = (QName)invocation.getArguments()[0];
 
-                Assert.assertEquals(faultQName.getLocalPart(), "TEC-1000");
-                Assert.assertEquals(faultQName.getPrefix(), "citrus");
-                Assert.assertEquals(faultQName.getNamespaceURI(), "http://citrusframework.org/citrus");
-                Assert.assertEquals(invocation.getArguments()[1], "Invalid request");
+            Assert.assertEquals(faultQName.getLocalPart(), "TEC-1000");
+            Assert.assertEquals(faultQName.getPrefix(), "citrus");
+            Assert.assertEquals(faultQName.getNamespaceURI(), "http://citrusframework.org/citrus");
+            Assert.assertEquals(invocation.getArguments()[1], "Invalid request");
 
-                return soapFault;
-            }
+            return soapFault;
         }).when(soapResponseBody).addFault((QName)any(), (String)any(), (Locale)any());
 
 
@@ -1197,7 +1169,7 @@ public class WebServiceEndpointTest {
     public void testMessageProcessingWithSoap12FaultInResponse() throws Exception {
         WebServiceEndpoint endpoint = new WebServiceEndpoint();
 
-        Map<String, Object> requestHeaders = new HashMap<String, Object>();
+        Map<String, Object> requestHeaders = new HashMap<>();
         requestHeaders.put(SoapMessageHeaders.SOAP_ACTION, "sayHello");
         final Message requestMessage = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?><TestRequest><Message>Hello World!</Message></TestRequest>", requestHeaders);
 
@@ -1250,24 +1222,18 @@ public class WebServiceEndpointTest {
 
         when(soapResponse.getSoapBody()).thenReturn(soapResponseBody);
 
-        doAnswer(new Answer<Soap12Fault>() {
-            @Override
-            public Soap12Fault answer(InvocationOnMock invocation) throws Throwable {
-                Assert.assertEquals(invocation.getArguments()[0], "Invalid request");
-                return soapFault;
-            }
+        doAnswer((Answer<Soap12Fault>) invocation -> {
+            Assert.assertEquals(invocation.getArguments()[0], "Invalid request");
+            return soapFault;
         }).when(soapResponseBody).addServerOrReceiverFault((String)any(), (Locale)any());
 
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                QName faultQName = (QName)invocation.getArguments()[0];
+        doAnswer(invocation -> {
+            QName faultQName = (QName)invocation.getArguments()[0];
 
-                Assert.assertEquals(faultQName.getLocalPart(), "TEC-1000");
-                Assert.assertEquals(faultQName.getPrefix(), "citrus");
-                Assert.assertEquals(faultQName.getNamespaceURI(), "http://citrusframework.org/citrus");
-                return null;
-            }
+            Assert.assertEquals(faultQName.getLocalPart(), "TEC-1000");
+            Assert.assertEquals(faultQName.getPrefix(), "citrus");
+            Assert.assertEquals(faultQName.getNamespaceURI(), "http://citrusframework.org/citrus");
+            return null;
         }).when(soapFault).addFaultSubcode((QName)any());
 
         endpoint.invoke(messageContext);

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/actions/ReceiveSoapMessageActionTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/actions/ReceiveSoapMessageActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,8 +33,6 @@ import org.citrusframework.ws.message.SoapMessage;
 import org.citrusframework.ws.validation.SoapAttachmentValidator;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -83,16 +81,13 @@ public class ReceiveSoapMessageActionTest extends AbstractTestNGUnitTest {
 
         when(consumer.receive(any(TestContext.class), anyLong())).thenReturn(controlMessage);
 
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                Assert.assertEquals(((List<SoapAttachment>)invocation.getArguments()[1]).size(), 1L);
-                SoapAttachment soapAttachment = ((List<SoapAttachment>)invocation.getArguments()[1]).get(0);
-                Assert.assertEquals(soapAttachment.getContent(), "TestAttachment!");
-                Assert.assertNull(soapAttachment.getContentId());
-                Assert.assertEquals(soapAttachment.getContentType(), "text/plain");
-                return null;
-            }
+        doAnswer(invocation -> {
+            Assert.assertEquals(((List<SoapAttachment>)invocation.getArguments()[1]).size(), 1L);
+            SoapAttachment soapAttachment = ((List<SoapAttachment>)invocation.getArguments()[1]).get(0);
+            Assert.assertEquals(soapAttachment.getContent(), "TestAttachment!");
+            Assert.assertNull(soapAttachment.getContentId());
+            Assert.assertEquals(soapAttachment.getContentType(), "text/plain");
+            return null;
         }).when(attachmentValidator).validateAttachment((SoapMessage)any(), any(List.class));
 
         when(endpoint.getActor()).thenReturn(null);
@@ -127,17 +122,14 @@ public class ReceiveSoapMessageActionTest extends AbstractTestNGUnitTest {
 
         when(consumer.receive(any(TestContext.class), anyLong())).thenReturn(controlMessage);
 
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                Assert.assertEquals(((List<SoapAttachment>)invocation.getArguments()[1]).size(), 1L);
-                SoapAttachment soapAttachment = ((List<SoapAttachment>)invocation.getArguments()[1]).get(0);
-                Assert.assertEquals(soapAttachment.getContent(), "<TestAttachment><Message>Hello World!</Message></TestAttachment>");
-                Assert.assertEquals(soapAttachment.getContentId(), "myAttachment");
-                Assert.assertEquals(soapAttachment.getContentType(), "text/xml");
-                Assert.assertEquals(soapAttachment.getCharsetName(), "UTF-16");
-                return null;
-            }
+        doAnswer(invocation -> {
+            Assert.assertEquals(((List<SoapAttachment>)invocation.getArguments()[1]).size(), 1L);
+            SoapAttachment soapAttachment = ((List<SoapAttachment>)invocation.getArguments()[1]).get(0);
+            Assert.assertEquals(soapAttachment.getContent(), "<TestAttachment><Message>Hello World!</Message></TestAttachment>");
+            Assert.assertEquals(soapAttachment.getContentId(), "myAttachment");
+            Assert.assertEquals(soapAttachment.getContentType(), "text/xml");
+            Assert.assertEquals(soapAttachment.getCharsetName(), "UTF-16");
+            return null;
         }).when(attachmentValidator).validateAttachment((SoapMessage)any(), (List)any());
 
         when(endpoint.getActor()).thenReturn(null);
@@ -178,24 +170,21 @@ public class ReceiveSoapMessageActionTest extends AbstractTestNGUnitTest {
 
         when(consumer.receive(any(TestContext.class), anyLong())).thenReturn(controlMessage);
 
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                Assert.assertEquals(((List<SoapAttachment>)invocation.getArguments()[1]).size(), 2L);
+        doAnswer(invocation -> {
+            Assert.assertEquals(((List<SoapAttachment>)invocation.getArguments()[1]).size(), 2L);
 
-                SoapAttachment soapAttachment = ((List<SoapAttachment>)invocation.getArguments()[1]).get(0);
-                Assert.assertEquals(soapAttachment.getContent(), "<TestAttachment><Message>Hello World1!</Message></TestAttachment>");
-                Assert.assertEquals(soapAttachment.getContentId(), "1stAttachment");
-                Assert.assertEquals(soapAttachment.getContentType(), "text/xml");
-                Assert.assertEquals(soapAttachment.getCharsetName(), "UTF-8");
+            SoapAttachment soapAttachment = ((List<SoapAttachment>)invocation.getArguments()[1]).get(0);
+            Assert.assertEquals(soapAttachment.getContent(), "<TestAttachment><Message>Hello World1!</Message></TestAttachment>");
+            Assert.assertEquals(soapAttachment.getContentId(), "1stAttachment");
+            Assert.assertEquals(soapAttachment.getContentType(), "text/xml");
+            Assert.assertEquals(soapAttachment.getCharsetName(), "UTF-8");
 
-                soapAttachment = ((List<SoapAttachment>)invocation.getArguments()[1]).get(1);
-                Assert.assertEquals(soapAttachment.getContent(), "<TestAttachment><Message>Hello World2!</Message></TestAttachment>");
-                Assert.assertEquals(soapAttachment.getContentId(), "2ndAttachment");
-                Assert.assertEquals(soapAttachment.getContentType(), "text/xml");
-                Assert.assertEquals(soapAttachment.getCharsetName(), "UTF-16");
-                return null;
-            }
+            soapAttachment = ((List<SoapAttachment>)invocation.getArguments()[1]).get(1);
+            Assert.assertEquals(soapAttachment.getContent(), "<TestAttachment><Message>Hello World2!</Message></TestAttachment>");
+            Assert.assertEquals(soapAttachment.getContentId(), "2ndAttachment");
+            Assert.assertEquals(soapAttachment.getContentType(), "text/xml");
+            Assert.assertEquals(soapAttachment.getCharsetName(), "UTF-16");
+            return null;
         }).when(attachmentValidator).validateAttachment((SoapMessage)any(), (List)any());
 
         when(endpoint.getActor()).thenReturn(null);
@@ -230,17 +219,14 @@ public class ReceiveSoapMessageActionTest extends AbstractTestNGUnitTest {
 
         when(consumer.receive(any(TestContext.class), anyLong())).thenReturn(controlMessage);
 
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                Assert.assertEquals(((List<SoapAttachment>)invocation.getArguments()[1]).size(), 1L);
-                SoapAttachment soapAttachment = ((List<SoapAttachment>)invocation.getArguments()[1]).get(0);
-                Assert.assertEquals(soapAttachment.getContent(), "");
-                Assert.assertEquals(soapAttachment.getContentId(), "myAttachment");
-                Assert.assertEquals(soapAttachment.getContentType(), "text/plain");
-                Assert.assertEquals(soapAttachment.getCharsetName(), "UTF-8");
-                return null;
-            }
+        doAnswer(invocation -> {
+            Assert.assertEquals(((List<SoapAttachment>)invocation.getArguments()[1]).size(), 1L);
+            SoapAttachment soapAttachment = ((List<SoapAttachment>)invocation.getArguments()[1]).get(0);
+            Assert.assertEquals(soapAttachment.getContent(), "");
+            Assert.assertEquals(soapAttachment.getContentId(), "myAttachment");
+            Assert.assertEquals(soapAttachment.getContentType(), "text/plain");
+            Assert.assertEquals(soapAttachment.getCharsetName(), "UTF-8");
+            return null;
         }).when(attachmentValidator).validateAttachment(any(SoapMessage.class), any(List.class));
 
         when(endpoint.getActor()).thenReturn(null);
@@ -301,17 +287,14 @@ public class ReceiveSoapMessageActionTest extends AbstractTestNGUnitTest {
 
         when(consumer.receive(any(TestContext.class), anyLong())).thenReturn(controlMessage);
 
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                Assert.assertEquals(((List<SoapAttachment>)invocation.getArguments()[1]).size(), 1L);
-                SoapAttachment soapAttachment = ((List<SoapAttachment>)invocation.getArguments()[1]).get(0);
-                Assert.assertEquals(soapAttachment.getContent().trim(), "<TestAttachment><Message>Hello World!</Message></TestAttachment>");
-                Assert.assertEquals(soapAttachment.getContentId(), "myAttachment");
-                Assert.assertEquals(soapAttachment.getContentType(), "text/xml");
-                Assert.assertEquals(soapAttachment.getCharsetName(), "UTF-8");
-                return null;
-            }
+        doAnswer(invocation -> {
+            Assert.assertEquals(((List<SoapAttachment>)invocation.getArguments()[1]).size(), 1L);
+            SoapAttachment soapAttachment = ((List<SoapAttachment>)invocation.getArguments()[1]).get(0);
+            Assert.assertEquals(soapAttachment.getContent().trim(), "<TestAttachment><Message>Hello World!</Message></TestAttachment>");
+            Assert.assertEquals(soapAttachment.getContentId(), "myAttachment");
+            Assert.assertEquals(soapAttachment.getContentType(), "text/xml");
+            Assert.assertEquals(soapAttachment.getCharsetName(), "UTF-8");
+            return null;
         }).when(attachmentValidator).validateAttachment(any(SoapMessage.class), any(List.class));
 
         when(endpoint.getActor()).thenReturn(null);
@@ -348,17 +331,14 @@ public class ReceiveSoapMessageActionTest extends AbstractTestNGUnitTest {
 
         when(consumer.receive(any(TestContext.class), anyLong())).thenReturn(controlMessage);
 
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                Assert.assertEquals(((List<SoapAttachment>)invocation.getArguments()[1]).size(), 1L);
-                SoapAttachment soapAttachment = ((List<SoapAttachment>)invocation.getArguments()[1]).get(0);
-                Assert.assertEquals(soapAttachment.getContent().trim(), "<TestAttachment><Message>Hello World!</Message></TestAttachment>");
-                Assert.assertEquals(soapAttachment.getContentId(), "myAttachment");
-                Assert.assertEquals(soapAttachment.getContentType(), "text/xml");
-                Assert.assertEquals(soapAttachment.getCharsetName(), "UTF-8");
-                return null;
-            }
+        doAnswer(invocation -> {
+            Assert.assertEquals(((List<SoapAttachment>)invocation.getArguments()[1]).size(), 1L);
+            SoapAttachment soapAttachment = ((List<SoapAttachment>)invocation.getArguments()[1]).get(0);
+            Assert.assertEquals(soapAttachment.getContent().trim(), "<TestAttachment><Message>Hello World!</Message></TestAttachment>");
+            Assert.assertEquals(soapAttachment.getContentId(), "myAttachment");
+            Assert.assertEquals(soapAttachment.getContentType(), "text/xml");
+            Assert.assertEquals(soapAttachment.getCharsetName(), "UTF-8");
+            return null;
         }).when(attachmentValidator).validateAttachment(any(SoapMessage.class), any(List.class));
 
         when(endpoint.getActor()).thenReturn(null);
@@ -395,17 +375,14 @@ public class ReceiveSoapMessageActionTest extends AbstractTestNGUnitTest {
 
         when(consumer.receive(any(TestContext.class), anyLong())).thenReturn(controlMessage);
 
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                Assert.assertEquals(((List<SoapAttachment>)invocation.getArguments()[1]).size(), 1L);
-                SoapAttachment soapAttachment = ((List<SoapAttachment>)invocation.getArguments()[1]).get(0);
-                Assert.assertEquals(soapAttachment.getContent().trim(), "<TestAttachment><Message>Hello World!</Message></TestAttachment>");
-                Assert.assertEquals(soapAttachment.getContentId(), "myAttachment");
-                Assert.assertEquals(soapAttachment.getContentType(), "text/xml");
-                Assert.assertEquals(soapAttachment.getCharsetName(), "UTF-8");
-                return null;
-            }
+        doAnswer(invocation -> {
+            Assert.assertEquals(((List<SoapAttachment>)invocation.getArguments()[1]).size(), 1L);
+            SoapAttachment soapAttachment = ((List<SoapAttachment>)invocation.getArguments()[1]).get(0);
+            Assert.assertEquals(soapAttachment.getContent().trim(), "<TestAttachment><Message>Hello World!</Message></TestAttachment>");
+            Assert.assertEquals(soapAttachment.getContentId(), "myAttachment");
+            Assert.assertEquals(soapAttachment.getContentType(), "text/xml");
+            Assert.assertEquals(soapAttachment.getCharsetName(), "UTF-8");
+            return null;
         }).when(attachmentValidator).validateAttachment(any(SoapMessage.class), any(List.class));
 
         when(endpoint.getActor()).thenReturn(null);

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/actions/SendSoapFaultActionTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/actions/SendSoapFaultActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,8 +27,6 @@ import org.citrusframework.messaging.Producer;
 import org.citrusframework.ws.UnitTestSupport;
 import org.citrusframework.ws.message.SoapFault;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -61,18 +59,15 @@ public class SendSoapFaultActionTest extends UnitTestSupport {
         when(endpoint.getEndpointConfiguration()).thenReturn(endpointConfiguration);
         when(endpointConfiguration.getTimeout()).thenReturn(5000L);
 
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                Message sentMessage = (Message)invocation.getArguments()[0];
-                Assert.assertTrue(sentMessage instanceof SoapFault);
+        doAnswer(invocation -> {
+            Message sentMessage = (Message)invocation.getArguments()[0];
+            Assert.assertTrue(sentMessage instanceof SoapFault);
 
-                SoapFault soapFault = (SoapFault) sentMessage;
-                Assert.assertEquals(soapFault.getFaultCode(), "{http://citrusframework.org}ws:TEC-1000");
-                Assert.assertEquals(soapFault.getFaultString(), "Internal server error");
-                Assert.assertEquals(soapFault.getLocale(), Locale.ENGLISH);
-                return null;
-            }
+            SoapFault soapFault = (SoapFault) sentMessage;
+            Assert.assertEquals(soapFault.getFaultCode(), "{http://citrusframework.org}ws:TEC-1000");
+            Assert.assertEquals(soapFault.getFaultString(), "Internal server error");
+            Assert.assertEquals(soapFault.getLocale(), Locale.ENGLISH);
+            return null;
         }).when(producer).send(any(Message.class), any(TestContext.class));
 
         when(endpoint.getActor()).thenReturn(null);
@@ -97,19 +92,16 @@ public class SendSoapFaultActionTest extends UnitTestSupport {
         when(endpoint.getEndpointConfiguration()).thenReturn(endpointConfiguration);
         when(endpointConfiguration.getTimeout()).thenReturn(5000L);
 
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                Message sentMessage = (Message)invocation.getArguments()[0];
-                Assert.assertTrue(sentMessage instanceof SoapFault);
+        doAnswer(invocation -> {
+            Message sentMessage = (Message)invocation.getArguments()[0];
+            Assert.assertTrue(sentMessage instanceof SoapFault);
 
-                SoapFault soapFault = (SoapFault) sentMessage;
-                Assert.assertEquals(soapFault.getFaultCode(), "{http://citrusframework.org}ws:TEC-1000");
-                Assert.assertEquals(soapFault.getFaultString(), "Internal server error");
-                Assert.assertEquals(soapFault.getLocale(), Locale.ENGLISH);
-                Assert.assertEquals(soapFault.getFaultActor(), "SERVER");
-                return null;
-            }
+            SoapFault soapFault = (SoapFault) sentMessage;
+            Assert.assertEquals(soapFault.getFaultCode(), "{http://citrusframework.org}ws:TEC-1000");
+            Assert.assertEquals(soapFault.getFaultString(), "Internal server error");
+            Assert.assertEquals(soapFault.getLocale(), Locale.ENGLISH);
+            Assert.assertEquals(soapFault.getFaultActor(), "SERVER");
+            return null;
         }).when(producer).send(any(Message.class), any(TestContext.class));
 
         when(endpoint.getActor()).thenReturn(null);
@@ -132,18 +124,15 @@ public class SendSoapFaultActionTest extends UnitTestSupport {
         when(endpoint.getEndpointConfiguration()).thenReturn(endpointConfiguration);
         when(endpointConfiguration.getTimeout()).thenReturn(5000L);
 
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                Message sentMessage = (Message)invocation.getArguments()[0];
-                Assert.assertTrue(sentMessage instanceof SoapFault);
+        doAnswer(invocation -> {
+            Message sentMessage = (Message)invocation.getArguments()[0];
+            Assert.assertTrue(sentMessage instanceof SoapFault);
 
-                SoapFault soapFault = (SoapFault) sentMessage;
-                Assert.assertEquals(soapFault.getFaultCode(), "{http://citrusframework.org}ws:TEC-1000");
-                Assert.assertNull(soapFault.getFaultString());
-                Assert.assertEquals(soapFault.getLocale(), Locale.ENGLISH);
-                return null;
-            }
+            SoapFault soapFault = (SoapFault) sentMessage;
+            Assert.assertEquals(soapFault.getFaultCode(), "{http://citrusframework.org}ws:TEC-1000");
+            Assert.assertNull(soapFault.getFaultString());
+            Assert.assertEquals(soapFault.getLocale(), Locale.ENGLISH);
+            return null;
         }).when(producer).send(any(Message.class), any(TestContext.class));
 
         when(endpoint.getActor()).thenReturn(null);
@@ -170,18 +159,15 @@ public class SendSoapFaultActionTest extends UnitTestSupport {
         when(endpoint.getEndpointConfiguration()).thenReturn(endpointConfiguration);
         when(endpointConfiguration.getTimeout()).thenReturn(5000L);
 
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                Message sentMessage = (Message)invocation.getArguments()[0];
-                Assert.assertTrue(sentMessage instanceof SoapFault);
+        doAnswer(invocation -> {
+            Message sentMessage = (Message)invocation.getArguments()[0];
+            Assert.assertTrue(sentMessage instanceof SoapFault);
 
-                SoapFault soapFault = (SoapFault) sentMessage;
-                Assert.assertEquals(soapFault.getFaultCode(), "{http://citrusframework.org}ws:TEC-1000");
-                Assert.assertEquals(soapFault.getFaultString(), "Internal server error");
-                Assert.assertEquals(soapFault.getLocale(), Locale.ENGLISH);
-                return null;
-            }
+            SoapFault soapFault = (SoapFault) sentMessage;
+            Assert.assertEquals(soapFault.getFaultCode(), "{http://citrusframework.org}ws:TEC-1000");
+            Assert.assertEquals(soapFault.getFaultString(), "Internal server error");
+            Assert.assertEquals(soapFault.getLocale(), Locale.ENGLISH);
+            return null;
         }).when(producer).send(any(Message.class), any(TestContext.class));
 
         when(endpoint.getActor()).thenReturn(null);

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/actions/SendSoapMessageActionTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/actions/SendSoapMessageActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,8 +32,6 @@ import org.citrusframework.validation.builder.DefaultMessageBuilder;
 import org.citrusframework.ws.message.SoapAttachment;
 import org.citrusframework.ws.message.SoapMessage;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -65,21 +63,18 @@ public class SendSoapMessageActionTest extends AbstractTestNGUnitTest {
         reset(webServiceEndpoint, producer);
 
         when(webServiceEndpoint.createProducer()).thenReturn(producer);
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                SoapMessage soapMessage = ((SoapMessage)invocation.getArguments()[0]);
-                Assert.assertTrue(soapMessage.isMtomEnabled());
-                Assert.assertEquals(soapMessage.getPayload(String.class), "<TestRequest><Text><xop:Include xmlns:xop=\"http://www.w3.org/2004/08/xop/include\" href=\"cid:mtomText%40citrusframework.org\"/></Text></TestRequest>");
+        doAnswer(invocation -> {
+            SoapMessage soapMessage = ((SoapMessage)invocation.getArguments()[0]);
+            Assert.assertTrue(soapMessage.isMtomEnabled());
+            Assert.assertEquals(soapMessage.getPayload(String.class), "<TestRequest><Text><xop:Include xmlns:xop=\"http://www.w3.org/2004/08/xop/include\" href=\"cid:mtomText%40citrusframework.org\"/></Text></TestRequest>");
 
-                Assert.assertEquals(soapMessage.getAttachments().size(), 1L);
-                SoapAttachment constructedAttachment = ((SoapMessage)invocation.getArguments()[0]).getAttachments().get(0);
-                Assert.assertEquals(constructedAttachment.getContentId(), "mtomText@citrusframework.org");
-                Assert.assertEquals(constructedAttachment.getContentType(), "text/xml");
-                Assert.assertEquals(constructedAttachment.getContent(), "<TestAttachment><Message>Hello World!</Message></TestAttachment>");
-                Assert.assertEquals(constructedAttachment.getCharsetName(), "UTF-8");
-                return null;
-            }
+            Assert.assertEquals(soapMessage.getAttachments().size(), 1L);
+            SoapAttachment constructedAttachment = ((SoapMessage)invocation.getArguments()[0]).getAttachments().get(0);
+            Assert.assertEquals(constructedAttachment.getContentId(), "mtomText@citrusframework.org");
+            Assert.assertEquals(constructedAttachment.getContentType(), "text/xml");
+            Assert.assertEquals(constructedAttachment.getContent(), "<TestAttachment><Message>Hello World!</Message></TestAttachment>");
+            Assert.assertEquals(constructedAttachment.getCharsetName(), "UTF-8");
+            return null;
         }).when(producer).send(any(Message.class), any(TestContext.class));
 
         when(webServiceEndpoint.getActor()).thenReturn(null);
@@ -109,16 +104,13 @@ public class SendSoapMessageActionTest extends AbstractTestNGUnitTest {
         reset(webServiceEndpoint, producer);
 
         when(webServiceEndpoint.createProducer()).thenReturn(producer);
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                SoapMessage soapMessage = ((SoapMessage)invocation.getArguments()[0]);
-                Assert.assertTrue(soapMessage.isMtomEnabled());
-                Assert.assertEquals(soapMessage.getPayload(String.class), "<TestRequest><Image>SU1BR0VfREFUQQ==</Image></TestRequest>");
+        doAnswer(invocation -> {
+            SoapMessage soapMessage = ((SoapMessage)invocation.getArguments()[0]);
+            Assert.assertTrue(soapMessage.isMtomEnabled());
+            Assert.assertEquals(soapMessage.getPayload(String.class), "<TestRequest><Image>SU1BR0VfREFUQQ==</Image></TestRequest>");
 
-                Assert.assertEquals(soapMessage.getAttachments().size(), 0L);
-                return null;
-            }
+            Assert.assertEquals(soapMessage.getAttachments().size(), 0L);
+            return null;
         }).when(producer).send(any(Message.class), any(TestContext.class));
 
         when(webServiceEndpoint.getActor()).thenReturn(null);
@@ -148,16 +140,13 @@ public class SendSoapMessageActionTest extends AbstractTestNGUnitTest {
         reset(webServiceEndpoint, producer);
 
         when(webServiceEndpoint.createProducer()).thenReturn(producer);
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                SoapMessage soapMessage = ((SoapMessage)invocation.getArguments()[0]);
-                Assert.assertTrue(soapMessage.isMtomEnabled());
-                Assert.assertEquals(soapMessage.getPayload(String.class), "<TestRequest><Image>494D4147455F44415441</Image></TestRequest>");
+        doAnswer(invocation -> {
+            SoapMessage soapMessage = ((SoapMessage)invocation.getArguments()[0]);
+            Assert.assertTrue(soapMessage.isMtomEnabled());
+            Assert.assertEquals(soapMessage.getPayload(String.class), "<TestRequest><Image>494D4147455F44415441</Image></TestRequest>");
 
-                Assert.assertEquals(soapMessage.getAttachments().size(), 0L);
-                return null;
-            }
+            Assert.assertEquals(soapMessage.getAttachments().size(), 0L);
+            return null;
         }).when(producer).send(any(Message.class), any(TestContext.class));
 
         when(webServiceEndpoint.getActor()).thenReturn(null);
@@ -185,21 +174,18 @@ public class SendSoapMessageActionTest extends AbstractTestNGUnitTest {
         reset(webServiceEndpoint, producer);
 
         when(webServiceEndpoint.createProducer()).thenReturn(producer);
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                SoapMessage soapMessage = ((SoapMessage)invocation.getArguments()[0]);
-                Assert.assertTrue(soapMessage.isMtomEnabled());
-                Assert.assertEquals(soapMessage.getPayload(String.class), "<TestRequest><Text>mtomText</Text></TestRequest>");
+        doAnswer(invocation -> {
+            SoapMessage soapMessage = ((SoapMessage)invocation.getArguments()[0]);
+            Assert.assertTrue(soapMessage.isMtomEnabled());
+            Assert.assertEquals(soapMessage.getPayload(String.class), "<TestRequest><Text>mtomText</Text></TestRequest>");
 
-                Assert.assertEquals(soapMessage.getAttachments().size(), 1L);
-                SoapAttachment constructedAttachment = ((SoapMessage)invocation.getArguments()[0]).getAttachments().get(0);
-                Assert.assertEquals(constructedAttachment.getContentId(), "mtomText");
-                Assert.assertEquals(constructedAttachment.getContentType(), "text/xml");
-                Assert.assertEquals(constructedAttachment.getContent(), "<TestAttachment><Message>Hello World!</Message></TestAttachment>");
-                Assert.assertEquals(constructedAttachment.getCharsetName(), "UTF-8");
-                return null;
-            }
+            Assert.assertEquals(soapMessage.getAttachments().size(), 1L);
+            SoapAttachment constructedAttachment = ((SoapMessage)invocation.getArguments()[0]).getAttachments().get(0);
+            Assert.assertEquals(constructedAttachment.getContentId(), "mtomText");
+            Assert.assertEquals(constructedAttachment.getContentType(), "text/xml");
+            Assert.assertEquals(constructedAttachment.getContent(), "<TestAttachment><Message>Hello World!</Message></TestAttachment>");
+            Assert.assertEquals(constructedAttachment.getCharsetName(), "UTF-8");
+            return null;
         }).when(producer).send(any(Message.class), any(TestContext.class));
 
         when(webServiceEndpoint.getActor()).thenReturn(null);
@@ -229,21 +215,18 @@ public class SendSoapMessageActionTest extends AbstractTestNGUnitTest {
         reset(webServiceEndpoint, producer);
 
         when(webServiceEndpoint.createProducer()).thenReturn(producer);
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                SoapMessage soapMessage = ((SoapMessage)invocation.getArguments()[0]);
-                Assert.assertTrue(soapMessage.isMtomEnabled());
-                Assert.assertEquals(soapMessage.getPayload(String.class), "<TestRequest><Image>mtomImage</Image></TestRequest>");
+        doAnswer(invocation -> {
+            SoapMessage soapMessage = ((SoapMessage)invocation.getArguments()[0]);
+            Assert.assertTrue(soapMessage.isMtomEnabled());
+            Assert.assertEquals(soapMessage.getPayload(String.class), "<TestRequest><Image>mtomImage</Image></TestRequest>");
 
-                Assert.assertEquals(soapMessage.getAttachments().size(), 1L);
-                SoapAttachment constructedAttachment = ((SoapMessage)invocation.getArguments()[0]).getAttachments().get(0);
-                Assert.assertEquals(constructedAttachment.getContentId(), "mtomImage");
-                Assert.assertEquals(constructedAttachment.getContentType(), "image/png");
-                Assert.assertEquals(constructedAttachment.getContent(), "IMAGE_DATA");
-                Assert.assertEquals(constructedAttachment.getCharsetName(), "UTF-8");
-                return null;
-            }
+            Assert.assertEquals(soapMessage.getAttachments().size(), 1L);
+            SoapAttachment constructedAttachment = ((SoapMessage)invocation.getArguments()[0]).getAttachments().get(0);
+            Assert.assertEquals(constructedAttachment.getContentId(), "mtomImage");
+            Assert.assertEquals(constructedAttachment.getContentType(), "image/png");
+            Assert.assertEquals(constructedAttachment.getContent(), "IMAGE_DATA");
+            Assert.assertEquals(constructedAttachment.getCharsetName(), "UTF-8");
+            return null;
         }).when(producer).send(any(Message.class), any(TestContext.class));
 
         when(webServiceEndpoint.getActor()).thenReturn(null);
@@ -299,17 +282,14 @@ public class SendSoapMessageActionTest extends AbstractTestNGUnitTest {
         reset(webServiceEndpoint, producer);
 
         when(webServiceEndpoint.createProducer()).thenReturn(producer);
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                Assert.assertEquals(((SoapMessage)invocation.getArguments()[0]).getAttachments().size(), 1L);
-                SoapAttachment constructedAttachment = ((SoapMessage)invocation.getArguments()[0]).getAttachments().get(0);
-                Assert.assertNull(constructedAttachment.getContentId());
-                Assert.assertEquals(constructedAttachment.getContentType(), "text/plain");
-                Assert.assertEquals(constructedAttachment.getContent(), "<TestAttachment><Message>Hello World!</Message></TestAttachment>");
-                Assert.assertEquals(constructedAttachment.getCharsetName(), "UTF-8");
-                return null;
-            }
+        doAnswer(invocation -> {
+            Assert.assertEquals(((SoapMessage)invocation.getArguments()[0]).getAttachments().size(), 1L);
+            SoapAttachment constructedAttachment = ((SoapMessage)invocation.getArguments()[0]).getAttachments().get(0);
+            Assert.assertNull(constructedAttachment.getContentId());
+            Assert.assertEquals(constructedAttachment.getContentType(), "text/plain");
+            Assert.assertEquals(constructedAttachment.getContent(), "<TestAttachment><Message>Hello World!</Message></TestAttachment>");
+            Assert.assertEquals(constructedAttachment.getCharsetName(), "UTF-8");
+            return null;
         }).when(producer).send(any(Message.class), any(TestContext.class));
 
         when(webServiceEndpoint.getActor()).thenReturn(null);
@@ -337,17 +317,14 @@ public class SendSoapMessageActionTest extends AbstractTestNGUnitTest {
         reset(webServiceEndpoint, producer);
 
         when(webServiceEndpoint.createProducer()).thenReturn(producer);
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                Assert.assertEquals(((SoapMessage)invocation.getArguments()[0]).getAttachments().size(), 1L);
-                SoapAttachment constructedAttachment = ((SoapMessage)invocation.getArguments()[0]).getAttachments().get(0);
-                Assert.assertEquals(constructedAttachment.getContentId(), "myAttachment");
-                Assert.assertEquals(constructedAttachment.getContentType(), "text/xml");
-                Assert.assertEquals(constructedAttachment.getContent(), "<TestAttachment><Message>Hello World!</Message></TestAttachment>");
-                Assert.assertEquals(constructedAttachment.getCharsetName(), "UTF-16");
-                return null;
-            }
+        doAnswer(invocation -> {
+            Assert.assertEquals(((SoapMessage)invocation.getArguments()[0]).getAttachments().size(), 1L);
+            SoapAttachment constructedAttachment = ((SoapMessage)invocation.getArguments()[0]).getAttachments().get(0);
+            Assert.assertEquals(constructedAttachment.getContentId(), "myAttachment");
+            Assert.assertEquals(constructedAttachment.getContentType(), "text/xml");
+            Assert.assertEquals(constructedAttachment.getContent(), "<TestAttachment><Message>Hello World!</Message></TestAttachment>");
+            Assert.assertEquals(constructedAttachment.getCharsetName(), "UTF-16");
+            return null;
         }).when(producer).send(any(Message.class), any(TestContext.class));
 
         when(webServiceEndpoint.getActor()).thenReturn(null);
@@ -366,7 +343,7 @@ public class SendSoapMessageActionTest extends AbstractTestNGUnitTest {
         DefaultMessageBuilder messageBuilder = new DefaultMessageBuilder();
         messageBuilder.setPayloadBuilder(new DefaultPayloadBuilder("<TestRequest><Message>Hello World!</Message></TestRequest>"));
 
-        List<SoapAttachment> attachments = new ArrayList<SoapAttachment>();
+        List<SoapAttachment> attachments = new ArrayList<>();
         SoapAttachment attachment = new SoapAttachment();
         attachment.setContentId("1stAttachment");
         attachment.setContentType("text/xml");
@@ -384,23 +361,20 @@ public class SendSoapMessageActionTest extends AbstractTestNGUnitTest {
         reset(webServiceEndpoint, producer);
 
         when(webServiceEndpoint.createProducer()).thenReturn(producer);
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                Assert.assertEquals(((SoapMessage)invocation.getArguments()[0]).getAttachments().size(), 2L);
-                SoapAttachment constructedAttachment = ((SoapMessage)invocation.getArguments()[0]).getAttachments().get(0);
-                Assert.assertEquals(constructedAttachment.getContentId(), "1stAttachment");
-                Assert.assertEquals(constructedAttachment.getContentType(), "text/xml");
-                Assert.assertEquals(constructedAttachment.getContent(), "<TestAttachment><Message>Hello World1!</Message></TestAttachment>");
-                Assert.assertEquals(constructedAttachment.getCharsetName(), "UTF-8");
+        doAnswer(invocation -> {
+            Assert.assertEquals(((SoapMessage)invocation.getArguments()[0]).getAttachments().size(), 2L);
+            SoapAttachment constructedAttachment = ((SoapMessage)invocation.getArguments()[0]).getAttachments().get(0);
+            Assert.assertEquals(constructedAttachment.getContentId(), "1stAttachment");
+            Assert.assertEquals(constructedAttachment.getContentType(), "text/xml");
+            Assert.assertEquals(constructedAttachment.getContent(), "<TestAttachment><Message>Hello World1!</Message></TestAttachment>");
+            Assert.assertEquals(constructedAttachment.getCharsetName(), "UTF-8");
 
-                constructedAttachment = ((SoapMessage)invocation.getArguments()[0]).getAttachments().get(1);
-                Assert.assertEquals(constructedAttachment.getContentId(), "2ndAttachment");
-                Assert.assertEquals(constructedAttachment.getContentType(), "text/xml");
-                Assert.assertEquals(constructedAttachment.getContent(), "<TestAttachment><Message>Hello World2!</Message></TestAttachment>");
-                Assert.assertEquals(constructedAttachment.getCharsetName(), "UTF-16");
-                return null;
-            }
+            constructedAttachment = ((SoapMessage)invocation.getArguments()[0]).getAttachments().get(1);
+            Assert.assertEquals(constructedAttachment.getContentId(), "2ndAttachment");
+            Assert.assertEquals(constructedAttachment.getContentType(), "text/xml");
+            Assert.assertEquals(constructedAttachment.getContent(), "<TestAttachment><Message>Hello World2!</Message></TestAttachment>");
+            Assert.assertEquals(constructedAttachment.getCharsetName(), "UTF-16");
+            return null;
         }).when(producer).send(any(Message.class), any(TestContext.class));
 
         when(webServiceEndpoint.getActor()).thenReturn(null);
@@ -446,17 +420,14 @@ public class SendSoapMessageActionTest extends AbstractTestNGUnitTest {
         reset(webServiceEndpoint, producer);
 
         when(webServiceEndpoint.createProducer()).thenReturn(producer);
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                Assert.assertEquals(((SoapMessage)invocation.getArguments()[0]).getAttachments().size(), 1L);
-                SoapAttachment constructedAttachment = ((SoapMessage)invocation.getArguments()[0]).getAttachments().get(0);
-                Assert.assertNull(constructedAttachment.getContentId());
-                Assert.assertEquals(constructedAttachment.getContentType(), "text/plain");
-                Assert.assertEquals(constructedAttachment.getContent().trim(), "<TestAttachment><Message>Hello World!</Message></TestAttachment>");
-                Assert.assertEquals(constructedAttachment.getCharsetName(), "UTF-8");
-                return null;
-            }
+        doAnswer(invocation -> {
+            Assert.assertEquals(((SoapMessage)invocation.getArguments()[0]).getAttachments().size(), 1L);
+            SoapAttachment constructedAttachment = ((SoapMessage)invocation.getArguments()[0]).getAttachments().get(0);
+            Assert.assertNull(constructedAttachment.getContentId());
+            Assert.assertEquals(constructedAttachment.getContentType(), "text/plain");
+            Assert.assertEquals(constructedAttachment.getContent().trim(), "<TestAttachment><Message>Hello World!</Message></TestAttachment>");
+            Assert.assertEquals(constructedAttachment.getCharsetName(), "UTF-8");
+            return null;
         }).when(producer).send(any(Message.class), any(TestContext.class));
 
         when(webServiceEndpoint.getActor()).thenReturn(null);
@@ -483,17 +454,14 @@ public class SendSoapMessageActionTest extends AbstractTestNGUnitTest {
         reset(webServiceEndpoint, producer);
 
         when(webServiceEndpoint.createProducer()).thenReturn(producer);
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                Assert.assertEquals(((SoapMessage)invocation.getArguments()[0]).getAttachments().size(), 1L);
-                SoapAttachment constructedAttachment = ((SoapMessage)invocation.getArguments()[0]).getAttachments().get(0);
-                Assert.assertNull(constructedAttachment.getContentId());
-                Assert.assertEquals(constructedAttachment.getContentType(), "text/plain");
-                Assert.assertEquals(constructedAttachment.getContent(), "<TestAttachment><Message>Hello World!</Message></TestAttachment>");
-                Assert.assertEquals(constructedAttachment.getCharsetName(), "UTF-8");
-                return null;
-            }
+        doAnswer(invocation -> {
+            Assert.assertEquals(((SoapMessage)invocation.getArguments()[0]).getAttachments().size(), 1L);
+            SoapAttachment constructedAttachment = ((SoapMessage)invocation.getArguments()[0]).getAttachments().get(0);
+            Assert.assertNull(constructedAttachment.getContentId());
+            Assert.assertEquals(constructedAttachment.getContentType(), "text/plain");
+            Assert.assertEquals(constructedAttachment.getContent(), "<TestAttachment><Message>Hello World!</Message></TestAttachment>");
+            Assert.assertEquals(constructedAttachment.getCharsetName(), "UTF-8");
+            return null;
         }).when(producer).send(any(Message.class), any(TestContext.class));
 
         when(webServiceEndpoint.getActor()).thenReturn(null);
@@ -520,17 +488,14 @@ public class SendSoapMessageActionTest extends AbstractTestNGUnitTest {
         reset(webServiceEndpoint, producer);
 
         when(webServiceEndpoint.createProducer()).thenReturn(producer);
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                Assert.assertEquals(((SoapMessage)invocation.getArguments()[0]).getAttachments().size(), 1L);
-                SoapAttachment constructedAttachment = ((SoapMessage)invocation.getArguments()[0]).getAttachments().get(0);
-                Assert.assertNull(constructedAttachment.getContentId());
-                Assert.assertEquals(constructedAttachment.getContentType(), "text/plain");
-                Assert.assertEquals(constructedAttachment.getContent().trim(), "<TestAttachment><Message>Hello World!</Message></TestAttachment>");
-                Assert.assertEquals(constructedAttachment.getCharsetName(), "UTF-8");
-                return null;
-            }
+        doAnswer(invocation -> {
+            Assert.assertEquals(((SoapMessage)invocation.getArguments()[0]).getAttachments().size(), 1L);
+            SoapAttachment constructedAttachment = ((SoapMessage)invocation.getArguments()[0]).getAttachments().get(0);
+            Assert.assertNull(constructedAttachment.getContentId());
+            Assert.assertEquals(constructedAttachment.getContentType(), "text/plain");
+            Assert.assertEquals(constructedAttachment.getContent().trim(), "<TestAttachment><Message>Hello World!</Message></TestAttachment>");
+            Assert.assertEquals(constructedAttachment.getCharsetName(), "UTF-8");
+            return null;
         }).when(producer).send(any(Message.class), any(TestContext.class));
 
         when(webServiceEndpoint.getActor()).thenReturn(null);
@@ -554,16 +519,13 @@ public class SendSoapMessageActionTest extends AbstractTestNGUnitTest {
         reset(webServiceEndpoint, producer);
 
         when(webServiceEndpoint.createProducer()).thenReturn(producer);
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                Message constructedMessage = (Message)invocation.getArguments()[0];
+        doAnswer(invocation -> {
+            Message constructedMessage = (Message)invocation.getArguments()[0];
 
-                Assert.assertEquals(constructedMessage.getHeaderData().size(), 1L);
-                Assert.assertEquals(constructedMessage.getHeaderData().get(0),
-                        "<TestHeader><operation>soapOperation</operation></TestHeader>");
-                return null;
-            }
+            Assert.assertEquals(constructedMessage.getHeaderData().size(), 1L);
+            Assert.assertEquals(constructedMessage.getHeaderData().get(0),
+                    "<TestHeader><operation>soapOperation</operation></TestHeader>");
+            return null;
         }).when(producer).send(any(Message.class), any(TestContext.class));
 
         when(webServiceEndpoint.getActor()).thenReturn(null);
@@ -587,18 +549,15 @@ public class SendSoapMessageActionTest extends AbstractTestNGUnitTest {
         reset(webServiceEndpoint, producer);
 
         when(webServiceEndpoint.createProducer()).thenReturn(producer);
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                Message constructedMessage = (Message)invocation.getArguments()[0];
+        doAnswer(invocation -> {
+            Message constructedMessage = (Message)invocation.getArguments()[0];
 
-                Assert.assertEquals(constructedMessage.getHeaderData().size(), 2L);
-                Assert.assertEquals(constructedMessage.getHeaderData().get(0),
-                        "<TestHeader><operation>soapOperation1</operation></TestHeader>");
-                Assert.assertEquals(constructedMessage.getHeaderData().get(1),
-                        "<TestHeader><operation>soapOperation2</operation></TestHeader>");
-                return null;
-            }
+            Assert.assertEquals(constructedMessage.getHeaderData().size(), 2L);
+            Assert.assertEquals(constructedMessage.getHeaderData().get(0),
+                    "<TestHeader><operation>soapOperation1</operation></TestHeader>");
+            Assert.assertEquals(constructedMessage.getHeaderData().get(1),
+                    "<TestHeader><operation>soapOperation2</operation></TestHeader>");
+            return null;
         }).when(producer).send(any(Message.class), any(TestContext.class));
 
         when(webServiceEndpoint.getActor()).thenReturn(null);
@@ -621,16 +580,13 @@ public class SendSoapMessageActionTest extends AbstractTestNGUnitTest {
         reset(webServiceEndpoint, producer);
 
         when(webServiceEndpoint.createProducer()).thenReturn(producer);
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                Message constructedMessage = (Message)invocation.getArguments()[0];
+        doAnswer(invocation -> {
+            Message constructedMessage = (Message)invocation.getArguments()[0];
 
-                Assert.assertEquals(constructedMessage.getHeaderData().size(), 1L);
-                Assert.assertEquals(constructedMessage.getHeaderData().get(0).trim(),
-                        "<TestHeader><operation>soapOperation</operation></TestHeader>");
-                return null;
-            }
+            Assert.assertEquals(constructedMessage.getHeaderData().size(), 1L);
+            Assert.assertEquals(constructedMessage.getHeaderData().get(0).trim(),
+                    "<TestHeader><operation>soapOperation</operation></TestHeader>");
+            return null;
         }).when(producer).send(any(Message.class), any(TestContext.class));
 
         when(webServiceEndpoint.getActor()).thenReturn(null);
@@ -655,16 +611,13 @@ public class SendSoapMessageActionTest extends AbstractTestNGUnitTest {
         reset(webServiceEndpoint, producer);
 
         when(webServiceEndpoint.createProducer()).thenReturn(producer);
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                Message constructedMessage = (Message)invocation.getArguments()[0];
+        doAnswer(invocation -> {
+            Message constructedMessage = (Message)invocation.getArguments()[0];
 
-                Assert.assertEquals(constructedMessage.getHeaderData().size(), 1L);
-                Assert.assertEquals(constructedMessage.getHeaderData().get(0),
-                        "<TestHeader><operation>soapOperation</operation></TestHeader>");
-                return null;
-            }
+            Assert.assertEquals(constructedMessage.getHeaderData().size(), 1L);
+            Assert.assertEquals(constructedMessage.getHeaderData().get(0),
+                    "<TestHeader><operation>soapOperation</operation></TestHeader>");
+            return null;
         }).when(producer).send(any(Message.class), any(TestContext.class));
 
         when(webServiceEndpoint.getActor()).thenReturn(null);
@@ -689,16 +642,13 @@ public class SendSoapMessageActionTest extends AbstractTestNGUnitTest {
         reset(webServiceEndpoint, producer);
 
         when(webServiceEndpoint.createProducer()).thenReturn(producer);
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                Message constructedMessage = (Message)invocation.getArguments()[0];
+        doAnswer(invocation -> {
+            Message constructedMessage = (Message)invocation.getArguments()[0];
 
-                Assert.assertEquals(constructedMessage.getHeaderData().size(), 1L);
-                Assert.assertEquals(constructedMessage.getHeaderData().get(0).trim(),
-                        "<TestHeader><operation>soapOperation</operation></TestHeader>");
-                return null;
-            }
+            Assert.assertEquals(constructedMessage.getHeaderData().size(), 1L);
+            Assert.assertEquals(constructedMessage.getHeaderData().get(0).trim(),
+                    "<TestHeader><operation>soapOperation</operation></TestHeader>");
+            return null;
         }).when(producer).send(any(Message.class), any(TestContext.class));
 
         when(webServiceEndpoint.getActor()).thenReturn(null);

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/interceptor/DelegatingEndpointInterceptorTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/interceptor/DelegatingEndpointInterceptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,13 +62,13 @@ public class DelegatingEndpointInterceptorTest {
     }
 
     @Test
-    public void testShouldIntercept() throws Exception {
+    public void testShouldIntercept() {
         Assert.assertTrue(delegatingEndpointInterceptor.shouldIntercept(messageContext, webServiceEndpoint));
     }
 
     @Test
     public void testIntercept() throws Exception {
-        List<EndpointInterceptor> interceptors = new ArrayList<EndpointInterceptor>();
+        List<EndpointInterceptor> interceptors = new ArrayList<>();
         interceptors.add(endpointInterceptorMock);
         interceptors.add(smartEndpointInterceptorMock);
 
@@ -97,7 +97,7 @@ public class DelegatingEndpointInterceptorTest {
     public void testInterceptSoapMustUnderstand() throws Exception {
         QName soapHeader = new QName("http://citrusframework.org", "soapMustUnderstand", "citrus");
 
-        List<EndpointInterceptor> interceptors = new ArrayList<EndpointInterceptor>();
+        List<EndpointInterceptor> interceptors = new ArrayList<>();
         interceptors.add(endpointInterceptorMock);
         interceptors.add(smartEndpointInterceptorMock);
         interceptors.add(soapEndpointInterceptorMock);

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/interceptor/SoapMustUnderstandEndpointInterceptorTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/interceptor/SoapMustUnderstandEndpointInterceptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,7 +82,7 @@ public class SoapMustUnderstandEndpointInterceptorTest {
     public void testMultipleMustUnderstandHeaders() {
         SoapMustUnderstandEndpointInterceptor interceptor = new SoapMustUnderstandEndpointInterceptor();
 
-        List<String> headers = new ArrayList<String>();
+        List<String> headers = new ArrayList<>();
         headers.add("{http://citrusframework.org/soap-mustunderstand}UserId");
         headers.add("TransactionId");
         headers.add("{http://citrusframework.org/soap-mustunderstand/operation}Operation");

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/message/callback/SoapRequestMessageCallbackTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/message/callback/SoapRequestMessageCallbackTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,8 +34,6 @@ import jakarta.xml.soap.MimeHeader;
 import jakarta.xml.soap.MimeHeaders;
 import jakarta.xml.soap.SOAPMessage;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.springframework.core.io.InputStreamSource;
 import org.springframework.ws.soap.SoapBody;
 import org.springframework.ws.soap.SoapEnvelope;
@@ -258,21 +256,17 @@ public class SoapRequestMessageCallbackTest extends AbstractTestNGUnitTest {
         when(soapRequest.getSoapBody()).thenReturn(soapBody);
         when(soapBody.getPayloadResult()).thenReturn(new StringResult());
 
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                InputStreamSource contentStream = (InputStreamSource)invocation.getArguments()[1];
-                BufferedReader reader = new BufferedReader(new InputStreamReader(contentStream.getInputStream()));
+        doAnswer(invocation -> {
+            InputStreamSource contentStream = (InputStreamSource) invocation.getArguments()[1];
+            BufferedReader reader = new BufferedReader(new InputStreamReader(contentStream.getInputStream()));
 
-                Assert.assertEquals(reader.readLine(), "This is a SOAP attachment");
-                Assert.assertEquals(reader.readLine(), "with multi-line");
+            Assert.assertEquals(reader.readLine(), "This is a SOAP attachment");
+            Assert.assertEquals(reader.readLine(), "with multi-line");
 
-                reader.close();
-                return null;
-            }
-        }).when(soapRequest).addAttachment(eq(attachment.getContentId()), (InputStreamSource)any(), eq(attachment.getContentType()));
+            reader.close();
+            return null;
+        }).when(soapRequest).addAttachment(eq(attachment.getContentId()), any(), eq(attachment.getContentType()));
 
         callback.doWithMessage(soapRequest);
-
     }
 }

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/message/callback/SoapResponseMessageCallbackTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/message/callback/SoapResponseMessageCallbackTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,8 +65,8 @@ public class SoapResponseMessageCallbackTest extends AbstractTestNGUnitTest {
     public void testSoapBody() throws TransformerException, IOException {
         SoapResponseMessageCallback callback = new SoapResponseMessageCallback(new WebServiceEndpointConfiguration(), context);
 
-        Set<SoapHeaderElement> soapHeaders = new HashSet<SoapHeaderElement>();
-        Set<Attachment> soapAttachments = new HashSet<Attachment>();
+        Set<SoapHeaderElement> soapHeaders = new HashSet<>();
+        Set<Attachment> soapAttachments = new HashSet<>();
 
         reset(soapResponse, soapEnvelope, soapBody, soapHeader);
 
@@ -96,8 +96,8 @@ public class SoapResponseMessageCallbackTest extends AbstractTestNGUnitTest {
     public void testSoapAction() throws TransformerException, IOException {
         SoapResponseMessageCallback callback = new SoapResponseMessageCallback(new WebServiceEndpointConfiguration(), context);
 
-        Set<SoapHeaderElement> soapHeaders = new HashSet<SoapHeaderElement>();
-        Set<Attachment> soapAttachments = new HashSet<Attachment>();
+        Set<SoapHeaderElement> soapHeaders = new HashSet<>();
+        Set<Attachment> soapAttachments = new HashSet<>();
 
         reset(soapResponse, soapEnvelope, soapBody, soapHeader);
 
@@ -132,8 +132,8 @@ public class SoapResponseMessageCallbackTest extends AbstractTestNGUnitTest {
 
         SoapResponseMessageCallback callback = new SoapResponseMessageCallback(new WebServiceEndpointConfiguration(), context);
 
-        Set<SoapHeaderElement> soapHeaders = new HashSet<SoapHeaderElement>();
-        Set<Attachment> soapAttachments = new HashSet<Attachment>();
+        Set<SoapHeaderElement> soapHeaders = new HashSet<>();
+        Set<Attachment> soapAttachments = new HashSet<>();
 
         reset(soapResponse, soapEnvelope, soapBody, soapHeader);
 
@@ -166,10 +166,10 @@ public class SoapResponseMessageCallbackTest extends AbstractTestNGUnitTest {
 
         SoapHeaderElement soapHeaderElement = Mockito.mock(SoapHeaderElement.class);
 
-        Set<SoapHeaderElement> soapHeaders = new HashSet<SoapHeaderElement>();
+        Set<SoapHeaderElement> soapHeaders = new HashSet<>();
         soapHeaders.add(soapHeaderElement);
 
-        Set<Attachment> soapAttachments = new HashSet<Attachment>();
+        Set<Attachment> soapAttachments = new HashSet<>();
 
         reset(soapResponse, soapEnvelope, soapBody, soapHeader, soapHeaderElement);
 
@@ -208,8 +208,8 @@ public class SoapResponseMessageCallbackTest extends AbstractTestNGUnitTest {
 
         SoapResponseMessageCallback callback = new SoapResponseMessageCallback(new WebServiceEndpointConfiguration(), context);
 
-        Set<SoapHeaderElement> soapHeaders = new HashSet<SoapHeaderElement>();
-        Set<Attachment> soapAttachments = new HashSet<Attachment>();
+        Set<SoapHeaderElement> soapHeaders = new HashSet<>();
+        Set<Attachment> soapAttachments = new HashSet<>();
         soapAttachments.add(attachment);
 
         reset(soapResponse, soapEnvelope, soapBody, soapHeader);

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/servlet/CitrusMessageDispatcherServletTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/servlet/CitrusMessageDispatcherServletTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,18 +62,17 @@ public class CitrusMessageDispatcherServletTest extends AbstractTestNGUnitTest {
     }
 
     @Test
-    public void testNoBeansInContext() throws Exception {
+    public void testNoBeansInContext() {
         reset(webServiceServer);
         GenericApplicationContext applicationContext = new GenericApplicationContext();
         applicationContext.refresh();
 
         servlet.initStrategies(applicationContext);
-
     }
 
     @Test
-    public void testConfigureHandlerInterceptor() throws Exception {
-        List<Object> interceptors = new ArrayList<Object>();
+    public void testConfigureHandlerInterceptor() {
+        List<Object> interceptors = new ArrayList<>();
         interceptors.add(new LoggingEndpointInterceptor());
         interceptors.add(new SoapMustUnderstandEndpointInterceptor());
 
@@ -101,11 +100,10 @@ public class CitrusMessageDispatcherServletTest extends AbstractTestNGUnitTest {
         Assert.assertFalse(webServiceEndpoint.getEndpointConfiguration().isKeepSoapEnvelope());
         Assert.assertNull(webServiceEndpoint.getDefaultNamespaceUri());
         Assert.assertEquals(webServiceEndpoint.getDefaultPrefix(), "");
-
     }
 
     @Test
-    public void testConfigureMessageEndpoint() throws Exception {
+    public void testConfigureMessageEndpoint() {
         reset(webServiceServer);
 
         when(webServiceServer.getInterceptors()).thenReturn(null);
@@ -127,6 +125,5 @@ public class CitrusMessageDispatcherServletTest extends AbstractTestNGUnitTest {
         Assert.assertTrue(webServiceEndpoint.getEndpointConfiguration().isKeepSoapEnvelope());
         Assert.assertEquals(webServiceEndpoint.getDefaultNamespaceUri(), "http://citrusframework.org");
         Assert.assertEquals(webServiceEndpoint.getDefaultPrefix(), "CITRUS");
-
     }
 }

--- a/endpoints/citrus-zookeeper/src/main/java/org/citrusframework/zookeeper/client/ZooClient.java
+++ b/endpoints/citrus-zookeeper/src/main/java/org/citrusframework/zookeeper/client/ZooClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2015 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package org.citrusframework.zookeeper.client;
 
 import org.citrusframework.exceptions.CitrusRuntimeException;
-import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZooKeeper;
 import org.slf4j.Logger;
@@ -111,11 +110,6 @@ public class ZooClient {
     }
 
     private Watcher getConnectionWatcher() {
-        return new Watcher() {
-            @Override
-            public void process(WatchedEvent event) {
-                logger.debug(String.format("Connection Event: %s", event.toString()));
-            }
-        };
+        return event -> logger.debug(String.format("Connection Event: %s", event.toString()));
     }
 }

--- a/endpoints/citrus-zookeeper/src/main/java/org/citrusframework/zookeeper/command/Create.java
+++ b/endpoints/citrus-zookeeper/src/main/java/org/citrusframework/zookeeper/command/Create.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2015 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,19 @@
 
 package org.citrusframework.zookeeper.command;
 
-import org.citrusframework.context.TestContext;
-import org.citrusframework.exceptions.CitrusRuntimeException;
-import org.citrusframework.zookeeper.client.ZooClient;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.ACL;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.zookeeper.client.ZooClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+
+import static java.lang.String.format;
 
 /**
  * @author Martin Maher
@@ -115,15 +117,11 @@ public class Create extends AbstractZooCommand<ZooResponse> {
     }
 
     private List<ACL> lookupAcl(String acl) {
-        switch (acl) {
-            case ACL_ALL:
-                return ZooDefs.Ids.CREATOR_ALL_ACL;
-            case ACL_OPEN:
-                return ZooDefs.Ids.OPEN_ACL_UNSAFE;
-            case ACL_READ:
-                return ZooDefs.Ids.READ_ACL_UNSAFE;
-            default:
-                throw new CitrusRuntimeException(String.format("ACL '%s' not supported", acl));
-        }
+        return switch (acl) {
+            case ACL_ALL -> ZooDefs.Ids.CREATOR_ALL_ACL;
+            case ACL_OPEN -> ZooDefs.Ids.OPEN_ACL_UNSAFE;
+            case ACL_READ -> ZooDefs.Ids.READ_ACL_UNSAFE;
+            default -> throw new CitrusRuntimeException(format("ACL '%s' not supported", acl));
+        };
     }
 }

--- a/endpoints/citrus-zookeeper/src/main/java/org/citrusframework/zookeeper/command/Delete.java
+++ b/endpoints/citrus-zookeeper/src/main/java/org/citrusframework/zookeeper/command/Delete.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2015 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@ import org.citrusframework.zookeeper.client.ZooClient;
 import org.apache.zookeeper.AsyncCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static java.lang.Integer.parseInt;
 
 /**
  * @author Martin Maher
@@ -47,7 +49,7 @@ public class Delete extends AbstractZooCommand<ZooResponse> {
         setCommandResult(commandResult);
 
         String path = this.getParameter(PATH, context);
-        int version = Integer.valueOf(this.getParameter(VERSION, context));
+        int version = parseInt(this.getParameter(VERSION, context));
 
         try {
             zookeeperClient.getZooKeeperClient().delete(path, version, getDeleteCallback(commandResult), null);
@@ -79,12 +81,9 @@ public class Delete extends AbstractZooCommand<ZooResponse> {
     }
 
     private AsyncCallback.VoidCallback getDeleteCallback(final ZooResponse commandResult) {
-        return new AsyncCallback.VoidCallback() {
-            @Override
-            public void processResult(int responseCode, String path, Object ctx) {
-                commandResult.setResponseParam(RESPONSE_CODE, responseCode);
-                commandResult.setResponseParam(PATH, path);
-            }
+        return (responseCode, path, ctx) -> {
+            commandResult.setResponseParam(RESPONSE_CODE, responseCode);
+            commandResult.setResponseParam(PATH, path);
         };
     }
 

--- a/endpoints/citrus-zookeeper/src/main/java/org/citrusframework/zookeeper/command/SetData.java
+++ b/endpoints/citrus-zookeeper/src/main/java/org/citrusframework/zookeeper/command/SetData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2015 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,8 @@ import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static java.lang.Integer.parseInt;
 
 /**
  * @author Martin Maher
@@ -49,7 +51,7 @@ public class SetData extends AbstractZooCommand<ZooResponse> {
 
         String path = this.getParameter(PATH, context);
         String data = this.getParameter(DATA, context);
-        int version = Integer.valueOf(this.getParameter(VERSION, context));
+        int version = parseInt(this.getParameter(VERSION, context));
 
         try {
             Stat stat = zookeeperClient.getZooKeeperClient().setData(path, data.getBytes(), version);

--- a/endpoints/citrus-zookeeper/src/test/java/org/citrusframework/zookeeper/actions/dsl/ZooExecuteTestActionBuilderTest.java
+++ b/endpoints/citrus-zookeeper/src/test/java/org/citrusframework/zookeeper/actions/dsl/ZooExecuteTestActionBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2016 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,6 @@ import org.testng.annotations.Test;
 
 import static org.citrusframework.dsl.PathExpressionSupport.path;
 import static org.citrusframework.zookeeper.actions.ZooExecuteAction.Builder.zookeeper;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 /**

--- a/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/configuration/beans/BeansConfiguration.java
+++ b/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/configuration/beans/BeansConfiguration.java
@@ -69,24 +69,22 @@ public class BeansConfiguration extends GroovyObjectSupport {
         Object[] args = (Object[]) argLine;
         if (args.length == 2) {
             Class<?> type = (Class<?>) args[0];
-            if (args[1] instanceof Closure) {
-                Closure<?> closure = (Closure<?>) args[1];
+            if (args[1] instanceof Closure<?> closure) {
 
                 try {
-                    Object bean = type.newInstance();
+                    Object bean = type.getDeclaredConstructor().newInstance();
                     closure.setResolveStrategy(Closure.DELEGATE_ONLY);
                     closure.setDelegate(bean);
                     closure.call();
 
                     citrus.getCitrusContext().bind(name, bean);
                     return bean;
-                } catch (InstantiationException | IllegalAccessException e) {
+                } catch (IllegalAccessException | InstantiationException | InvocationTargetException | NoSuchMethodException e) {
                     throw new GroovyRuntimeException(String.format("Failed to instantiate bean of type '%s'", type), e);
                 }
             }
         } else if (args.length == 1) {
-            if (args[0] instanceof Closure) {
-                Closure<?> closure = (Closure<?>) args[0];
+            if (args[0] instanceof Closure<?> closure) {
                 closure.setResolveStrategy(Closure.DELEGATE_ONLY);
 
                 Object bean = closure.call();

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/actions/ReceiveMessageActionTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/actions/ReceiveMessageActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,6 @@ import org.mockito.MockitoAnnotations;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 /**
@@ -75,9 +74,10 @@ public class ReceiveMessageActionTest extends AbstractTestNGUnitTest {
     @SuppressWarnings({ "unchecked" })
     public void testReceiveMessageWithMessageBuilderScriptData() {
         DefaultMessageBuilder controlMessageBuilder = new DefaultMessageBuilder();
-        String markup = "markupBuilder.TestRequest(){\n" +
-                "Message('Hello World!')\n" +
-                "}";
+        String markup = """
+                markupBuilder.TestRequest(){
+                    Message('Hello World!')
+                }""";
         controlMessageBuilder.setPayloadBuilder(new GroovyScriptPayloadBuilder(markup));
 
         Message controlMessage = new DefaultMessage("<TestRequest>" + System.lineSeparator() +
@@ -116,9 +116,10 @@ public class ReceiveMessageActionTest extends AbstractTestNGUnitTest {
         context.setVariable("text", "Hello World!");
 
         DefaultMessageBuilder controlMessageBuilder = new DefaultMessageBuilder();
-        String markup = "markupBuilder.TestRequest(){\n" +
-                "Message('${text}')\n" +
-                "}";
+        String markup = """
+                markupBuilder.TestRequest(){
+                    Message('${text}')
+                }""";
         controlMessageBuilder.setPayloadBuilder(new GroovyScriptPayloadBuilder(markup));
 
         Message controlMessage = new DefaultMessage("<TestRequest>" + System.lineSeparator() +

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/GroovyTemplateLoaderTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/GroovyTemplateLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2024 the original author or authors.
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with
@@ -49,9 +49,10 @@ public class GroovyTemplateLoaderTest extends UnitTestSupport {
         Assert.assertEquals(template.getParameter().size(), 3);
         Assert.assertEquals(template.getParameter().get("foo"), "");
         Assert.assertEquals(template.getParameter().get("bar"), "barValue");
-        Assert.assertEquals(template.getParameter().get("baz"), "foo\n" +
-                "        bar\n" +
-                "        baz");
+        Assert.assertEquals(template.getParameter().get("baz"), """
+                foo
+                        bar
+                        baz""");
         Assert.assertEquals(template.getActions().size(), 2);
         Assert.assertFalse(template.isGlobalContext());
     }

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/ReceiveTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/ReceiveTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2024 the original author or authors.
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with
@@ -91,10 +91,11 @@ public class ReceiveTest extends AbstractGroovyActionDslTest {
                 "                <TestMessage xmlns=\"http://citrusframework.org/test\">Hello Citrus</TestMessage>")
                                 .addHeaderData("<Header xmlns=\"http://citrusframework.org/test\"><operation>hello</operation></Header>")
                                 .setHeader("operation", "sayHello"));
-        helloQueue.send(new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<TestRequest>\n" +
-                "    <Message>Hello World!</Message>\n" +
-                "</TestRequest>").setHeader("operation", "sayHello"));
+        helloQueue.send(new DefaultMessage("""
+                <?xml version="1.0" encoding="UTF-8"?>
+                <TestRequest>
+                    <Message>Hello World!</Message>
+                </TestRequest>""").setHeader("operation", "sayHello"));
         helloQueue.send(new DefaultMessage("<TestMessage>Hello Citrus</TestMessage>").setHeader("operation", "sayHello"));
         helloQueue.send(new DefaultMessage("<TestMessage>Hello Citrus</TestMessage>").setHeader("operation", "sayHello"));
         helloQueue.send(new DefaultMessage("<ns:TestMessage xmlns:ns=\"http://citrusframework.org\">Hello Citrus</ns:TestMessage>").setHeader("operation", "sayHello"));

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/SendTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/SendTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2024 the original author or authors.
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with
@@ -142,10 +142,11 @@ public class SendTest extends AbstractGroovyActionDslTest {
         Assert.assertEquals(action.getMessageProcessors().size(), 0);
         Assert.assertEquals(action.getEndpointUri(), "helloEndpoint");
 
-        controlMessage = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<TestRequest>\n" +
-                "    <Message>Hello World!</Message>\n" +
-                "</TestRequest>");
+        controlMessage = new DefaultMessage("""
+                <?xml version="1.0" encoding="UTF-8"?>
+                <TestRequest>
+                    <Message>Hello World!</Message>
+                </TestRequest>""");
         receivedMessage = helloQueue.receive();
         headerValidator.validateMessage(receivedMessage, controlMessage, context, new HeaderValidationContext());
         validator.validateMessage(receivedMessage, controlMessage, context, new DefaultValidationContext());

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/integration/actions/LoadPropertiesJavaIT.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/integration/actions/LoadPropertiesJavaIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,16 +42,19 @@ public class LoadPropertiesJavaIT extends TestNGCitrusSpringSupport {
 
         run(echo("Verify variables support (replacement in properties)"));
 
-        run(groovy("import org.citrusframework.*\n" +
-          "import org.citrusframework.variable.*\n" +
-          "import org.citrusframework.context.TestContext\n" +
-          "import org.citrusframework.script.GroovyAction.ScriptExecutor\n" +
-          "import org.testng.Assert;\n" +
-          "public class GScript implements ScriptExecutor {\n" +
-              "public void execute(TestContext context) {\n" +
-                  "Assert.assertEquals(\"${welcomeText}\", \"Hello Mr. X\")\n" +
-                  "Assert.assertEquals(\"${todayDate}\", \"${checkDate}\")\n" +
-              "}\n" +
-          "}\n"));
+        run(groovy("""
+                import org.citrusframework.*
+                import org.citrusframework.variable.*
+                import org.citrusframework.context.TestContext
+                import org.citrusframework.script.GroovyAction.ScriptExecutor
+                import org.testng.Assert;
+                
+                public class GScript implements ScriptExecutor {
+                    public void execute(TestContext context) {
+                        Assert.assertEquals("${welcomeText}", "Hello Mr. X")
+                        Assert.assertEquals("${todayDate}", "${checkDate}")
+                    }
+                }
+                """));
     }
 }

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/script/GroovyActionTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/script/GroovyActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,15 +61,18 @@ public class GroovyActionTest extends AbstractTestNGUnitTest {
 
     @Test
     public void testCustomScriptExecutorImplementation() {
-        String script = "import org.citrusframework.*\n" +
-        		"import org.citrusframework.variable.*\n" +
-        		"import org.citrusframework.context.TestContext\n" +
-        		"import org.citrusframework.script.GroovyAction.ScriptExecutor\n\n" +
-        		"public class GScript implements ScriptExecutor {\n" +
-        		"public void execute(TestContext context) {\n" +
-        		    "context.setVariable('text', 'Script with class definition test successful.')\n" +
-        		    "println context.getVariable('text')\n" +
-        		"}}";
+        String script = """
+                import org.citrusframework.*
+                import org.citrusframework.variable.*
+                import org.citrusframework.context.TestContext
+                import org.citrusframework.script.GroovyAction.ScriptExecutor
+
+                public class GScript implements ScriptExecutor {
+                    public void execute(TestContext context) {
+                        context.setVariable('text', 'Script with class definition test successful.')
+                        println context.getVariable('text')
+                    }
+                }""";
 
         GroovyAction bean = new GroovyAction.Builder()
                 .script(script)
@@ -79,10 +82,12 @@ public class GroovyActionTest extends AbstractTestNGUnitTest {
 
     @Test
     public void testCustomClassImplementation() {
-        String script = "public class CustomClass {\n" +
-                "public void run() {\n" +
-                    "println 'Just executed custom class implementation'\n" +
-                "}}";
+        String script = """
+                public class CustomClass {
+                    public void run() {
+                        println 'Just executed custom class implementation'
+                    }
+                }""";
 
         GroovyAction bean = new GroovyAction.Builder()
                 .script(script)

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/validation/script/TemplateBasedScriptBuilderTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/validation/script/TemplateBasedScriptBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,11 +35,13 @@ public class TemplateBasedScriptBuilderTest {
                     ).withCode("BODY")
                     .build()
             ),
-            "+++HEAD+++\n" +
-                "\n" +
-                "BODY\n" +
-                "\n" +
-                "+++TAIL+++\n"
+            """
+            +++HEAD+++
+
+            BODY
+
+            +++TAIL+++
+            """
         );
     }
 }

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/IterateTestActionBuilderTest.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/IterateTestActionBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2015 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import org.citrusframework.context.TestContext;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import static java.lang.Integer.parseInt;
 import static org.citrusframework.actions.CreateVariablesAction.Builder.createVariable;
 import static org.citrusframework.container.Iterate.Builder.iterate;
 import static org.testng.Assert.assertEquals;
@@ -66,7 +67,7 @@ public class IterateTestActionBuilderTest extends UnitTestSupport {
                 () -> new AbstractTestAction() {
                 @Override
                 public void doExecute(TestContext context) {
-                    Assert.assertTrue(Integer.valueOf(context.getVariable("index")) > 0);
+                    Assert.assertTrue(parseInt(context.getVariable("index")) > 0);
                 }
             }));
 

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/integration/actions/ApplyTestBehaviorIT.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/integration/actions/ApplyTestBehaviorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -124,10 +124,7 @@ public class ApplyTestBehaviorIT extends TestNGCitrusSpringSupport {
     public void shouldApplyInContainerWithFinally() {
         run(sequential()
                 .actions(
-                        applyBehavior(runner -> {
-                            runner.run(doFinally()
-                                    .actions(echo("Finally say GoodBye!")));
-                        }),
+                        applyBehavior(runner -> runner.run(doFinally().actions(echo("Finally say GoodBye!")))),
                         echo("In Germany they say:"),
                         apply().behavior(new SayHelloBehavior("Hallo")).on(this),
                         echo("In Spain they say:"),

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/integration/actions/EchoActionJavaIT.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/integration/actions/EchoActionJavaIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,9 +34,7 @@ public class EchoActionJavaIT extends TestNGCitrusSpringSupport {
 
         run(echo("Today is citrus:currentDate()"));
 
-        $(context -> {
-            context.setVariable("today", "citrus:currentDate()");
-        });
+        $(context -> context.setVariable("today", "citrus:currentDate()"));
 
         run(echo("Today is ${today}"));
     }

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/integration/actions/TransformActionJavaIT.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/integration/actions/TransformActionJavaIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,16 +36,17 @@ public class TransformActionJavaIT extends TestNGCitrusSpringSupport {
             .source("<TestRequest>" +
                         "<Message>Hello World!</Message>" +
                     "</TestRequest>")
-            .xslt("<xsl:stylesheet version=\"1.0\" xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\">\n" +
-                        "<xsl:template match=\"/\">\n" +
-                        "<html>\n" +
-                            "<body>\n" +
-                                "<h2>Test Request</h2>\n" +
-                                "<p>Message: <xsl:value-of select=\"TestRequest/Message\"/></p>\n" +
-                            "</body>\n" +
-                        "</html>\n" +
-                        "</xsl:template>\n" +
-                    "</xsl:stylesheet>")
+            .xslt("""
+                    <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+                        <xsl:template match="/">
+                            <html>
+                                <body>
+                                    <h2>Test Request</h2>
+                                    <p>Message: <xsl:value-of select="TestRequest/Message"/></p>
+                                </body>
+                            </html>
+                        </xsl:template>
+                    </xsl:stylesheet>""")
             .result("result"));
 
         run(echo("${result}"));

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/integration/util/InvocationDummy.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/integration/util/InvocationDummy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,12 +63,11 @@ public class InvocationDummy {
     }
 
     public void invoke(String[] args) {
-        for (int i = 0; i < args.length; i++) {
-
-            checkNotVariable(args[i]);
+        for (var arg : args) {
+            checkNotVariable(arg);
 
             if (logger.isDebugEnabled()) {
-                logger.debug("Methode invoke with argument: " + args[i]);
+                logger.debug("Methode invoke with argument: " + arg);
             }
         }
     }

--- a/runtime/citrus-xml/src/main/java/org/citrusframework/xml/TestActions.java
+++ b/runtime/citrus-xml/src/main/java/org/citrusframework/xml/TestActions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2024 the original author or authors.
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with
@@ -110,9 +110,7 @@ public class TestActions {
                 action = ((JAXBElement<?>) object).getValue();
             }
 
-            if (object instanceof Node) {
-                Node node = (Node) object;
-
+            if (object instanceof Node node) {
                 Optional<TestActionBuilder<?>> builder = XmlTestActionBuilder.lookup(node.getLocalName(), node.getNamespaceURI());
                 if (builder.isPresent()) {
                     try {

--- a/runtime/citrus-xml/src/main/java/org/citrusframework/xml/XmlTestCase.java
+++ b/runtime/citrus-xml/src/main/java/org/citrusframework/xml/XmlTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with
@@ -117,7 +117,7 @@ public class XmlTestCase {
 
         public List<Variable> getVariables() {
             if (variables == null) {
-                variables = new ArrayList<Variable>();
+                variables = new ArrayList<>();
             }
             return this.variables;
         }

--- a/runtime/citrus-xml/src/test/java/org/citrusframework/xml/actions/ReceiveTest.java
+++ b/runtime/citrus-xml/src/test/java/org/citrusframework/xml/actions/ReceiveTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2024 the original author or authors.
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with
@@ -88,10 +88,11 @@ public class ReceiveTest extends AbstractXmlActionTest {
                 "<TestMessage xmlns=\"http://citrusframework.org/test\">Hello Citrus</TestMessage>")
                                 .addHeaderData("<Header xmlns=\"http://citrusframework.org/test\"><operation>hello</operation></Header>")
                                 .setHeader("operation", "sayHello"));
-        helloQueue.send(new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<TestRequest>\n" +
-                "    <Message>Hello World!</Message>\n" +
-                "</TestRequest>").setHeader("operation", "sayHello"));
+        helloQueue.send(new DefaultMessage("""
+                <?xml version="1.0" encoding="UTF-8"?>
+                <TestRequest>
+                    <Message>Hello World!</Message>
+                </TestRequest>""").setHeader("operation", "sayHello"));
         helloQueue.send(new DefaultMessage("<TestMessage>Hello Citrus</TestMessage>").setHeader("operation", "sayHello"));
         helloQueue.send(new DefaultMessage("<TestMessage>Hello Citrus</TestMessage>").setHeader("operation", "sayHello"));
         helloQueue.send(new DefaultMessage("<ns:TestMessage xmlns:ns=\"http://citrusframework.org\">Hello Citrus</ns:TestMessage>").setHeader("operation", "sayHello"));

--- a/runtime/citrus-xml/src/test/java/org/citrusframework/xml/actions/SendTest.java
+++ b/runtime/citrus-xml/src/test/java/org/citrusframework/xml/actions/SendTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2024 the original author or authors.
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with
@@ -140,10 +140,11 @@ public class SendTest extends AbstractXmlActionTest {
         Assert.assertEquals(action.getMessageProcessors().size(), 0);
         Assert.assertEquals(action.getEndpointUri(), "helloEndpoint");
 
-        controlMessage = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<TestRequest>\n" +
-                "    <Message>Hello World!</Message>\n" +
-                "</TestRequest>");
+        controlMessage = new DefaultMessage("""
+                <?xml version="1.0" encoding="UTF-8"?>
+                <TestRequest>
+                    <Message>Hello World!</Message>
+                </TestRequest>""");
         receivedMessage = helloQueue.receive();
         headerValidator.validateMessage(receivedMessage, controlMessage, context, new HeaderValidationContext());
         validator.validateMessage(receivedMessage, controlMessage, context, new DefaultValidationContext());

--- a/runtime/citrus-xml/src/test/java/org/citrusframework/xml/container/TemplateTest.java
+++ b/runtime/citrus-xml/src/test/java/org/citrusframework/xml/container/TemplateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2024 the original author or authors.
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with
@@ -51,11 +51,13 @@ public class TemplateTest extends AbstractXmlActionTest {
         Assert.assertEquals(template.getParameter().get("foo"), "");
         Assert.assertEquals(template.getParameter().get("bar"), "barValue");
         Assert.assertEquals(template.getParameter().get("baz"),
-                "\n" +
-                        "        foo\n" +
-                        "        bar\n" +
-                        "        baz\n" +
-                        "      ");
+                """
+
+                        foo
+                        bar
+                        baz
+                      \
+                """);
         Assert.assertEquals(template.getActions().size(), 2);
         Assert.assertFalse(template.isGlobalContext());
     }

--- a/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/actions/ReceiveTest.java
+++ b/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/actions/ReceiveTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2024 the original author or authors.
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with
@@ -87,10 +87,11 @@ public class ReceiveTest extends AbstractYamlActionTest {
                 "<TestMessage xmlns=\"http://citrusframework.org/test\">Hello Citrus</TestMessage>")
                                 .addHeaderData("<Header xmlns=\"http://citrusframework.org/test\"><operation>hello</operation></Header>")
                                 .setHeader("operation", "sayHello"));
-        helloQueue.send(new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<TestRequest>\n" +
-                "    <Message>Hello World!</Message>\n" +
-                "</TestRequest>").setHeader("operation", "sayHello"));
+        helloQueue.send(new DefaultMessage("""
+                <?xml version="1.0" encoding="UTF-8"?>
+                <TestRequest>
+                    <Message>Hello World!</Message>
+                </TestRequest>""").setHeader("operation", "sayHello"));
         helloQueue.send(new DefaultMessage("<TestMessage>Hello Citrus</TestMessage>").setHeader("operation", "sayHello"));
         helloQueue.send(new DefaultMessage("<TestMessage>Hello Citrus</TestMessage>").setHeader("operation", "sayHello"));
         helloQueue.send(new DefaultMessage("<ns:TestMessage xmlns:ns=\"http://citrusframework.org\">Hello Citrus</ns:TestMessage>").setHeader("operation", "sayHello"));

--- a/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/actions/SendTest.java
+++ b/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/actions/SendTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2024 the original author or authors.
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with
@@ -142,10 +142,11 @@ public class SendTest extends AbstractYamlActionTest {
         Assert.assertEquals(action.getMessageProcessors().size(), 0);
         Assert.assertEquals(action.getEndpointUri(), "helloEndpoint");
 
-        controlMessage = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<TestRequest>\n" +
-                "    <Message>Hello World!</Message>\n" +
-                "</TestRequest>");
+        controlMessage = new DefaultMessage("""
+                <?xml version="1.0" encoding="UTF-8"?>
+                <TestRequest>
+                    <Message>Hello World!</Message>
+                </TestRequest>""");
         receivedMessage = helloQueue.receive();
         headerValidator.validateMessage(receivedMessage, controlMessage, context, new HeaderValidationContext());
         validator.validateMessage(receivedMessage, controlMessage, context, new DefaultValidationContext());

--- a/tools/docs-generator/src/main/java/org/citrusframework/docs/HtmlTestDocsGenerator.java
+++ b/tools/docs-generator/src/main/java/org/citrusframework/docs/HtmlTestDocsGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2018 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,8 @@ import javax.xml.transform.stream.StreamResult;
 import java.io.*;
 import java.util.*;
 
+import static java.lang.Integer.parseInt;
+
 /**
  * Class to automatically generate a list of all available tests in HTML.
  * 
@@ -47,9 +49,9 @@ public class HtmlTestDocsGenerator extends AbstractTestDocsGenerator {
     }
     
     @Override
-    public void doHeader(OutputStream buffered) throws TransformerException, IOException, SAXException {
+    public void doHeader(OutputStream buffered) throws IOException {
         List<File> testFiles = getTestFiles();
-        int maxEntries = testFiles.size() / Integer.valueOf(getTestDocProperties().getProperty("overview.columns"));
+        int maxEntries = testFiles.size() / parseInt(getTestDocProperties().getProperty("overview.columns"));
 
         buffered.write("<td style=\"border:1px solid #bbbbbb;\">".getBytes());
         buffered.write("<ol>".getBytes());

--- a/tools/docs-generator/src/main/java/org/citrusframework/docs/SvgTestDocsGenerator.java
+++ b/tools/docs-generator/src/main/java/org/citrusframework/docs/SvgTestDocsGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2018 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ public final class SvgTestDocsGenerator extends AbstractTestDocsGenerator {
         try {
             List<File> testFiles = getTestFiles();
 
-            for (File testFile : testFiles) {
+            for (var testFile : testFiles) {
                 logger.info("Working on test " + testFile.getName());
 
                 fos = getFileOutputStream(testFile.getName().substring(0, testFile.getName().lastIndexOf('.')) + ".svg");
@@ -76,11 +76,7 @@ public final class SvgTestDocsGenerator extends AbstractTestDocsGenerator {
                 buffered.flush();
                 fos.close();
             }
-        } catch (TransformerException e) {
-            throw new CitrusRuntimeException(e);
-        } catch (SAXException e) {
-            throw new CitrusRuntimeException(e);
-        } catch (IOException e) {
+        } catch (TransformerException | SAXException | IOException e) {
             throw new CitrusRuntimeException(e);
         } finally {
             if (buffered != null) {

--- a/tools/jbang/src/main/java/org/citrusframework/jbang/commands/Init.java
+++ b/tools/jbang/src/main/java/org/citrusframework/jbang/commands/Init.java
@@ -14,20 +14,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.citrusframework.jbang.commands;
+
+import org.citrusframework.jbang.CitrusJBangMain;
+import org.citrusframework.util.FileUtils;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
 
 import java.io.File;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Stack;
 
-import org.citrusframework.util.FileUtils;
-import org.citrusframework.jbang.CitrusJBangMain;
-import picocli.CommandLine.Command;
-import picocli.CommandLine.Option;
-import picocli.CommandLine.Parameters;
+import static java.nio.file.Files.writeString;
 
 @Command(name = "init", description = "Creates a new Citrus test")
 public class Init extends CitrusCommand {
@@ -68,16 +70,14 @@ public class Init extends CitrusCommand {
         File target = new File(directory, file);
         content = content.replaceFirst("\\{\\{ \\.Name }}", name);
 
-        Files.write(target.toPath(), content.getBytes(StandardCharsets.UTF_8));
+        writeString(target.toPath(), content);
         return 0;
     }
 
     static class FileConsumer extends ParameterConsumer<Init> {
         @Override
         protected void doConsumeParameters(Stack<String> args, Init cmd) {
-            String arg = args.pop();
-            cmd.file = arg;
+            cmd.file = args.pop();
         }
     }
-
 }

--- a/tools/jbang/src/main/java/org/citrusframework/jbang/commands/ListTests.java
+++ b/tools/jbang/src/main/java/org/citrusframework/jbang/commands/ListTests.java
@@ -14,12 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.citrusframework.jbang.commands;
 
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+package org.citrusframework.jbang.commands;
 
 import com.github.freva.asciitable.AsciiTable;
 import com.github.freva.asciitable.Column;
@@ -29,6 +25,14 @@ import main.CitrusJBang;
 import org.citrusframework.jbang.CitrusJBangMain;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static java.lang.Long.compare;
+import static java.lang.Long.parseLong;
 
 @Command(name = "ls", description = "List running Citrus tests")
 public class ListTests extends CitrusCommand {
@@ -127,16 +131,13 @@ public class ListTests extends CitrusCommand {
             s = s.substring(1);
             negate = -1;
         }
-        switch (s) {
-            case "pid":
-                return Long.compare(Long.parseLong(o1.pid), Long.parseLong(o2.pid)) * negate;
-            case "name":
-                return o1.name.compareToIgnoreCase(o2.name) * negate;
-            case "age":
-                return Long.compare(o1.uptime, o2.uptime) * negate;
-            default:
-                return 0;
-        }
+
+        return switch (s) {
+            case "pid" -> compare(parseLong(o1.pid), parseLong(o2.pid)) * negate;
+            case "name" -> o1.name.compareToIgnoreCase(o2.name) * negate;
+            case "age" -> compare(o1.uptime, o2.uptime) * negate;
+            default -> 0;
+        };
     }
 
     protected static long extractSince(ProcessHandle ph) {

--- a/tools/restdocs/src/main/java/org/citrusframework/restdocs/soap/RestDocSoapRequestConverter.java
+++ b/tools/restdocs/src/main/java/org/citrusframework/restdocs/soap/RestDocSoapRequestConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2016 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,15 +70,15 @@ public class RestDocSoapRequestConverter implements RequestConverter<MessageCont
 
     protected HttpHeaders extractHeaders(MessageContext messageContext) {
         HttpHeaders httpHeaders = new HttpHeaders();
-        if (messageContext.getRequest() instanceof SaajSoapMessage) {
-            Map<String, String> mimeHeaders = new HashMap<String, String>();
-            MimeHeaders messageMimeHeaders = ((SaajSoapMessage)messageContext.getRequest()).getSaajMessage().getMimeHeaders();
+        if (messageContext.getRequest() instanceof SaajSoapMessage saajSoapMessage) {
+            Map<String, String> mimeHeaders = new HashMap<>();
+            MimeHeaders messageMimeHeaders = saajSoapMessage.getSaajMessage().getMimeHeaders();
 
             if (messageMimeHeaders != null) {
-                Iterator<?> mimeHeaderIterator = messageMimeHeaders.getAllHeaders();
+                Iterator<MimeHeader> mimeHeaderIterator = messageMimeHeaders.getAllHeaders();
                 while (mimeHeaderIterator.hasNext()) {
-                    MimeHeader mimeHeader = (MimeHeader)mimeHeaderIterator.next();
-                    // http headers can have multipile values so headers might occur several times in map
+                    MimeHeader mimeHeader = mimeHeaderIterator.next();
+                    // http headers can have multiple values so headers might occur several times in map
                     if (mimeHeaders.containsKey(mimeHeader.getName())) {
                         // header is already present, so concat values to a single comma delimited string
                         String value = mimeHeaders.get(mimeHeader.getName());
@@ -89,7 +89,7 @@ public class RestDocSoapRequestConverter implements RequestConverter<MessageCont
                     }
                 }
 
-                for (Map.Entry<String, String> httpHeaderEntry : mimeHeaders.entrySet()) {
+                for (var httpHeaderEntry : mimeHeaders.entrySet()) {
                     httpHeaders.add(httpHeaderEntry.getKey(), httpHeaderEntry.getValue());
                 }
             }

--- a/tools/restdocs/src/test/java/org/citrusframework/restdocs/http/RestDocClientInterceptorTest.java
+++ b/tools/restdocs/src/test/java/org/citrusframework/restdocs/http/RestDocClientInterceptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2016 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ import java.net.URI;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -78,13 +77,10 @@ public class RestDocClientInterceptorTest {
 
         ClientHttpRequestExecution configureExecution = Mockito.mock(ClientHttpRequestExecution.class);
 
-        when(configureExecution.execute(any(HttpRequest.class), any(byte[].class))).thenAnswer(new Answer<ClientHttpResponse>() {
-            @Override
-            public ClientHttpResponse answer(InvocationOnMock invocation) throws Throwable {
-                interceptor.intercept((HttpRequest) invocation.getArguments()[0], (byte[]) invocation.getArguments()[1], execution);
+        when(configureExecution.execute(any(HttpRequest.class), any(byte[].class))).thenAnswer((Answer<ClientHttpResponse>) invocation -> {
+            interceptor.intercept((HttpRequest) invocation.getArguments()[0], (byte[]) invocation.getArguments()[1], execution);
 
-                return response;
-            }
+            return response;
         });
 
         CitrusRestDocsSupport.restDocsConfigurer(restDocumentation).intercept(request, "TestMessage".getBytes(), configureExecution);
@@ -98,13 +94,10 @@ public class RestDocClientInterceptorTest {
 
         ClientHttpRequestExecution configureExecution = Mockito.mock(ClientHttpRequestExecution.class);
 
-        when(configureExecution.execute(any(HttpRequest.class), any(byte[].class))).thenAnswer(new Answer<ClientHttpResponse>() {
-            @Override
-            public ClientHttpResponse answer(InvocationOnMock invocation) throws Throwable {
-                interceptor.intercept((HttpRequest) invocation.getArguments()[0], (byte[]) invocation.getArguments()[1], execution);
+        when(configureExecution.execute(any(HttpRequest.class), any(byte[].class))).thenAnswer((Answer<ClientHttpResponse>) invocation -> {
+            interceptor.intercept((HttpRequest) invocation.getArguments()[0], (byte[]) invocation.getArguments()[1], execution);
 
-                return response;
-            }
+            return response;
         });
 
         CitrusRestDocsSupport.restDocsConfigurer(restDocumentation).snippets().withTemplateFormat(TemplateFormats.markdown()).intercept(request, "TestMessage".getBytes(), configureExecution);

--- a/tools/restdocs/src/test/java/org/citrusframework/restdocs/soap/RestDocSoapClientInterceptorTest.java
+++ b/tools/restdocs/src/test/java/org/citrusframework/restdocs/soap/RestDocSoapClientInterceptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2016 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@ import java.util.Map;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.springframework.restdocs.ManualRestDocumentation;
 import org.springframework.restdocs.RestDocumentationContext;
@@ -114,45 +113,33 @@ public class RestDocSoapClientInterceptorTest {
         when(messageContext.getRequest()).thenReturn(request);
         when(messageContext.getResponse()).thenReturn(response);
 
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                restDocConfiguration = (Map<String, Object>) invocation.getArguments()[1];
-                when(messageContext.getProperty(CitrusRestDocSoapConfigurer.REST_DOC_SOAP_CONFIGURATION)).thenReturn(restDocConfiguration);
-                return null;
-            }
+        doAnswer(invocation -> {
+            restDocConfiguration = (Map<String, Object>) invocation.getArguments()[1];
+            when(messageContext.getProperty(CitrusRestDocSoapConfigurer.REST_DOC_SOAP_CONFIGURATION)).thenReturn(restDocConfiguration);
+            return null;
         }).when(messageContext).setProperty(eq(CitrusRestDocSoapConfigurer.REST_DOC_SOAP_CONFIGURATION), any());
         when(messageContext.containsProperty(CitrusRestDocSoapConfigurer.REST_DOC_SOAP_CONFIGURATION)).thenReturn(true);
 
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                restDocumentationContext = (RestDocumentationContext) invocation.getArguments()[1];
-                when(messageContext.getProperty(RestDocumentationContext.class.getName())).thenReturn(restDocumentationContext);
-                return null;
-            }
+        doAnswer(invocation -> {
+            restDocumentationContext = (RestDocumentationContext) invocation.getArguments()[1];
+            when(messageContext.getProperty(RestDocumentationContext.class.getName())).thenReturn(restDocumentationContext);
+            return null;
         }).when(messageContext).setProperty(eq(RestDocumentationContext.class.getName()), any());
 
-        doAnswer(new Answer<Object>() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                OutputStream os = (OutputStream) invocation.getArguments()[0];
+        doAnswer((Answer<Object>) invocation -> {
+            OutputStream os = (OutputStream) invocation.getArguments()[0];
 
-                FileCopyUtils.copy(requestBody.getBytes(), os);
+            FileCopyUtils.copy(requestBody.getBytes(), os);
 
-                return null;
-            }
+            return null;
         }).when(request).writeTo(any(OutputStream.class));
 
-        doAnswer(new Answer<Object>() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                OutputStream os = (OutputStream) invocation.getArguments()[0];
+        doAnswer((Answer<Object>) invocation -> {
+            OutputStream os = (OutputStream) invocation.getArguments()[0];
 
-                FileCopyUtils.copy(responseBody.getBytes(), os);
+            FileCopyUtils.copy(responseBody.getBytes(), os);
 
-                return null;
-            }
+            return null;
         }).when(response).writeTo(any(OutputStream.class));
 
         this.interceptor = CitrusRestDocsSoapSupport.restDocsInterceptor(identifier, snippets);

--- a/tools/test-generator/src/main/java/org/citrusframework/generate/javadsl/JavaTestGenerator.java
+++ b/tools/test-generator/src/main/java/org/citrusframework/generate/javadsl/JavaTestGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2018 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -170,12 +170,11 @@ public class JavaTestGenerator<T extends JavaTestGenerator<T>> extends AbstractT
      * @return The annotation spec for test cases
      */
     private AnnotationSpec[] getTestAnnotations() {
-        switch (getFramework()){
-            case JUNIT4: return createJunit4TestAnnotations();
-            case JUNIT5: return createJunit5Annotations();
-            case TESTNG: return createTestNgTestAnnotations();
-            default: throw new CitrusRuntimeException("Unsupported framework: " + getFramework());
-        }
+        return switch (getFramework()) {
+            case JUNIT4 -> createJunit4TestAnnotations();
+            case JUNIT5 -> createJunit5Annotations();
+            case TESTNG -> createTestNgTestAnnotations();
+        };
     }
 
     /**

--- a/validation/citrus-validation-groovy/src/main/java/org/citrusframework/validation/script/GroovyScriptMessageValidator.java
+++ b/validation/citrus-validation-groovy/src/main/java/org/citrusframework/validation/script/GroovyScriptMessageValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,11 +78,7 @@ public class GroovyScriptMessageValidator extends AbstractMessageValidator<Scrip
             if (StringUtils.hasText(validationScript)) {
                 logger.debug("Start groovy message validation ...");
 
-                GroovyClassLoader loader = AccessController.doPrivileged(new PrivilegedAction<GroovyClassLoader>() {
-                    public GroovyClassLoader run() {
-                        return new GroovyClassLoader(GroovyScriptMessageValidator.class.getClassLoader());
-                    }
-                });
+                GroovyClassLoader loader = AccessController.doPrivileged((PrivilegedAction<GroovyClassLoader>) () -> new GroovyClassLoader(GroovyScriptMessageValidator.class.getClassLoader()));
                 Class<?> groovyClass = loader.parseClass(TemplateBasedScriptBuilder.fromTemplateResource(scriptTemplateResource)
                                                             .withCode(validationScript)
                                                             .build());

--- a/validation/citrus-validation-groovy/src/test/java/org/citrusframework/integration/ValidateSqlResultSetJavaIT.java
+++ b/validation/citrus-validation-groovy/src/test/java/org/citrusframework/integration/ValidateSqlResultSetJavaIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,8 +54,10 @@ public class ValidateSqlResultSetJavaIT extends TestNGCitrusSpringSupport {
 
         run(query(dataSource)
             .statement("SELECT REQUEST_TAG AS RTAG, DESCRIPTION AS DESC FROM ORDERS")
-            .validateScript("assert rows.size() == ${rowsCount}\n" +
-                    "assert rows[0].RTAG == '${rtag}'\n" +
-                    "assert rows[0].DESC == '${desc}'\n", ScriptTypes.GROOVY));
+            .validateScript("""
+                    assert rows.size() == ${rowsCount}
+                    assert rows[0].RTAG == '${rtag}'
+                    assert rows[0].DESC == '${desc}'
+                    """, ScriptTypes.GROOVY));
     }
 }

--- a/validation/citrus-validation-groovy/src/test/java/org/citrusframework/validation/script/GroovyJsonMessageValidatorTest.java
+++ b/validation/citrus-validation-groovy/src/test/java/org/citrusframework/validation/script/GroovyJsonMessageValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2012 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,12 +44,14 @@ public class GroovyJsonMessageValidatorTest extends AbstractTestNGUnitTest {
         Message message = new DefaultMessage("{\"person\":{\"name\":\"Christoph\",\"age\":31," +
         		"\"pets\":[\"dog\",\"cat\"]}}");
 
-        String validationScript = "assert json.size() == 1 \n" +
-                                  "assert json.person.name == 'Christoph' \n" +
-                                  "assert json.person.age == 31 \n" +
-                                  "assert json.person.pets.size() == 2 \n" +
-                                  "assert json.person.pets[0] == 'dog' \n" +
-                                  "assert json.person.pets[1] == 'cat' \n";
+        String validationScript = """
+                assert json.size() == 1\s
+                assert json.person.name == 'Christoph'\s
+                assert json.person.age == 31\s
+                assert json.person.pets.size() == 2\s
+                assert json.person.pets[0] == 'dog'\s
+                assert json.person.pets[1] == 'cat'\s
+                """;
 
         ScriptValidationContext validationContext = new ScriptValidationContext.Builder()
                 .scriptType(ScriptTypes.GROOVY)

--- a/validation/citrus-validation-groovy/src/test/java/org/citrusframework/validation/script/GroovyScriptMessageValidatorTest.java
+++ b/validation/citrus-validation-groovy/src/test/java/org/citrusframework/validation/script/GroovyScriptMessageValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2011 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,9 +48,10 @@ public class GroovyScriptMessageValidatorTest extends AbstractTestNGUnitTest {
 
     @Test
     public void testGroovyScriptValidation() throws ValidationException {
-        String validationScript = "assert headers.operation == 'unitTesting'\n" +
-        		"assert payload == 'This is plain text!'\n" +
-        		"assert payload.contains('!')";
+        String validationScript = """
+                assert headers.operation == 'unitTesting'
+                assert payload == 'This is plain text!'
+                assert payload.contains('!')""";
 
         ScriptValidationContext validationContext = new ScriptValidationContext.Builder()
                 .scriptType(ScriptTypes.GROOVY)
@@ -62,9 +63,10 @@ public class GroovyScriptMessageValidatorTest extends AbstractTestNGUnitTest {
 
     @Test
     public void testGroovyScriptValidationVariableSupport() throws ValidationException {
-        String validationScript = "assert headers.operation == 'unitTesting'\n" +
-                "assert payload == '${plainText}'\n" +
-                "assert payload.contains('!')";
+        String validationScript = """
+                assert headers.operation == 'unitTesting'
+                assert payload == '${plainText}'
+                assert payload.contains('!')""";
 
         context.setVariable("plainText", "This is plain text!");
 
@@ -78,9 +80,10 @@ public class GroovyScriptMessageValidatorTest extends AbstractTestNGUnitTest {
 
     @Test
     public void testGroovyScriptValidationWrongValue() throws ValidationException {
-        String validationScript = "assert headers.operation == 'somethingElse'\n" +
-                "assert payload == 'This is plain text!'\n" +
-                "assert payload.contains('!')";
+        String validationScript = """
+                assert headers.operation == 'somethingElse'
+                assert payload == 'This is plain text!'
+                assert payload.contains('!')""";
 
         ScriptValidationContext validationContext = new ScriptValidationContext.Builder()
                 .scriptType(ScriptTypes.GROOVY)

--- a/validation/citrus-validation-groovy/src/test/java/org/citrusframework/validation/script/GroovyXmlMessageValidatorTest.java
+++ b/validation/citrus-validation-groovy/src/test/java/org/citrusframework/validation/script/GroovyXmlMessageValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,10 +53,11 @@ public class GroovyXmlMessageValidatorTest extends AbstractTestNGUnitTest {
 
     @Test
     public void testGroovyScriptValidation() throws ValidationException {
-        String validationScript = "assert root.children().size() == 3 \n" +
-                        "assert root.CorrelationId.text() == 'Kx1R123456789' \n" +
-                        "assert root.BookingId.text() == 'Bx1G987654321' \n" +
-                        "assert root.Text.text() == 'Hello TestFramework'";
+        String validationScript = """
+                assert root.children().size() == 3\s
+                assert root.CorrelationId.text() == 'Kx1R123456789'\s
+                assert root.BookingId.text() == 'Bx1G987654321'\s
+                assert root.Text.text() == 'Hello TestFramework'""";
 
         ScriptValidationContext validationContext = new ScriptValidationContext.Builder()
                 .scriptType(ScriptTypes.GROOVY)
@@ -71,10 +72,11 @@ public class GroovyXmlMessageValidatorTest extends AbstractTestNGUnitTest {
         context.setVariable("user", "TestFramework");
         context.setVariable("correlationId", "Kx1R123456789");
 
-        String validationScript = "assert root.children().size() == 3 \n" +
-                        "assert root.CorrelationId.text() == '${correlationId}' \n" +
-                        "assert root.BookingId.text() == 'Bx1G987654321' \n" +
-                        "assert root.Text.text() == 'Hello ' + context.getVariable(\"user\")";
+        String validationScript = """
+                assert root.children().size() == 3\s
+                assert root.CorrelationId.text() == '${correlationId}'\s
+                assert root.BookingId.text() == 'Bx1G987654321'\s
+                assert root.Text.text() == 'Hello ' + context.getVariable("user")""";
 
         ScriptValidationContext validationContext = new ScriptValidationContext.Builder()
                 .scriptType(ScriptTypes.GROOVY)
@@ -86,10 +88,11 @@ public class GroovyXmlMessageValidatorTest extends AbstractTestNGUnitTest {
 
     @Test
     public void testGroovyScriptValidationFailed() {
-        String validationScript = "assert root.children().size() == 3 \n" +
-                        "assert root.CorrelationId.text() == 'Kx1R123456789' \n" +
-                        "assert root.BookingId.text() == 'Bx1G987654321' \n" +
-                        "assert root.Text == 'Hello Citrus'"; //should fail
+        String validationScript = """
+                assert root.children().size() == 3\s
+                assert root.CorrelationId.text() == 'Kx1R123456789'\s
+                assert root.BookingId.text() == 'Bx1G987654321'\s
+                assert root.Text == 'Hello Citrus'"""; //should fail
 
         ScriptValidationContext validationContext = new ScriptValidationContext.Builder()
                 .scriptType(ScriptTypes.GROOVY)

--- a/validation/citrus-validation-groovy/src/test/java/org/citrusframework/validation/script/ReceiveMessageActionTest.java
+++ b/validation/citrus-validation-groovy/src/test/java/org/citrusframework/validation/script/ReceiveMessageActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,6 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.Test;
 
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 /**

--- a/validation/citrus-validation-hamcrest/src/main/java/org/citrusframework/validation/matcher/hamcrest/provider/AntPathMatcherProvider.java
+++ b/validation/citrus-validation-hamcrest/src/main/java/org/citrusframework/validation/matcher/hamcrest/provider/AntPathMatcherProvider.java
@@ -1,9 +1,27 @@
+/*
+ * Copyright 2006-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.citrusframework.validation.matcher.hamcrest.provider;
 
 import org.citrusframework.validation.matcher.hamcrest.HamcrestMatcherProvider;
 import org.hamcrest.CustomMatcher;
 import org.hamcrest.Matcher;
 import org.springframework.util.AntPathMatcher;
+
+import static java.lang.String.format;
 
 /**
  * @author Christoph Deppisch
@@ -17,7 +35,7 @@ public class AntPathMatcherProvider implements HamcrestMatcherProvider {
 
     @Override
     public Matcher<String> provideMatcher(String predicate) {
-        return new CustomMatcher<String>(String.format("path matching %s", predicate)) {
+        return new CustomMatcher<>(format("path matching %s", predicate)) {
             @Override
             public boolean matches(Object item) {
                 return ((item instanceof String) && new AntPathMatcher().match(predicate, (String) item));

--- a/validation/citrus-validation-json/src/main/java/org/citrusframework/json/JsonSettings.java
+++ b/validation/citrus-validation-json/src/main/java/org/citrusframework/json/JsonSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with
@@ -19,7 +19,12 @@
 
 package org.citrusframework.json;
 
-import net.minidev.json.parser.JSONParser;
+import static java.lang.Boolean.parseBoolean;
+import static java.lang.Integer.parseInt;
+import static net.minidev.json.parser.JSONParser.MODE_JSON_SIMPLE;
+import static net.minidev.json.parser.JSONParser.MODE_PERMISSIVE;
+import static net.minidev.json.parser.JSONParser.MODE_RFC4627;
+import static net.minidev.json.parser.JSONParser.MODE_STRICTEST;
 
 /**
  * @author Christoph Deppisch
@@ -32,7 +37,7 @@ public final class JsonSettings {
 
     private static final String PERMISSIVE_MODE_PROPERTY = "citrus.json.permissive.mode";
     private static final String PERMISSIVE_MODE_ENV = "CITRUS_JSON_PERMISSIVE_MODE";
-    private static final String PERMISSIVE_MODE_DEFAULT = String.valueOf(JSONParser.MODE_JSON_SIMPLE);
+    private static final String PERMISSIVE_MODE_DEFAULT = String.valueOf(MODE_JSON_SIMPLE);
 
     /**
      * Private constructor prevent instantiation of utility class
@@ -49,18 +54,13 @@ public final class JsonSettings {
         String mode = System.getProperty(PERMISSIVE_MODE_PROPERTY, System.getenv(PERMISSIVE_MODE_ENV) != null ?
                         System.getenv(PERMISSIVE_MODE_ENV) : PERMISSIVE_MODE_DEFAULT);
 
-        switch (mode) {
-            case "SIMPLE":
-                return JSONParser.MODE_JSON_SIMPLE;
-            case "RFC4627":
-                return JSONParser.MODE_RFC4627;
-            case "STRICTEST":
-                return JSONParser.MODE_STRICTEST;
-            case "PERMISSIVE":
-                return JSONParser.MODE_PERMISSIVE;
-            default:
-                return Integer.parseInt(mode);
-        }
+        return switch (mode) {
+            case "SIMPLE" -> MODE_JSON_SIMPLE;
+            case "RFC4627" -> MODE_RFC4627;
+            case "STRICTEST" -> MODE_STRICTEST;
+            case "PERMISSIVE" -> MODE_PERMISSIVE;
+            default -> parseInt(mode);
+        };
     }
 
     /**
@@ -68,7 +68,7 @@ public final class JsonSettings {
      * @return
      */
     public static boolean isStrict() {
-        return Boolean.parseBoolean(
+        return parseBoolean(
                 System.getProperty(MESSAGE_VALIDATION_STRICT_PROPERTY, System.getenv(MESSAGE_VALIDATION_STRICT_ENV) != null ?
                         System.getenv(MESSAGE_VALIDATION_STRICT_ENV) : MESSAGE_VALIDATION_STRICT_DEFAULT));
     }

--- a/validation/citrus-validation-json/src/main/java/org/citrusframework/validation/json/JsonMappingValidationProcessor.java
+++ b/validation/citrus-validation-json/src/main/java/org/citrusframework/validation/json/JsonMappingValidationProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2015 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -137,7 +137,7 @@ public abstract class JsonMappingValidationProcessor<T> extends AbstractValidati
                         "please add proper validation logic");
             }
 
-            return new JsonMappingValidationProcessor<T>(resultType, mapper) {
+            return new JsonMappingValidationProcessor<>(resultType, mapper) {
                 @Override
                 public void validate(T payload, Map<String, Object> headers, TestContext context) {
                     validationProcessor.validate(payload, headers, context);

--- a/validation/citrus-validation-json/src/main/java/org/citrusframework/validation/json/schema/JsonSchemaValidation.java
+++ b/validation/citrus-validation-json/src/main/java/org/citrusframework/validation/json/schema/JsonSchemaValidation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2018 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 

--- a/validation/citrus-validation-json/src/test/java/org/citrusframework/integration/JsonMappingValidationProcessorIT.java
+++ b/validation/citrus-validation-json/src/test/java/org/citrusframework/integration/JsonMappingValidationProcessorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2015 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,14 +86,10 @@ public class JsonMappingValidationProcessorIT extends TestNGCitrusSpringSupport 
                 .message()
                 .validate(JsonSupport.validate(Person.class)
                     .mapper(mapper)
-                    .validator((person, headers, context) -> {
-                        Assert.assertEquals(person.name, "christoph");
-                    }).build())
+                    .validator((person, headers, context) -> Assert.assertEquals(person.name, "christoph")).build())
                 .validate(JsonSupport.validate(Person.class)
                     .mapper(mapper)
-                    .validator((person, headers, context) -> {
-                        Assert.assertTrue(person.age > 30);
-                    }).build())
+                    .validator((person, headers, context) -> Assert.assertTrue(person.age > 30)).build())
         );
     }
 
@@ -110,14 +106,10 @@ public class JsonMappingValidationProcessorIT extends TestNGCitrusSpringSupport 
                 .message()
                 .validate(JsonSupport.validate(Person.class)
                         .mapper(mapper)
-                        .validator((person, headers, context) -> {
-                            Assert.assertTrue(person.age > 30);
-                        }).build())
+                        .validator((person, headers, context) -> Assert.assertTrue(person.age > 30)).build())
                 .validate(JsonSupport.validate(Person.class)
                         .mapper(mapper)
-                        .validator((person, headers, context) -> {
-                            Assert.assertEquals(person.name, "should fail");
-                        }).build())
+                        .validator((person, headers, context) -> Assert.assertEquals(person.name, "should fail")).build())
         );
     }
 
@@ -134,9 +126,7 @@ public class JsonMappingValidationProcessorIT extends TestNGCitrusSpringSupport 
                 .message()
                 .validate(JsonSupport.validate(Person.class)
                         .mapper(mapper)
-                        .validator((person, headers, context) -> {
-                            Assert.assertEquals(person.name, "should fail");
-                        }).build())
+                        .validator((person, headers, context) -> Assert.assertEquals(person.name, "should fail")).build())
         );
     }
 

--- a/validation/citrus-validation-json/src/test/java/org/citrusframework/validation/json/JsonTextMessageValidatorTest.java
+++ b/validation/citrus-validation-json/src/test/java/org/citrusframework/validation/json/JsonTextMessageValidatorTest.java
@@ -37,7 +37,6 @@ import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 /**

--- a/validation/citrus-validation-json/src/test/java/org/citrusframework/validation/json/schema/JsonSchemaValidationTest.java
+++ b/validation/citrus-validation-json/src/test/java/org/citrusframework/validation/json/schema/JsonSchemaValidationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2018 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,19 +82,20 @@ public class JsonSchemaValidationTest {
                 .thenReturn(Collections.singletonList(schema));
 
         // Create the received message
-        Message receivedMessage = new DefaultMessage("[\n" +
-                "              {\n" +
-                "                \"id\": 2,\n" +
-                "                \"name\": \"An ice sculpture\",\n" +
-                "                \"price\": 12.50,\n" +
-                "                \"tags\": [\"cold\", \"ice\"],\n" +
-                "                \"dimensions\": {\n" +
-                    "                \"length\": 7.0,\n" +
-                    "                \"width\": 12.0,\n" +
-                    "                \"height\": 9.5\n" +
-                "                 }\n" +
-                "              }\n" +
-                "            ]");
+        Message receivedMessage = new DefaultMessage("""
+                [
+                  {
+                    "id": 2,
+                    "name": "An ice sculpture",
+                    "price": 12.50,
+                    "tags": ["cold", "ice"],
+                    "dimensions": {
+                    "length": 7.0,
+                    "width": 12.0,
+                    "height": 9.5
+                     }
+                  }
+                ]""");
 
 
         GraciousProcessingReport report = fixture.validate(
@@ -124,18 +125,19 @@ public class JsonSchemaValidationTest {
         when(jsonSchemaFilterMock.filter(schemaRepositories,  validationContextMock, referenceResolverMock))
                 .thenReturn(Collections.singletonList(schema));
 
-        Message receivedMessage = new DefaultMessage("[\n" +
-                "              {\n" +
-                "                \"name\": \"An ice sculpture\",\n" +
-                "                \"price\": 12.50,\n" +
-                "                \"tags\": [\"cold\", \"ice\"],\n" +
-                "                \"dimensions\": {\n" +
-                    "                \"length\": 7.0,\n" +
-                    "                \"width\": 12.0,\n" +
-                    "                \"height\": 9.5\n" +
-                "                 }\n" +
-                "              }\n" +
-                "            ]");
+        Message receivedMessage = new DefaultMessage("""
+                [
+                  {
+                    "name": "An ice sculpture",
+                    "price": 12.50,
+                    "tags": ["cold", "ice"],
+                    "dimensions": {
+                    "length": 7.0,
+                    "width": 12.0,
+                    "height": 9.5
+                     }
+                  }
+                ]""");
 
         GraciousProcessingReport report = fixture.validate(
                 receivedMessage,
@@ -170,19 +172,20 @@ public class JsonSchemaValidationTest {
         when(jsonSchemaFilterMock.filter(schemaRepositories,  validationContextMock, referenceResolverMock))
                 .thenReturn(Collections.singletonList(schema));
 
-        Message receivedMessage = new DefaultMessage("[\n" +
-                "              {\n" +
-                "                \"id\": 2,\n" +
-                "                \"name\": \"An ice sculpture\",\n" +
-                "                \"price\": 12.50,\n" +
-                "                \"tags\": [\"cold\", \"ice\"],\n" +
-                "                \"dimensions\": {\n" +
-                    "                \"length\": 7.0,\n" +
-                    "                \"width\": 12.0,\n" +
-                    "                \"height\": 9.5\n" +
-                "                 }\n" +
-                "              }\n" +
-                "            ]");
+        Message receivedMessage = new DefaultMessage("""
+                [
+                  {
+                    "id": 2,
+                    "name": "An ice sculpture",
+                    "price": 12.50,
+                    "tags": ["cold", "ice"],
+                    "dimensions": {
+                    "length": 7.0,
+                    "width": 12.0,
+                    "height": 9.5
+                     }
+                  }
+                ]""");
 
         GraciousProcessingReport report = fixture.validate(
                 receivedMessage,
@@ -222,19 +225,20 @@ public class JsonSchemaValidationTest {
         when(jsonSchemaFilterMock.filter(repositoryList,  validationContextMock, referenceResolverMock))
                 .thenReturn(List.of(invalidSchema, validSchema));
 
-        Message receivedMessage = new DefaultMessage("[\n" +
-                "              {\n" +
-                "                \"id\": 2,\n" +
-                "                \"name\": \"An ice sculpture\",\n" +
-                "                \"price\": 12.50,\n" +
-                "                \"tags\": [\"cold\", \"ice\"],\n" +
-                "                \"dimensions\": {\n" +
-                    "                \"length\": 7.0,\n" +
-                    "                \"width\": 12.0,\n" +
-                    "                \"height\": 9.5\n" +
-                "                 }\n" +
-                "              }\n" +
-                "            ]");
+        Message receivedMessage = new DefaultMessage("""
+                [
+                  {
+                    "id": 2,
+                    "name": "An ice sculpture",
+                    "price": 12.50,
+                    "tags": ["cold", "ice"],
+                    "dimensions": {
+                    "length": 7.0,
+                    "width": 12.0,
+                    "height": 9.5
+                     }
+                  }
+                ]""");
 
         GraciousProcessingReport report = fixture.validate(
                 receivedMessage,

--- a/validation/citrus-validation-text/src/main/java/org/citrusframework/validation/text/PlainTextMessageValidator.java
+++ b/validation/citrus-validation-text/src/main/java/org/citrusframework/validation/text/PlainTextMessageValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2011 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,9 @@ import org.citrusframework.validation.DefaultMessageValidator;
 import org.citrusframework.validation.context.ValidationContext;
 import org.citrusframework.validation.matcher.ValidationMatcherUtils;
 
+import static java.lang.Boolean.parseBoolean;
+import static java.lang.Integer.parseInt;
+
 /**
  * Plain text validator using simple String comparison.
  *
@@ -41,14 +44,13 @@ public class PlainTextMessageValidator extends DefaultMessageValidator {
     public static final String IGNORE_WHITESPACE_PROPERTY = "citrus.plaintext.validation.ignore.whitespace";
     public static final String IGNORE_WHITESPACE_ENV = "CITRUS_PLAINTEXT_VALIDATION_IGNORE_WHITESPACE";
 
-    private boolean ignoreNewLineType = Boolean.valueOf(System.getProperty(IGNORE_NEWLINE_TYPE_PROPERTY, System.getenv(IGNORE_NEWLINE_TYPE_ENV) != null ?
+    private boolean ignoreNewLineType = parseBoolean(System.getProperty(IGNORE_NEWLINE_TYPE_PROPERTY, System.getenv(IGNORE_NEWLINE_TYPE_ENV) != null ?
             System.getenv(IGNORE_NEWLINE_TYPE_ENV) : "false"));
-    private boolean ignoreWhitespace = Boolean.valueOf(System.getProperty(IGNORE_WHITESPACE_PROPERTY, System.getenv(IGNORE_WHITESPACE_ENV) != null ?
+    private boolean ignoreWhitespace = parseBoolean(System.getProperty(IGNORE_WHITESPACE_PROPERTY, System.getenv(IGNORE_WHITESPACE_ENV) != null ?
             System.getenv(IGNORE_WHITESPACE_ENV) : "false"));
 
     @Override
-    public void validateMessage(Message receivedMessage, Message controlMessage,
-                                TestContext context, ValidationContext validationContext) throws ValidationException {
+    public void validateMessage(Message receivedMessage, Message controlMessage, TestContext context, ValidationContext validationContext) throws ValidationException {
         if (controlMessage == null || controlMessage.getPayload() == null) {
             logger.debug("Skip message payload validation as no control message was defined");
             return;
@@ -96,7 +98,7 @@ public class PlainTextMessageValidator extends DefaultMessageValidator {
             String actualValue;
 
             if (ignoreMatcher.groupCount() > 0 && StringUtils.hasText(ignoreMatcher.group(1))) {
-                int end = ignoreMatcher.start() + Integer.valueOf(ignoreMatcher.group(1));
+                int end = ignoreMatcher.start() + parseInt(ignoreMatcher.group(1));
                 if (end > result.length()) {
                     end = result.length();
                 }

--- a/validation/citrus-validation-xml/src/main/java/org/citrusframework/util/XMLUtils.java
+++ b/validation/citrus-validation-xml/src/main/java/org/citrusframework/util/XMLUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -137,21 +137,23 @@ public final class XMLUtils {
             }
         }
 
-        StringBuffer pathName;
+        StringBuilder pathName;
         Node parent;
-        for (int j=0; j<elements.getLength(); j++) {
-            int cnt = numToks-1;
-            pathName = new StringBuffer(element);
+        for (int j = 0; j < elements.getLength(); j++) {
+            int cnt = numToks - 1;
+            pathName = new StringBuilder(element);
             parent = elements.item(j).getParentNode();
             do {
                 if (parent != null) {
                     pathName.insert(0, '.');
-                    pathName.insert(0, parent.getLocalName());//getNodeName());
+                    pathName.insert(0, parent.getLocalName());
 
                     parent = parent.getParentNode();
                 }
             } while (parent != null && --cnt > 0);
-            if (pathName.toString().equals(pathExpression)) {return elements.item(j);}
+            if (pathName.toString().equals(pathExpression)) {
+                return elements.item(j);
+            }
         }
 
         return null;
@@ -278,7 +280,7 @@ public final class XMLUtils {
      * @return map containing namespace prefix - namespace url pairs.
      */
     public static Map<String, String> lookupNamespaces(Node referenceNode) {
-        Map<String, String> namespaces = new HashMap<String, String>();
+        Map<String, String> namespaces = new HashMap<>();
 
         Node node;
         if (referenceNode.getNodeType() == Node.DOCUMENT_NODE) {

--- a/validation/citrus-validation-xml/src/main/java/org/citrusframework/variable/dictionary/xml/AbstractXmlDataDictionary.java
+++ b/validation/citrus-validation-xml/src/main/java/org/citrusframework/variable/dictionary/xml/AbstractXmlDataDictionary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,9 +91,7 @@ public abstract class AbstractXmlDataDictionary extends AbstractDataDictionary<N
 
         @Override
         public short acceptNode(Node node) {
-            if (node instanceof Element) {
-                Element element = (Element) node;
-
+            if (node instanceof Element element) {
                 if (StringUtils.hasText(DomUtils.getTextValue(element))) {
                     element.setTextContent(translate(element, DomUtils.getTextValue(element), context));
                 } else if (!element.hasChildNodes()) {

--- a/validation/citrus-validation-xml/src/main/java/org/citrusframework/xml/schema/SchemaMappingStrategyChain.java
+++ b/validation/citrus-validation-xml/src/main/java/org/citrusframework/xml/schema/SchemaMappingStrategyChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2012 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ import org.w3c.dom.Document;
 public class SchemaMappingStrategyChain implements XsdSchemaMappingStrategy {
     
     /** List of strategies to use in this chain */
-    private List<XsdSchemaMappingStrategy> strategies = new ArrayList<XsdSchemaMappingStrategy>();
+    private List<XsdSchemaMappingStrategy> strategies = new ArrayList<>();
 
     /**
      * {@inheritDoc}

--- a/validation/citrus-validation-xml/src/main/java/org/citrusframework/xml/schema/WsdlXsdSchema.java
+++ b/validation/citrus-validation-xml/src/main/java/org/citrusframework/xml/schema/WsdlXsdSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2012 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -109,8 +109,7 @@ public class WsdlXsdSchema extends AbstractSchemaCollection {
         if (types != null) {
             List<?> schemaTypes = types.getExtensibilityElements();
             for (Object schemaObject : schemaTypes) {
-                if (schemaObject instanceof SchemaImpl) {
-                    SchemaImpl schema = (SchemaImpl) schemaObject;
+                if (schemaObject instanceof SchemaImpl schema) {
                     inheritNamespaces(schema, definition);
 
                     addImportedSchemas(schema);

--- a/validation/citrus-validation-xml/src/main/java/org/citrusframework/xml/xpath/XPathUtils.java
+++ b/validation/citrus-validation-xml/src/main/java/org/citrusframework/xml/xpath/XPathUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ public abstract class XPathUtils {
      * @return
      */
     public static Map<String, String> getDynamicNamespaces(String expression) {
-        Map<String, String> namespaces = new HashMap<String, String>();
+        Map<String, String> namespaces = new HashMap<>();
 
         if (expression.contains(DYNAMIC_NS_START) && expression.contains(DYNAMIC_NS_END)) {
             String[] tokens = expression.split("\\" + DYNAMIC_NS_START);

--- a/validation/citrus-validation-xml/src/test/java/org/citrusframework/HeaderValuesTest.java
+++ b/validation/citrus-validation-xml/src/test/java/org/citrusframework/HeaderValuesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,7 +79,7 @@ public class HeaderValuesTest extends UnitTestSupport {
                             + "</element>"
                             + "</root>"));
 
-        HashMap<String, Object> validateHeaderValues = new HashMap<String, Object>();
+        HashMap<String, Object> validateHeaderValues = new HashMap<>();
         validateHeaderValues.put("header-valueA", "A");
 
         controlMessageBuilder.addHeaderBuilder(new DefaultHeaderBuilder(validateHeaderValues));
@@ -122,7 +122,7 @@ public class HeaderValuesTest extends UnitTestSupport {
                             + "</element>"
                             + "</root>"));
 
-        HashMap<String, Object> validateHeaderValues = new HashMap<String, Object>();
+        HashMap<String, Object> validateHeaderValues = new HashMap<>();
         validateHeaderValues.put("header-valueA", "A");
         validateHeaderValues.put("header-valueB", "B");
         validateHeaderValues.put("header-valueC", "C");
@@ -168,7 +168,7 @@ public class HeaderValuesTest extends UnitTestSupport {
                             + "</element>"
                             + "</root>"));
 
-        HashMap<String, Object> validateHeaderValues = new HashMap<String, Object>();
+        HashMap<String, Object> validateHeaderValues = new HashMap<>();
         validateHeaderValues.put("header-valueA", "wrong");
 
         controlMessageBuilder.addHeaderBuilder(new DefaultHeaderBuilder(validateHeaderValues));
@@ -211,7 +211,7 @@ public class HeaderValuesTest extends UnitTestSupport {
                             + "</element>"
                             + "</root>"));
 
-        HashMap<String, Object> validateHeaderValues = new HashMap<String, Object>();
+        HashMap<String, Object> validateHeaderValues = new HashMap<>();
         validateHeaderValues.put("header-wrong", "A");
 
         controlMessageBuilder.addHeaderBuilder(new DefaultHeaderBuilder(validateHeaderValues));
@@ -254,7 +254,7 @@ public class HeaderValuesTest extends UnitTestSupport {
                             + "</element>"
                             + "</root>"));
 
-        HashMap<String, Object> validateHeaderValues = new HashMap<String, Object>();
+        HashMap<String, Object> validateHeaderValues = new HashMap<>();
         validateHeaderValues.put("header-valueA", "");
         validateHeaderValues.put("header-valueB", "");
         validateHeaderValues.put("header-valueC", "");
@@ -299,7 +299,7 @@ public class HeaderValuesTest extends UnitTestSupport {
                             + "</element>"
                             + "</root>"));
 
-        HashMap<String, Object> validateHeaderValues = new HashMap<String, Object>();
+        HashMap<String, Object> validateHeaderValues = new HashMap<>();
         validateHeaderValues.put("header-valueA", "null");
         validateHeaderValues.put("header-valueB", "null");
         validateHeaderValues.put("header-valueC", "null");
@@ -344,7 +344,7 @@ public class HeaderValuesTest extends UnitTestSupport {
                             + "</element>"
                             + "</root>"));
 
-        HashMap<String, String> extractHeaderValues = new HashMap<String, String>();
+        HashMap<String, String> extractHeaderValues = new HashMap<>();
         extractHeaderValues.put("header-valueA", "${valueA}");
         extractHeaderValues.put("header-valueB", "${valueB}");
 

--- a/validation/citrus-validation-xml/src/test/java/org/citrusframework/IgnoreElementsLegacyTest.java
+++ b/validation/citrus-validation-xml/src/test/java/org/citrusframework/IgnoreElementsLegacyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,7 +80,7 @@ public class IgnoreElementsLegacyTest extends UnitTestSupport {
             + "</element>"
             + "</root>"));
 
-        Set<String> ignoreMessageElements = new HashSet<String>();
+        Set<String> ignoreMessageElements = new HashSet<>();
         ignoreMessageElements.add("root.element.sub-elementA");
         ignoreMessageElements.add("sub-elementB");
 
@@ -107,7 +107,7 @@ public class IgnoreElementsLegacyTest extends UnitTestSupport {
             + "</element>"
             + "</root>"));
 
-        Set<String> ignoreMessageElements = new HashSet<String>();
+        Set<String> ignoreMessageElements = new HashSet<>();
         ignoreMessageElements.add("root.element.sub-elementA.attribute");
         ignoreMessageElements.add("sub-elementB.attribute");
 
@@ -143,7 +143,7 @@ public class IgnoreElementsLegacyTest extends UnitTestSupport {
                         + "<element additonal-attribute='some'>Wrong text</element>"
                         + "</root>"));
 
-        Set<String> ignoreMessageElements = new HashSet<String>();
+        Set<String> ignoreMessageElements = new HashSet<>();
         ignoreMessageElements.add("root");
 
         XmlMessageValidationContext validationContext = new XmlMessageValidationContext.Builder()
@@ -169,7 +169,7 @@ public class IgnoreElementsLegacyTest extends UnitTestSupport {
             + "</element>"
             + "</root>"));
 
-        Set<String> ignoreMessageElements = new HashSet<String>();
+        Set<String> ignoreMessageElements = new HashSet<>();
         ignoreMessageElements.add("root.element.sub-elementA");
         ignoreMessageElements.add("sub-elementB");
 

--- a/validation/citrus-validation-xml/src/test/java/org/citrusframework/IgnoreElementsTest.java
+++ b/validation/citrus-validation-xml/src/test/java/org/citrusframework/IgnoreElementsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,7 +81,7 @@ public class IgnoreElementsTest extends UnitTestSupport {
             + "</element>"
             + "</root>"));
 
-        Set<String> ignoreMessageElements = new HashSet<String>();
+        Set<String> ignoreMessageElements = new HashSet<>();
         ignoreMessageElements.add("//root/element/sub-elementA");
         ignoreMessageElements.add("//sub-elementB");
 
@@ -119,7 +119,7 @@ public class IgnoreElementsTest extends UnitTestSupport {
                 + "</element>"
                 + "</root>"));
 
-        Set<String> ignoreMessageElements = new HashSet<String>();
+        Set<String> ignoreMessageElements = new HashSet<>();
         ignoreMessageElements.add("//sub-element");
 
         XmlMessageValidationContext validationContext = new XmlMessageValidationContext.Builder()
@@ -156,7 +156,7 @@ public class IgnoreElementsTest extends UnitTestSupport {
                 + "</element>"
                 + "</root>"));
 
-        Set<String> ignoreMessageElements = new HashSet<String>();
+        Set<String> ignoreMessageElements = new HashSet<>();
         ignoreMessageElements.add("//sub-element[1]");
         ignoreMessageElements.add("//sub-element[3]");
 
@@ -197,7 +197,7 @@ public class IgnoreElementsTest extends UnitTestSupport {
                 + "</element>"
                 + "</root>"));
 
-        Set<String> ignoreMessageElements = new HashSet<String>();
+        Set<String> ignoreMessageElements = new HashSet<>();
         ignoreMessageElements.add("/*");
 
         XmlMessageValidationContext validationContext = new XmlMessageValidationContext.Builder()
@@ -223,7 +223,7 @@ public class IgnoreElementsTest extends UnitTestSupport {
                 + "</element>"
                 + "</root>"));
 
-        Set<String> ignoreMessageElements = new HashSet<String>();
+        Set<String> ignoreMessageElements = new HashSet<>();
         ignoreMessageElements.add("//root/element/sub-elementA/@attribute");
         ignoreMessageElements.add("//sub-elementB/@attribute");
 
@@ -250,7 +250,7 @@ public class IgnoreElementsTest extends UnitTestSupport {
                 + "</element>"
                 + "</root>"));
 
-        Set<String> ignoreMessageElements = new HashSet<String>();
+        Set<String> ignoreMessageElements = new HashSet<>();
         ignoreMessageElements.add("//@attribute");
 
         XmlMessageValidationContext validationContext = new XmlMessageValidationContext.Builder()
@@ -293,7 +293,7 @@ public class IgnoreElementsTest extends UnitTestSupport {
                 + "</element>"
                 + "</root>"));
 
-        Set<String> ignoreMessageElements = new HashSet<String>();
+        Set<String> ignoreMessageElements = new HashSet<>();
         ignoreMessageElements.add("//sub-element[1]/@attribute");
         ignoreMessageElements.add("//sub-element[2]/@attribute");
 
@@ -329,7 +329,7 @@ public class IgnoreElementsTest extends UnitTestSupport {
                         + "<element additonal-attribute='some'>Wrong text</element>"
                         + "</root>"));
 
-        Set<String> ignoreMessageElements = new HashSet<String>();
+        Set<String> ignoreMessageElements = new HashSet<>();
         ignoreMessageElements.add("//root");
 
         XmlMessageValidationContext validationContext = new XmlMessageValidationContext.Builder()
@@ -355,7 +355,7 @@ public class IgnoreElementsTest extends UnitTestSupport {
                 + "</element>"
                 + "</root>"));
 
-        Set<String> ignoreMessageElements = new HashSet<String>();
+        Set<String> ignoreMessageElements = new HashSet<>();
         ignoreMessageElements.add("//root/element/sub-elementA");
         ignoreMessageElements.add("//sub-elementB");
 
@@ -437,7 +437,7 @@ public class IgnoreElementsTest extends UnitTestSupport {
                 + "</element>"
                 + "</root>"));
 
-        Set<String> ignoreMessageElements = new HashSet<String>();
+        Set<String> ignoreMessageElements = new HashSet<>();
         ignoreMessageElements.add("//something-else");
 
         XmlMessageValidationContext validationContext = new XmlMessageValidationContext.Builder()

--- a/validation/citrus-validation-xml/src/test/java/org/citrusframework/UnitTestSupport.java
+++ b/validation/citrus-validation-xml/src/test/java/org/citrusframework/UnitTestSupport.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.citrusframework;
 
 import java.util.List;
@@ -30,7 +46,7 @@ public abstract class UnitTestSupport extends AbstractTestNGUnitTest {
         factory.getMessageValidatorRegistry().addMessageValidator("xpath", new XpathMessageValidator());
         factory.getMessageValidatorRegistry().addMessageValidator("xhtml", new XhtmlMessageValidator());
         factory.getMessageValidatorRegistry().addMessageValidator("xhtmlXpath", new XhtmlXpathMessageValidator());
-        factory.getMessageValidatorRegistry().addMessageValidator("plaintext", new MessageValidator<ValidationContext>() {
+        factory.getMessageValidatorRegistry().addMessageValidator("plaintext", new MessageValidator<>() {
             @Override
             public void validateMessage(Message receivedMessage, Message controlMessage, TestContext context, List<ValidationContext> validationContexts) throws ValidationException {
                 Assert.assertEquals(receivedMessage.getPayload(String.class), controlMessage.getPayload());

--- a/validation/citrus-validation-xml/src/test/java/org/citrusframework/VariableSupportTest.java
+++ b/validation/citrus-validation-xml/src/test/java/org/citrusframework/VariableSupportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -236,7 +236,7 @@ public class VariableSupportTest extends UnitTestSupport {
         context.getVariables().put("variableB", "B");
         context.getVariables().put("variableC", "C");
 
-        HashMap<String, Object> validateHeaderValues = new HashMap<String, Object>();
+        HashMap<String, Object> validateHeaderValues = new HashMap<>();
         validateHeaderValues.put("header-valueA", "${variableA}");
         validateHeaderValues.put("header-valueB", "${variableB}");
         validateHeaderValues.put("header-valueC", "${variableC}");
@@ -283,7 +283,7 @@ public class VariableSupportTest extends UnitTestSupport {
 
         context.getVariables().put("variableC", "c");
 
-        HashMap<String, Object> validateHeaderValues = new HashMap<String, Object>();
+        HashMap<String, Object> validateHeaderValues = new HashMap<>();
         validateHeaderValues.put("header-valueA", "citrus:upperCase('a')");
         validateHeaderValues.put("header-valueB", "citrus:upperCase('b')");
         validateHeaderValues.put("header-valueC", "citrus:upperCase(${variableC})");
@@ -332,7 +332,7 @@ public class VariableSupportTest extends UnitTestSupport {
         context.getVariables().put("variableB", "header-valueB");
         context.getVariables().put("variableC", "header-valueC");
 
-        HashMap<String, Object> validateHeaderValues = new HashMap<String, Object>();
+        HashMap<String, Object> validateHeaderValues = new HashMap<>();
         validateHeaderValues.put("${variableA}", "A");
         validateHeaderValues.put("${variableB}", "B");
         validateHeaderValues.put("${variableC}", "C");
@@ -377,7 +377,7 @@ public class VariableSupportTest extends UnitTestSupport {
                 + "</element>"
                 + "</root>"));
 
-        HashMap<String, Object> validateHeaderValues = new HashMap<String, Object>();
+        HashMap<String, Object> validateHeaderValues = new HashMap<>();
         validateHeaderValues.put("citrus:concat('header', '-', 'valueA')", "A");
         validateHeaderValues.put("citrus:concat('header', '-', 'valueB')", "B");
         validateHeaderValues.put("citrus:concat('header', '-', 'valueC')", "C");

--- a/validation/citrus-validation-xml/src/test/java/org/citrusframework/actions/dsl/ReceiveMessageActionBuilderTest.java
+++ b/validation/citrus-validation-xml/src/test/java/org/citrusframework/actions/dsl/ReceiveMessageActionBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2015 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1426,18 +1426,19 @@ public class ReceiveMessageActionBuilderTest extends UnitTestSupport {
                         .setHeader("operation", "sayHello"));
 
         when(schema.getTargetNamespace()).thenReturn("http://citrusframework.org/test");
-        when(schema.getSource()).thenReturn(new StringSource("<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\n" +
-                "     xmlns=\"http://citrusframework.org/test\"\n" +
-                "     targetNamespace=\"http://citrusframework.org/test\"\n" +
-                "     elementFormDefault=\"qualified\"\n" +
-                "     attributeFormDefault=\"unqualified\">\n" +
-                "    <xs:element name=\"TestRequest\">\n" +
-                "      <xs:complexType>\n" +
-                "          <xs:sequence>\n" +
-                "            <xs:element name=\"Message\" type=\"xs:string\"/>\n" +
-                "          </xs:sequence>\n" +
-                "      </xs:complexType>\n" +
-                "    </xs:element></xs:schema>"));
+        when(schema.getSource()).thenReturn(new StringSource("""
+                <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                     xmlns="http://citrusframework.org/test"
+                     targetNamespace="http://citrusframework.org/test"
+                     elementFormDefault="qualified"
+                     attributeFormDefault="unqualified">
+                    <xs:element name="TestRequest">
+                      <xs:complexType>
+                          <xs:sequence>
+                            <xs:element name="Message" type="xs:string"/>
+                          </xs:sequence>
+                      </xs:complexType>
+                    </xs:element></xs:schema>"""));
 
         context.setReferenceResolver(new SpringBeanReferenceResolver(applicationContext).withFallback(referenceResolver));
         DefaultTestCaseRunner runner = new DefaultTestCaseRunner(context);

--- a/validation/citrus-validation-xml/src/test/java/org/citrusframework/util/XMLUtilsTest.java
+++ b/validation/citrus-validation-xml/src/test/java/org/citrusframework/util/XMLUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -377,8 +377,10 @@ public class XMLUtilsTest {
 
         Document doc = XMLUtils.parseMessagePayload(payload);
 
-        Assert.assertEquals(XMLUtils.serialize(doc), "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<testRequest xmlns=\"http://citrusframework.org/test-default\">ÄäÖöÜü</testRequest>\n");
+        Assert.assertEquals(XMLUtils.serialize(doc), """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <testRequest xmlns="http://citrusframework.org/test-default">ÄäÖöÜü</testRequest>
+                """);
     }
 
     @Test

--- a/validation/citrus-validation-xml/src/test/java/org/citrusframework/validation/xml/DomXmlMessageValidatorTest.java
+++ b/validation/citrus-validation-xml/src/test/java/org/citrusframework/validation/xml/DomXmlMessageValidatorTest.java
@@ -515,7 +515,7 @@ public class DomXmlMessageValidatorTest extends UnitTestSupport {
                         + "</element>"
                     + "</root>");
 
-        Map<String, String> expectedNamespaces = new HashMap<String, String>();
+        Map<String, String> expectedNamespaces = new HashMap<>();
         expectedNamespaces.put("", "http://citrusframework.org/test");
 
         DomXmlMessageValidator validator = new DomXmlMessageValidator();
@@ -530,7 +530,7 @@ public class DomXmlMessageValidatorTest extends UnitTestSupport {
                         + "</ns1:element>"
                     + "</ns1:root>");
 
-        Map<String, String> expectedNamespaces = new HashMap<String, String>();
+        Map<String, String> expectedNamespaces = new HashMap<>();
         expectedNamespaces.put("ns1", "http://citrusframework.org/ns1");
 
         DomXmlMessageValidator validator = new DomXmlMessageValidator();
@@ -545,7 +545,7 @@ public class DomXmlMessageValidatorTest extends UnitTestSupport {
                         + "</element>"
                     + "</root>");
 
-        Map<String, String> expectedNamespaces = new HashMap<String, String>();
+        Map<String, String> expectedNamespaces = new HashMap<>();
         expectedNamespaces.put("", "http://citrusframework.org/default");
         expectedNamespaces.put("ns1", "http://citrusframework.org/ns1");
 
@@ -561,7 +561,7 @@ public class DomXmlMessageValidatorTest extends UnitTestSupport {
                         + "</element>"
                     + "</root>");
 
-        Map<String, String> expectedNamespaces = new HashMap<String, String>();
+        Map<String, String> expectedNamespaces = new HashMap<>();
         expectedNamespaces.put("", "http://citrusframework.org/default");
         expectedNamespaces.put("ns1", "http://citrusframework.org/ns1");
         expectedNamespaces.put("ns2", "http://citrusframework.org/ns2");
@@ -578,7 +578,7 @@ public class DomXmlMessageValidatorTest extends UnitTestSupport {
                         + "</element>"
                     + "</root>");
 
-        Map<String, String> expectedNamespaces = new HashMap<String, String>();
+        Map<String, String> expectedNamespaces = new HashMap<>();
         expectedNamespaces.put("", "http://citrusframework.org/wrong");
 
         DomXmlMessageValidator validator = new DomXmlMessageValidator();
@@ -593,7 +593,7 @@ public class DomXmlMessageValidatorTest extends UnitTestSupport {
                         + "</ns1:element>"
                     + "</ns1:root>");
 
-        Map<String, String> expectedNamespaces = new HashMap<String, String>();
+        Map<String, String> expectedNamespaces = new HashMap<>();
         expectedNamespaces.put("ns1", "http://citrusframework.org/ns1/wrong");
 
         DomXmlMessageValidator validator = new DomXmlMessageValidator();
@@ -608,7 +608,7 @@ public class DomXmlMessageValidatorTest extends UnitTestSupport {
                         + "</element>"
                     + "</root>");
 
-        Map<String, String> expectedNamespaces = new HashMap<String, String>();
+        Map<String, String> expectedNamespaces = new HashMap<>();
         expectedNamespaces.put("", "http://citrusframework.org/default/wrong");
         expectedNamespaces.put("ns1", "http://citrusframework.org/ns1");
 
@@ -624,7 +624,7 @@ public class DomXmlMessageValidatorTest extends UnitTestSupport {
                         + "</element>"
                     + "</root>");
 
-        Map<String, String> expectedNamespaces = new HashMap<String, String>();
+        Map<String, String> expectedNamespaces = new HashMap<>();
         expectedNamespaces.put("", "http://citrusframework.org/default");
         expectedNamespaces.put("ns1", "http://citrusframework.org/ns1/wrong");
         expectedNamespaces.put("ns2", "http://citrusframework.org/ns2");
@@ -641,7 +641,7 @@ public class DomXmlMessageValidatorTest extends UnitTestSupport {
                         + "</element>"
                     + "</root>");
 
-        Map<String, String> expectedNamespaces = new HashMap<String, String>();
+        Map<String, String> expectedNamespaces = new HashMap<>();
         expectedNamespaces.put("", "http://citrusframework.org/default");
         expectedNamespaces.put("nswrong", "http://citrusframework.org/ns1");
         expectedNamespaces.put("ns2", "http://citrusframework.org/ns2");
@@ -658,7 +658,7 @@ public class DomXmlMessageValidatorTest extends UnitTestSupport {
                         + "</ns0:element>"
                     + "</ns0:root>");
 
-        Map<String, String> expectedNamespaces = new HashMap<String, String>();
+        Map<String, String> expectedNamespaces = new HashMap<>();
         expectedNamespaces.put("", "http://citrusframework.org/default");
         expectedNamespaces.put("ns1", "http://citrusframework.org/ns1");
         expectedNamespaces.put("ns2", "http://citrusframework.org/ns2");
@@ -675,7 +675,7 @@ public class DomXmlMessageValidatorTest extends UnitTestSupport {
                         + "</element>"
                     + "</root>");
 
-        Map<String, String> expectedNamespaces = new HashMap<String, String>();
+        Map<String, String> expectedNamespaces = new HashMap<>();
         expectedNamespaces.put("ns0", "http://citrusframework.org/default");
         expectedNamespaces.put("ns1", "http://citrusframework.org/ns1");
         expectedNamespaces.put("ns2", "http://citrusframework.org/ns2");
@@ -692,7 +692,7 @@ public class DomXmlMessageValidatorTest extends UnitTestSupport {
                         + "</element>"
                     + "</root>");
 
-        Map<String, String> expectedNamespaces = new HashMap<String, String>();
+        Map<String, String> expectedNamespaces = new HashMap<>();
         expectedNamespaces.put("", "http://citrusframework.org/default");
         expectedNamespaces.put("ns1", "http://citrusframework.org/ns1");
         expectedNamespaces.put("ns2", "http://citrusframework.org/ns2");
@@ -710,7 +710,7 @@ public class DomXmlMessageValidatorTest extends UnitTestSupport {
                         + "</element>"
                     + "</root>");
 
-        Map<String, String> expectedNamespaces = new HashMap<String, String>();
+        Map<String, String> expectedNamespaces = new HashMap<>();
         expectedNamespaces.put("", "http://citrusframework.org/default");
         expectedNamespaces.put("ns1", "http://citrusframework.org/ns1");
         expectedNamespaces.put("ns2", "http://citrusframework.org/ns2");
@@ -758,7 +758,7 @@ public class DomXmlMessageValidatorTest extends UnitTestSupport {
                     + "</root>");
 
 
-        Set<String> ignoreExpressions = new HashSet<String>();
+        Set<String> ignoreExpressions = new HashSet<>();
         ignoreExpressions.add("//root/element/sub-element1");
 
         XmlMessageValidationContext validationContext = new XmlMessageValidationContext.Builder()

--- a/validation/citrus-validation-xml/src/test/java/org/citrusframework/validation/xml/ReceiveMessageActionTest.java
+++ b/validation/citrus-validation-xml/src/test/java/org/citrusframework/validation/xml/ReceiveMessageActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -414,11 +414,11 @@ public class ReceiveMessageActionTest extends AbstractTestNGUnitTest {
         DefaultMessageBuilder controlMessageBuilder = new DefaultMessageBuilder();
         controlMessageBuilder.setPayloadBuilder(new DefaultPayloadBuilder("<TestRequest><Message>Hello World!</Message></TestRequest>"));
 
-        Map<String, Object> headers = new HashMap<String, Object>();
+        Map<String, Object> headers = new HashMap<>();
         headers.put("Operation", "sayHello");
         controlMessageBuilder.addHeaderBuilder(new DefaultHeaderBuilder(headers));
 
-        Map<String, Object> controlHeaders = new HashMap<String, Object>();
+        Map<String, Object> controlHeaders = new HashMap<>();
         controlHeaders.put("Operation", "sayHello");
         Message controlMessage = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>", controlHeaders);
 
@@ -444,11 +444,11 @@ public class ReceiveMessageActionTest extends AbstractTestNGUnitTest {
 
         context.setVariable("myOperation", "sayHello");
 
-        Map<String, Object> headers = new HashMap<String, Object>();
+        Map<String, Object> headers = new HashMap<>();
         headers.put("Operation", "${myOperation}");
         controlMessageBuilder.addHeaderBuilder(new DefaultHeaderBuilder(headers));
 
-        Map<String, Object> controlHeaders = new HashMap<String, Object>();
+        Map<String, Object> controlHeaders = new HashMap<>();
         controlHeaders.put("Operation", "sayHello");
         Message controlMessage = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>", controlHeaders);
 
@@ -472,11 +472,11 @@ public class ReceiveMessageActionTest extends AbstractTestNGUnitTest {
         DefaultMessageBuilder controlMessageBuilder = new DefaultMessageBuilder();
         controlMessageBuilder.setPayloadBuilder(new DefaultPayloadBuilder("<TestRequest><Message>Hello World!</Message></TestRequest>"));
 
-        Map<String, Object> headers = new HashMap<String, Object>();
+        Map<String, Object> headers = new HashMap<>();
         headers.put("Operation", "${myOperation}");
         controlMessageBuilder.addHeaderBuilder(new DefaultHeaderBuilder(headers));
 
-        Map<String, Object> controlHeaders = new HashMap<String, Object>();
+        Map<String, Object> controlHeaders = new HashMap<>();
         controlHeaders.put("Operation", "sayHello");
         Message controlMessage = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>", controlHeaders);
 
@@ -530,14 +530,14 @@ public class ReceiveMessageActionTest extends AbstractTestNGUnitTest {
         DefaultMessageBuilder controlMessageBuilder = new DefaultMessageBuilder();
         controlMessageBuilder.setPayloadBuilder(new DefaultPayloadBuilder("<TestRequest><Message>Hello World!</Message></TestRequest>"));
 
-        Map<String, String> headers = new HashMap<String, String>();
+        Map<String, String> headers = new HashMap<>();
         headers.put("Operation", "myOperation");
 
         MessageHeaderVariableExtractor headerVariableExtractor = new MessageHeaderVariableExtractor.Builder()
                 .headers(headers)
                 .build();
 
-        Map<String, Object> controlHeaders = new HashMap<String, Object>();
+        Map<String, Object> controlHeaders = new HashMap<>();
         controlHeaders.put("Operation", "sayHello");
         Message controlMessage = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>", controlHeaders);
 
@@ -685,7 +685,7 @@ public class ReceiveMessageActionTest extends AbstractTestNGUnitTest {
         Map<String, Object> messageElements = new HashMap<>();
         messageElements.put("/pfx:TestRequest/pfx:Message", "Hello World!");
 
-        Map<String, String> namespaces = new HashMap<String, String>();
+        Map<String, String> namespaces = new HashMap<>();
         namespaces.put("pfx", "http://citrusframework.org/unittest");
 
         Message controlMessage = new DefaultMessage("<ns0:TestRequest xmlns:ns0=\"http://citrusframework.org/unittest\">" +
@@ -913,7 +913,7 @@ public class ReceiveMessageActionTest extends AbstractTestNGUnitTest {
         Map<String, Object> extractMessageElements = new HashMap<>();
         extractMessageElements.put("/pfx:TestRequest/pfx:Message", "messageVar");
 
-        Map<String, String> namespaces = new HashMap<String, String>();
+        Map<String, String> namespaces = new HashMap<>();
         namespaces.put("pfx", "http://citrusframework.org/unittest");
 
         XpathPayloadVariableExtractor variableExtractor = new XpathPayloadVariableExtractor.Builder()
@@ -978,7 +978,7 @@ public class ReceiveMessageActionTest extends AbstractTestNGUnitTest {
 
         String messageSelector = "Operation = 'sayHello'";
 
-        Map<String, Object> headers = new HashMap<String, Object>();
+        Map<String, Object> headers = new HashMap<>();
         headers.put("Operation", "sayHello");
         Message controlMessage = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>", headers);
 
@@ -1005,7 +1005,7 @@ public class ReceiveMessageActionTest extends AbstractTestNGUnitTest {
 
         String messageSelector = "Operation = 'sayHello'";
 
-        Map<String, Object> headers = new HashMap<String, Object>();
+        Map<String, Object> headers = new HashMap<>();
         headers.put("Operation", "sayHello");
         Message controlMessage = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>", headers);
 
@@ -1034,7 +1034,7 @@ public class ReceiveMessageActionTest extends AbstractTestNGUnitTest {
         Map<String, String> messageSelector = new HashMap<>();
         messageSelector.put("Operation", "sayHello");
 
-        Map<String, Object> headers = new HashMap<String, Object>();
+        Map<String, Object> headers = new HashMap<>();
         headers.put("Operation", "sayHello");
         Message controlMessage = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>", headers);
 
@@ -1062,7 +1062,7 @@ public class ReceiveMessageActionTest extends AbstractTestNGUnitTest {
         Map<String, String> messageSelector = new HashMap<>();
         messageSelector.put("Operation", "sayHello");
 
-        Map<String, Object> headers = new HashMap<String, Object>();
+        Map<String, Object> headers = new HashMap<>();
         headers.put("Operation", "sayHello");
         Message controlMessage = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>", headers);
 

--- a/validation/citrus-validation-xml/src/test/java/org/citrusframework/validation/xml/SendMessageActionTest.java
+++ b/validation/citrus-validation-xml/src/test/java/org/citrusframework/validation/xml/SendMessageActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2010 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,10 +65,11 @@ public class SendMessageActionTest extends AbstractTestNGUnitTest {
             .expressions(overwriteElements)
             .build();
 
-        final Message controlMessage = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<TestRequest>\n" +
-                "    <Message>Hello World!</Message>\n" +
-                "</TestRequest>");
+        final Message controlMessage = new DefaultMessage("""
+                <?xml version="1.0" encoding="UTF-8"?>
+                <TestRequest>
+                    <Message>Hello World!</Message>
+                </TestRequest>""");
 
         reset(endpoint, producer, endpointConfiguration);
         when(endpoint.createProducer()).thenReturn(producer);
@@ -101,10 +102,11 @@ public class SendMessageActionTest extends AbstractTestNGUnitTest {
                 .expressions(overwriteElements)
                 .build();
 
-        final Message controlMessage = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<TestRequest>\n" +
-                "    <Message>Hello World!</Message>\n" +
-                "</TestRequest>");
+        final Message controlMessage = new DefaultMessage("""
+                <?xml version="1.0" encoding="UTF-8"?>
+                <TestRequest>
+                    <Message>Hello World!</Message>
+                </TestRequest>""");
 
         reset(endpoint, producer, endpointConfiguration);
         when(endpoint.createProducer()).thenReturn(producer);
@@ -138,10 +140,11 @@ public class SendMessageActionTest extends AbstractTestNGUnitTest {
                 .expressions(overwriteElements)
                 .build();
 
-        final Message controlMessage = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<ns0:TestRequest xmlns:ns0=\"http://citrusframework.org/unittest\">\n" +
-                "    <ns0:Message>Hello World!</ns0:Message>\n" +
-                "</ns0:TestRequest>");
+        final Message controlMessage = new DefaultMessage("""
+                <?xml version="1.0" encoding="UTF-8"?>
+                <ns0:TestRequest xmlns:ns0="http://citrusframework.org/unittest">
+                    <ns0:Message>Hello World!</ns0:Message>
+                </ns0:TestRequest>""");
 
         reset(endpoint, producer, endpointConfiguration);
         when(endpoint.createProducer()).thenReturn(producer);
@@ -175,10 +178,11 @@ public class SendMessageActionTest extends AbstractTestNGUnitTest {
                 .expressions(overwriteElements)
                 .build();
 
-        final Message controlMessage = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<TestRequest xmlns=\"http://citrusframework.org/unittest\">\n" +
-                "    <Message>Hello World!</Message>\n" +
-                "</TestRequest>");
+        final Message controlMessage = new DefaultMessage("""
+                <?xml version="1.0" encoding="UTF-8"?>
+                <TestRequest xmlns="http://citrusframework.org/unittest">
+                    <Message>Hello World!</Message>
+                </TestRequest>""");
 
         reset(endpoint, producer, endpointConfiguration);
         when(endpoint.createProducer()).thenReturn(producer);

--- a/validation/citrus-validation-xml/src/test/java/org/citrusframework/variable/dictionary/xml/NodeMappingDataDictionaryTest.java
+++ b/validation/citrus-validation-xml/src/test/java/org/citrusframework/variable/dictionary/xml/NodeMappingDataDictionaryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ public class NodeMappingDataDictionaryTest extends UnitTestSupport {
     public void testTranslateExactMatchStrategy() {
         Message message = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?><TestMessage><Text>Hello World!</Text><OtherText>No changes</OtherText></TestMessage>");
 
-        Map<String, String> mappings = new HashMap<String, String>();
+        Map<String, String> mappings = new HashMap<>();
         mappings.put("Something.Else", "NotFound!");
         mappings.put("TestMessage.Text", "Hello!");
 
@@ -45,18 +45,19 @@ public class NodeMappingDataDictionaryTest extends UnitTestSupport {
         dictionary.setMappings(mappings);
 
         dictionary.processMessage(message, context);
-        Assert.assertEquals(message.getPayload(String.class).trim(), "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<TestMessage>\n" +
-                "    <Text>Hello!</Text>\n" +
-                "    <OtherText>No changes</OtherText>\n" +
-                "</TestMessage>");
+        Assert.assertEquals(message.getPayload(String.class).trim(), """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <TestMessage>
+                    <Text>Hello!</Text>
+                    <OtherText>No changes</OtherText>
+                </TestMessage>""");
     }
 
     @Test
     public void testTranslateStartsWithStrategy() {
         Message message = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?><TestMessage><Text>Hello World!</Text><OtherText>Good Bye!</OtherText></TestMessage>");
 
-        Map<String, String> mappings = new HashMap<String, String>();
+        Map<String, String> mappings = new HashMap<>();
         mappings.put("TestMessage.Text", "Hello!");
         mappings.put("TestMessage.Other", "Bye!");
 
@@ -65,18 +66,19 @@ public class NodeMappingDataDictionaryTest extends UnitTestSupport {
         dictionary.setPathMappingStrategy(DataDictionary.PathMappingStrategy.STARTS_WITH);
 
         dictionary.processMessage(message, context);
-        Assert.assertEquals(message.getPayload(String.class).trim(), "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<TestMessage>\n" +
-                "    <Text>Hello!</Text>\n" +
-                "    <OtherText>Bye!</OtherText>\n" +
-                "</TestMessage>");
+        Assert.assertEquals(message.getPayload(String.class).trim(), """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <TestMessage>
+                    <Text>Hello!</Text>
+                    <OtherText>Bye!</OtherText>
+                </TestMessage>""");
     }
 
     @Test
     public void testTranslateEndsWithStrategy() {
         Message message = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?><TestMessage><Text>Hello World!</Text><OtherText>Good Bye!</OtherText></TestMessage>");
 
-        Map<String, String> mappings = new HashMap<String, String>();
+        Map<String, String> mappings = new HashMap<>();
         mappings.put("Text", "Hello!");
 
         NodeMappingDataDictionary dictionary = new NodeMappingDataDictionary();
@@ -84,18 +86,19 @@ public class NodeMappingDataDictionaryTest extends UnitTestSupport {
         dictionary.setPathMappingStrategy(DataDictionary.PathMappingStrategy.ENDS_WITH);
 
         dictionary.processMessage(message, context);
-        Assert.assertEquals(message.getPayload(String.class).trim(), "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<TestMessage>\n" +
-                "    <Text>Hello!</Text>\n" +
-                "    <OtherText>Hello!</OtherText>\n" +
-                "</TestMessage>");
+        Assert.assertEquals(message.getPayload(String.class).trim(), """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <TestMessage>
+                    <Text>Hello!</Text>
+                    <OtherText>Hello!</OtherText>
+                </TestMessage>""");
     }
 
     @Test
     public void testTranslateAttributes() {
         Message message = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?><TestMessage><Text name=\"helloText\">Hello World!</Text><OtherText name=\"goodbyeText\">No changes</OtherText></TestMessage>");
 
-        Map<String, String> mappings = new HashMap<String, String>();
+        Map<String, String> mappings = new HashMap<>();
         mappings.put("TestMessage.Text", "Hello!");
         mappings.put("TestMessage.Text.name", "newName");
 
@@ -103,18 +106,19 @@ public class NodeMappingDataDictionaryTest extends UnitTestSupport {
         dictionary.setMappings(mappings);
 
         dictionary.processMessage(message, context);
-        Assert.assertEquals(message.getPayload(String.class).trim(), "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<TestMessage>\n" +
-                "    <Text name=\"newName\">Hello!</Text>\n" +
-                "    <OtherText name=\"goodbyeText\">No changes</OtherText>\n" +
-                "</TestMessage>");
+        Assert.assertEquals(message.getPayload(String.class).trim(), """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <TestMessage>
+                    <Text name="newName">Hello!</Text>
+                    <OtherText name="goodbyeText">No changes</OtherText>
+                </TestMessage>""");
     }
 
     @Test
     public void testTranslateMultipleAttributes() {
         Message message = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?><TestMessage><Text name=\"helloText\">Hello World!</Text><OtherText name=\"goodbyeText\">No changes</OtherText></TestMessage>");
 
-        Map<String, String> mappings = new HashMap<String, String>();
+        Map<String, String> mappings = new HashMap<>();
         mappings.put("name", "newName");
 
         NodeMappingDataDictionary dictionary = new NodeMappingDataDictionary();
@@ -122,18 +126,19 @@ public class NodeMappingDataDictionaryTest extends UnitTestSupport {
         dictionary.setPathMappingStrategy(DataDictionary.PathMappingStrategy.ENDS_WITH);
 
         dictionary.processMessage(message, context);
-        Assert.assertEquals(message.getPayload(String.class).trim(), "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<TestMessage>\n" +
-                "    <Text name=\"newName\">Hello World!</Text>\n" +
-                "    <OtherText name=\"newName\">No changes</OtherText>\n" +
-                "</TestMessage>");
+        Assert.assertEquals(message.getPayload(String.class).trim(), """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <TestMessage>
+                    <Text name="newName">Hello World!</Text>
+                    <OtherText name="newName">No changes</OtherText>
+                </TestMessage>""");
     }
 
     @Test
     public void testTranslateWithVariables() {
         Message message = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?><TestMessage><Text name=\"\">Hello World!</Text><OtherText>No changes</OtherText></TestMessage>");
 
-        Map<String, String> mappings = new HashMap<String, String>();
+        Map<String, String> mappings = new HashMap<>();
         mappings.put("TestMessage.Text", "${newText}");
         mappings.put("TestMessage.Text.name", "citrus:upperCase('text')");
 
@@ -143,11 +148,12 @@ public class NodeMappingDataDictionaryTest extends UnitTestSupport {
         dictionary.setMappings(mappings);
 
         dictionary.processMessage(message, context);
-        Assert.assertEquals(message.getPayload(String.class).trim(), "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<TestMessage>\n" +
-                "    <Text name=\"TEXT\">Hello!</Text>\n" +
-                "    <OtherText>No changes</OtherText>\n" +
-                "</TestMessage>");
+        Assert.assertEquals(message.getPayload(String.class).trim(), """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <TestMessage>
+                    <Text name="TEXT">Hello!</Text>
+                    <OtherText>No changes</OtherText>
+                </TestMessage>""");
     }
 
     @Test
@@ -161,48 +167,51 @@ public class NodeMappingDataDictionaryTest extends UnitTestSupport {
         dictionary.initialize();
 
         dictionary.processMessage(message, context);
-        Assert.assertEquals(message.getPayload(String.class).trim(), "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<TestMessage>\n" +
-                "    <Text name=\"newName\">Hello!</Text>\n" +
-                "    <OtherText>No changes</OtherText>\n" +
-                "</TestMessage>");
+        Assert.assertEquals(message.getPayload(String.class).trim(), """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <TestMessage>
+                    <Text name="newName">Hello!</Text>
+                    <OtherText>No changes</OtherText>
+                </TestMessage>""");
     }
 
     @Test
     public void testTranslateWithNestedAndEmptyElements() {
         Message message = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?><TestMessage><Text><value></value></Text><OtherText></OtherText></TestMessage>");
 
-        Map<String, String> mappings = new HashMap<String, String>();
+        Map<String, String> mappings = new HashMap<>();
         mappings.put("TestMessage.Text.value", "Hello!");
 
         NodeMappingDataDictionary dictionary = new NodeMappingDataDictionary();
         dictionary.setMappings(mappings);
 
         dictionary.processMessage(message, context);
-        Assert.assertEquals(message.getPayload(String.class).trim(), "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<TestMessage>\n" +
-                "    <Text>\n" +
-                "        <value>Hello!</value>\n" +
-                "    </Text>\n" +
-                "    <OtherText/>\n" +
-                "</TestMessage>");
+        Assert.assertEquals(message.getPayload(String.class).trim(), """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <TestMessage>
+                    <Text>
+                        <value>Hello!</value>
+                    </Text>
+                    <OtherText/>
+                </TestMessage>""");
     }
 
     @Test
     public void testTranslateNoResult() {
         Message message = new DefaultMessage("<?xml version=\"1.0\" encoding=\"UTF-8\"?><TestMessage><Text>Hello World!</Text><OtherText>No changes</OtherText></TestMessage>");
 
-        Map<String, String> mappings = new HashMap<String, String>();
+        Map<String, String> mappings = new HashMap<>();
         mappings.put("Something.Else", "NotFound!");
 
         NodeMappingDataDictionary dictionary = new NodeMappingDataDictionary();
         dictionary.setMappings(mappings);
 
         dictionary.processMessage(message, context);
-        Assert.assertEquals(message.getPayload(String.class).trim(), "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<TestMessage>\n" +
-                "    <Text>Hello World!</Text>\n" +
-                "    <OtherText>No changes</OtherText>\n" +
-                "</TestMessage>");
+        Assert.assertEquals(message.getPayload(String.class).trim(), """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <TestMessage>
+                    <Text>Hello World!</Text>
+                    <OtherText>No changes</OtherText>
+                </TestMessage>""");
     }
 }

--- a/validation/citrus-validation-xml/src/test/java/org/citrusframework/variable/dictionary/xml/XpathMappingDataDictionaryTest.java
+++ b/validation/citrus-validation-xml/src/test/java/org/citrusframework/variable/dictionary/xml/XpathMappingDataDictionaryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2013 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,11 +63,12 @@ public class XpathMappingDataDictionaryTest extends AbstractTestNGUnitTest {
         dictionary.setMappings(mappings);
 
         dictionary.processMessage(message, context);
-        Assert.assertEquals(message.getPayload(String.class).trim(), "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<TestMessage>\n" +
-                "    <Text>Hello!</Text>\n" +
-                "    <OtherText name=\"bar\">No changes</OtherText>\n" +
-                "</TestMessage>");
+        Assert.assertEquals(message.getPayload(String.class).trim(), """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <TestMessage>
+                    <Text>Hello!</Text>
+                    <OtherText name="bar">No changes</OtherText>
+                </TestMessage>""");
     }
 
     @Test
@@ -82,11 +83,12 @@ public class XpathMappingDataDictionaryTest extends AbstractTestNGUnitTest {
         dictionary.setMappings(mappings);
 
         dictionary.processMessage(message, context);
-        Assert.assertEquals(message.getPayload(String.class).trim(), "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<TestMessage>\n" +
-                "    <Text>Hello!</Text>\n" +
-                "    <OtherText name=\"bar\">Hello!</OtherText>\n" +
-                "</TestMessage>");
+        Assert.assertEquals(message.getPayload(String.class).trim(), """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <TestMessage>
+                    <Text>Hello!</Text>
+                    <OtherText name="bar">Hello!</OtherText>
+                </TestMessage>""");
     }
 
     @Test
@@ -101,11 +103,12 @@ public class XpathMappingDataDictionaryTest extends AbstractTestNGUnitTest {
         dictionary.setMappings(mappings);
 
         dictionary.processMessage(message, context);
-        Assert.assertEquals(message.getPayload(String.class).trim(), "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<ns1:TestMessage xmlns:ns1=\"http://www.foo.bar\">\n" +
-                "    <ns1:Text>Hello!</ns1:Text>\n" +
-                "    <ns1:OtherText name=\"bar\">No changes</ns1:OtherText>\n" +
-                "</ns1:TestMessage>");
+        Assert.assertEquals(message.getPayload(String.class).trim(), """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <ns1:TestMessage xmlns:ns1="http://www.foo.bar">
+                    <ns1:Text>Hello!</ns1:Text>
+                    <ns1:OtherText name="bar">No changes</ns1:OtherText>
+                </ns1:TestMessage>""");
     }
 
     @Test
@@ -126,11 +129,12 @@ public class XpathMappingDataDictionaryTest extends AbstractTestNGUnitTest {
         dictionary.setNamespaceContextBuilder(namespaceContextBuilder);
 
         dictionary.processMessage(message, context);
-        Assert.assertEquals(message.getPayload(String.class).trim(), "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<ns1:TestMessage xmlns:ns1=\"http://www.foo.bar\">\n" +
-                "    <ns1:Text>Hello!</ns1:Text>\n" +
-                "    <ns1:OtherText name=\"bar\">No changes</ns1:OtherText>\n" +
-                "</ns1:TestMessage>");
+        Assert.assertEquals(message.getPayload(String.class).trim(), """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <ns1:TestMessage xmlns:ns1="http://www.foo.bar">
+                    <ns1:Text>Hello!</ns1:Text>
+                    <ns1:OtherText name="bar">No changes</ns1:OtherText>
+                </ns1:TestMessage>""");
     }
 
     @Test
@@ -147,11 +151,12 @@ public class XpathMappingDataDictionaryTest extends AbstractTestNGUnitTest {
         dictionary.setMappings(mappings);
 
         dictionary.processMessage(message, context);
-        Assert.assertEquals(message.getPayload(String.class).trim(), "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<TestMessage>\n" +
-                "    <Text>Hello!</Text>\n" +
-                "    <OtherText name=\"bar\">No changes</OtherText>\n" +
-                "</TestMessage>");
+        Assert.assertEquals(message.getPayload(String.class).trim(), """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <TestMessage>
+                    <Text>Hello!</Text>
+                    <OtherText name="bar">No changes</OtherText>
+                </TestMessage>""");
     }
 
     @Test
@@ -163,11 +168,12 @@ public class XpathMappingDataDictionaryTest extends AbstractTestNGUnitTest {
         dictionary.initialize();
 
         dictionary.processMessage(message, context);
-        Assert.assertEquals(message.getPayload(String.class).trim(), "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<TestMessage>\n" +
-                "    <Text>Hello!</Text>\n" +
-                "    <OtherText name=\"bar\">GoodBye!</OtherText>\n" +
-                "</TestMessage>");
+        Assert.assertEquals(message.getPayload(String.class).trim(), """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <TestMessage>
+                    <Text>Hello!</Text>
+                    <OtherText name="bar">GoodBye!</OtherText>
+                </TestMessage>""");
     }
 
     @Test
@@ -182,11 +188,12 @@ public class XpathMappingDataDictionaryTest extends AbstractTestNGUnitTest {
         dictionary.setMappings(mappings);
 
         dictionary.processMessage(message, context);
-        Assert.assertEquals(message.getPayload(String.class).trim(), "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<TestMessage>\n" +
-                "    <Text>Hello World!</Text>\n" +
-                "    <OtherText name=\"bar\">No changes</OtherText>\n" +
-                "</TestMessage>");
+        Assert.assertEquals(message.getPayload(String.class).trim(), """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <TestMessage>
+                    <Text>Hello World!</Text>
+                    <OtherText name="bar">No changes</OtherText>
+                </TestMessage>""");
     }
 
     @Test

--- a/validation/citrus-validation-xml/src/test/java/org/citrusframework/xml/schema/RootQNameSchemaMappingStrategyTest.java
+++ b/validation/citrus-validation-xml/src/test/java/org/citrusframework/xml/schema/RootQNameSchemaMappingStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2012 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,10 +41,10 @@ public class RootQNameSchemaMappingStrategyTest {
     public void testPositiveMapping() {
         RootQNameSchemaMappingStrategy strategy = new RootQNameSchemaMappingStrategy();
 
-        List<XsdSchema> schemas = new ArrayList<XsdSchema>();
+        List<XsdSchema> schemas = new ArrayList<>();
         schemas.add(schemaMock);
 
-        Map<String, XsdSchema> mappings = new HashMap<String, XsdSchema>();
+        Map<String, XsdSchema> mappings = new HashMap<>();
         mappings.put("foo", schemaMock);
         mappings.put("bar", Mockito.mock(XsdSchema.class));
 
@@ -63,10 +63,10 @@ public class RootQNameSchemaMappingStrategyTest {
     public void testPositiveMappingWithNamespaces() {
         RootQNameSchemaMappingStrategy strategy = new RootQNameSchemaMappingStrategy();
 
-        List<XsdSchema> schemas = new ArrayList<XsdSchema>();
+        List<XsdSchema> schemas = new ArrayList<>();
         schemas.add(schemaMock);
 
-        Map<String, XsdSchema> mappings = new HashMap<String, XsdSchema>();
+        Map<String, XsdSchema> mappings = new HashMap<>();
         mappings.put("{http://citrusframework.org/schema/foo}foo", Mockito.mock(XsdSchema.class));
         mappings.put("{http://citrusframework.org/schema}foo", schemaMock);
         mappings.put("bar", Mockito.mock(XsdSchema.class));
@@ -86,10 +86,10 @@ public class RootQNameSchemaMappingStrategyTest {
     public void testNoMappingFound() {
         RootQNameSchemaMappingStrategy strategy = new RootQNameSchemaMappingStrategy();
 
-        List<XsdSchema> schemas = new ArrayList<XsdSchema>();
+        List<XsdSchema> schemas = new ArrayList<>();
         schemas.add(schemaMock);
 
-        Map<String, XsdSchema> mappings = new HashMap<String, XsdSchema>();
+        Map<String, XsdSchema> mappings = new HashMap<>();
         mappings.put("{http://citrusframework.org/schema/foos}foos", Mockito.mock(XsdSchema.class));
         mappings.put("{http://citrusframework.org/schema}foos", schemaMock);
 
@@ -108,10 +108,10 @@ public class RootQNameSchemaMappingStrategyTest {
     public void testMappingErrorWithNamespaceInconstistency() {
         RootQNameSchemaMappingStrategy strategy = new RootQNameSchemaMappingStrategy();
 
-        List<XsdSchema> schemas = new ArrayList<XsdSchema>();
+        List<XsdSchema> schemas = new ArrayList<>();
         schemas.add(schemaMock);
 
-        Map<String, XsdSchema> mappings = new HashMap<String, XsdSchema>();
+        Map<String, XsdSchema> mappings = new HashMap<>();
         mappings.put("{http://citrusframework.org/schema/foo}foo", Mockito.mock(XsdSchema.class));
         mappings.put("{http://citrusframework.org/schema}foo", schemaMock);
         mappings.put("bar", Mockito.mock(XsdSchema.class));

--- a/validation/citrus-validation-xml/src/test/java/org/citrusframework/xml/schema/SchemaMappingStrategyChainTest.java
+++ b/validation/citrus-validation-xml/src/test/java/org/citrusframework/xml/schema/SchemaMappingStrategyChainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2012 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,14 +42,14 @@ public class SchemaMappingStrategyChainTest {
         RootQNameSchemaMappingStrategy qNameStrategy = new RootQNameSchemaMappingStrategy();
         TargetNamespaceSchemaMappingStrategy namespaceStrategy = new TargetNamespaceSchemaMappingStrategy();
         
-        List<XsdSchema> schemas = new ArrayList<XsdSchema>();
+        List<XsdSchema> schemas = new ArrayList<>();
         schemas.add(schemaMock);
 
-        Map<String, XsdSchema> mappings = new HashMap<String, XsdSchema>();
+        Map<String, XsdSchema> mappings = new HashMap<>();
         mappings.put("{http://citrusframework.org/schema}foo", schemaMock);
         qNameStrategy.setMappings(mappings);
         
-        List<XsdSchemaMappingStrategy> strategies = new ArrayList<XsdSchemaMappingStrategy>();
+        List<XsdSchemaMappingStrategy> strategies = new ArrayList<>();
         strategies.add(qNameStrategy);
         strategies.add(namespaceStrategy);
         
@@ -77,14 +77,14 @@ public class SchemaMappingStrategyChainTest {
         RootQNameSchemaMappingStrategy qNameStrategy = new RootQNameSchemaMappingStrategy();
         TargetNamespaceSchemaMappingStrategy namespaceStrategy = new TargetNamespaceSchemaMappingStrategy();
         
-        List<XsdSchema> schemas = new ArrayList<XsdSchema>();
+        List<XsdSchema> schemas = new ArrayList<>();
         schemas.add(schemaMock);
 
-        Map<String, XsdSchema> mappings = new HashMap<String, XsdSchema>();
+        Map<String, XsdSchema> mappings = new HashMap<>();
         mappings.put("{http://citrusframework.org/schema}foo", schemaMock);
         qNameStrategy.setMappings(mappings);
         
-        List<XsdSchemaMappingStrategy> strategies = new ArrayList<XsdSchemaMappingStrategy>();
+        List<XsdSchemaMappingStrategy> strategies = new ArrayList<>();
         strategies.add(qNameStrategy);
         strategies.add(namespaceStrategy);
         

--- a/validation/citrus-validation-xml/src/test/java/org/citrusframework/xml/schema/TargetNamespaceSchemaMappingStrategyTest.java
+++ b/validation/citrus-validation-xml/src/test/java/org/citrusframework/xml/schema/TargetNamespaceSchemaMappingStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2012 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ public class TargetNamespaceSchemaMappingStrategyTest {
     public void testPositiveMappingWithNamespaces() {
         TargetNamespaceSchemaMappingStrategy strategy = new TargetNamespaceSchemaMappingStrategy();
         
-        List<XsdSchema> schemas = new ArrayList<XsdSchema>();
+        List<XsdSchema> schemas = new ArrayList<>();
         schemas.add(schemaMock);
 
         reset(schemaMock);
@@ -53,7 +53,7 @@ public class TargetNamespaceSchemaMappingStrategyTest {
     public void testNoMappingFound() {
         TargetNamespaceSchemaMappingStrategy strategy = new TargetNamespaceSchemaMappingStrategy();
         
-        List<XsdSchema> schemas = new ArrayList<XsdSchema>();
+        List<XsdSchema> schemas = new ArrayList<>();
         schemas.add(schemaMock);
 
         reset(schemaMock);

--- a/validation/citrus-validation-xml/src/test/java/org/citrusframework/xml/xpath/XPathUtilsTest.java
+++ b/validation/citrus-validation-xml/src/test/java/org/citrusframework/xml/xpath/XPathUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2012 the original author or authors.
+ * Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ public class XPathUtilsTest {
 
     @Test
     public void testDynamicNamespaceReplacement() {
-        Map<String, String> namespaces = new HashMap<String, String>();
+        Map<String, String> namespaces = new HashMap<>();
         namespaces.put("ns1", "http://citrusframework.org/foo");
         namespaces.put("ns2", "http://citrusframework.org/bar");
         namespaces.put("ns3", "http://citrusframework.org/foo-bar");


### PR DESCRIPTION
the citrusframework exists quit long and a lot of things have changed with the continuous improvement of java. this commit removes some old-fashioned code from previous versions, that can be done otherwise in JDK 17.