### PR TITLE
reduce logging level of successful validations

### DIFF
--- a/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/.mvn/wrapper/MavenWrapperDownloader.java
@@ -106,5 +106,4 @@ public class MavenWrapperDownloader {
         fos.close();
         rbc.close();
     }
-
 }

--- a/catalog/citrus-endpoint-catalog/src/main/java/org/citrusframework/dsl/endpoint/CitrusEndpoints.java
+++ b/catalog/citrus-endpoint-catalog/src/main/java/org/citrusframework/dsl/endpoint/CitrusEndpoints.java
@@ -200,5 +200,4 @@ public abstract class CitrusEndpoints {
     public static CamelEndpointCatalog camel() {
         return CamelEndpointCatalog.camel();
     }
-
 }

--- a/connectors/citrus-docker/src/main/java/org/citrusframework/docker/actions/DockerExecuteAction.java
+++ b/connectors/citrus-docker/src/main/java/org/citrusframework/docker/actions/DockerExecuteAction.java
@@ -101,9 +101,7 @@ public class DockerExecuteAction extends AbstractTestAction {
      * @param context
      */
     private void validateCommandResult(DockerCommand command, TestContext context) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Starting Docker command result validation");
-        }
+        logger.debug("Starting Docker command result validation");
 
         if (StringUtils.hasText(expectedCommandResult)) {
             if (command.getCommandResult() == null) {
@@ -114,7 +112,7 @@ public class DockerExecuteAction extends AbstractTestAction {
                 String commandResultJson = jsonMapper.writeValueAsString(command.getCommandResult());
                 JsonMessageValidationContext validationContext = new JsonMessageValidationContext();
                 getMessageValidator(context).validateMessage(new DefaultMessage(commandResultJson), new DefaultMessage(expectedCommandResult), context, Collections.singletonList(validationContext));
-                logger.info("Docker command result validation successful - all values OK!");
+                logger.debug("Docker command result validation successful - all values OK!");
             } catch (JsonProcessingException e) {
                 throw new CitrusRuntimeException(e);
             }
@@ -138,12 +136,12 @@ public class DockerExecuteAction extends AbstractTestAction {
         // try to find json message validator in registry
         Optional<MessageValidator<? extends ValidationContext>> defaultJsonMessageValidator = context.getMessageValidatorRegistry().findMessageValidator(DEFAULT_JSON_MESSAGE_VALIDATOR);
 
-        if (!defaultJsonMessageValidator.isPresent()
+        if (defaultJsonMessageValidator.isEmpty()
                 && context.getReferenceResolver().isResolvable(DEFAULT_JSON_MESSAGE_VALIDATOR)) {
             defaultJsonMessageValidator = Optional.of(context.getReferenceResolver().resolve(DEFAULT_JSON_MESSAGE_VALIDATOR, MessageValidator.class));
         }
 
-        if (!defaultJsonMessageValidator.isPresent()) {
+        if (defaultJsonMessageValidator.isEmpty()) {
             // try to find json message validator via resource path lookup
             defaultJsonMessageValidator = MessageValidator.lookup("json");
         }

--- a/connectors/citrus-docker/src/main/java/org/citrusframework/docker/command/ContainerStart.java
+++ b/connectors/citrus-docker/src/main/java/org/citrusframework/docker/command/ContainerStart.java
@@ -73,5 +73,4 @@ public class ContainerStart extends AbstractDockerCommand<ResponseItem> {
             return this;
         }
     }
-
 }

--- a/connectors/citrus-docker/src/main/java/org/citrusframework/docker/command/ImageRemove.java
+++ b/connectors/citrus-docker/src/main/java/org/citrusframework/docker/command/ImageRemove.java
@@ -99,5 +99,4 @@ public class ImageRemove extends AbstractDockerCommand<ResponseItem> {
             return this;
         }
     }
-
 }

--- a/connectors/citrus-docker/src/test/java/org/citrusframework/docker/endpoint/builder/DockerEndpointsTest.java
+++ b/connectors/citrus-docker/src/test/java/org/citrusframework/docker/endpoint/builder/DockerEndpointsTest.java
@@ -39,5 +39,4 @@ public class DockerEndpointsTest {
         Assert.assertTrue(EndpointBuilder.lookup("docker.client").isPresent());
         Assert.assertEquals(EndpointBuilder.lookup("docker.client").get().getClass(), DockerClientBuilder.class);
     }
-
 }

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/actions/KubernetesExecuteAction.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/actions/KubernetesExecuteAction.java
@@ -96,14 +96,12 @@ public class KubernetesExecuteAction extends AbstractTestAction {
     @Override
     public void doExecute(TestContext context) {
         try {
-            if (logger.isDebugEnabled()) {
-                logger.debug(String.format("Executing Kubernetes command '%s'", command.getName()));
-            }
+            logger.debug("Executing Kubernetes command '{}'", command.getName());
             command.execute(kubernetesClient, context);
 
             validateCommandResult(command, context);
 
-            logger.info(String.format("Kubernetes command execution successful: '%s'", command.getName()));
+            logger.debug("Kubernetes command execution successful: '{}'", command.getName());
         } catch (CitrusRuntimeException e) {
             throw e;
         } catch (Exception e) {
@@ -117,9 +115,7 @@ public class KubernetesExecuteAction extends AbstractTestAction {
      * @param context
      */
     private void validateCommandResult(KubernetesCommand<?, ?> command, TestContext context) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Starting Kubernetes command result validation");
-        }
+        logger.debug("Starting Kubernetes command result validation");
 
         CommandResult<?> result = command.getCommandResult();
         if (StringUtils.hasText(commandResult) || !commandResultExpressions.isEmpty()) {
@@ -132,7 +128,7 @@ public class KubernetesExecuteAction extends AbstractTestAction {
                         .getObjectMapper().writeValueAsString(result);
                 if (StringUtils.hasText(commandResult)) {
                     getMessageValidator(context).validateMessage(new DefaultMessage(commandResultJson), new DefaultMessage(commandResult), context, Collections.singletonList(new JsonMessageValidationContext()));
-                    logger.info("Kubernetes command result validation successful - all values OK!");
+                    logger.debug("Kubernetes command result validation successful - all values OK!");
                 }
 
                 if (!commandResultExpressions.isEmpty()) {
@@ -140,7 +136,7 @@ public class KubernetesExecuteAction extends AbstractTestAction {
                             .expressions(commandResultExpressions)
                             .build();
                     getPathValidator(context).validateMessage(new DefaultMessage(commandResultJson), new DefaultMessage(commandResult), context, Collections.singletonList(validationContext));
-                    logger.info("Kubernetes command result path validation successful - all values OK!");
+                    logger.debug("Kubernetes command result path validation successful - all values OK!");
                 }
             } catch (JsonProcessingException e) {
                 throw new CitrusRuntimeException(e);
@@ -165,12 +161,12 @@ public class KubernetesExecuteAction extends AbstractTestAction {
         // try to find json message validator in registry
         Optional<MessageValidator<? extends ValidationContext>> defaultJsonMessageValidator = context.getMessageValidatorRegistry().findMessageValidator(DEFAULT_JSON_MESSAGE_VALIDATOR);
 
-        if (!defaultJsonMessageValidator.isPresent()
+        if (defaultJsonMessageValidator.isEmpty()
                 && context.getReferenceResolver().isResolvable(DEFAULT_JSON_MESSAGE_VALIDATOR)) {
             defaultJsonMessageValidator = Optional.of(context.getReferenceResolver().resolve(DEFAULT_JSON_MESSAGE_VALIDATOR, MessageValidator.class));
         }
 
-        if (!defaultJsonMessageValidator.isPresent()) {
+        if (defaultJsonMessageValidator.isEmpty()) {
             // try to find json message validator via resource path lookup
             defaultJsonMessageValidator = MessageValidator.lookup("json");
         }
@@ -195,12 +191,12 @@ public class KubernetesExecuteAction extends AbstractTestAction {
         // try to find json message validator in registry
         Optional<MessageValidator<? extends ValidationContext>> defaultJsonMessageValidator = context.getMessageValidatorRegistry().findMessageValidator(DEFAULT_JSON_PATH_MESSAGE_VALIDATOR);
 
-        if (!defaultJsonMessageValidator.isPresent()
+        if (defaultJsonMessageValidator.isEmpty()
                 && context.getReferenceResolver().isResolvable(DEFAULT_JSON_PATH_MESSAGE_VALIDATOR)) {
             defaultJsonMessageValidator = Optional.of(context.getReferenceResolver().resolve(DEFAULT_JSON_PATH_MESSAGE_VALIDATOR, MessageValidator.class));
         }
 
-        if (!defaultJsonMessageValidator.isPresent()) {
+        if (defaultJsonMessageValidator.isEmpty()) {
             // try to find json message validator via resource path lookup
             defaultJsonMessageValidator = MessageValidator.lookup("json-path");
         }

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/command/ListResult.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/command/ListResult.java
@@ -126,5 +126,4 @@ public class ListResult<T> {
     public void setKind(String kind) {
         this.kind = kind;
     }
-
 }

--- a/connectors/citrus-kubernetes/src/test/java/org/citrusframework/kubernetes/endpoint/KubernetesEndpointComponentTest.java
+++ b/connectors/citrus-kubernetes/src/test/java/org/citrusframework/kubernetes/endpoint/KubernetesEndpointComponentTest.java
@@ -85,5 +85,4 @@ public class KubernetesEndpointComponentTest {
     public void testLookupByQualifier() {
         Assert.assertTrue(EndpointComponent.lookup("k8s").isPresent());
     }
-
 }

--- a/connectors/citrus-kubernetes/src/test/java/org/citrusframework/kubernetes/endpoint/builder/KubernetesEndpointsTest.java
+++ b/connectors/citrus-kubernetes/src/test/java/org/citrusframework/kubernetes/endpoint/builder/KubernetesEndpointsTest.java
@@ -42,5 +42,4 @@ public class KubernetesEndpointsTest {
         Assert.assertTrue(EndpointBuilder.lookup("k8s.client").isPresent());
         Assert.assertEquals(EndpointBuilder.lookup("k8s.client").get().getClass(), KubernetesClientBuilder.class);
     }
-
 }

--- a/connectors/citrus-kubernetes/src/test/java/org/citrusframework/kubernetes/integration/KubernetesServiceConfiguration.java
+++ b/connectors/citrus-kubernetes/src/test/java/org/citrusframework/kubernetes/integration/KubernetesServiceConfiguration.java
@@ -67,5 +67,4 @@ public class KubernetesServiceConfiguration {
                     .build()
                 ).build();
     }
-
 }

--- a/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/OpenApiTestDataGenerator.java
+++ b/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/OpenApiTestDataGenerator.java
@@ -349,5 +349,4 @@ public class OpenApiTestDataGenerator {
                 return "";
         }
     }
-
 }

--- a/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/actions/OpenApiClientResponseActionBuilder.java
+++ b/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/actions/OpenApiClientResponseActionBuilder.java
@@ -128,5 +128,4 @@ public class OpenApiClientResponseActionBuilder extends HttpClientResponseAction
             return super.build(context, messageType);
         }
     }
-
 }

--- a/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/actions/OpenApiServerRequestActionBuilder.java
+++ b/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/actions/OpenApiServerRequestActionBuilder.java
@@ -146,5 +146,4 @@ public class OpenApiServerRequestActionBuilder extends HttpServerRequestActionBu
             return super.build(context, messageType);
         }
     }
-
 }

--- a/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/actions/OpenApiServerResponseActionBuilder.java
+++ b/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/actions/OpenApiServerResponseActionBuilder.java
@@ -131,5 +131,4 @@ public class OpenApiServerResponseActionBuilder extends HttpServerResponseAction
             return super.build(context, messageType);
         }
     }
-
 }

--- a/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/xml/ObjectFactory.java
+++ b/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/xml/ObjectFactory.java
@@ -49,5 +49,4 @@ public class ObjectFactory {
     public OpenApi createOpenApi() {
         return new OpenApi();
     }
-
 }

--- a/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/xml/OpenApi.java
+++ b/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/xml/OpenApi.java
@@ -601,5 +601,4 @@ public class OpenApi implements TestActionBuilder<TestAction>, ReferenceResolver
             this.extract = extract;
         }
     }
-
 }

--- a/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/yaml/OpenApi.java
+++ b/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/yaml/OpenApi.java
@@ -540,5 +540,4 @@ public class OpenApi implements TestActionBuilder<TestAction>, ReferenceResolver
             this.extract = extract;
         }
     }
-
 }

--- a/connectors/citrus-openapi/src/test/java/org/citrusframework/openapi/actions/OpenApiActionBuilderTest.java
+++ b/connectors/citrus-openapi/src/test/java/org/citrusframework/openapi/actions/OpenApiActionBuilderTest.java
@@ -35,5 +35,4 @@ public class OpenApiActionBuilderTest {
         Assert.assertTrue(TestActionBuilder.lookup("openapi").isPresent());
         Assert.assertEquals(TestActionBuilder.lookup("openapi").get().getClass(), OpenApiActionBuilder.class);
     }
-
 }

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/actions/AbstractSeleniumAction.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/actions/AbstractSeleniumAction.java
@@ -90,5 +90,4 @@ public abstract class AbstractSeleniumAction extends AbstractTestAction implemen
         }
 
     }
-
 }

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/actions/AlertAction.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/actions/AlertAction.java
@@ -76,7 +76,7 @@ public class AlertAction extends AbstractSeleniumAction {
                 }
 
             }
-            logger.info("Alert text validation successful - All values Ok");
+            logger.debug("Alert text validation successful - All values Ok");
         }
 
         context.setVariable(SeleniumHeaders.SELENIUM_ALERT_TEXT, alert.getText());

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/ObjectFactory.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/ObjectFactory.java
@@ -49,5 +49,4 @@ public class ObjectFactory {
     public Selenium createSelenium() {
         return new Selenium();
     }
-
 }

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/Page.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/xml/Page.java
@@ -172,5 +172,4 @@ public class Page extends AbstractSeleniumAction.Builder<PageAction, Page> imple
             this.arguments = arguments;
         }
     }
-
 }

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/AlertActionTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/AlertActionTest.java
@@ -149,5 +149,4 @@ public class AlertActionTest extends AbstractTestNGUnitTest {
                 .build();
         action.execute(context);
     }
-
 }

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/CheckInputActionTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/CheckInputActionTest.java
@@ -96,5 +96,4 @@ public class CheckInputActionTest extends AbstractTestNGUnitTest {
 
         verify(element, times(0)).click();
     }
-
 }

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/ClearBrowserCacheActionTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/ClearBrowserCacheActionTest.java
@@ -53,5 +53,4 @@ public class ClearBrowserCacheActionTest extends AbstractTestNGUnitTest {
 
         verify(webDriverOptions).deleteAllCookies();
     }
-
 }

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/CloseWindowActionTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/CloseWindowActionTest.java
@@ -181,5 +181,4 @@ public class CloseWindowActionTest extends AbstractTestNGUnitTest {
                 .build();
         action.execute(context);
     }
-
 }

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/FillFormActionTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/FillFormActionTest.java
@@ -122,5 +122,4 @@ public class FillFormActionTest extends AbstractTestNGUnitTest {
         verify(element).sendKeys("secret");
         verify(element).click();
     }
-
 }

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/FindElementActionTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/FindElementActionTest.java
@@ -198,5 +198,4 @@ public class FindElementActionTest extends AbstractTestNGUnitTest {
                 .build();
         action.execute(context);
     }
-
 }

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/GetStoredFileActionTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/GetStoredFileActionTest.java
@@ -65,5 +65,4 @@ public class GetStoredFileActionTest extends AbstractTestNGUnitTest {
                 .build();
         action.execute(context);
     }
-
 }

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/HoverActionTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/HoverActionTest.java
@@ -77,5 +77,4 @@ public class HoverActionTest extends AbstractTestNGUnitTest {
                 .build();
         action.execute(context);
     }
-
 }

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/JavaScriptActionTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/JavaScriptActionTest.java
@@ -112,5 +112,4 @@ public class JavaScriptActionTest extends AbstractTestNGUnitTest {
                 .build();
         action.execute(context);
     }
-
 }

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/MakeScreenshotActionTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/MakeScreenshotActionTest.java
@@ -78,5 +78,4 @@ public class MakeScreenshotActionTest extends AbstractTestNGUnitTest {
         File stored = new File("target/MyTest_screenshot.png");
         Assert.assertTrue(stored.exists());
     }
-
 }

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/NavigateActionTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/NavigateActionTest.java
@@ -130,5 +130,4 @@ public class NavigateActionTest extends AbstractTestNGUnitTest {
 
         verify(navigation).refresh();
     }
-
 }

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/OpenWindowActionTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/OpenWindowActionTest.java
@@ -92,5 +92,4 @@ public class OpenWindowActionTest extends AbstractTestNGUnitTest {
                 .build();
         action.execute(context);
     }
-
 }

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/PageActionTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/PageActionTest.java
@@ -222,5 +222,4 @@ public class PageActionTest extends AbstractTestNGUnitTest {
             form.submit();
         }
     }
-
 }

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/SetInputActionTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/SetInputActionTest.java
@@ -88,5 +88,4 @@ public class SetInputActionTest extends AbstractTestNGUnitTest {
 
         verify(option).click();
     }
-
 }

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/StartBrowserActionTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/StartBrowserActionTest.java
@@ -119,5 +119,4 @@ public class StartBrowserActionTest extends AbstractTestNGUnitTest {
         verify(seleniumBrowser).stop();
         verify(seleniumBrowser).start();
     }
-
 }

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/StoreFileActionTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/StoreFileActionTest.java
@@ -65,5 +65,4 @@ public class StoreFileActionTest extends AbstractTestNGUnitTest {
 
         Assert.assertNotNull(seleniumBrowser.getStoredFile("file.xml"));
     }
-
 }

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/SwitchWindowActionTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/SwitchWindowActionTest.java
@@ -120,5 +120,4 @@ public class SwitchWindowActionTest extends AbstractTestNGUnitTest {
                 .build();
         action.execute(context);
     }
-
 }

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/config/annotation/SeleniumBrowserConfigParserTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/config/annotation/SeleniumBrowserConfigParserTest.java
@@ -164,5 +164,4 @@ public class SeleniumBrowserConfigParserTest extends AbstractTestNGUnitTest {
     public void testLookupByQualifier() {
         Assert.assertTrue(AnnotationConfigParser.lookup("selenium.browser").isPresent());
     }
-
 }

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/config/xml/SeleniumActionsParserTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/config/xml/SeleniumActionsParserTest.java
@@ -180,5 +180,4 @@ public class SeleniumActionsParserTest extends AbstractActionParserTest<Abstract
         Assert.assertNotNull(stopAction.getBrowser());
         Assert.assertEquals(stopAction.getName(), "selenium:stop");
     }
-
 }

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/endpoint/SeleniumEndpointComponentTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/endpoint/SeleniumEndpointComponentTest.java
@@ -103,5 +103,4 @@ public class SeleniumEndpointComponentTest {
     public void testLookupByQualifier() {
         Assert.assertTrue(EndpointComponent.lookup("selenium").isPresent());
     }
-
 }

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/endpoint/builder/SeleniumEndpointsTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/endpoint/builder/SeleniumEndpointsTest.java
@@ -39,5 +39,4 @@ public class SeleniumEndpointsTest {
         Assert.assertTrue(EndpointBuilder.lookup("selenium.browser").isPresent());
         Assert.assertEquals(EndpointBuilder.lookup("selenium.browser").get().getClass(), SeleniumBrowserBuilder.class);
     }
-
 }

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/groovy/SeleniumTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/groovy/SeleniumTest.java
@@ -290,5 +290,4 @@ public class SeleniumTest extends AbstractGroovyActionDslTest {
         Assert.assertNotNull(stopAction.getBrowser());
         Assert.assertEquals(stopAction.getName(), "selenium:stop");
     }
-
 }

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/xml/SeleniumTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/xml/SeleniumTest.java
@@ -297,5 +297,4 @@ public class SeleniumTest extends AbstractXmlActionTest {
         Assert.assertTrue(XmlTestActionBuilder.lookup("selenium").isPresent());
         Assert.assertEquals(XmlTestActionBuilder.lookup("selenium").get().getClass(), Selenium.class);
     }
-
 }

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/yaml/SeleniumTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/yaml/SeleniumTest.java
@@ -298,5 +298,4 @@ public class SeleniumTest extends AbstractYamlActionTest {
         Assert.assertTrue(YamlTestActionBuilder.lookup("selenium").isPresent());
         Assert.assertEquals(YamlTestActionBuilder.lookup("selenium").get().getClass(), Selenium.class);
     }
-
 }

--- a/connectors/citrus-sql/src/main/java/org/citrusframework/actions/ExecuteSQLQueryAction.java
+++ b/connectors/citrus-sql/src/main/java/org/citrusframework/actions/ExecuteSQLQueryAction.java
@@ -57,6 +57,7 @@ import static java.lang.Integer.parseInt;
  * @since 2008
  */
 public class ExecuteSQLQueryAction extends AbstractDatabaseConnectingTestAction {
+
     /** Map holding all column values to be validated, keys represent the column names */
     protected final Map<String, List<String>> controlResultSet;
 
@@ -105,9 +106,7 @@ public class ExecuteSQLQueryAction extends AbstractDatabaseConnectingTestAction 
             final List<Map<String, Object>> allResultRows = new ArrayList<>();
 
             if (getTransactionManager() != null) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Using transaction manager: " + getTransactionManager().getClass().getName());
-                }
+                logger.debug("Using transaction manager: {}", getTransactionManager().getClass().getName());
 
                 TransactionTemplate transactionTemplate = new TransactionTemplate(getTransactionManager());
                 transactionTemplate.setTimeout(parseInt(context.replaceDynamicContentInString(getTransactionTimeout())));
@@ -153,13 +152,11 @@ public class ExecuteSQLQueryAction extends AbstractDatabaseConnectingTestAction 
                 toExecute = context.replaceDynamicContentInString(statement.trim());
             }
 
-            if (logger.isDebugEnabled()) {
-                logger.debug("Executing SQL query: " + toExecute);
-            }
+            logger.debug("Executing SQL query: {}", toExecute);
 
             List<Map<String, Object>> results = getJdbcTemplate().queryForList(toExecute);
 
-            logger.info("SQL query execution successful");
+            logger.debug("SQL query execution successful");
 
             allResultRows.addAll(results);
             fillColumnValuesMap(results, columnValuesMap);
@@ -265,7 +262,7 @@ public class ExecuteSQLQueryAction extends AbstractDatabaseConnectingTestAction 
             result.append(it.next());
             while (it.hasNext()) {
                 String nextValue = it.next();
-                result.append(";" + (nextValue == null ? NULL_VALUE : nextValue));
+                result.append(";").append(nextValue == null ? NULL_VALUE : nextValue);
             }
 
             return result.toString();
@@ -295,7 +292,7 @@ public class ExecuteSQLQueryAction extends AbstractDatabaseConnectingTestAction 
             return;
         }
         performControlResultSetValidation(columnValuesMap, context);
-        logger.info("SQL query validation successful: All values OK");
+        logger.debug("SQL query validation successful: All values OK");
     }
 
     private void performControlResultSetValidation(final Map<String, List<String>> columnValuesMap, TestContext context)
@@ -345,9 +342,7 @@ public class ExecuteSQLQueryAction extends AbstractDatabaseConnectingTestAction 
     protected void validateSingleValue(String columnName, String controlValue, String resultValue, TestContext context) {
         // check if value is ignored
         if (controlValue.equals(CitrusSettings.IGNORE_PLACEHOLDER)) {
-            if (logger.isDebugEnabled()) {
-                logger.debug("Ignoring column value '" + columnName + "(resultValue)'");
-            }
+            logger.debug("Ignoring column value '{} (resultValue)'", columnName);
             return;
         }
 
@@ -358,10 +353,7 @@ public class ExecuteSQLQueryAction extends AbstractDatabaseConnectingTestAction 
 
         if (resultValue == null) {
             if (isCitrusNullValue(controlValue)) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Validating database value for column: ''" +
-                            columnName + "'' value as expected: NULL - value OK");
-                }
+                logger.debug("Validating database value for column: '{}' value as expected: NULL - value OK", columnName);
                 return;
             } else {
                 throw new ValidationException("Validation failed for column: '" +  columnName + "'"
@@ -370,16 +362,13 @@ public class ExecuteSQLQueryAction extends AbstractDatabaseConnectingTestAction 
         }
 
         if (resultValue.equals(controlValue)) {
-            if (logger.isDebugEnabled()) {
-                logger.debug("Validation successful for column: '" + columnName +
-                        "' expected value: " + controlValue + " - value OK");
-            }
+            logger.debug("Validation successful for column: '{}' expected value: {} - value OK", columnName, controlValue);
         } else {
             throw new ValidationException("Validation failed for column: '" +  columnName + "'"
                     + " found value: '"
                     + resultValue
                     + "' expected value: "
-                    + ((controlValue.length()==0) ? NULL_VALUE : controlValue));
+                    + (controlValue.isEmpty() ? NULL_VALUE : controlValue));
         }
     }
 
@@ -389,7 +378,7 @@ public class ExecuteSQLQueryAction extends AbstractDatabaseConnectingTestAction 
      * @return
      */
     private boolean isCitrusNullValue(String controlValue) {
-        return controlValue.equalsIgnoreCase(NULL_VALUE) || controlValue.length() == 0;
+        return controlValue.equalsIgnoreCase(NULL_VALUE) || controlValue.isEmpty();
     }
 
     /**

--- a/connectors/citrus-sql/src/main/java/org/citrusframework/sql/xml/ObjectFactory.java
+++ b/connectors/citrus-sql/src/main/java/org/citrusframework/sql/xml/ObjectFactory.java
@@ -49,5 +49,4 @@ public class ObjectFactory {
     public Sql createSql() {
         return new Sql();
     }
-
 }

--- a/connectors/citrus-sql/src/test/java/org/citrusframework/sql/groovy/PlsqlTest.java
+++ b/connectors/citrus-sql/src/test/java/org/citrusframework/sql/groovy/PlsqlTest.java
@@ -83,5 +83,4 @@ public class PlsqlTest extends AbstractGroovyActionDslTest {
         Assert.assertEquals(action.getTransactionTimeout(), "5000");
         Assert.assertEquals(action.getTransactionIsolationLevel(), "ISOLATION_READ_COMMITTED");
     }
-
 }

--- a/connectors/citrus-sql/src/test/java/org/citrusframework/sql/groovy/SqlTest.java
+++ b/connectors/citrus-sql/src/test/java/org/citrusframework/sql/groovy/SqlTest.java
@@ -178,5 +178,4 @@ public class SqlTest extends AbstractGroovyActionDslTest {
         Assert.assertNotNull(queryAction.getScriptValidationContext());
         Assert.assertEquals(queryAction.getScriptValidationContext().getValidationScriptResourcePath(), "classpath:org/citrusframework/sql/validate.groovy");
     }
-
 }

--- a/connectors/citrus-sql/src/test/java/org/citrusframework/sql/xml/PlsqlTest.java
+++ b/connectors/citrus-sql/src/test/java/org/citrusframework/sql/xml/PlsqlTest.java
@@ -83,5 +83,4 @@ public class PlsqlTest extends AbstractXmlActionTest {
         Assert.assertEquals(action.getTransactionTimeout(), "5000");
         Assert.assertEquals(action.getTransactionIsolationLevel(), "ISOLATION_READ_COMMITTED");
     }
-
 }

--- a/connectors/citrus-sql/src/test/java/org/citrusframework/sql/xml/SqlTest.java
+++ b/connectors/citrus-sql/src/test/java/org/citrusframework/sql/xml/SqlTest.java
@@ -188,5 +188,4 @@ public class SqlTest extends AbstractXmlActionTest {
         Assert.assertTrue(XmlTestActionBuilder.lookup("plsql").isPresent());
         Assert.assertEquals(XmlTestActionBuilder.lookup("plsql").get().getClass(), Plsql.class);
     }
-
 }

--- a/connectors/citrus-sql/src/test/java/org/citrusframework/sql/yaml/PlsqlTest.java
+++ b/connectors/citrus-sql/src/test/java/org/citrusframework/sql/yaml/PlsqlTest.java
@@ -83,5 +83,4 @@ public class PlsqlTest extends AbstractYamlActionTest {
         Assert.assertEquals(action.getTransactionTimeout(), "5000");
         Assert.assertEquals(action.getTransactionIsolationLevel(), "ISOLATION_READ_COMMITTED");
     }
-
 }

--- a/connectors/citrus-sql/src/test/java/org/citrusframework/sql/yaml/SqlTest.java
+++ b/connectors/citrus-sql/src/test/java/org/citrusframework/sql/yaml/SqlTest.java
@@ -191,5 +191,4 @@ public class SqlTest extends AbstractYamlActionTest {
         Assert.assertTrue(YamlTestActionBuilder.lookup("plsql").isPresent());
         Assert.assertEquals(YamlTestActionBuilder.lookup("plsql").get().getClass(), Plsql.class);
     }
-
 }

--- a/core/citrus-api/src/main/java/org/citrusframework/CitrusVersion.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/CitrusVersion.java
@@ -65,5 +65,4 @@ public final class CitrusVersion {
     public static String version() {
         return version;
     }
-
 }

--- a/core/citrus-api/src/main/java/org/citrusframework/TestAction.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/TestAction.java
@@ -56,5 +56,4 @@ public interface TestAction {
     default TestActor getActor() {
         return null;
     }
-
 }

--- a/core/citrus-api/src/main/java/org/citrusframework/TestCaseMetaInfo.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/TestCaseMetaInfo.java
@@ -132,5 +132,4 @@ public class TestCaseMetaInfo {
     public Status getStatus() {
         return status;
     }
-
 }

--- a/core/citrus-api/src/main/java/org/citrusframework/context/TestContext.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/context/TestContext.java
@@ -1075,5 +1075,4 @@ public class TestContext implements ReferenceResolverAware, TestActionListenerAw
             return this.getClass();
         }
     }
-
 }

--- a/core/citrus-api/src/main/java/org/citrusframework/endpoint/AbstractEndpointConfiguration.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/endpoint/AbstractEndpointConfiguration.java
@@ -41,5 +41,4 @@ public abstract class AbstractEndpointConfiguration implements EndpointConfigura
     public void setTimeout(long timeout) {
         this.timeout = timeout;
     }
-
 }

--- a/core/citrus-api/src/main/java/org/citrusframework/exceptions/CitrusRuntimeException.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/exceptions/CitrusRuntimeException.java
@@ -105,5 +105,4 @@ public class CitrusRuntimeException extends RuntimeException {
 
         return stack;
     }
-
 }

--- a/core/citrus-api/src/main/java/org/citrusframework/exceptions/MissingExpectedMessageException.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/exceptions/MissingExpectedMessageException.java
@@ -56,5 +56,4 @@ public class MissingExpectedMessageException extends CitrusRuntimeException {
     public MissingExpectedMessageException(String message, Throwable cause) {
         super(message, cause);
     }
-
 }

--- a/core/citrus-api/src/main/java/org/citrusframework/exceptions/ReplyMessageTimeoutException.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/exceptions/ReplyMessageTimeoutException.java
@@ -50,5 +50,4 @@ public class ReplyMessageTimeoutException extends MessageTimeoutException {
 
         return String.format("Failed to receive synchronous reply message on endpoint: '%s'", endpoint);
     }
-
 }

--- a/core/citrus-api/src/main/java/org/citrusframework/message/MessageHeaderType.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/message/MessageHeaderType.java
@@ -132,5 +132,4 @@ public enum MessageHeaderType {
     public Class<?> getHeaderClass() {
         return clazz;
     }
-
 }

--- a/core/citrus-api/src/main/java/org/citrusframework/util/DefaultTypeConverter.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/util/DefaultTypeConverter.java
@@ -195,7 +195,7 @@ public class DefaultTypeConverter implements TypeConverter {
             return convertAfter(target, type);
         } catch (Exception e) {
             if (String.class.equals(type)) {
-                logger.warn(String.format("Using default toString representation because object type conversion failed with: %s", e.getMessage()));
+                logger.warn("Using default toString representation because object type conversion failed with: {}", e.getMessage());
                 return (T) target.toString();
             }
 
@@ -240,7 +240,7 @@ public class DefaultTypeConverter implements TypeConverter {
      */
     protected <T> T convertAfter(Object target, Class<T> type) {
         if (String.class.equals(type)) {
-            logger.warn(String.format("Using default toString representation for object type %s", target.getClass()));
+            logger.warn("Using default toString representation for object type {}", target.getClass());
             return (T) target.toString();
         }
 

--- a/core/citrus-api/src/main/java/org/citrusframework/validation/matcher/DefaultControlExpressionParser.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/validation/matcher/DefaultControlExpressionParser.java
@@ -70,5 +70,4 @@ public class DefaultControlExpressionParser implements ControlExpressionParser {
             }
         }
     }
-
 }

--- a/core/citrus-api/src/test/java/org/citrusframework/config/annotation/AnnotationConfigParserTest.java
+++ b/core/citrus-api/src/test/java/org/citrusframework/config/annotation/AnnotationConfigParserTest.java
@@ -31,5 +31,4 @@ public class AnnotationConfigParserTest {
         Map<String, AnnotationConfigParser> validators = AnnotationConfigParser.lookup();
         Assert.assertEquals(validators.size(), 0L);
     }
-
 }

--- a/core/citrus-api/src/test/java/org/citrusframework/message/MessagePayloadUtilsTest.java
+++ b/core/citrus-api/src/test/java/org/citrusframework/message/MessagePayloadUtilsTest.java
@@ -68,5 +68,4 @@ public class MessagePayloadUtilsTest {
         Assert.assertEquals(MessagePayloadUtils.prettyPrint(String.format("<root><text language=\"eng\" important=\"true\"><![CDATA[%n  Citrus rocks!%n  ]]></text></root>")),
                 String.format("<root>%n  <text language=\"eng\" important=\"true\">%n    <![CDATA[%n  Citrus rocks!%n  ]]>%n  </text>%n</root>%n"));
     }
-
 }

--- a/core/citrus-api/src/test/java/org/citrusframework/util/DefaultTypeConverterTest.java
+++ b/core/citrus-api/src/test/java/org/citrusframework/util/DefaultTypeConverterTest.java
@@ -77,5 +77,4 @@ public class DefaultTypeConverterTest {
         Assert.assertEquals(converter.convertIfNecessary(payload.getBytes(), String.class), Arrays.toString(payload.getBytes()));
         Assert.assertEquals(converter.convertIfNecessary(ByteBuffer.wrap(payload.getBytes()), String.class), payload);
     }
-
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/actions/AntRunAction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/actions/AntRunAction.java
@@ -348,5 +348,4 @@ public class AntRunAction extends AbstractTestAction {
             return new AntRunAction(this);
         }
     }
-
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/actions/CreateVariablesAction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/actions/CreateVariablesAction.java
@@ -106,5 +106,4 @@ public class CreateVariablesAction extends AbstractTestAction {
             return new CreateVariablesAction(this);
         }
     }
-
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/container/Assert.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/container/Assert.java
@@ -96,11 +96,9 @@ public class Assert extends AbstractActionContainer {
                 }
             }
 
-            if (logger.isDebugEnabled()) {
-                logger.debug("Asserted exception is as expected: " + e.getClass() + ": " + e.getLocalizedMessage());
-            }
+            logger.debug("Asserted exception is as expected ({}): {}", e.getClass(), e.getLocalizedMessage());
 
-            logger.info("Assert exception validation successful: All values OK");
+            logger.debug("Assert exception validation successful: All values OK");
 
             return;
         }

--- a/core/citrus-base/src/main/java/org/citrusframework/context/TestContextFactory.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/context/TestContextFactory.java
@@ -414,5 +414,4 @@ public class TestContextFactory implements ReferenceResolverAware {
     public void setSegmentVariableExtractorRegistry(SegmentVariableExtractorRegistry segmentVariableExtractorRegistry) {
         this.segmentVariableExtractorRegistry = segmentVariableExtractorRegistry;
     }
-
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/endpoint/adapter/mapping/AbstractMappingKeyExtractor.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/endpoint/adapter/mapping/AbstractMappingKeyExtractor.java
@@ -59,5 +59,4 @@ public abstract class AbstractMappingKeyExtractor implements MappingKeyExtractor
     public void setMappingKeySuffix(String mappingKeySuffix) {
         this.mappingKeySuffix = mappingKeySuffix;
     }
-
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/endpoint/direct/DirectProducer.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/endpoint/direct/DirectProducer.java
@@ -29,6 +29,7 @@ import org.citrusframework.util.StringUtils;
  * @author Christoph Deppisch
  */
 public class DirectProducer implements Producer {
+
     /** Logger */
     private static final Logger logger = LoggerFactory.getLogger(DirectProducer.class);
 
@@ -52,13 +53,8 @@ public class DirectProducer implements Producer {
     public void send(Message message, TestContext context) {
         String destinationQueueName = getDestinationQueueName();
 
-        if (logger.isDebugEnabled()) {
-            logger.debug(String.format("Sending message to queue: '%s'", destinationQueueName));
-        }
-
-        if (logger.isDebugEnabled()) {
-            logger.debug("Message to send is:" + System.getProperty("line.separator") + message.toString());
-        }
+        logger.debug("Sending message to queue: '{}'", destinationQueueName);
+        logger.debug("Message to send is:\n{}", message);
 
         try {
             getDestinationQueue(context).send(message);
@@ -66,7 +62,7 @@ public class DirectProducer implements Producer {
             throw new CitrusRuntimeException(String.format("Failed to send message to queue: '%s'", destinationQueueName), e);
         }
 
-        logger.info(String.format("Message was sent to queue: '%s'", destinationQueueName));
+        logger.info("Message was sent to queue: '{}'", destinationQueueName);
     }
 
     /**

--- a/core/citrus-base/src/main/java/org/citrusframework/functions/core/AbstractDateFunction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/functions/core/AbstractDateFunction.java
@@ -89,5 +89,4 @@ public abstract class AbstractDateFunction implements Function {
     protected SimpleDateFormat getDefaultDateFormat() {
         return new SimpleDateFormat("dd.MM.yyyy");
     }
-
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/functions/core/CeilingFunction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/functions/core/CeilingFunction.java
@@ -44,5 +44,4 @@ public class CeilingFunction implements Function {
 
         return String.valueOf(ceil(parseDouble(parameterList.get(0))));
     }
-
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/functions/core/DecodeBase64Function.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/functions/core/DecodeBase64Function.java
@@ -49,5 +49,4 @@ public class DecodeBase64Function implements Function {
             throw new CitrusRuntimeException("Unsupported character encoding", e);
         }
     }
-
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/functions/core/DigestAuthHeaderFunction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/functions/core/DigestAuthHeaderFunction.java
@@ -111,5 +111,4 @@ public class DigestAuthHeaderFunction implements Function {
     public void setNonceValidity(Long nonceValidity) {
         this.nonceValidity = nonceValidity;
     }
-
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/functions/core/EncodeBase64Function.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/functions/core/EncodeBase64Function.java
@@ -49,5 +49,4 @@ public class EncodeBase64Function implements Function {
             throw new CitrusRuntimeException("Unsupported character encoding", e);
         }
     }
-
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/functions/core/LocalHostAddressFunction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/functions/core/LocalHostAddressFunction.java
@@ -47,6 +47,5 @@ public class LocalHostAddressFunction implements Function {
             throw new CitrusRuntimeException("Unable to locate local host address", e);
         }
     }
-
 }
 

--- a/core/citrus-base/src/main/java/org/citrusframework/functions/core/LowerCaseFunction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/functions/core/LowerCaseFunction.java
@@ -40,5 +40,4 @@ public class LowerCaseFunction implements Function {
 
         return (parameterList.get(0)).toLowerCase();
     }
-
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/functions/core/StringLengthFunction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/functions/core/StringLengthFunction.java
@@ -40,5 +40,4 @@ public class StringLengthFunction implements Function {
 
         return String.valueOf((parameterList.get(0)).length());
     }
-
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/functions/core/SumFunction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/functions/core/SumFunction.java
@@ -46,5 +46,4 @@ public class SumFunction implements Function {
 
         return Double.valueOf(result).toString();
     }
-
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/functions/core/UpperCaseFunction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/functions/core/UpperCaseFunction.java
@@ -40,5 +40,4 @@ public class UpperCaseFunction implements Function {
 
         return (parameterList.get(0)).toUpperCase();
     }
-
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/functions/core/UrlDecodeFunction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/functions/core/UrlDecodeFunction.java
@@ -49,5 +49,4 @@ public class UrlDecodeFunction implements Function {
             throw new CitrusRuntimeException("Unsupported character encoding", e);
         }
     }
-
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/functions/core/UrlEncodeFunction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/functions/core/UrlEncodeFunction.java
@@ -49,5 +49,4 @@ public class UrlEncodeFunction implements Function {
             throw new CitrusRuntimeException("Unsupported character encoding", e);
         }
     }
-
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/message/correlation/DefaultCorrelationManager.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/message/correlation/DefaultCorrelationManager.java
@@ -90,5 +90,4 @@ public class DefaultCorrelationManager<T> implements CorrelationManager<T> {
     public ObjectStore<T> getObjectStore() {
         return this.objectStore;
     }
-
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/message/selector/DelegatingMessageSelector.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/message/selector/DelegatingMessageSelector.java
@@ -83,5 +83,4 @@ public class DelegatingMessageSelector implements MessageSelector {
     public void addMessageSelectorFactory(MessageSelectorFactory factory) {
         this.factories.add(factory);
     }
-
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/report/HtmlReporter.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/report/HtmlReporter.java
@@ -404,5 +404,4 @@ public class HtmlReporter extends AbstractOutputFileReporter implements TestList
             this.description = description;
         }
     }
-
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/util/MessageUtils.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/util/MessageUtils.java
@@ -63,5 +63,4 @@ public class MessageUtils {
                 .map(payload->IsJsonPredicate.getInstance().test(payload))
                 .orElse(true);
     }
-
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/util/PropertyUtils.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/util/PropertyUtils.java
@@ -116,5 +116,4 @@ public final class PropertyUtils {
 
         return newStr.toString();
     }
-
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/validation/DefaultHeaderValidator.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/validation/DefaultHeaderValidator.java
@@ -75,7 +75,7 @@ public class DefaultHeaderValidator implements HeaderValidator {
         }
 
         if (logger.isDebugEnabled()) {
-            logger.debug("Validating header element: " + headerName + "='" + expectedValue + "': OK.");
+            logger.debug("Validating header element: " + headerName + "='" + expectedValue + "': OK");
         }
     }
 

--- a/core/citrus-base/src/main/java/org/citrusframework/validation/DefaultMessageHeaderValidator.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/validation/DefaultMessageHeaderValidator.java
@@ -91,7 +91,7 @@ public class DefaultMessageHeaderValidator extends AbstractMessageValidator<Head
                                     try {
                                         return context.getReferenceResolver().resolve(beanName, HeaderValidator.class);
                                     } catch (CitrusRuntimeException e) {
-                                        logger.warn("Failed to resolve header validator for name: " + beanName);
+                                        logger.warn("Failed to resolve header validator for name: {}", beanName);
                                         return null;
                                     }
                                 })
@@ -107,7 +107,7 @@ public class DefaultMessageHeaderValidator extends AbstractMessageValidator<Head
                     ).validateHeader(headerName, receivedHeaders.get(headerName), controlValue, context, validationContext);
         }
 
-        logger.info("Message header validation successful: All values OK");
+        logger.debug("Message header validation successful: All values OK");
     }
 
     /**
@@ -151,7 +151,7 @@ public class DefaultMessageHeaderValidator extends AbstractMessageValidator<Head
                 validationContext.isHeaderNameIgnoreCase()) {
             String key = headerName;
 
-            logger.debug(String.format("Finding case insensitive header for key '%s'", key));
+            logger.debug("Finding case insensitive header for key '{}'", key);
 
             headerName = receivedHeaders
                     .entrySet()
@@ -161,7 +161,7 @@ public class DefaultMessageHeaderValidator extends AbstractMessageValidator<Head
                     .findFirst()
                     .orElseThrow(() -> new ValidationException("Validation failed: No matching header for key '" + key + "'"));
 
-            logger.info(String.format("Found matching case insensitive header name: %s", headerName));
+            logger.trace("Found matching case insensitive header name: {}", headerName);
         }
 
         return headerName;

--- a/core/citrus-base/src/main/java/org/citrusframework/validation/DefaultMessageValidatorRegistry.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/validation/DefaultMessageValidatorRegistry.java
@@ -31,5 +31,4 @@ public class DefaultMessageValidatorRegistry extends MessageValidatorRegistry {
         MessageValidator.lookup().forEach(this::addMessageValidator);
         SchemaValidator.lookup().forEach(this::addSchemaValidator);
     }
-
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/validation/DelegatingPayloadVariableExtractor.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/validation/DelegatingPayloadVariableExtractor.java
@@ -194,5 +194,4 @@ public class DelegatingPayloadVariableExtractor implements VariableExtractor {
     public void setNamespaces(Map<String, String> namespaces) {
         this.namespaces = namespaces;
     }
-
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/validation/builder/StaticMessageBuilder.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/validation/builder/StaticMessageBuilder.java
@@ -100,5 +100,4 @@ public class StaticMessageBuilder extends DefaultMessageBuilder {
     public Message getMessage() {
         return message;
     }
-
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/validation/json/JsonMessageValidationContext.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/validation/json/JsonMessageValidationContext.java
@@ -173,5 +173,4 @@ public class JsonMessageValidationContext extends DefaultValidationContext imple
     public String getSchema() {
         return schema;
     }
-
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/validation/matcher/core/CreateVariableValidationMatcher.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/validation/matcher/core/CreateVariableValidationMatcher.java
@@ -39,11 +39,11 @@ public class CreateVariableValidationMatcher implements ValidationMatcher {
     public void validate(String fieldName, String value, List<String> controlParameters, TestContext context) throws ValidationException {
         String name = fieldName;
 
-        if (controlParameters != null && controlParameters.size() > 0) {
+        if (controlParameters != null && !controlParameters.isEmpty()) {
             name = controlParameters.get(0);
         }
 
-        logger.info("Setting variable: " + name + " to value: " + value);
+        logger.debug("Setting variable: " + name + " to value: " + value);
 
         context.setVariable(name, value);
     }

--- a/core/citrus-base/src/main/java/org/citrusframework/validation/matcher/core/WeekdayValidationMatcher.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/validation/matcher/core/WeekdayValidationMatcher.java
@@ -72,7 +72,7 @@ public class WeekdayValidationMatcher implements ValidationMatcher, ControlExpre
             cal.setTime(dateFormat.parse(value));
 
             if (cal.get(Calendar.DAY_OF_WEEK) == Weekday.valueOf(weekday).getConstantValue()) {
-                logger.info("Weekday validation matcher successful - All values OK");
+                logger.debug("Weekday validation matcher successful - All values OK");
             } else {
                 throw new ValidationException(this.getClass().getSimpleName() + " failed for field '" + fieldName + "'" +
                         ". Received invalid week day '" + value + "', expected date to be a '" + weekday + "'");

--- a/core/citrus-base/src/main/java/org/citrusframework/validation/script/ScriptValidationContext.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/validation/script/ScriptValidationContext.java
@@ -214,5 +214,4 @@ public class ScriptValidationContext extends DefaultValidationContext {
     public String getValidationScriptResourceCharset() {
         return validationScriptResourceCharset;
     }
-
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/validation/xml/XmlMessageValidationContext.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/validation/xml/XmlMessageValidationContext.java
@@ -276,5 +276,4 @@ public class XmlMessageValidationContext extends DefaultValidationContext implem
     public String getSchema() {
         return schema;
     }
-
 }

--- a/core/citrus-base/src/test/java/org/citrusframework/CitrusContextProviderTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/CitrusContextProviderTest.java
@@ -34,5 +34,4 @@ public class CitrusContextProviderTest {
     public void testTestLookup() {
         Assert.assertFalse(CitrusContextProvider.lookup(CitrusContextProvider.SPRING).isPresent());
     }
-
 }

--- a/core/citrus-base/src/test/java/org/citrusframework/TestCaseTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/TestCaseTest.java
@@ -222,5 +222,4 @@ public class TestCaseTest extends UnitTestSupport {
 
         waitingThread.ifPresent(thread -> Assert.fail(String.format("Waiting thread still alive: %s", thread.toString())));
     }
-
 }

--- a/core/citrus-base/src/test/java/org/citrusframework/actions/AbstractAsyncTestActionTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/actions/AbstractAsyncTestActionTest.java
@@ -84,5 +84,4 @@ public class AbstractAsyncTestActionTest extends UnitTestSupport {
 
         Assert.assertTrue(result.get(1000, TimeUnit.MILLISECONDS));
     }
-
 }

--- a/core/citrus-base/src/test/java/org/citrusframework/actions/PurgeEndpointActionTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/actions/PurgeEndpointActionTest.java
@@ -120,5 +120,4 @@ public class PurgeEndpointActionTest extends UnitTestSupport {
                 .build();
         purgeEndpointAction.execute(context);
     }
-
 }

--- a/core/citrus-base/src/test/java/org/citrusframework/actions/dsl/SendMessageActionBuilderTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/actions/dsl/SendMessageActionBuilderTest.java
@@ -715,5 +715,4 @@ public class SendMessageActionBuilderTest extends UnitTestSupport {
         Assert.assertEquals(action.getEndpoint(), messageEndpoint);
         Assert.assertEquals(action.getDataDictionary(), dictionary);
     }
-
 }

--- a/core/citrus-base/src/test/java/org/citrusframework/container/ConditionalTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/container/ConditionalTest.java
@@ -159,5 +159,4 @@ public class ConditionalTest extends UnitTestSupport {
 
         verify(action1).execute(this.context);
     }
-
 }

--- a/core/citrus-base/src/test/java/org/citrusframework/container/IterateTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/container/IterateTest.java
@@ -153,5 +153,4 @@ public class IterateTest extends UnitTestSupport {
 
         verify(action, times(5)).execute(context);
     }
-
 }

--- a/core/citrus-base/src/test/java/org/citrusframework/container/RepeatOnErrorUntilTrueTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/container/RepeatOnErrorUntilTrueTest.java
@@ -83,5 +83,4 @@ public class RepeatOnErrorUntilTrueTest extends UnitTestSupport {
         repeat.execute(context);
         verify(action, times(4)).execute(context);
     }
-
 }

--- a/core/citrus-base/src/test/java/org/citrusframework/container/RepeatUntilTrueTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/container/RepeatUntilTrueTest.java
@@ -93,5 +93,4 @@ public class RepeatUntilTrueTest extends UnitTestSupport {
 
         verify(action, times(4)).execute(context);
     }
-
 }

--- a/core/citrus-base/src/test/java/org/citrusframework/container/TimerTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/container/TimerTest.java
@@ -141,5 +141,4 @@ public class TimerTest extends UnitTestSupport {
     private void assertTimerIndex(int expectedValue, Timer timer) {
         assertEquals(context.getVariable(timer.getTimerId() + Timer.INDEX_SUFFIX), String.valueOf(expectedValue));
     }
-
 }

--- a/core/citrus-base/src/test/java/org/citrusframework/endpoint/direct/DirectEndpointProducerTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/endpoint/direct/DirectEndpointProducerTest.java
@@ -106,5 +106,4 @@ public class DirectEndpointProducerTest {
 
         Assert.fail("Missing " + CitrusRuntimeException.class + " because no message was received");
     }
-
 }

--- a/core/citrus-base/src/test/java/org/citrusframework/endpoint/direct/DirectEndpointSyncProducerTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/endpoint/direct/DirectEndpointSyncProducerTest.java
@@ -265,5 +265,4 @@ public class DirectEndpointSyncProducerTest {
 
         Assert.assertEquals(channelSyncProducer.receive(new DefaultMessageCorrelator().getCorrelationKey(message), context), message);
     }
-
 }

--- a/core/citrus-base/src/test/java/org/citrusframework/functions/core/RandomUUIDFunctionTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/functions/core/RandomUUIDFunctionTest.java
@@ -32,5 +32,4 @@ public class RandomUUIDFunctionTest extends UnitTestSupport {
     public void testFunction() {
         Assert.assertNotNull(function.execute(Collections.<String>emptyList(), context));
     }
-
 }

--- a/core/citrus-base/src/test/java/org/citrusframework/functions/core/ReadFileResourceFunctionTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/functions/core/ReadFileResourceFunctionTest.java
@@ -83,5 +83,4 @@ public class ReadFileResourceFunctionTest extends UnitTestSupport {
     public void testInvalidFunctionUsage() {
         function.execute(Collections.emptyList(), context);
     }
-
 }

--- a/core/citrus-base/src/test/java/org/citrusframework/message/DefaultMessageStoreTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/message/DefaultMessageStoreTest.java
@@ -44,5 +44,4 @@ public class DefaultMessageStoreTest extends UnitTestSupport {
         endpoint.setName("testEndpoint");
         Assert.assertEquals(messageStore.constructMessageName(new SendMessageAction.Builder().build(), endpoint), "send(testEndpoint)");
     }
-
 }

--- a/core/citrus-base/src/test/java/org/citrusframework/message/selector/HeaderMatchingMessageSelectorTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/message/selector/HeaderMatchingMessageSelectorTest.java
@@ -101,5 +101,4 @@ public class HeaderMatchingMessageSelectorTest extends UnitTestSupport {
         Assert.assertTrue(messageSelector.accept(acceptMessage));
         Assert.assertFalse(messageSelector.accept(declineMessage));
     }
-
 }

--- a/core/citrus-base/src/test/java/org/citrusframework/util/FileUtilsTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/util/FileUtilsTest.java
@@ -71,5 +71,4 @@ public class FileUtilsTest extends UnitTestSupport {
         Assert.assertEquals(FileUtils.getFileName("foo.bar.java"), "foo.bar.java");
         Assert.assertEquals(FileUtils.getFileName("/path/to/some/foo.bar.java"), "foo.bar.java");
     }
-
 }

--- a/core/citrus-base/src/test/java/org/citrusframework/validation/DefaultMessageHeaderValidatorTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/validation/DefaultMessageHeaderValidatorTest.java
@@ -134,5 +134,4 @@ public class DefaultMessageHeaderValidatorTest extends UnitTestSupport {
 
         validator.validateMessage(receivedMessage, controlMessage, context, validationContext);
     }
-
 }

--- a/core/citrus-base/src/test/java/org/citrusframework/validation/DefaultTextEqualsMessageValidatorTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/validation/DefaultTextEqualsMessageValidatorTest.java
@@ -96,5 +96,4 @@ public class DefaultTextEqualsMessageValidatorTest extends UnitTestSupport {
            new Object[]{ "Hello!", "Hi!" },
         };
     }
-
 }

--- a/core/citrus-base/src/test/java/org/citrusframework/validation/MessageValidatorRegistryTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/validation/MessageValidatorRegistryTest.java
@@ -360,5 +360,4 @@ public class MessageValidatorRegistryTest {
         Assert.assertTrue(jsonSchema.isPresent());
         Assert.assertEquals(jsonSchema.get(), jsonSchemaValidator);
     }
-
 }

--- a/core/citrus-base/src/test/java/org/citrusframework/validation/ValidationUtilsTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/validation/ValidationUtilsTest.java
@@ -140,5 +140,4 @@ public class ValidationUtilsTest extends UnitTestSupport {
             }
         }
     }
-
 }

--- a/core/citrus-base/src/test/java/org/citrusframework/validation/matcher/ValidationMatcherRegistryTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/validation/matcher/ValidationMatcherRegistryTest.java
@@ -66,5 +66,4 @@ public class ValidationMatcherRegistryTest extends UnitTestSupport {
             Assert.assertTrue(e.getMessage().contains("unknown:"));
         }
     }
-
 }

--- a/core/citrus-spring/src/main/java/org/citrusframework/config/CitrusConversionServiceConfiguration.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/config/CitrusConversionServiceConfiguration.java
@@ -39,5 +39,4 @@ public class CitrusConversionServiceConfiguration {
         conversionServiceFactoryBean.setConverters(converters);
         return conversionServiceFactoryBean;
     }
-
 }

--- a/core/citrus-spring/src/main/java/org/citrusframework/config/handler/CitrusConfigNamespaceHandler.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/config/handler/CitrusConfigNamespaceHandler.java
@@ -94,5 +94,4 @@ public class CitrusConfigNamespaceHandler extends NamespaceHandlerSupport {
             }
         });
     }
-
 }

--- a/core/citrus-spring/src/main/java/org/citrusframework/config/handler/CitrusTestCaseNamespaceHandler.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/config/handler/CitrusTestCaseNamespaceHandler.java
@@ -42,5 +42,4 @@ public class CitrusTestCaseNamespaceHandler extends NamespaceHandlerSupport {
             registerBeanDefinitionParser(actionParserEntry.getKey(), actionParserEntry.getValue());
         }
     }
-
 }

--- a/core/citrus-spring/src/main/java/org/citrusframework/config/util/ValidateMessageParserUtil.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/config/util/ValidateMessageParserUtil.java
@@ -48,5 +48,4 @@ public class ValidateMessageParserUtil {
             }
         }
     }
-
 }

--- a/core/citrus-spring/src/main/java/org/citrusframework/config/util/VariableExtractorParserUtil.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/config/util/VariableExtractorParserUtil.java
@@ -69,5 +69,4 @@ public class VariableExtractorParserUtil {
 
         variableExtractors.add(payloadVariableExtractor);
     }
-
 }

--- a/core/citrus-spring/src/main/java/org/citrusframework/config/xml/AbstractIteratingTestContainerFactoryBean.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/config/xml/AbstractIteratingTestContainerFactoryBean.java
@@ -56,5 +56,4 @@ public abstract class AbstractIteratingTestContainerFactoryBean<T extends Abstra
     public void setStart(int start) {
         getBuilder().startsWith(start);
     }
-
 }

--- a/core/citrus-spring/src/main/java/org/citrusframework/config/xml/BaseTestCaseMetaInfoParser.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/config/xml/BaseTestCaseMetaInfoParser.java
@@ -97,5 +97,4 @@ public abstract class BaseTestCaseMetaInfoParser<T extends TestCaseMetaInfo> imp
      */
     protected void parseAdditionalProperties(Element metaInfoElement, BeanDefinitionBuilder metaInfoBuilder) {
     }
-
 }

--- a/core/citrus-spring/src/main/java/org/citrusframework/config/xml/ConditionalParser.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/config/xml/ConditionalParser.java
@@ -93,5 +93,4 @@ public class ConditionalParser implements BeanDefinitionParser {
             return builder;
         }
     }
-
 }

--- a/core/citrus-spring/src/main/java/org/citrusframework/config/xml/JavaActionParser.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/config/xml/JavaActionParser.java
@@ -161,5 +161,4 @@ public class JavaActionParser implements BeanDefinitionParser {
             return builder;
         }
     }
-
 }

--- a/core/citrus-spring/src/main/java/org/citrusframework/config/xml/SequenceAfterTestParser.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/config/xml/SequenceAfterTestParser.java
@@ -28,5 +28,4 @@ public class SequenceAfterTestParser extends AbstractTestBoundaryActionContainer
     protected Class<? extends AbstractTestBoundaryActionContainer> getContainerClass() {
         return SequenceAfterTest.class;
     }
-
 }

--- a/core/citrus-spring/src/main/java/org/citrusframework/config/xml/SequenceBeforeSuiteParser.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/config/xml/SequenceBeforeSuiteParser.java
@@ -29,5 +29,4 @@ public class SequenceBeforeSuiteParser  extends AbstractSuiteActionContainerPars
     protected Class<? extends AbstractSuiteActionContainer> getContainerClass() {
         return SequenceBeforeSuite.class;
     }
-
 }

--- a/core/citrus-spring/src/main/java/org/citrusframework/config/xml/SequenceBeforeTestParser.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/config/xml/SequenceBeforeTestParser.java
@@ -29,5 +29,4 @@ public class SequenceBeforeTestParser extends AbstractTestBoundaryActionContaine
     protected Class<? extends AbstractTestBoundaryActionContainer> getContainerClass() {
         return SequenceBeforeTest.class;
     }
-
 }

--- a/core/citrus-spring/src/main/java/org/citrusframework/context/TestContextFactoryBean.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/context/TestContextFactoryBean.java
@@ -357,5 +357,4 @@ public class TestContextFactoryBean extends TestContextFactory implements Factor
     public SegmentVariableExtractorRegistry getSegmentVariableExtractorRegistry() {
         return delegate.getSegmentVariableExtractorRegistry();
     }
-
 }

--- a/core/citrus-spring/src/main/java/org/citrusframework/reporter/ReporterConfig.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/reporter/ReporterConfig.java
@@ -79,5 +79,4 @@ public class ReporterConfig {
             return "true".equals(context.getEnvironment().getProperty(DEFAULT_HTML_REPORTER_ENABLED_PROPERTY, "true"));
         }
     }
-
 }

--- a/core/citrus-spring/src/test/java/org/citrusframework/config/xml/ConditionalParserTest.java
+++ b/core/citrus-spring/src/test/java/org/citrusframework/config/xml/ConditionalParserTest.java
@@ -37,5 +37,4 @@ public class ConditionalParserTest extends AbstractActionParserTest<Conditional>
         final Conditional action = this.getNextTestActionFromTest();
         Assert.assertEquals(action.getActionCount(), 2);
     }
-
 }

--- a/core/citrus-spring/src/test/java/org/citrusframework/config/xml/CreateVariablesActionParserTest.java
+++ b/core/citrus-spring/src/test/java/org/citrusframework/config/xml/CreateVariablesActionParserTest.java
@@ -38,5 +38,4 @@ public class CreateVariablesActionParserTest extends AbstractActionParserTest<Cr
         Assert.assertEquals(action.getVariables().get("sum"), "script:<groovy>(1+2+3+4+5)");
         Assert.assertEquals(action.getVariables().get("embeddedXml"), "<embeddedXml>This is an embedded Xml variable value</embeddedXml>");
     }
-
 }

--- a/core/citrus-spring/src/test/java/org/citrusframework/config/xml/NamespaceContextParserTest.java
+++ b/core/citrus-spring/src/test/java/org/citrusframework/config/xml/NamespaceContextParserTest.java
@@ -44,5 +44,4 @@ public class NamespaceContextParserTest extends AbstractBeanDefinitionParserTest
         Assert.assertEquals(namespaceContextBean.getNamespaceMappings().get("ns1"), "http://citrusframework.org/schemas/2");
         Assert.assertEquals(namespaceContextBean.getNamespaceMappings().get("ns2"), "http://citrusframework.org/schemas/3");
     }
-
 }

--- a/core/citrus-spring/src/test/java/org/citrusframework/context/SpringBeanReferenceResolverTest.java
+++ b/core/citrus-spring/src/test/java/org/citrusframework/context/SpringBeanReferenceResolverTest.java
@@ -78,5 +78,4 @@ public class SpringBeanReferenceResolverTest extends UnitTestSupport {
         Assert.assertEquals(resolver.resolve(unmarshallerName, Unmarshaller.class).getClass(), MarshallerAdapter.class);
         Assert.assertEquals(resolver.resolveAll(Unmarshaller.class).size(), 1L);
     }
-
 }

--- a/core/citrus-spring/src/test/java/org/citrusframework/reporter/ReporterConfigDisabledTest.java
+++ b/core/citrus-spring/src/test/java/org/citrusframework/reporter/ReporterConfigDisabledTest.java
@@ -44,5 +44,4 @@ public class ReporterConfigDisabledTest extends UnitTestSupport {
     public void testDefaultHtmlReporter() {
         Assert.assertThrows(NoSuchBeanDefinitionException.class, () -> applicationContext.getBean(CITRUS_HTML_REPORTER));
     }
-
 }

--- a/core/citrus-spring/src/test/java/org/citrusframework/reporter/ReporterConfigTest.java
+++ b/core/citrus-spring/src/test/java/org/citrusframework/reporter/ReporterConfigTest.java
@@ -43,5 +43,4 @@ public class ReporterConfigTest extends UnitTestSupport {
     public void testDefaultHtmlReporter() {
         Assert.assertTrue(applicationContext.getBean(CITRUS_HTML_REPORTER) instanceof  HtmlReporter);
     }
-
 }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/AbstractCamelRouteAction.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/AbstractCamelRouteAction.java
@@ -127,5 +127,4 @@ public abstract class AbstractCamelRouteAction extends AbstractTestAction {
             this.referenceResolver = referenceResolver;
         }
     }
-
 }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/endpoint/CamelConsumer.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/endpoint/CamelConsumer.java
@@ -124,5 +124,4 @@ public class CamelConsumer implements Consumer {
     public String getName() {
         return name;
     }
-
 }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/endpoint/CamelSyncConsumer.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/endpoint/CamelSyncConsumer.java
@@ -164,5 +164,4 @@ public class CamelSyncConsumer extends CamelConsumer implements ReplyProducer {
     public void setCorrelationManager(CorrelationManager<Exchange> correlationManager) {
         this.correlationManager = correlationManager;
     }
-
 }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/Camel.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/Camel.java
@@ -160,5 +160,4 @@ public class Camel implements TestActionBuilder<TestAction>, ReferenceResolverAw
     public void setReferenceResolver(ReferenceResolver referenceResolver) {
         this.referenceResolver = referenceResolver;
     }
-
 }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/ObjectFactory.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/ObjectFactory.java
@@ -49,5 +49,4 @@ public class ObjectFactory {
     public Camel createCamel() {
         return new Camel();
     }
-
 }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/Camel.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/Camel.java
@@ -99,5 +99,4 @@ public class Camel implements TestActionBuilder<TestAction>, ReferenceResolverAw
     public void setReferenceResolver(ReferenceResolver referenceResolver) {
         this.referenceResolver = referenceResolver;
     }
-
 }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/CreateRoutes.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/CreateRoutes.java
@@ -29,5 +29,4 @@ public class CreateRoutes implements CamelRouteActionBuilderWrapper<CreateCamelR
     public CreateCamelRouteAction.Builder getBuilder() {
         return builder;
     }
-
 }

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/actions/CamelActionBuilderTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/actions/CamelActionBuilderTest.java
@@ -35,5 +35,4 @@ public class CamelActionBuilderTest {
         Assert.assertTrue(TestActionBuilder.lookup("camel").isPresent());
         Assert.assertEquals(TestActionBuilder.lookup("camel").get().getClass(), CamelActionBuilder.class);
     }
-
 }

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/endpoint/CamelEndpointsTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/endpoint/CamelEndpointsTest.java
@@ -47,5 +47,4 @@ public class CamelEndpointsTest {
         Assert.assertTrue(EndpointBuilder.lookup("camel.inOnly").isPresent());
         Assert.assertEquals(EndpointBuilder.lookup("camel.inOnly").get().getClass(), CamelEndpointBuilder.class);
     }
-
 }

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/integration/CamelDataFormatIT.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/integration/CamelDataFormatIT.java
@@ -57,5 +57,4 @@ public class CamelDataFormatIT extends TestNGCitrusSpringSupport {
                 .type(MessageType.PLAINTEXT)
                 .body("Citrus rocks!"));
     }
-
 }

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/integration/CamelRouteIT.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/integration/CamelRouteIT.java
@@ -62,5 +62,4 @@ public class CamelRouteIT extends TestNGCitrusSupport {
                 .type(MessageType.PLAINTEXT)
                 .body("<News><Message>Citrus rocks!</Message></News>"));
     }
-
 }

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/integration/CamelTransformIT.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/integration/CamelTransformIT.java
@@ -73,5 +73,4 @@ public class CamelTransformIT extends TestNGCitrusSpringSupport {
                 .type(MessageType.PLAINTEXT)
                 .body("Citrus rocks!"));
     }
-
 }

--- a/endpoints/citrus-ftp/src/main/java/org/citrusframework/ftp/FtpSettings.java
+++ b/endpoints/citrus-ftp/src/main/java/org/citrusframework/ftp/FtpSettings.java
@@ -43,5 +43,4 @@ public class FtpSettings {
         return System.getProperty(MARSHALLER_TYPE_PROPERTY,
                 System.getenv(MARSHALLER_TYPE_ENV) != null ? System.getenv(MARSHALLER_TYPE_ENV) : MARSHALLER_TYPE_DEFAULT);
     }
-
 }

--- a/endpoints/citrus-ftp/src/main/java/org/citrusframework/ftp/message/FtpMessage.java
+++ b/endpoints/citrus-ftp/src/main/java/org/citrusframework/ftp/message/FtpMessage.java
@@ -498,5 +498,4 @@ public class FtpMessage extends DefaultMessage {
         this.marshaller = marshaller;
         return this;
     }
-
 }

--- a/endpoints/citrus-ftp/src/test/java/org/citrusframework/ftp/client/AbstractFtpClientTest.java
+++ b/endpoints/citrus-ftp/src/test/java/org/citrusframework/ftp/client/AbstractFtpClientTest.java
@@ -113,5 +113,4 @@ public abstract class AbstractFtpClientTest extends AbstractTestNGUnitTest {
                         new CitrusRuntimeException(String.format("File '%s' could not be found in the specified list of files.", fileName))
                 );
     }
-
 }

--- a/endpoints/citrus-ftp/src/test/java/org/citrusframework/ftp/client/SftpClientTest.java
+++ b/endpoints/citrus-ftp/src/test/java/org/citrusframework/ftp/client/SftpClientTest.java
@@ -254,5 +254,4 @@ public class SftpClientTest extends AbstractFtpClientTest {
             writer.write(fileContent, 0, fileContent.length());
         }
     }
-
 }

--- a/endpoints/citrus-ftp/src/test/java/org/citrusframework/ftp/config/xml/SftpServerParserTest.java
+++ b/endpoints/citrus-ftp/src/test/java/org/citrusframework/ftp/config/xml/SftpServerParserTest.java
@@ -79,5 +79,4 @@ public class SftpServerParserTest extends AbstractBeanDefinitionParserTest {
         Assert.assertEquals(server.getEndpointAdapter(), beanDefinitionContext.getBean("sftpServerAdapter"));
         Assert.assertNull(server.getActor());
     }
-
 }

--- a/endpoints/citrus-ftp/src/test/java/org/citrusframework/ftp/endpoint/builder/FtpEndpointsTest.java
+++ b/endpoints/citrus-ftp/src/test/java/org/citrusframework/ftp/endpoint/builder/FtpEndpointsTest.java
@@ -43,5 +43,4 @@ public class FtpEndpointsTest {
         Assert.assertTrue(EndpointBuilder.lookup("ftp.server").isPresent());
         Assert.assertEquals(EndpointBuilder.lookup("ftp.server").get().getClass(), FtpServerBuilder.class);
     }
-
 }

--- a/endpoints/citrus-ftp/src/test/java/org/citrusframework/ftp/endpoint/builder/ScpEndpointsTest.java
+++ b/endpoints/citrus-ftp/src/test/java/org/citrusframework/ftp/endpoint/builder/ScpEndpointsTest.java
@@ -43,5 +43,4 @@ public class ScpEndpointsTest {
         Assert.assertTrue(EndpointBuilder.lookup("scp.server").isPresent());
         Assert.assertEquals(EndpointBuilder.lookup("scp.server").get().getClass(), SftpServerBuilder.class);
     }
-
 }

--- a/endpoints/citrus-ftp/src/test/java/org/citrusframework/ftp/endpoint/builder/SftpEndpointsTest.java
+++ b/endpoints/citrus-ftp/src/test/java/org/citrusframework/ftp/endpoint/builder/SftpEndpointsTest.java
@@ -43,5 +43,4 @@ public class SftpEndpointsTest {
         Assert.assertTrue(EndpointBuilder.lookup("sftp.server").isPresent());
         Assert.assertEquals(EndpointBuilder.lookup("sftp.server").get().getClass(), SftpServerBuilder.class);
     }
-
 }

--- a/endpoints/citrus-ftp/src/test/java/org/citrusframework/ftp/message/FtpMarshallerTest.java
+++ b/endpoints/citrus-ftp/src/test/java/org/citrusframework/ftp/message/FtpMarshallerTest.java
@@ -53,5 +53,4 @@ public class FtpMarshallerTest {
                             "}" +
                         "}");
     }
-
 }

--- a/endpoints/citrus-ftp/src/test/java/org/citrusframework/ftp/server/FtpServerFtpLetTest.java
+++ b/endpoints/citrus-ftp/src/test/java/org/citrusframework/ftp/server/FtpServerFtpLetTest.java
@@ -79,5 +79,4 @@ public class FtpServerFtpLetTest {
         result = ftpLet.beforeCommand(ftpSession, ftpRequest);
         Assert.assertEquals(result, FtpletResult.DEFAULT);
     }
-
 }

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/config/handler/CitrusHttpConfigNamespaceHandler.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/config/handler/CitrusHttpConfigNamespaceHandler.java
@@ -31,5 +31,4 @@ public class CitrusHttpConfigNamespaceHandler extends NamespaceHandlerSupport {
         registerBeanDefinitionParser("server", new HttpServerParser());
         registerBeanDefinitionParser("client", new HttpClientParser());
     }
-
 }

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/model/ObjectFactory.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/model/ObjectFactory.java
@@ -40,5 +40,4 @@ public class ObjectFactory {
     public Control createControl() {
         return new Control();
     }
-
 }

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/security/User.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/security/User.java
@@ -98,5 +98,4 @@ public class User {
     public void setRoles(String[] roles) {
         this.roles = Arrays.copyOf(roles, roles.length);
     }
-
 }

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/servlet/CachingHttpServletRequestWrapper.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/servlet/CachingHttpServletRequestWrapper.java
@@ -170,5 +170,4 @@ public class CachingHttpServletRequestWrapper extends HttpServletRequestWrapper 
             return is.read();
         }
     }
-
 }

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/servlet/RequestCachingServletFilter.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/servlet/RequestCachingServletFilter.java
@@ -40,5 +40,4 @@ public class RequestCachingServletFilter extends OncePerRequestFilter {
             FilterChain filterChain) throws ServletException, IOException {
         filterChain.doFilter(new CachingHttpServletRequestWrapper(request), response);
     }
-
 }

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/xml/Http.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/xml/Http.java
@@ -1007,5 +1007,4 @@ public class Http implements TestActionBuilder<TestAction>, ReferenceResolverAwa
             }
         }
     }
-
 }

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/xml/ObjectFactory.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/xml/ObjectFactory.java
@@ -49,5 +49,4 @@ public class ObjectFactory {
     public Http createHttp() {
         return new Http();
     }
-
 }

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/yaml/Http.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/yaml/Http.java
@@ -877,5 +877,4 @@ public class Http implements TestActionBuilder<TestAction>, ReferenceResolverAwa
             }
         }
     }
-
 }

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/actions/HttpActionBuilderTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/actions/HttpActionBuilderTest.java
@@ -35,5 +35,4 @@ public class HttpActionBuilderTest {
         Assert.assertTrue(TestActionBuilder.lookup("http").isPresent());
         Assert.assertEquals(TestActionBuilder.lookup("http").get().getClass(), HttpActionBuilder.class);
     }
-
 }

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/actions/dsl/ReceiveHttpMessageTestActionBuilderTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/actions/dsl/ReceiveHttpMessageTestActionBuilderTest.java
@@ -195,5 +195,4 @@ public class ReceiveHttpMessageTestActionBuilderTest extends UnitTestSupport {
         Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get(HttpMessageHeaders.HTTP_REASON_PHRASE), "OK");
         Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get(HttpMessageHeaders.HTTP_VERSION), "HTTP/1.1");
     }
-
 }

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/actions/dsl/SendHttpMessageTestActionBuilderTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/actions/dsl/SendHttpMessageTestActionBuilderTest.java
@@ -280,5 +280,4 @@ public class SendHttpMessageTestActionBuilderTest extends UnitTestSupport {
         Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get(EndpointUriResolver.ENDPOINT_URI_HEADER_NAME), "http://localhost:8080/");
         Assert.assertEquals(messageBuilder.buildMessageHeaders(context).get(EndpointUriResolver.QUERY_PARAM_HEADER_NAME), "param1=value1,param2=value2");
     }
-
 }

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/config/xml/HttpClientParserTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/config/xml/HttpClientParserTest.java
@@ -117,5 +117,4 @@ public class HttpClientParserTest extends AbstractBeanDefinitionParserTest {
             Assert.assertTrue(ObjectHelper.assertNotNull(e.getMessage()).contains("One of the properties 'request-url' or 'endpoint-resolver' is required"));
         }
     }
-
 }

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/config/xml/HttpReceiveResponseActionParserTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/config/xml/HttpReceiveResponseActionParserTest.java
@@ -117,5 +117,4 @@ public class HttpReceiveResponseActionParserTest extends AbstractActionParserTes
             Assert.assertTrue(e.getCause().getMessage().startsWith("Neither http request uri nor http client endpoint reference is given"));
         }
     }
-
 }

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/config/xml/HttpSendRequestActionParserTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/config/xml/HttpSendRequestActionParserTest.java
@@ -122,5 +122,4 @@ public class HttpSendRequestActionParserTest extends AbstractActionParserTest<Se
             Assert.assertTrue(e.getCause().getMessage().startsWith("Neither http request uri nor http client endpoint reference is given"));
         }
     }
-
 }

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/config/xml/HttpSendResponseActionParserTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/config/xml/HttpSendResponseActionParserTest.java
@@ -76,5 +76,4 @@ public class HttpSendResponseActionParserTest extends AbstractActionParserTest<S
         Assert.assertNull(action.getEndpointUri());
         Assert.assertEquals(action.getActor(), beanDefinitionContext.getBean("testActor", TestActor.class));
     }
-
 }

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/endpoint/builder/HttpEndpointsTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/endpoint/builder/HttpEndpointsTest.java
@@ -43,5 +43,4 @@ public class HttpEndpointsTest {
         Assert.assertTrue(EndpointBuilder.lookup("http.server").isPresent());
         Assert.assertEquals(EndpointBuilder.lookup("http.server").get().getClass(), HttpServerBuilder.class);
     }
-
 }

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/integration/CustomMessageValidatorIT.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/integration/CustomMessageValidatorIT.java
@@ -107,5 +107,4 @@ public class CustomMessageValidatorIT extends TestNGCitrusSpringSupport {
                 .validate(xpath()
                         .expression("//doc/@text", "nothello"))));
     }
-
 }

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/servlet/GzipServletFilterTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/servlet/GzipServletFilterTest.java
@@ -121,5 +121,4 @@ public class GzipServletFilterTest {
         String unzipped = new String(response.getContentAsByteArray());
         Assert.assertEquals(unzipped, "Should not be compressed");
     }
-
 }

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/servlet/RequestCachingServletFilterTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/servlet/RequestCachingServletFilterTest.java
@@ -110,5 +110,4 @@ public class RequestCachingServletFilterTest {
         });
         filterChain.doFilter(request, response);
     }
-
 }

--- a/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/actions/PurgeJmsQueuesAction.java
+++ b/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/actions/PurgeJmsQueuesAction.java
@@ -379,5 +379,4 @@ public class PurgeJmsQueuesAction extends AbstractTestAction {
             this.referenceResolver = referenceResolver;
         }
     }
-
 }

--- a/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/config/xml/AbstractJmsEndpointParser.java
+++ b/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/config/xml/AbstractJmsEndpointParser.java
@@ -85,5 +85,4 @@ public abstract class AbstractJmsEndpointParser extends AbstractEndpointParser {
         BeanDefinitionParserUtils.setPropertyValue(endpointConfiguration,
                 element.getAttribute("polling-interval"), "pollingInterval");
     }
-
 }

--- a/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/endpoint/JmsConsumer.java
+++ b/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/endpoint/JmsConsumer.java
@@ -136,5 +136,4 @@ public class JmsConsumer extends AbstractSelectiveMessageConsumer {
     private String getDestinationNameWithSelector(String destinationName, String selector) {
         return destinationName + (StringUtils.hasText(selector) ? "(" + selector + ")" : "");
     }
-
 }

--- a/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/endpoint/JmsProducer.java
+++ b/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/endpoint/JmsProducer.java
@@ -118,5 +118,4 @@ public class JmsProducer implements Producer {
     public String getName() {
         return name;
     }
-
 }

--- a/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/endpoint/JmsSyncConsumer.java
+++ b/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/endpoint/JmsSyncConsumer.java
@@ -128,5 +128,4 @@ public class JmsSyncConsumer extends JmsConsumer implements ReplyProducer {
     public void setCorrelationManager(CorrelationManager<Destination> correlationManager) {
         this.correlationManager = correlationManager;
     }
-
 }

--- a/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/endpoint/JmsSyncEndpoint.java
+++ b/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/endpoint/JmsSyncEndpoint.java
@@ -85,5 +85,4 @@ public class JmsSyncEndpoint extends JmsEndpoint implements ShutdownPhase {
             jmsSyncMessageProducer.destroy();
         }
     }
-
 }

--- a/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/endpoint/JmsSyncEndpointConfiguration.java
+++ b/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/endpoint/JmsSyncEndpointConfiguration.java
@@ -106,5 +106,4 @@ public class JmsSyncEndpointConfiguration extends JmsEndpointConfiguration imple
     public void setPollingInterval(long pollingInterval) {
         this.pollingInterval = pollingInterval;
     }
-
 }

--- a/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/message/JmsMessageConverter.java
+++ b/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/message/JmsMessageConverter.java
@@ -170,5 +170,4 @@ public class JmsMessageConverter implements MessageConverter<jakarta.jms.Message
             throw new CitrusRuntimeException("Failed to convert jms message", e);
         }
     }
-
 }

--- a/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/xml/ObjectFactory.java
+++ b/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/xml/ObjectFactory.java
@@ -49,5 +49,4 @@ public class ObjectFactory {
     public PurgeQueues createPurgeQueues() {
         return new PurgeQueues();
     }
-
 }

--- a/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/actions/dsl/PurgeJmsQueueTestActionBuilderTest.java
+++ b/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/actions/dsl/PurgeJmsQueueTestActionBuilderTest.java
@@ -122,5 +122,4 @@ public class PurgeJmsQueueTestActionBuilderTest extends UnitTestSupport {
 
         verify(connection).start();
     }
-
 }

--- a/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/endpoint/JmsEndpointAdapterTest.java
+++ b/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/endpoint/JmsEndpointAdapterTest.java
@@ -124,5 +124,4 @@ public class JmsEndpointAdapterTest extends AbstractTestNGUnitTest {
         verify(connection).start();
         verify(tempReplyQueue).delete();
     }
-
 }

--- a/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/endpoint/JmsEndpointProducerTest.java
+++ b/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/endpoint/JmsEndpointProducerTest.java
@@ -129,5 +129,4 @@ public class JmsEndpointProducerTest extends AbstractTestNGUnitTest {
         endpoint.getEndpointConfiguration().setDestination(destination);
         endpoint.createProducer().send(null, context);
     }
-
 }

--- a/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/endpoint/JmsEndpointsTest.java
+++ b/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/endpoint/JmsEndpointsTest.java
@@ -41,5 +41,4 @@ public class JmsEndpointsTest {
         Assert.assertTrue(EndpointBuilder.lookup("jms.async").isPresent());
         Assert.assertEquals(EndpointBuilder.lookup("jms.async").get().getClass(), JmsEndpointBuilder.class);
     }
-
 }

--- a/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/integration/service/HelloServiceImpl.java
+++ b/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/integration/service/HelloServiceImpl.java
@@ -40,5 +40,4 @@ public class HelloServiceImpl extends AbstractMarshallingHelloService {
 
         return builder.build();
     }
-
 }

--- a/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/integration/service/model/FaultDetail.java
+++ b/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/integration/service/model/FaultDetail.java
@@ -155,5 +155,4 @@ public class FaultDetail {
     public void setText(String value) {
         this.text = value;
     }
-
 }

--- a/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/integration/service/model/FaultType.java
+++ b/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/integration/service/model/FaultType.java
@@ -98,5 +98,4 @@ public class FaultType {
     public void setMessage(String value) {
         this.message = value;
     }
-
 }

--- a/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/integration/service/model/HelloRequest.java
+++ b/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/integration/service/model/HelloRequest.java
@@ -155,5 +155,4 @@ public class HelloRequest {
     public void setText(String value) {
         this.text = value;
     }
-
 }

--- a/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/integration/service/model/HelloResponse.java
+++ b/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/integration/service/model/HelloResponse.java
@@ -183,5 +183,4 @@ public class HelloResponse {
     public void setFault(FaultType value) {
         this.fault = value;
     }
-
 }

--- a/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/integration/service/model/ObjectFactory.java
+++ b/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/integration/service/model/ObjectFactory.java
@@ -91,5 +91,4 @@ public class ObjectFactory {
     public RequestHeader createRequestHeader() {
         return new RequestHeader();
     }
-
 }

--- a/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/integration/service/model/RequestHeader.java
+++ b/endpoints/citrus-jms/src/test/java/org/citrusframework/jms/integration/service/model/RequestHeader.java
@@ -99,5 +99,4 @@ public class RequestHeader {
     public void setOperation(String value) {
         this.operation = value;
     }
-
 }

--- a/endpoints/citrus-jmx/src/main/java/org/citrusframework/jmx/config/xml/JmxClientParser.java
+++ b/endpoints/citrus-jmx/src/main/java/org/citrusframework/jmx/config/xml/JmxClientParser.java
@@ -62,5 +62,4 @@ public class JmxClientParser extends AbstractEndpointParser {
     protected Class<? extends EndpointConfiguration> getEndpointConfigurationClass() {
         return JmxEndpointConfiguration.class;
     }
-
 }

--- a/endpoints/citrus-jmx/src/main/java/org/citrusframework/jmx/model/ManagedBeanDefinition.java
+++ b/endpoints/citrus-jmx/src/main/java/org/citrusframework/jmx/model/ManagedBeanDefinition.java
@@ -324,5 +324,4 @@ public class ManagedBeanDefinition {
     public void setObjectName(String objectName) {
         this.objectName = objectName;
     }
-
 }

--- a/endpoints/citrus-jmx/src/main/java/org/citrusframework/jmx/model/ObjectFactory.java
+++ b/endpoints/citrus-jmx/src/main/java/org/citrusframework/jmx/model/ObjectFactory.java
@@ -65,5 +65,4 @@ public class ObjectFactory {
     public ManagedBeanResult.Object createManagedBeanResultObject() {
         return new ManagedBeanResult.Object();
     }
-
 }

--- a/endpoints/citrus-jmx/src/test/java/org/citrusframework/jmx/endpoint/JmxEndpointComponentTest.java
+++ b/endpoints/citrus-jmx/src/test/java/org/citrusframework/jmx/endpoint/JmxEndpointComponentTest.java
@@ -87,5 +87,4 @@ public class JmxEndpointComponentTest {
     public void testLookupByQualifier() {
         Assert.assertTrue(EndpointComponent.lookup("jmx").isPresent());
     }
-
 }

--- a/endpoints/citrus-jmx/src/test/java/org/citrusframework/jmx/endpoint/builder/JmxEndpointsTest.java
+++ b/endpoints/citrus-jmx/src/test/java/org/citrusframework/jmx/endpoint/builder/JmxEndpointsTest.java
@@ -43,5 +43,4 @@ public class JmxEndpointsTest {
         Assert.assertTrue(EndpointBuilder.lookup("jmx.server").isPresent());
         Assert.assertEquals(EndpointBuilder.lookup("jmx.server").get().getClass(), JmxServerBuilder.class);
     }
-
 }

--- a/endpoints/citrus-jmx/src/test/java/org/citrusframework/jmx/model/ManagedBeanDefinitionTest.java
+++ b/endpoints/citrus-jmx/src/test/java/org/citrusframework/jmx/model/ManagedBeanDefinitionTest.java
@@ -149,5 +149,4 @@ public class ManagedBeanDefinitionTest {
         Assert.assertEquals(info.getOperations()[0].getSignature()[0].getName(), "p1");
         Assert.assertNull(info.getOperations()[0].getReturnType());
     }
-
 }

--- a/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/config/xml/KafkaEmbeddedServerParserTest.java
+++ b/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/config/xml/KafkaEmbeddedServerParserTest.java
@@ -56,5 +56,4 @@ public class KafkaEmbeddedServerParserTest extends AbstractBeanDefinitionParserT
         Assert.assertEquals(kafkaServer.getBrokerProperties().size(), 1L);
         Assert.assertEquals(kafkaServer.getBrokerProperties().get("broker.id"), "1");
     }
-
 }

--- a/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/KafkaProducerTest.java
+++ b/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/KafkaProducerTest.java
@@ -139,5 +139,4 @@ public class KafkaProducerTest extends AbstractTestNGUnitTest {
 
         endpoint.createProducer().send(null, context);
     }
-
 }

--- a/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/builder/KafkaEndpointsTest.java
+++ b/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/builder/KafkaEndpointsTest.java
@@ -42,5 +42,4 @@ public class KafkaEndpointsTest {
         Assert.assertTrue(EndpointBuilder.lookup("kafka.async").isPresent());
         Assert.assertEquals(EndpointBuilder.lookup("kafka.async").get().getClass(), KafkaEndpointBuilder.class);
     }
-
 }

--- a/endpoints/citrus-mail/src/main/java/org/citrusframework/mail/MailSettings.java
+++ b/endpoints/citrus-mail/src/main/java/org/citrusframework/mail/MailSettings.java
@@ -43,5 +43,4 @@ public class MailSettings {
         return System.getProperty(MARSHALLER_TYPE_PROPERTY,
                 System.getenv(MARSHALLER_TYPE_ENV) != null ? System.getenv(MARSHALLER_TYPE_ENV) : MARSHALLER_TYPE_DEFAULT);
     }
-
 }

--- a/endpoints/citrus-mail/src/main/java/org/citrusframework/mail/model/MailRequest.java
+++ b/endpoints/citrus-mail/src/main/java/org/citrusframework/mail/model/MailRequest.java
@@ -163,5 +163,4 @@ public class MailRequest {
     public void setBody(BodyPart body) {
         this.body = body;
     }
-
 }

--- a/endpoints/citrus-mail/src/main/java/org/citrusframework/mail/model/ObjectFactory.java
+++ b/endpoints/citrus-mail/src/main/java/org/citrusframework/mail/model/ObjectFactory.java
@@ -76,5 +76,4 @@ public class ObjectFactory {
     public AcceptRequest createAcceptRequest() {
         return new AcceptRequest();
     }
-
 }

--- a/endpoints/citrus-mail/src/test/java/org/citrusframework/mail/endpoint/builder/MailEndpointsTest.java
+++ b/endpoints/citrus-mail/src/test/java/org/citrusframework/mail/endpoint/builder/MailEndpointsTest.java
@@ -43,5 +43,4 @@ public class MailEndpointsTest {
         Assert.assertTrue(EndpointBuilder.lookup("mail.server").isPresent());
         Assert.assertEquals(EndpointBuilder.lookup("mail.server").get().getClass(), MailServerBuilder.class);
     }
-
 }

--- a/endpoints/citrus-mail/src/test/java/org/citrusframework/mail/model/MailMarshallerTest.java
+++ b/endpoints/citrus-mail/src/test/java/org/citrusframework/mail/model/MailMarshallerTest.java
@@ -88,5 +88,4 @@ public class MailMarshallerTest {
             new Object[] { "org/citrusframework/mail/server/accept-request.json", "org/citrusframework/mail/server/accept-response.json" }
         };
     }
-
 }

--- a/endpoints/citrus-rmi/src/main/java/org/citrusframework/rmi/config/handler/RmiConfigNamespaceHandler.java
+++ b/endpoints/citrus-rmi/src/main/java/org/citrusframework/rmi/config/handler/RmiConfigNamespaceHandler.java
@@ -30,5 +30,4 @@ public class RmiConfigNamespaceHandler extends NamespaceHandlerSupport {
         registerBeanDefinitionParser("client", new RmiClientParser());
         registerBeanDefinitionParser("server", new RmiServerParser());
     }
-
 }

--- a/endpoints/citrus-rmi/src/main/java/org/citrusframework/rmi/model/ObjectFactory.java
+++ b/endpoints/citrus-rmi/src/main/java/org/citrusframework/rmi/model/ObjectFactory.java
@@ -67,5 +67,4 @@ public class ObjectFactory {
     public RmiServiceResult.Object createRmiServiceResultObject() {
         return new RmiServiceResult.Object();
     }
-
 }

--- a/endpoints/citrus-rmi/src/test/java/org/citrusframework/rmi/client/RmiClientTest.java
+++ b/endpoints/citrus-rmi/src/test/java/org/citrusframework/rmi/client/RmiClientTest.java
@@ -143,5 +143,4 @@ public class RmiClientTest extends AbstractTestNGUnitTest {
                 responseBody.replaceAll("\\s", "")
         );
     }
-
 }

--- a/endpoints/citrus-rmi/src/test/java/org/citrusframework/rmi/config/xml/RmiClientParserTest.java
+++ b/endpoints/citrus-rmi/src/test/java/org/citrusframework/rmi/config/xml/RmiClientParserTest.java
@@ -61,5 +61,4 @@ public class RmiClientParserTest extends AbstractBeanDefinitionParserTest {
         Assert.assertNull(rmiClient.getEndpointConfiguration().getMethod());
         Assert.assertEquals(rmiClient.getActor(), beanDefinitionContext.getBean("testActor", TestActor.class));
     }
-
 }

--- a/endpoints/citrus-rmi/src/test/java/org/citrusframework/rmi/config/xml/RmiServerParserTest.java
+++ b/endpoints/citrus-rmi/src/test/java/org/citrusframework/rmi/config/xml/RmiServerParserTest.java
@@ -68,5 +68,4 @@ public class RmiServerParserTest extends AbstractBeanDefinitionParserTest {
         Assert.assertEquals(rmiServer.getRemoteInterfaces().get(0), HelloService.class);
         Assert.assertEquals(rmiServer.getActor(), beanDefinitionContext.getBean("testActor", TestActor.class));
     }
-
 }

--- a/endpoints/citrus-rmi/src/test/java/org/citrusframework/rmi/endpoint/RmiEndpointComponentTest.java
+++ b/endpoints/citrus-rmi/src/test/java/org/citrusframework/rmi/endpoint/RmiEndpointComponentTest.java
@@ -119,5 +119,4 @@ public class RmiEndpointComponentTest {
     public void testLookupByQualifier() {
         Assert.assertTrue(EndpointComponent.lookup("rmi").isPresent());
     }
-
 }

--- a/endpoints/citrus-rmi/src/test/java/org/citrusframework/rmi/endpoint/builder/RmiEndpointsTest.java
+++ b/endpoints/citrus-rmi/src/test/java/org/citrusframework/rmi/endpoint/builder/RmiEndpointsTest.java
@@ -43,5 +43,4 @@ public class RmiEndpointsTest {
         Assert.assertTrue(EndpointBuilder.lookup("rmi.server").isPresent());
         Assert.assertEquals(EndpointBuilder.lookup("rmi.server").get().getClass(), RmiServerBuilder.class);
     }
-
 }

--- a/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/actions/PurgeMessageChannelAction.java
+++ b/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/actions/PurgeMessageChannelAction.java
@@ -296,5 +296,4 @@ public class PurgeMessageChannelAction extends AbstractTestAction {
             return new PurgeMessageChannelAction(this);
         }
     }
-
 }

--- a/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/channel/ChannelEndpoint.java
+++ b/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/channel/ChannelEndpoint.java
@@ -82,5 +82,4 @@ public class ChannelEndpoint extends AbstractEndpoint implements BeanFactoryAwar
     public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
         getEndpointConfiguration().setBeanFactory(beanFactory);
     }
-
 }

--- a/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/channel/ChannelSyncConsumer.java
+++ b/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/channel/ChannelSyncConsumer.java
@@ -126,5 +126,4 @@ public class ChannelSyncConsumer extends ChannelConsumer implements ReplyProduce
     public void setCorrelationManager(CorrelationManager<MessageChannel> correlationManager) {
         this.correlationManager = correlationManager;
     }
-
 }

--- a/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/channel/ChannelSyncEndpoint.java
+++ b/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/channel/ChannelSyncEndpoint.java
@@ -74,5 +74,4 @@ public class ChannelSyncEndpoint extends ChannelEndpoint {
 
         return messageChannelSyncProducer;
     }
-
 }

--- a/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/channel/ChannelSyncProducer.java
+++ b/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/channel/ChannelSyncProducer.java
@@ -129,5 +129,4 @@ public class ChannelSyncProducer extends ChannelProducer implements ReplyConsume
     public void setCorrelationManager(CorrelationManager<Message> correlationManager) {
         this.correlationManager = correlationManager;
     }
-
 }

--- a/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/channel/selector/DispatchingMessageSelector.java
+++ b/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/channel/selector/DispatchingMessageSelector.java
@@ -100,5 +100,4 @@ public class DispatchingMessageSelector implements MessageSelector {
 
         this.factories.add(factory);
     }
-
 }

--- a/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/channel/selector/RootQNameMessageSelector.java
+++ b/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/channel/selector/RootQNameMessageSelector.java
@@ -94,5 +94,4 @@ public class RootQNameMessageSelector extends AbstractMessageSelector {
             return new RootQNameMessageSelector(key, value, context);
         }
     }
-
 }

--- a/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/channel/selector/XpathPayloadMessageSelector.java
+++ b/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/channel/selector/XpathPayloadMessageSelector.java
@@ -102,5 +102,4 @@ public class XpathPayloadMessageSelector extends AbstractMessageSelector {
             return new XpathPayloadMessageSelector(key, value, context);
         }
     }
-
 }

--- a/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/config/handler/CitrusSpringIntegrationConfigNamespaceHandler.java
+++ b/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/config/handler/CitrusSpringIntegrationConfigNamespaceHandler.java
@@ -37,5 +37,4 @@ public class CitrusSpringIntegrationConfigNamespaceHandler extends NamespaceHand
         registerBeanDefinitionParser("channel-sync-endpoint", new ChannelSyncEndpointParser());
         registerBeanDefinitionParser("channel-endpoint-adapter", new ChannelEndpointAdapterParser());
     }
-
 }

--- a/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/springintegration/xml/ObjectFactory.java
+++ b/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/springintegration/xml/ObjectFactory.java
@@ -49,5 +49,4 @@ public class ObjectFactory {
     public PurgeChannels createPurgeChannels() {
         return new PurgeChannels();
     }
-
 }

--- a/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/actions/PurgeMessageChannelActionTest.java
+++ b/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/actions/PurgeMessageChannelActionTest.java
@@ -112,5 +112,4 @@ public class PurgeMessageChannelActionTest extends AbstractTestNGUnitTest {
         Assert.assertTrue(TestActionBuilder.lookup("purgeChannels").isPresent());
         Assert.assertEquals(TestActionBuilder.lookup("purgeChannels").get().getClass(), PurgeMessageChannelAction.Builder.class);
     }
-
 }

--- a/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/channel/ChannelEndpointProducerTest.java
+++ b/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/channel/ChannelEndpointProducerTest.java
@@ -103,5 +103,4 @@ public class ChannelEndpointProducerTest extends AbstractTestNGUnitTest {
 
         Assert.fail("Missing " + CitrusRuntimeException.class + " because no message was received");
     }
-
 }

--- a/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/channel/ChannelEndpointSyncProducerTest.java
+++ b/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/channel/ChannelEndpointSyncProducerTest.java
@@ -244,5 +244,4 @@ public class ChannelEndpointSyncProducerTest extends AbstractTestNGUnitTest {
 
         Assert.assertEquals(channelSyncProducer.receive(new DefaultMessageCorrelator().getCorrelationKey(message), context), message);
     }
-
 }

--- a/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/channel/endpoint/builder/MessageChannelEndpointsTest.java
+++ b/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/channel/endpoint/builder/MessageChannelEndpointsTest.java
@@ -43,5 +43,4 @@ public class MessageChannelEndpointsTest {
         Assert.assertTrue(EndpointBuilder.lookup("channel.async").isPresent());
         Assert.assertEquals(EndpointBuilder.lookup("channel.async").get().getClass(), ChannelEndpointBuilder.class);
     }
-
 }

--- a/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/channel/selector/HeaderMatchingMessageSelectorTest.java
+++ b/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/channel/selector/HeaderMatchingMessageSelectorTest.java
@@ -112,5 +112,4 @@ public class HeaderMatchingMessageSelectorTest extends UnitTestSupport {
         Assert.assertTrue(messageSelector.accept(acceptMessage));
         Assert.assertFalse(messageSelector.accept(declineMessage));
     }
-
 }

--- a/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/channel/selector/RootQNameMessageSelectorTest.java
+++ b/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/channel/selector/RootQNameMessageSelectorTest.java
@@ -77,5 +77,4 @@ public class RootQNameMessageSelectorTest extends UnitTestSupport {
             Assert.assertTrue(e.getMessage().startsWith("Invalid root QName"));
         }
     }
-
 }

--- a/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/integration/service/HelloServiceImpl.java
+++ b/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/integration/service/HelloServiceImpl.java
@@ -40,5 +40,4 @@ public class HelloServiceImpl extends AbstractMarshallingHelloService {
 
         return builder.build();
     }
-
 }

--- a/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/integration/service/model/FaultDetail.java
+++ b/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/integration/service/model/FaultDetail.java
@@ -155,5 +155,4 @@ public class FaultDetail {
     public void setText(String value) {
         this.text = value;
     }
-
 }

--- a/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/integration/service/model/FaultType.java
+++ b/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/integration/service/model/FaultType.java
@@ -98,5 +98,4 @@ public class FaultType {
     public void setMessage(String value) {
         this.message = value;
     }
-
 }

--- a/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/integration/service/model/HelloRequest.java
+++ b/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/integration/service/model/HelloRequest.java
@@ -155,5 +155,4 @@ public class HelloRequest {
     public void setText(String value) {
         this.text = value;
     }
-
 }

--- a/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/integration/service/model/HelloResponse.java
+++ b/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/integration/service/model/HelloResponse.java
@@ -183,5 +183,4 @@ public class HelloResponse {
     public void setFault(FaultType value) {
         this.fault = value;
     }
-
 }

--- a/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/integration/service/model/ObjectFactory.java
+++ b/endpoints/citrus-spring-integration/src/test/java/org/citrusframework/integration/service/model/ObjectFactory.java
@@ -75,5 +75,4 @@ public class ObjectFactory {
     public HelloRequest createHelloRequest() {
         return new HelloRequest();
     }
-
 }

--- a/endpoints/citrus-ssh/src/main/java/org/citrusframework/ssh/client/SshClient.java
+++ b/endpoints/citrus-ssh/src/main/java/org/citrusframework/ssh/client/SshClient.java
@@ -349,5 +349,4 @@ public class SshClient extends AbstractEndpoint implements Producer, ReplyConsum
     public void setCorrelationManager(CorrelationManager<Message> correlationManager) {
         this.correlationManager = correlationManager;
     }
-
 }

--- a/endpoints/citrus-ssh/src/main/java/org/citrusframework/ssh/endpoint/builder/SshEndpoints.java
+++ b/endpoints/citrus-ssh/src/main/java/org/citrusframework/ssh/endpoint/builder/SshEndpoints.java
@@ -38,5 +38,4 @@ public final class SshEndpoints extends ClientServerEndpointBuilder<SshClientBui
     public static SshEndpoints ssh() {
         return new SshEndpoints();
     }
-
 }

--- a/endpoints/citrus-ssh/src/main/java/org/citrusframework/ssh/message/SshMessageConverter.java
+++ b/endpoints/citrus-ssh/src/main/java/org/citrusframework/ssh/message/SshMessageConverter.java
@@ -65,5 +65,4 @@ public class SshMessageConverter implements MessageConverter<SshMessage, SshMess
 
         return new DefaultMessage(payload.toString());
     }
-
 }

--- a/endpoints/citrus-ssh/src/main/java/org/citrusframework/ssh/model/ObjectFactory.java
+++ b/endpoints/citrus-ssh/src/main/java/org/citrusframework/ssh/model/ObjectFactory.java
@@ -43,5 +43,4 @@ public class ObjectFactory {
     public SshResponse createSshResponse() {
         return new SshResponse();
     }
-
 }

--- a/endpoints/citrus-ssh/src/main/java/org/citrusframework/ssh/model/SshRequest.java
+++ b/endpoints/citrus-ssh/src/main/java/org/citrusframework/ssh/model/SshRequest.java
@@ -68,5 +68,4 @@ public class SshRequest implements SshMessage {
     public String getStdin() {
         return stdin;
     }
-
 }

--- a/endpoints/citrus-ssh/src/main/java/org/citrusframework/ssh/server/SshServer.java
+++ b/endpoints/citrus-ssh/src/main/java/org/citrusframework/ssh/server/SshServer.java
@@ -356,5 +356,4 @@ public class SshServer extends AbstractServer {
         this.messageConverter = messageConverter;
         this.endpointConfiguration.setMessageConverter(messageConverter);
     }
-
 }

--- a/endpoints/citrus-ssh/src/test/java/org/citrusframework/ssh/config/xml/SshServerParserTest.java
+++ b/endpoints/citrus-ssh/src/test/java/org/citrusframework/ssh/config/xml/SshServerParserTest.java
@@ -75,5 +75,4 @@ public class SshServerParserTest extends AbstractBeanDefinitionParserTest {
         Assert.assertEquals(server.getEndpointAdapter(), beanDefinitionContext.getBean("sshServerAdapter"));
         Assert.assertNull(server.getActor());
     }
-
 }

--- a/endpoints/citrus-ssh/src/test/java/org/citrusframework/ssh/endpoint/builder/SshEndpointsTest.java
+++ b/endpoints/citrus-ssh/src/test/java/org/citrusframework/ssh/endpoint/builder/SshEndpointsTest.java
@@ -43,5 +43,4 @@ public class SshEndpointsTest {
         Assert.assertTrue(EndpointBuilder.lookup("ssh.server").isPresent());
         Assert.assertEquals(EndpointBuilder.lookup("ssh.server").get().getClass(), SshServerBuilder.class);
     }
-
 }

--- a/endpoints/citrus-ssh/src/test/java/org/citrusframework/ssh/server/SshServerTest.java
+++ b/endpoints/citrus-ssh/src/test/java/org/citrusframework/ssh/server/SshServerTest.java
@@ -172,5 +172,4 @@ public class SshServerTest {
 
         throw new IllegalStateException("No free port between 2234 and 3000 found");
     }
-
 }

--- a/endpoints/citrus-vertx/src/main/java/org/citrusframework/vertx/config/handler/CitrusVertxConfigNamespaceHandler.java
+++ b/endpoints/citrus-vertx/src/main/java/org/citrusframework/vertx/config/handler/CitrusVertxConfigNamespaceHandler.java
@@ -30,5 +30,4 @@ public class CitrusVertxConfigNamespaceHandler extends NamespaceHandlerSupport {
         registerBeanDefinitionParser("endpoint", new VertxEndpointParser());
         registerBeanDefinitionParser("sync-endpoint", new VertxSyncEndpointParser());
     }
-
 }

--- a/endpoints/citrus-vertx/src/main/java/org/citrusframework/vertx/endpoint/VertxConsumer.java
+++ b/endpoints/citrus-vertx/src/main/java/org/citrusframework/vertx/endpoint/VertxConsumer.java
@@ -126,5 +126,4 @@ public class VertxConsumer extends AbstractMessageConsumer {
             return message;
         }
     }
-
 }

--- a/endpoints/citrus-vertx/src/main/java/org/citrusframework/vertx/endpoint/VertxProducer.java
+++ b/endpoints/citrus-vertx/src/main/java/org/citrusframework/vertx/endpoint/VertxProducer.java
@@ -103,5 +103,4 @@ public class VertxProducer implements Producer {
     public String getName() {
         return name;
     }
-
 }

--- a/endpoints/citrus-vertx/src/main/java/org/citrusframework/vertx/endpoint/VertxSyncConsumer.java
+++ b/endpoints/citrus-vertx/src/main/java/org/citrusframework/vertx/endpoint/VertxSyncConsumer.java
@@ -113,5 +113,4 @@ public class VertxSyncConsumer extends VertxConsumer implements ReplyProducer {
     public void setCorrelationManager(CorrelationManager<String> correlationManager) {
         this.correlationManager = correlationManager;
     }
-
 }

--- a/endpoints/citrus-vertx/src/main/java/org/citrusframework/vertx/endpoint/VertxSyncEndpointConfiguration.java
+++ b/endpoints/citrus-vertx/src/main/java/org/citrusframework/vertx/endpoint/VertxSyncEndpointConfiguration.java
@@ -43,5 +43,4 @@ public class VertxSyncEndpointConfiguration extends VertxEndpointConfiguration {
     public MessageCorrelator getCorrelator() {
         return correlator;
     }
-
 }

--- a/endpoints/citrus-vertx/src/main/java/org/citrusframework/vertx/endpoint/VertxSyncProducer.java
+++ b/endpoints/citrus-vertx/src/main/java/org/citrusframework/vertx/endpoint/VertxSyncProducer.java
@@ -121,5 +121,4 @@ public class VertxSyncProducer extends VertxProducer implements ReplyConsumer {
     public void setCorrelationManager(CorrelationManager<Message> correlationManager) {
         this.correlationManager = correlationManager;
     }
-
 }

--- a/endpoints/citrus-vertx/src/test/java/org/citrusframework/vertx/endpoint/builder/VertxEndpointsTest.java
+++ b/endpoints/citrus-vertx/src/test/java/org/citrusframework/vertx/endpoint/builder/VertxEndpointsTest.java
@@ -43,5 +43,4 @@ public class VertxEndpointsTest {
         Assert.assertTrue(EndpointBuilder.lookup("vertx.async").isPresent());
         Assert.assertEquals(EndpointBuilder.lookup("vertx.async").get().getClass(), VertxEndpointBuilder.class);
     }
-
 }

--- a/endpoints/citrus-websocket/src/main/java/org/citrusframework/websocket/client/WebSocketClientBuilder.java
+++ b/endpoints/citrus-websocket/src/main/java/org/citrusframework/websocket/client/WebSocketClientBuilder.java
@@ -83,5 +83,4 @@ public class WebSocketClientBuilder extends AbstractEndpointBuilder<WebSocketCli
         endpoint.getEndpointConfiguration().setTimeout(timeout);
         return this;
     }
-
 }

--- a/endpoints/citrus-websocket/src/main/java/org/citrusframework/websocket/config/handler/CitrusWebSocketConfigNamespaceHandler.java
+++ b/endpoints/citrus-websocket/src/main/java/org/citrusframework/websocket/config/handler/CitrusWebSocketConfigNamespaceHandler.java
@@ -31,5 +31,4 @@ public class CitrusWebSocketConfigNamespaceHandler extends NamespaceHandlerSuppo
         registerBeanDefinitionParser("endpoint", new WebSocketEndpointParser());
         registerBeanDefinitionParser("client", new WebSocketClientParser());
     }
-
 }

--- a/endpoints/citrus-websocket/src/main/java/org/citrusframework/websocket/config/xml/WebSocketClientParser.java
+++ b/endpoints/citrus-websocket/src/main/java/org/citrusframework/websocket/config/xml/WebSocketClientParser.java
@@ -58,5 +58,4 @@ public class WebSocketClientParser extends AbstractEndpointParser {
     protected Class<? extends EndpointConfiguration> getEndpointConfigurationClass() {
         return WebSocketClientEndpointConfiguration.class;
     }
-
 }

--- a/endpoints/citrus-websocket/src/main/java/org/citrusframework/websocket/config/xml/WebSocketEndpointParser.java
+++ b/endpoints/citrus-websocket/src/main/java/org/citrusframework/websocket/config/xml/WebSocketEndpointParser.java
@@ -51,5 +51,4 @@ public class WebSocketEndpointParser extends AbstractEndpointParser {
     protected Class<? extends EndpointConfiguration> getEndpointConfigurationClass() {
         return WebSocketServerEndpointConfiguration.class;
     }
-
 }

--- a/endpoints/citrus-websocket/src/test/java/org/citrusframework/websocket/config/xml/WebSocketClientParserTest.java
+++ b/endpoints/citrus-websocket/src/test/java/org/citrusframework/websocket/config/xml/WebSocketClientParserTest.java
@@ -67,5 +67,4 @@ public class WebSocketClientParserTest extends AbstractBeanDefinitionParserTest 
             Assert.assertTrue(e.getMessage().contains("One of the properties 'url' or 'endpoint-resolver' is required"));
         }
     }
-
 }

--- a/endpoints/citrus-websocket/src/test/java/org/citrusframework/websocket/config/xml/WebSocketEndpointParserTest.java
+++ b/endpoints/citrus-websocket/src/test/java/org/citrusframework/websocket/config/xml/WebSocketEndpointParserTest.java
@@ -61,5 +61,4 @@ public class WebSocketEndpointParserTest extends AbstractBeanDefinitionParserTes
         Assert.assertEquals(webSocketEndpoint.getEndpointConfiguration().getTimeout(), 10000L);
 
     }
-
 }

--- a/endpoints/citrus-websocket/src/test/java/org/citrusframework/websocket/endpoint/builder/WebSocketEndpointsTest.java
+++ b/endpoints/citrus-websocket/src/test/java/org/citrusframework/websocket/endpoint/builder/WebSocketEndpointsTest.java
@@ -43,5 +43,4 @@ public class WebSocketEndpointsTest {
         Assert.assertTrue(EndpointBuilder.lookup("websocket.server").isPresent());
         Assert.assertEquals(EndpointBuilder.lookup("websocket.server").get().getClass(), WebSocketServerBuilder.class);
     }
-
 }

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/actions/AssertSoapFault.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/actions/AssertSoapFault.java
@@ -112,8 +112,8 @@ public class AssertSoapFault extends AbstractActionContainer {
 
             validator.validateSoapFault(SoapFault.from(soapFaultException.getSoapFault()), controlFault, context, validationContext);
 
-            logger.debug("Asserted SOAP fault as expected: " + soapFaultException.getFaultCode() + ": " + soapFaultException.getFaultStringOrReason());
-            logger.info("Assert SOAP fault validation successful");
+            logger.debug("Asserted SOAP fault as expected: {}: {}", soapFaultException.getFaultCode(), soapFaultException.getFaultStringOrReason());
+            logger.debug("Assert SOAP fault validation successful");
 
             return;
         } catch (Exception e) {
@@ -471,8 +471,8 @@ public class AssertSoapFault extends AbstractActionContainer {
             if (validator == null) {
                 validator = new SimpleSoapFaultValidator();
             }
+
             return new AssertSoapFault(this);
         }
     }
-
 }

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/client/WebServiceClient.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/client/WebServiceClient.java
@@ -272,5 +272,4 @@ public class WebServiceClient extends AbstractEndpoint implements Producer, Repl
     public void setCorrelationManager(CorrelationManager<Message> correlationManager) {
         this.correlationManager = correlationManager;
     }
-
 }

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/config/handler/CitrusWsConfigNamespaceHandler.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/config/handler/CitrusWsConfigNamespaceHandler.java
@@ -32,5 +32,4 @@ public class CitrusWsConfigNamespaceHandler extends NamespaceHandlerSupport {
         registerBeanDefinitionParser("jetty-server", new WebServiceServerParser());
         registerBeanDefinitionParser("client", new WebServiceClientParser());
     }
-
 }

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/config/handler/CitrusWsTestcaseNamespaceHandler.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/config/handler/CitrusWsTestcaseNamespaceHandler.java
@@ -33,5 +33,4 @@ public class CitrusWsTestcaseNamespaceHandler extends NamespaceHandlerSupport {
         registerBeanDefinitionParser("send-fault", new SendSoapFaultActionParser());
         registerBeanDefinitionParser("receive", new ReceiveSoapMessageActionParser());
     }
-
 }

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/interceptor/DelegatingEndpointInterceptor.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/interceptor/DelegatingEndpointInterceptor.java
@@ -119,5 +119,4 @@ public class DelegatingEndpointInterceptor implements SmartEndpointInterceptor, 
     public void setInterceptors(List<EndpointInterceptor> interceptors) {
         this.interceptors = interceptors;
     }
-
 }

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/security/User.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/security/User.java
@@ -98,5 +98,4 @@ public class User {
     public void setRoles(String[] roles) {
         this.roles = Arrays.copyOf(roles, roles.length);
     }
-
 }

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/validation/AbstractSoapAttachmentValidator.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/validation/AbstractSoapAttachmentValidator.java
@@ -48,15 +48,13 @@ public abstract class AbstractSoapAttachmentValidator implements SoapAttachmentV
         for (SoapAttachment controlAttachment : controlAttachments) {
             SoapAttachment attachment = findAttachment(soapMessage, controlAttachment);
 
-            if (logger.isDebugEnabled()) {
-                logger.debug("Found attachment with contentId '" + controlAttachment.getContentId() + "'");
-            }
+            logger.debug("Found attachment with contentId '{}'", controlAttachment.getContentId());
 
             validateAttachmentContentId(attachment, controlAttachment);
             validateAttachmentContentType(attachment, controlAttachment);
             validateAttachmentContent(attachment, controlAttachment);
 
-            logger.info("SOAP attachment validation successful: All values OK");
+            logger.debug("SOAP attachment validation successful: All values OK");
         }
     }
 
@@ -103,27 +101,26 @@ public abstract class AbstractSoapAttachmentValidator implements SoapAttachmentV
      */
     protected void validateAttachmentContentId(SoapAttachment receivedAttachment, SoapAttachment controlAttachment) {
         //in case contentId was not set in test case, skip validation
-        if (!StringUtils.hasText(controlAttachment.getContentId())) { return; }
+        if (!StringUtils.hasText(controlAttachment.getContentId())) {
+            return;
+        }
 
         if (receivedAttachment.getContentId() != null) {
             if (controlAttachment.getContentId() == null) {
                 throw new ValidationException(buildValidationErrorMessage("Values not equal for attachment contentId",
-                            null, receivedAttachment.getContentId()));
+                        null, receivedAttachment.getContentId()));
             }
 
             if (!receivedAttachment.getContentId().equals(controlAttachment.getContentId())) {
                 throw new ValidationException(buildValidationErrorMessage("Values not equal for attachment contentId",
-                            controlAttachment.getContentId(), receivedAttachment.getContentId()));
+                        controlAttachment.getContentId(), receivedAttachment.getContentId()));
             }
         } else if (StringUtils.hasText(controlAttachment.getContentId())) {
             throw new ValidationException(buildValidationErrorMessage("Values not equal for attachment contentId",
-                        controlAttachment.getContentId(), null));
+                    controlAttachment.getContentId(), null));
         }
 
-        if (logger.isDebugEnabled()) {
-            logger.debug("Validating attachment contentId: " + receivedAttachment.getContentId() +
-                    "='" + controlAttachment.getContentId() + "': OK.");
-        }
+        logger.debug("Validating attachment contentId: {}='{}': OK", receivedAttachment.getContentId(), controlAttachment.getContentId());
     }
 
     /**
@@ -150,10 +147,7 @@ public abstract class AbstractSoapAttachmentValidator implements SoapAttachmentV
                         controlAttachment.getContentType(), null));
         }
 
-        if (logger.isDebugEnabled()) {
-            logger.debug("Validating attachment contentType: " + receivedAttachment.getContentType() +
-                    "='" + controlAttachment.getContentType() + "': OK.");
-        }
+        logger.debug("Validating attachment contentType: {}='{}': OK", receivedAttachment.getContentType(), controlAttachment.getContentType());
     }
 
     /**

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/validation/SimpleSoapFaultValidator.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/validation/SimpleSoapFaultValidator.java
@@ -42,16 +42,14 @@ public class SimpleSoapFaultValidator extends AbstractFaultDetailValidator {
         String receivedDetail = received.replaceAll("\\s", "");
         String controlDetail = control.replaceAll("\\s", "");
 
-        if (logger.isDebugEnabled()) {
-            logger.debug("Received fault detail:\n" + received.strip());
-            logger.debug("Control fault detail:\n" + control.strip());
-        }
+        logger.debug("Received fault detail:\n{}", received.strip());
+        logger.debug("Control fault detail:\n{}", control.strip());
 
         if (!receivedDetail.equals(controlDetail)) {
             throw new ValidationException("SOAP fault validation failed! Fault detail does not match: expected \n'" +
                     controlDetail + "' \n received \n'" + receivedDetail + "'");
         }
 
-        logger.info("SOAP fault detail validation successful: All values OK");
+        logger.debug("SOAP fault detail validation successful: All values OK");
     }
 }

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/xml/ObjectFactory.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/xml/ObjectFactory.java
@@ -49,5 +49,4 @@ public class ObjectFactory {
     public Soap createSoap() {
         return new Soap();
     }
-
 }

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/xml/Soap.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/xml/Soap.java
@@ -1228,5 +1228,4 @@ public class Soap implements TestActionBuilder<TestAction>, ReferenceResolverAwa
             }
         }
     }
-
 }

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/actions/SendSoapMessageActionTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/actions/SendSoapMessageActionTest.java
@@ -659,5 +659,4 @@ public class SendSoapMessageActionTest extends AbstractTestNGUnitTest {
                 .build();
         soapMessageAction.execute(context);
     }
-
 }

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/actions/dsl/ReceiveSoapMessageTestActionBuilderTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/actions/dsl/ReceiveSoapMessageTestActionBuilderTest.java
@@ -358,5 +358,4 @@ public class ReceiveSoapMessageTestActionBuilderTest extends UnitTestSupport {
         Assert.assertEquals(action.getEndpointUri(), "fooMessageEndpoint");
         Assert.assertEquals(action.getMessageType(), MessageType.XML.name());
     }
-
 }

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/endpoint/builder/WebServiceEndpointsTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/endpoint/builder/WebServiceEndpointsTest.java
@@ -43,5 +43,4 @@ public class WebServiceEndpointsTest {
         Assert.assertTrue(EndpointBuilder.lookup("soap.server").isPresent());
         Assert.assertEquals(EndpointBuilder.lookup("soap.server").get().getClass(), WebServiceServerBuilder.class);
     }
-
 }

--- a/endpoints/citrus-zookeeper/src/main/java/org/citrusframework/zookeeper/actions/ZooExecuteAction.java
+++ b/endpoints/citrus-zookeeper/src/main/java/org/citrusframework/zookeeper/actions/ZooExecuteAction.java
@@ -110,13 +110,13 @@ public class ZooExecuteAction extends AbstractTestAction {
     public void doExecute(TestContext context) {
         try {
             if (logger.isDebugEnabled()) {
-                logger.debug(String.format("Executing zookeeper command '%s'", command.getName()));
+                logger.debug("Executing zookeeper command '{}'", command.getName());
             }
             command.execute(zookeeperClient, context);
 
             validateCommandResult(command, context);
 
-            logger.info(String.format("Zookeeper command execution successful: '%s'", command.getName()));
+            logger.info("Zookeeper command execution successful: '{}'", command.getName());
         } catch (CitrusRuntimeException e) {
             throw e;
         } catch (Exception e) {
@@ -137,12 +137,12 @@ public class ZooExecuteAction extends AbstractTestAction {
         // try to find json message validator in registry
         Optional<MessageValidator<? extends ValidationContext>> defaultJsonMessageValidator = context.getMessageValidatorRegistry().findMessageValidator(DEFAULT_JSON_MESSAGE_VALIDATOR);
 
-        if (!defaultJsonMessageValidator.isPresent()
+        if (defaultJsonMessageValidator.isEmpty()
                 && context.getReferenceResolver().isResolvable(DEFAULT_JSON_MESSAGE_VALIDATOR)) {
             defaultJsonMessageValidator = Optional.of(context.getReferenceResolver().resolve(DEFAULT_JSON_MESSAGE_VALIDATOR, MessageValidator.class));
         }
 
-        if (!defaultJsonMessageValidator.isPresent()) {
+        if (defaultJsonMessageValidator.isEmpty()) {
             // try to find json message validator via resource path lookup
             defaultJsonMessageValidator = MessageValidator.lookup("json");
         }
@@ -167,12 +167,12 @@ public class ZooExecuteAction extends AbstractTestAction {
         // try to find json message validator in registry
         Optional<MessageValidator<? extends ValidationContext>> defaultJsonMessageValidator = context.getMessageValidatorRegistry().findMessageValidator(DEFAULT_JSON_PATH_MESSAGE_VALIDATOR);
 
-        if (!defaultJsonMessageValidator.isPresent()
+        if (defaultJsonMessageValidator.isEmpty()
                 && context.getReferenceResolver().isResolvable(DEFAULT_JSON_PATH_MESSAGE_VALIDATOR)) {
             defaultJsonMessageValidator = Optional.of(context.getReferenceResolver().resolve(DEFAULT_JSON_PATH_MESSAGE_VALIDATOR, MessageValidator.class));
         }
 
-        if (!defaultJsonMessageValidator.isPresent()) {
+        if (defaultJsonMessageValidator.isEmpty()) {
             // try to find json message validator via resource path lookup
             defaultJsonMessageValidator = MessageValidator.lookup("json-path");
         }
@@ -196,9 +196,7 @@ public class ZooExecuteAction extends AbstractTestAction {
             processor.process(commandResult, context);
         }
 
-        if (logger.isDebugEnabled()) {
-            logger.debug("Validating Zookeeper response");
-        }
+        logger.debug("Validating Zookeeper response");
 
         if (StringUtils.hasText(expectedCommandResult)) {
             assertResultExists(commandResult);
@@ -211,7 +209,7 @@ public class ZooExecuteAction extends AbstractTestAction {
             getPathValidator(context).validateMessage(commandResult, null, context, Collections.singletonList(jsonPathMessageValidationContext));
         }
 
-        logger.info("Zookeeper command result validation successful - all values OK!");
+        logger.debug("Zookeeper command result validation successful - all values OK!");
 
         if (command.getResultCallback() != null) {
             command.getResultCallback().doWithCommandResult(command.getCommandResult(), context);
@@ -511,5 +509,4 @@ public class ZooExecuteAction extends AbstractTestAction {
             return new ZooExecuteAction(this);
         }
     }
-
 }

--- a/endpoints/citrus-zookeeper/src/main/java/org/citrusframework/zookeeper/command/Exists.java
+++ b/endpoints/citrus-zookeeper/src/main/java/org/citrusframework/zookeeper/command/Exists.java
@@ -67,5 +67,4 @@ public class Exists extends AbstractZooCommand<ZooResponse> {
         getParameters().put(PATH, path);
         return this;
     }
-
 }

--- a/endpoints/citrus-zookeeper/src/main/java/org/citrusframework/zookeeper/command/GetChildren.java
+++ b/endpoints/citrus-zookeeper/src/main/java/org/citrusframework/zookeeper/command/GetChildren.java
@@ -70,5 +70,4 @@ public class GetChildren extends AbstractZooCommand<ZooResponse> {
         getParameters().put(PATH, path);
         return this;
     }
-
 }

--- a/endpoints/citrus-zookeeper/src/main/java/org/citrusframework/zookeeper/command/GetData.java
+++ b/endpoints/citrus-zookeeper/src/main/java/org/citrusframework/zookeeper/command/GetData.java
@@ -66,5 +66,4 @@ public class GetData extends AbstractZooCommand<ZooResponse> {
         getParameters().put(PATH, path);
         return this;
     }
-
 }

--- a/endpoints/citrus-zookeeper/src/main/java/org/citrusframework/zookeeper/command/SetData.java
+++ b/endpoints/citrus-zookeeper/src/main/java/org/citrusframework/zookeeper/command/SetData.java
@@ -91,5 +91,4 @@ public class SetData extends AbstractZooCommand<ZooResponse> {
         getParameters().put(VERSION, version);
         return this;
     }
-
 }

--- a/runtime/citrus-cucumber/src/test/java/org/citrusframework/cucumber/config/xml/StepTemplateParserTest.java
+++ b/runtime/citrus-cucumber/src/test/java/org/citrusframework/cucumber/config/xml/StepTemplateParserTest.java
@@ -68,5 +68,4 @@ public class StepTemplateParserTest extends AbstractBeanDefinitionParserTest {
         Assert.assertEquals(template.getActions().size(), 1L);
         Assert.assertEquals(((EchoAction)template.getActions().get(0)).getMessage(), "You just said: ${body}");
     }
-
 }

--- a/runtime/citrus-cucumber/src/test/java/org/citrusframework/cucumber/integration/echo/EchoSteps.java
+++ b/runtime/citrus-cucumber/src/test/java/org/citrusframework/cucumber/integration/echo/EchoSteps.java
@@ -67,5 +67,4 @@ public class EchoSteps {
             .type(MessageType.PLAINTEXT)
             .body("You just said: " + body));
     }
-
 }

--- a/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/actions/ActionsScript.java
+++ b/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/actions/ActionsScript.java
@@ -66,5 +66,4 @@ public class ActionsScript {
                 script.startsWith("$finally {") || script.startsWith("$finally{") ||
                 script.startsWith("$(");
     }
-
 }

--- a/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/actions/SendActionBuilderWrapper.java
+++ b/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/actions/SendActionBuilderWrapper.java
@@ -107,5 +107,4 @@ public class SendActionBuilderWrapper extends SendMessageAction.SendMessageActio
             }
         }
     }
-
 }

--- a/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/configuration/endpoints/EndpointConfigurationScript.java
+++ b/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/configuration/endpoints/EndpointConfigurationScript.java
@@ -57,5 +57,4 @@ public class EndpointConfigurationScript {
      */
     protected void onCreate(Endpoint endpoint) {
     }
-
 }

--- a/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/xml/ObjectFactory.java
+++ b/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/xml/ObjectFactory.java
@@ -49,5 +49,4 @@ public class ObjectFactory {
     public Groovy createGroovy() {
         return new Groovy();
     }
-
 }

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/actions/SendMessageActionTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/actions/SendMessageActionTest.java
@@ -158,5 +158,4 @@ public class SendMessageActionTest extends AbstractTestNGUnitTest {
         DefaultMessageHeaderValidator validator = new DefaultMessageHeaderValidator();
         validator.validateMessage(toSend, controlMessage, context, new HeaderValidationContext());
     }
-
 }

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/config/xml/parser/GroovyScriptMessageBuilderParserTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/config/xml/parser/GroovyScriptMessageBuilderParserTest.java
@@ -31,5 +31,4 @@ public class GroovyScriptMessageBuilderParserTest {
 
         Assert.assertTrue(CitrusXmlConfigParser.lookup("script", "groovy").isPresent());
     }
-
 }

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/PurgeEndpointTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/PurgeEndpointTest.java
@@ -102,5 +102,4 @@ public class PurgeEndpointTest extends AbstractGroovyActionDslTest {
         Assert.assertEquals(action.getEndpointNames().size(), 1);
         Assert.assertEquals(action.getEndpointNames().get(0), "testEndpoint");
     }
-
 }

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/StartTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/StartTest.java
@@ -80,5 +80,4 @@ public class StartTest extends AbstractGroovyActionDslTest {
         verify(myFooServer).start();
         verify(myBarServer).start();
     }
-
 }

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/StopTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/StopTest.java
@@ -83,5 +83,4 @@ public class StopTest extends AbstractGroovyActionDslTest {
         verify(myFooServer).stop();
         verify(myBarServer).stop();
     }
-
 }

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/TraceVariablesTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/TraceVariablesTest.java
@@ -55,5 +55,4 @@ public class TraceVariablesTest extends AbstractGroovyActionDslTest {
         Assert.assertEquals(action.getVariableNames().get(0), "foo");
         Assert.assertEquals(action.getVariableNames().get(1), "bar");
     }
-
 }

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/TransformTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/TransformTest.java
@@ -63,5 +63,4 @@ public class TransformTest extends AbstractGroovyActionDslTest {
 
         Assert.assertTrue(context.getVariable("transform-result").contains("<p>Message: Hello World!</p>"));
     }
-
 }

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/AsyncTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/AsyncTest.java
@@ -58,5 +58,4 @@ public class AsyncTest extends AbstractGroovyActionDslTest {
         Assert.assertEquals(((EchoAction)action.getErrorActions().get(0)).getMessage(), "Failed!");
 
     }
-
 }

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/ConditionalTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/ConditionalTest.java
@@ -51,5 +51,4 @@ public class ConditionalTest extends AbstractGroovyActionDslTest {
         Assert.assertEquals(((Conditional) result.getTestAction(1)).getActionCount(), 1L);
         Assert.assertEquals(((Conditional) result.getTestAction(1)).getTestAction(0).getClass(), FailAction.class);
     }
-
 }

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/IterateTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/IterateTest.java
@@ -69,5 +69,4 @@ public class IterateTest extends AbstractGroovyActionDslTest {
         Assert.assertEquals(action.getTestAction(0).getClass(), EchoAction.class);
         Assert.assertEquals(action.getTestAction(1).getClass(), EchoAction.class);
     }
-
 }

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/ParallelTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/ParallelTest.java
@@ -55,5 +55,4 @@ public class ParallelTest extends AbstractGroovyActionDslTest {
         Assert.assertEquals(action.getActions().get(1).getClass(), EchoAction.class);
         Assert.assertEquals(action.getActions().get(2).getClass(), EchoAction.class);
     }
-
 }

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/RepeatOnErrorTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/RepeatOnErrorTest.java
@@ -76,5 +76,4 @@ public class RepeatOnErrorTest extends AbstractGroovyActionDslTest {
         Assert.assertEquals(action.getActionCount(), 1);
         Assert.assertEquals(action.getTestAction(0).getClass(), EchoAction.class);
     }
-
 }

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/RepeatTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/RepeatTest.java
@@ -65,5 +65,4 @@ public class RepeatTest extends AbstractGroovyActionDslTest {
         Assert.assertEquals(action.getTestAction(0).getClass(), EchoAction.class);
         Assert.assertEquals(action.getTestAction(1).getClass(), EchoAction.class);
     }
-
 }

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/SequentialTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/SequentialTest.java
@@ -43,5 +43,4 @@ public class SequentialTest extends AbstractGroovyActionDslTest {
         Assert.assertEquals(result.getTestAction(0).getClass(), Sequence.class);
         Assert.assertEquals(((Sequence) result.getTestAction(0)).getActionCount(), 2L);
     }
-
 }

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/TimerTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/TimerTest.java
@@ -69,5 +69,4 @@ public class TimerTest extends AbstractGroovyActionDslTest {
         Assert.assertEquals(action.getInterval(), defaultInterval);
         Assert.assertEquals(action.getActionCount(), 1);
     }
-
 }

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/WaitForTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/WaitForTest.java
@@ -146,5 +146,4 @@ public class WaitForTest extends AbstractGroovyActionDslTest {
             Assert.assertEquals(((EchoAction) condition.getAction()).getMessage(), ((EchoAction)((ActionCondition) expectedCondition).getAction()).getMessage());
         }
     }
-
 }

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/xml/GroovyTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/xml/GroovyTest.java
@@ -69,5 +69,4 @@ public class GroovyTest extends AbstractXmlActionTest {
         Assert.assertTrue(XmlTestActionBuilder.lookup("groovy").isPresent());
         Assert.assertEquals(XmlTestActionBuilder.lookup("groovy").get().getClass(), Groovy.class);
     }
-
 }

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/yaml/GroovyTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/yaml/GroovyTest.java
@@ -70,5 +70,4 @@ public class GroovyTest extends AbstractYamlActionTest {
         Assert.assertTrue(YamlTestActionBuilder.lookup("groovy").isPresent());
         Assert.assertEquals(YamlTestActionBuilder.lookup("groovy").get().getClass(), Groovy.class);
     }
-
 }

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/message/builder/script/GroovyScriptPayloadBuilderTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/message/builder/script/GroovyScriptPayloadBuilderTest.java
@@ -30,5 +30,4 @@ public class GroovyScriptPayloadBuilderTest {
         Assert.assertTrue(ScriptPayloadBuilder.lookup("groovy").isPresent());
         Assert.assertEquals(ScriptPayloadBuilder.lookup("groovy").get().getClass(), GroovyScriptPayloadBuilder.class);
     }
-
 }

--- a/runtime/citrus-quarkus/citrus-quarkus-it/src/main/java/org/citrusframework/quarkus/app/DemoApplication.java
+++ b/runtime/citrus-quarkus/citrus-quarkus-it/src/main/java/org/citrusframework/quarkus/app/DemoApplication.java
@@ -29,5 +29,4 @@ public class DemoApplication {
     void onStart(@Observes StartupEvent ev) {
         logger.info("Demo application started!");
     }
-
 }

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/AssertExceptionTestActionBuilderTest.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/AssertExceptionTestActionBuilderTest.java
@@ -97,5 +97,4 @@ public class AssertExceptionTestActionBuilderTest extends UnitTestSupport {
         assertEquals(container.getException(), CitrusRuntimeException.class);
         assertEquals(container.getMessage(), "Unknown variable 'foo'");
     }
-
 }

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/IterateTestActionBuilderTest.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/IterateTestActionBuilderTest.java
@@ -109,5 +109,4 @@ public class IterateTestActionBuilderTest extends UnitTestSupport {
         assertEquals(container.getStep(), 1);
         assertEquals(container.getStart(), 0);
     }
-
 }

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/integration/inject/ContextInjectionJavaIT.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/integration/inject/ContextInjectionJavaIT.java
@@ -62,5 +62,4 @@ public class ContextInjectionJavaIT extends TestNGCitrusSpringSupport {
     public Object[][] testData() {
         return new Object[][] { { "hello", globalContext }, { "bye", globalContext } };
     }
-
 }

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/integration/parameter/DataProviderIT.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/integration/parameter/DataProviderIT.java
@@ -55,5 +55,4 @@ public class DataProviderIT extends TestNGCitrusSpringSupport {
             { "Hallo Citrus!" },
         };
     }
-
 }

--- a/runtime/citrus-xml/src/main/java/org/citrusframework/xml/ObjectFactory.java
+++ b/runtime/citrus-xml/src/main/java/org/citrusframework/xml/ObjectFactory.java
@@ -59,5 +59,4 @@ public class ObjectFactory {
     public Template createTemplate() {
         return new Template();
     }
-
 }

--- a/runtime/citrus-xml/src/main/java/org/citrusframework/xml/XmlTestCase.java
+++ b/runtime/citrus-xml/src/main/java/org/citrusframework/xml/XmlTestCase.java
@@ -184,5 +184,4 @@ public class XmlTestCase {
             }
         }
     }
-
 }

--- a/runtime/citrus-xml/src/main/java/org/citrusframework/xml/actions/Send.java
+++ b/runtime/citrus-xml/src/main/java/org/citrusframework/xml/actions/Send.java
@@ -111,5 +111,4 @@ public class Send implements TestActionBuilder<SendMessageAction>, ReferenceReso
         builder.setReferenceResolver(referenceResolver);
         this.referenceResolver = referenceResolver;
     }
-
 }

--- a/runtime/citrus-xml/src/main/java/org/citrusframework/xml/container/ObjectFactory.java
+++ b/runtime/citrus-xml/src/main/java/org/citrusframework/xml/container/ObjectFactory.java
@@ -129,5 +129,4 @@ public class ObjectFactory {
     public Async createAsync() {
         return new Async();
     }
-
 }

--- a/runtime/citrus-xml/src/test/java/org/citrusframework/xml/actions/PurgeEndpointTest.java
+++ b/runtime/citrus-xml/src/test/java/org/citrusframework/xml/actions/PurgeEndpointTest.java
@@ -98,5 +98,4 @@ public class PurgeEndpointTest extends AbstractXmlActionTest {
         Assert.assertEquals(action.getEndpointNames().size(), 1);
         Assert.assertEquals(action.getEndpointNames().get(0), "testEndpoint1");
     }
-
 }

--- a/runtime/citrus-xml/src/test/java/org/citrusframework/xml/actions/StartTest.java
+++ b/runtime/citrus-xml/src/test/java/org/citrusframework/xml/actions/StartTest.java
@@ -74,5 +74,4 @@ public class StartTest extends AbstractXmlActionTest {
         verify(myFooServer).start();
         verify(myBarServer).start();
     }
-
 }

--- a/runtime/citrus-xml/src/test/java/org/citrusframework/xml/actions/StopTest.java
+++ b/runtime/citrus-xml/src/test/java/org/citrusframework/xml/actions/StopTest.java
@@ -77,5 +77,4 @@ public class StopTest extends AbstractXmlActionTest {
         verify(myFooServer).stop();
         verify(myBarServer).stop();
     }
-
 }

--- a/runtime/citrus-xml/src/test/java/org/citrusframework/xml/actions/TraceVariablesTest.java
+++ b/runtime/citrus-xml/src/test/java/org/citrusframework/xml/actions/TraceVariablesTest.java
@@ -55,5 +55,4 @@ public class TraceVariablesTest extends AbstractXmlActionTest {
         Assert.assertEquals(action.getVariableNames().get(0), "foo");
         Assert.assertEquals(action.getVariableNames().get(1), "bar");
     }
-
 }

--- a/runtime/citrus-xml/src/test/java/org/citrusframework/xml/actions/TransformTest.java
+++ b/runtime/citrus-xml/src/test/java/org/citrusframework/xml/actions/TransformTest.java
@@ -63,5 +63,4 @@ public class TransformTest extends AbstractXmlActionTest {
 
         Assert.assertTrue(context.getVariable("transform-result").contains("<p>Message: Hello World!</p>"));
     }
-
 }

--- a/runtime/citrus-xml/src/test/java/org/citrusframework/xml/container/AsyncTest.java
+++ b/runtime/citrus-xml/src/test/java/org/citrusframework/xml/container/AsyncTest.java
@@ -58,5 +58,4 @@ public class AsyncTest extends AbstractXmlActionTest {
         Assert.assertEquals(((EchoAction)action.getErrorActions().get(0)).getMessage(), "Failed!");
 
     }
-
 }

--- a/runtime/citrus-xml/src/test/java/org/citrusframework/xml/container/ConditionalTest.java
+++ b/runtime/citrus-xml/src/test/java/org/citrusframework/xml/container/ConditionalTest.java
@@ -51,5 +51,4 @@ public class ConditionalTest extends AbstractXmlActionTest {
         Assert.assertEquals(((Conditional) result.getTestAction(1)).getActionCount(), 1L);
         Assert.assertEquals(((Conditional) result.getTestAction(1)).getTestAction(0).getClass(), FailAction.class);
     }
-
 }

--- a/runtime/citrus-xml/src/test/java/org/citrusframework/xml/container/IterateTest.java
+++ b/runtime/citrus-xml/src/test/java/org/citrusframework/xml/container/IterateTest.java
@@ -69,5 +69,4 @@ public class IterateTest extends AbstractXmlActionTest {
         Assert.assertEquals(action.getTestAction(0).getClass(), EchoAction.class);
         Assert.assertEquals(action.getTestAction(1).getClass(), EchoAction.class);
     }
-
 }

--- a/runtime/citrus-xml/src/test/java/org/citrusframework/xml/container/ParallelTest.java
+++ b/runtime/citrus-xml/src/test/java/org/citrusframework/xml/container/ParallelTest.java
@@ -55,5 +55,4 @@ public class ParallelTest extends AbstractXmlActionTest {
         Assert.assertEquals(action.getActions().get(1).getClass(), EchoAction.class);
         Assert.assertEquals(action.getActions().get(2).getClass(), EchoAction.class);
     }
-
 }

--- a/runtime/citrus-xml/src/test/java/org/citrusframework/xml/container/RepeatOnErrorTest.java
+++ b/runtime/citrus-xml/src/test/java/org/citrusframework/xml/container/RepeatOnErrorTest.java
@@ -76,5 +76,4 @@ public class RepeatOnErrorTest extends AbstractXmlActionTest {
         Assert.assertEquals(action.getActionCount(), 1);
         Assert.assertEquals(action.getTestAction(0).getClass(), EchoAction.class);
     }
-
 }

--- a/runtime/citrus-xml/src/test/java/org/citrusframework/xml/container/RepeatTest.java
+++ b/runtime/citrus-xml/src/test/java/org/citrusframework/xml/container/RepeatTest.java
@@ -65,5 +65,4 @@ public class RepeatTest extends AbstractXmlActionTest {
         Assert.assertEquals(action.getTestAction(0).getClass(), EchoAction.class);
         Assert.assertEquals(action.getTestAction(1).getClass(), EchoAction.class);
     }
-
 }

--- a/runtime/citrus-xml/src/test/java/org/citrusframework/xml/container/SequentialTest.java
+++ b/runtime/citrus-xml/src/test/java/org/citrusframework/xml/container/SequentialTest.java
@@ -43,5 +43,4 @@ public class SequentialTest extends AbstractXmlActionTest {
         Assert.assertEquals(result.getTestAction(0).getClass(), Sequence.class);
         Assert.assertEquals(((Sequence) result.getTestAction(0)).getActionCount(), 2L);
     }
-
 }

--- a/runtime/citrus-xml/src/test/java/org/citrusframework/xml/container/TimerTest.java
+++ b/runtime/citrus-xml/src/test/java/org/citrusframework/xml/container/TimerTest.java
@@ -69,5 +69,4 @@ public class TimerTest extends AbstractXmlActionTest {
         Assert.assertEquals(action.getInterval(), defaultInterval);
         Assert.assertEquals(action.getActionCount(), 1);
     }
-
 }

--- a/runtime/citrus-xml/src/test/java/org/citrusframework/xml/container/WaitForTest.java
+++ b/runtime/citrus-xml/src/test/java/org/citrusframework/xml/container/WaitForTest.java
@@ -146,5 +146,4 @@ public class WaitForTest extends AbstractXmlActionTest {
             Assert.assertEquals(((EchoAction) condition.getAction()).getMessage(), ((EchoAction)((ActionCondition) expectedCondition).getAction()).getMessage());
         }
     }
-
 }

--- a/runtime/citrus-yaml/src/main/java/org/citrusframework/yaml/actions/Send.java
+++ b/runtime/citrus-yaml/src/main/java/org/citrusframework/yaml/actions/Send.java
@@ -93,5 +93,4 @@ public class Send implements TestActionBuilder<SendMessageAction>, ReferenceReso
         builder.setReferenceResolver(referenceResolver);
         this.referenceResolver = referenceResolver;
     }
-
 }

--- a/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/actions/AntRunTest.java
+++ b/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/actions/AntRunTest.java
@@ -74,5 +74,4 @@ public class AntRunTest extends AbstractYamlActionTest {
         Assert.assertNotNull(action.getBuildListener());
         Assert.assertEquals(action.getBuildListener().getClass(), DefaultLogger.class);
     }
-
 }

--- a/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/actions/PurgeEndpointTest.java
+++ b/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/actions/PurgeEndpointTest.java
@@ -98,5 +98,4 @@ public class PurgeEndpointTest extends AbstractYamlActionTest {
         Assert.assertEquals(action.getEndpointNames().size(), 1);
         Assert.assertEquals(action.getEndpointNames().get(0), "testEndpoint1");
     }
-
 }

--- a/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/actions/StartTest.java
+++ b/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/actions/StartTest.java
@@ -74,5 +74,4 @@ public class StartTest extends AbstractYamlActionTest {
         verify(myFooServer).start();
         verify(myBarServer).start();
     }
-
 }

--- a/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/actions/StopTest.java
+++ b/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/actions/StopTest.java
@@ -77,5 +77,4 @@ public class StopTest extends AbstractYamlActionTest {
         verify(myFooServer).stop();
         verify(myBarServer).stop();
     }
-
 }

--- a/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/actions/TraceVariablesTest.java
+++ b/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/actions/TraceVariablesTest.java
@@ -55,5 +55,4 @@ public class TraceVariablesTest extends AbstractYamlActionTest {
         Assert.assertEquals(action.getVariableNames().get(0), "foo");
         Assert.assertEquals(action.getVariableNames().get(1), "bar");
     }
-
 }

--- a/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/actions/TransformTest.java
+++ b/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/actions/TransformTest.java
@@ -63,5 +63,4 @@ public class TransformTest extends AbstractYamlActionTest {
 
         Assert.assertTrue(context.getVariable("transform-result").contains("<p>Message: Hello World!</p>"));
     }
-
 }

--- a/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/container/AsyncTest.java
+++ b/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/container/AsyncTest.java
@@ -58,5 +58,4 @@ public class AsyncTest extends AbstractYamlActionTest {
         Assert.assertEquals(((EchoAction)action.getErrorActions().get(0)).getMessage(), "Failed!");
 
     }
-
 }

--- a/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/container/ConditionalTest.java
+++ b/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/container/ConditionalTest.java
@@ -51,5 +51,4 @@ public class ConditionalTest extends AbstractYamlActionTest {
         Assert.assertEquals(((Conditional) result.getTestAction(1)).getActionCount(), 1L);
         Assert.assertEquals(((Conditional) result.getTestAction(1)).getTestAction(0).getClass(), FailAction.class);
     }
-
 }

--- a/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/container/IterateTest.java
+++ b/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/container/IterateTest.java
@@ -69,5 +69,4 @@ public class IterateTest extends AbstractYamlActionTest {
         Assert.assertEquals(action.getTestAction(0).getClass(), EchoAction.class);
         Assert.assertEquals(action.getTestAction(1).getClass(), EchoAction.class);
     }
-
 }

--- a/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/container/ParallelTest.java
+++ b/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/container/ParallelTest.java
@@ -55,5 +55,4 @@ public class ParallelTest extends AbstractYamlActionTest {
         Assert.assertEquals(action.getActions().get(1).getClass(), EchoAction.class);
         Assert.assertEquals(action.getActions().get(2).getClass(), EchoAction.class);
     }
-
 }

--- a/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/container/RepeatOnErrorTest.java
+++ b/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/container/RepeatOnErrorTest.java
@@ -76,5 +76,4 @@ public class RepeatOnErrorTest extends AbstractYamlActionTest {
         Assert.assertEquals(action.getActionCount(), 1);
         Assert.assertEquals(action.getTestAction(0).getClass(), EchoAction.class);
     }
-
 }

--- a/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/container/RepeatTest.java
+++ b/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/container/RepeatTest.java
@@ -65,5 +65,4 @@ public class RepeatTest extends AbstractYamlActionTest {
         Assert.assertEquals(action.getTestAction(0).getClass(), EchoAction.class);
         Assert.assertEquals(action.getTestAction(1).getClass(), EchoAction.class);
     }
-
 }

--- a/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/container/SequentialTest.java
+++ b/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/container/SequentialTest.java
@@ -43,5 +43,4 @@ public class SequentialTest extends AbstractYamlActionTest {
         Assert.assertEquals(result.getTestAction(0).getClass(), Sequence.class);
         Assert.assertEquals(((Sequence) result.getTestAction(0)).getActionCount(), 2L);
     }
-
 }

--- a/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/container/TimerTest.java
+++ b/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/container/TimerTest.java
@@ -69,5 +69,4 @@ public class TimerTest extends AbstractYamlActionTest {
         Assert.assertEquals(action.getInterval(), defaultInterval);
         Assert.assertEquals(action.getActionCount(), 1);
     }
-
 }

--- a/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/container/WaitForTest.java
+++ b/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/container/WaitForTest.java
@@ -146,5 +146,4 @@ public class WaitForTest extends AbstractYamlActionTest {
             Assert.assertEquals(((EchoAction) condition.getAction()).getMessage(), ((EchoAction)((ActionCondition) expectedCondition).getAction()).getMessage());
         }
     }
-
 }

--- a/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/main/TestNGEngineTest.java
+++ b/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/main/TestNGEngineTest.java
@@ -52,5 +52,4 @@ public class TestNGEngineTest {
         });
         engine.run();
     }
-
 }

--- a/src/manual/actions-generic-action.adoc
+++ b/src/manual/actions-generic-action.adoc
@@ -89,7 +89,6 @@ public class SpecialDatabaseCleanupAction extends AbstractTestAction {
 
         jdbcTemplate.execute("...");
     }
-
 }
 ----
 

--- a/src/manual/actions-purge-channels.adoc
+++ b/src/manual/actions-purge-channels.adoc
@@ -115,7 +115,6 @@ public class TimeBasedMessageSelector implements MessageSelector {
             return true;
         }
     }
-
 }
 ----
 

--- a/src/manual/runtimes-cucumber.adoc
+++ b/src/manual/runtimes-cucumber.adoc
@@ -153,7 +153,6 @@ public class EchoSteps {
                     .type(MessageType.PLAINTEXT)
                     .body(body));
     }
-
 }
 ----
 

--- a/tools/docs-generator/src/main/java/org/citrusframework/docs/HtmlTestDocsGenerator.java
+++ b/tools/docs-generator/src/main/java/org/citrusframework/docs/HtmlTestDocsGenerator.java
@@ -213,5 +213,4 @@ public class HtmlTestDocsGenerator extends AbstractTestDocsGenerator {
     public String getPageTitle() {
         return pageTitle;
     }
-
 }

--- a/tools/jbang/dist/CitrusJBang.java
+++ b/tools/jbang/dist/CitrusJBang.java
@@ -37,5 +37,4 @@ public class CitrusJBang {
     public static void main(String... args) {
         CitrusJBangMain.run(args);
     }
-
 }

--- a/tools/jbang/src/main/java/main/CitrusJBang.java
+++ b/tools/jbang/src/main/java/main/CitrusJBang.java
@@ -37,5 +37,4 @@ public class CitrusJBang {
     public static void main(String... args) {
         CitrusJBangMain.run(args);
     }
-
 }

--- a/tools/jbang/src/main/java/org/citrusframework/jbang/CitrusJBangMain.java
+++ b/tools/jbang/src/main/java/org/citrusframework/jbang/CitrusJBangMain.java
@@ -48,5 +48,4 @@ public class CitrusJBangMain implements Callable<Integer> {
         commandLine.execute("--help");
         return 0;
     }
-
 }

--- a/tools/jbang/src/main/java/org/citrusframework/jbang/JsonSupport.java
+++ b/tools/jbang/src/main/java/org/citrusframework/jbang/JsonSupport.java
@@ -40,5 +40,4 @@ public class JsonSupport {
     public static ObjectMapper json() {
         return OBJECT_MAPPER;
     }
-
 }

--- a/tools/jbang/src/main/java/org/citrusframework/jbang/commands/CitrusCommand.java
+++ b/tools/jbang/src/main/java/org/citrusframework/jbang/commands/CitrusCommand.java
@@ -76,5 +76,4 @@ public abstract class CitrusCommand implements Callable<Integer> {
 
         protected abstract void doConsumeParameters(Stack<String> args, T cmd);
     }
-
 }

--- a/tools/jbang/src/main/java/org/citrusframework/jbang/commands/Complete.java
+++ b/tools/jbang/src/main/java/org/citrusframework/jbang/commands/Complete.java
@@ -42,5 +42,4 @@ public class Complete extends CitrusCommand {
         out.flush();
         return 0;
     }
-
 }

--- a/tools/jbang/src/main/java/org/citrusframework/jbang/commands/ListTests.java
+++ b/tools/jbang/src/main/java/org/citrusframework/jbang/commands/ListTests.java
@@ -154,5 +154,4 @@ public class ListTests extends CitrusCommand {
         String ago;
         long uptime;
     }
-
 }

--- a/tools/maven/citrus-maven-plugin/src/main/java/org/citrusframework/mvn/plugin/config/docs/ExcelDocConfiguration.java
+++ b/tools/maven/citrus-maven-plugin/src/main/java/org/citrusframework/mvn/plugin/config/docs/ExcelDocConfiguration.java
@@ -143,5 +143,4 @@ public class ExcelDocConfiguration {
     public void setHeaders(String headers) {
         this.headers = headers;
     }
-
 }

--- a/tools/maven/citrus-maven-plugin/src/main/java/org/citrusframework/mvn/plugin/config/docs/HtmlDocConfiguration.java
+++ b/tools/maven/citrus-maven-plugin/src/main/java/org/citrusframework/mvn/plugin/config/docs/HtmlDocConfiguration.java
@@ -145,5 +145,4 @@ public class HtmlDocConfiguration implements Serializable {
     public void setLogo(String logo) {
         this.logo = logo;
     }
-
 }

--- a/tools/test-generator/src/main/java/org/citrusframework/generate/javadsl/MessagingJavaTestGenerator.java
+++ b/tools/test-generator/src/main/java/org/citrusframework/generate/javadsl/MessagingJavaTestGenerator.java
@@ -205,5 +205,4 @@ public class MessagingJavaTestGenerator<T extends MessagingJavaTestGenerator<T>>
     public String getEndpoint() {
         return endpoint;
     }
-
 }

--- a/tools/test-generator/src/main/java/org/citrusframework/generate/xml/MessagingXmlTestGenerator.java
+++ b/tools/test-generator/src/main/java/org/citrusframework/generate/xml/MessagingXmlTestGenerator.java
@@ -189,5 +189,4 @@ public class MessagingXmlTestGenerator<T extends MessagingXmlTestGenerator> exte
     public String getEndpoint() {
         return endpoint;
     }
-
 }

--- a/tools/test-generator/src/main/java/org/citrusframework/generate/xml/XmlTestGenerator.java
+++ b/tools/test-generator/src/main/java/org/citrusframework/generate/xml/XmlTestGenerator.java
@@ -182,5 +182,4 @@ public class XmlTestGenerator<T extends XmlTestGenerator> extends AbstractTempla
     public void setMode(GeneratorMode mode) {
         this.mode = mode;
     }
-
 }

--- a/tools/test-generator/src/test/java/org/citrusframework/generate/javadsl/SwaggerJavaTestGeneratorTest.java
+++ b/tools/test-generator/src/test/java/org/citrusframework/generate/javadsl/SwaggerJavaTestGeneratorTest.java
@@ -84,5 +84,4 @@ public class SwaggerJavaTestGeneratorTest {
         Assert.assertTrue(javaContent.contains("package org.citrusframework;"));
         Assert.assertTrue(javaContent.contains("extends TestNGCitrusSupport"));
     }
-
 }

--- a/tools/test-generator/src/test/java/org/citrusframework/generate/javadsl/WsdlJavaTestGeneratorTest.java
+++ b/tools/test-generator/src/test/java/org/citrusframework/generate/javadsl/WsdlJavaTestGeneratorTest.java
@@ -74,5 +74,4 @@ public class WsdlJavaTestGeneratorTest {
         Assert.assertTrue(javaContent.contains(requestName));
         Assert.assertTrue(javaContent.contains(responseName));
     }
-
 }

--- a/tools/test-generator/src/test/java/org/citrusframework/generate/provider/MessageCodeProviderTest.java
+++ b/tools/test-generator/src/test/java/org/citrusframework/generate/provider/MessageCodeProviderTest.java
@@ -56,5 +56,4 @@ class MessageCodeProviderTest {
         //THEN
         assertEquals(expectedCode, code.build().toString());
     }
-
 }

--- a/tools/test-generator/src/test/java/org/citrusframework/generate/provider/ReceiveCodeProviderTest.java
+++ b/tools/test-generator/src/test/java/org/citrusframework/generate/provider/ReceiveCodeProviderTest.java
@@ -42,5 +42,4 @@ class ReceiveCodeProviderTest {
         //THEN
         assertEquals(expectedString, code.toString());
     }
-
 }

--- a/tools/test-generator/src/test/java/org/citrusframework/generate/xml/SwaggerXmlTestGeneratorTest.java
+++ b/tools/test-generator/src/test/java/org/citrusframework/generate/xml/SwaggerXmlTestGeneratorTest.java
@@ -93,5 +93,4 @@ public class SwaggerXmlTestGeneratorTest {
         Assert.assertTrue(xmlContent.contains("<description>This is a sample test</description>"));
         Assert.assertTrue(xmlContent.contains("<testcase name=\"" + name + "\">"));
     }
-
 }

--- a/tools/test-generator/src/test/java/org/citrusframework/generate/xml/WsdlXmlTestGeneratorTest.java
+++ b/tools/test-generator/src/test/java/org/citrusframework/generate/xml/WsdlXmlTestGeneratorTest.java
@@ -72,5 +72,4 @@ public class WsdlXmlTestGeneratorTest {
         Assert.assertTrue(xmlContent.contains("<data>&lt;" + requestName));
         Assert.assertTrue(xmlContent.contains("<data>&lt;" + responseName));
     }
-
 }

--- a/validation/citrus-validation-groovy/src/main/java/org/citrusframework/validation/script/GroovyScriptMessageValidator.java
+++ b/validation/citrus-validation-groovy/src/main/java/org/citrusframework/validation/script/GroovyScriptMessageValidator.java
@@ -90,7 +90,7 @@ public class GroovyScriptMessageValidator extends AbstractMessageValidator<Scrip
                 GroovyObject groovyObject = (GroovyObject) groovyClass.newInstance();
                 ((GroovyScriptExecutor) groovyObject).validate(receivedMessage, context);
 
-                logger.info("Groovy message validation successful: All values OK");
+                logger.debug("Groovy message validation successful: All values OK");
             }
         } catch (CompilationFailedException | InstantiationException | IllegalAccessException e) {
             throw new CitrusRuntimeException(e);

--- a/validation/citrus-validation-groovy/src/main/java/org/citrusframework/validation/script/sql/GroovySqlResultSetValidator.java
+++ b/validation/citrus-validation-groovy/src/main/java/org/citrusframework/validation/script/sql/GroovySqlResultSetValidator.java
@@ -89,7 +89,7 @@ public class GroovySqlResultSetValidator implements SqlResultSetScriptValidator 
                     GroovyObject groovyObject = (GroovyObject) groovyClass.getDeclaredConstructor().newInstance();
                     ((SqlResultSetScriptExecutor) groovyObject).validate(resultSet, context);
 
-                    logger.info("Groovy SQL result set validation successful: All values OK");
+                    logger.debug("Groovy SQL result set validation successful: All values OK");
                 }
             } catch (CompilationFailedException | InstantiationException | InvocationTargetException | IllegalAccessException | NoSuchMethodException e) {
                 throw new CitrusRuntimeException(e);

--- a/validation/citrus-validation-groovy/src/test/java/org/citrusframework/validation/script/GroovyJsonMessageValidatorTest.java
+++ b/validation/citrus-validation-groovy/src/test/java/org/citrusframework/validation/script/GroovyJsonMessageValidatorTest.java
@@ -90,5 +90,4 @@ public class GroovyJsonMessageValidatorTest extends AbstractTestNGUnitTest {
 
         Assert.assertNotNull(validator.findValidationContext(validationContexts));
     }
-
 }

--- a/validation/citrus-validation-hamcrest/src/main/java/org/citrusframework/validation/HamcrestHeaderValidator.java
+++ b/validation/citrus-validation-hamcrest/src/main/java/org/citrusframework/validation/HamcrestHeaderValidator.java
@@ -49,7 +49,7 @@ public class HamcrestHeaderValidator implements HeaderValidator {
         }
 
         if (logger.isDebugEnabled()) {
-            logger.debug("Header validation: " + headerName + "='" + controlValue + "': OK.");
+            logger.debug("Header validation: " + headerName + "='" + controlValue + "': OK");
         }
     }
 

--- a/validation/citrus-validation-hamcrest/src/test/java/org/citrusframework/validation/DefaultMessageHeaderValidatorTest.java
+++ b/validation/citrus-validation-hamcrest/src/test/java/org/citrusframework/validation/DefaultMessageHeaderValidatorTest.java
@@ -59,5 +59,4 @@ public class DefaultMessageHeaderValidatorTest extends AbstractTestNGUnitTest {
 
         validator.validateMessage(receivedMessage, controlMessage, context, validationContext);
     }
-
 }

--- a/validation/citrus-validation-json/src/main/java/org/citrusframework/validation/json/JsonMappingValidationProcessor.java
+++ b/validation/citrus-validation-json/src/main/java/org/citrusframework/validation/json/JsonMappingValidationProcessor.java
@@ -68,7 +68,7 @@ public abstract class JsonMappingValidationProcessor<T> extends AbstractValidati
 
         validate(readJson(message), message.getHeaders(), context);
 
-        logger.info("JSON object validation successful: All values OK");
+        logger.debug("JSON object validation successful: All values OK");
     }
 
     private T readJson(Message message) {

--- a/validation/citrus-validation-json/src/main/java/org/citrusframework/validation/json/JsonPathMessageValidator.java
+++ b/validation/citrus-validation-json/src/main/java/org/citrusframework/validation/json/JsonPathMessageValidator.java
@@ -76,12 +76,10 @@ public class JsonPathMessageValidator extends AbstractMessageValidator<JsonPathM
                 //do the validation of actual and expected value for element
                 ValidationUtils.validateValues(jsonPathResult, expectedValue, jsonPathExpression, context);
 
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Validating element: " + jsonPathExpression + "='" + expectedValue + "': OK.");
-                }
+                logger.debug("Validating element: {}='{}': OK", jsonPathExpression, expectedValue);
             }
 
-            logger.info("JSONPath element validation successful: All values OK");
+            logger.debug("JSONPath element validation successful: All values OK");
         } catch (ParseException e) {
             throw new CitrusRuntimeException("Failed to parse JSON text", e);
         }
@@ -97,7 +95,7 @@ public class JsonPathMessageValidator extends AbstractMessageValidator<JsonPathM
         List<JsonPathMessageValidationContext> jsonPathMessageValidationContexts = validationContexts.stream()
                 .filter(JsonPathMessageValidationContext.class::isInstance)
                 .map(JsonPathMessageValidationContext.class::cast)
-                .collect(Collectors.toList());
+                .toList();
 
         if (jsonPathMessageValidationContexts.size() > 1) {
             // Collect all jsonPath expressions and combine into one single validation context

--- a/validation/citrus-validation-json/src/main/java/org/citrusframework/validation/json/JsonTextMessageValidator.java
+++ b/validation/citrus-validation-json/src/main/java/org/citrusframework/validation/json/JsonTextMessageValidator.java
@@ -84,7 +84,7 @@ public class JsonTextMessageValidator extends AbstractMessageValidator<JsonMessa
         elementValidatorProvider.getValidator(strict, context, validationContext).validate(
                 parseJson(permissiveMode, receivedJsonText, controlJsonText)
         );
-        logger.info("JSON message validation successful: All values OK");
+        logger.debug("JSON message validation successful: All values OK");
     }
 
     @Override
@@ -165,5 +165,4 @@ public class JsonTextMessageValidator extends AbstractMessageValidator<JsonMessa
         setPermissiveMode(permissiveMode);
         return this;
     }
-
 }

--- a/validation/citrus-validation-json/src/main/java/org/citrusframework/validation/json/schema/JsonSchemaValidation.java
+++ b/validation/citrus-validation-json/src/main/java/org/citrusframework/validation/json/schema/JsonSchemaValidation.java
@@ -76,11 +76,11 @@ public class JsonSchemaValidation implements SchemaValidator<JsonMessageValidati
                 context.getReferenceResolver());
 
         if (!report.isSuccess()) {
-            logger.error("Failed to validate Json schema for message:\n" + message.getPayload(String.class));
+            logger.error("Failed to validate Json schema for message:\n{}", message.getPayload(String.class));
             throw new ValidationException(constructErrorMessage(report));
         }
 
-        logger.info("Json schema validation successful: All values OK");
+        logger.debug("Json schema validation successful: All values OK");
     }
 
     /**

--- a/validation/citrus-validation-json/src/main/java/org/citrusframework/variable/dictionary/json/JsonPathMappingDataDictionary.java
+++ b/validation/citrus-validation-json/src/main/java/org/citrusframework/variable/dictionary/json/JsonPathMappingDataDictionary.java
@@ -67,5 +67,4 @@ public class JsonPathMappingDataDictionary extends AbstractJsonDataDictionary {
 
         super.initialize();
     }
-
 }

--- a/validation/citrus-validation-json/src/test/java/org/citrusframework/endpoint/adapter/mapping/JsonPayloadMappingKeyExtractorTest.java
+++ b/validation/citrus-validation-json/src/test/java/org/citrusframework/endpoint/adapter/mapping/JsonPayloadMappingKeyExtractorTest.java
@@ -63,5 +63,4 @@ public class JsonPayloadMappingKeyExtractorTest {
             Assert.assertEquals(e.getMessage(), "Failed to evaluate JSON path expression: $.I_DO_NOT_EXIST");
         }
     }
-
 }

--- a/validation/citrus-validation-json/src/test/java/org/citrusframework/validation/json/ReceiveMessageActionTest.java
+++ b/validation/citrus-validation-json/src/test/java/org/citrusframework/validation/json/ReceiveMessageActionTest.java
@@ -290,5 +290,4 @@ public class ReceiveMessageActionTest extends AbstractTestNGUnitTest {
 
         Assert.fail("Missing " + CitrusRuntimeException.class + " for receiving unexpected empty message payload");
     }
-
 }

--- a/validation/citrus-validation-json/src/test/java/org/citrusframework/validation/json/SendMessageActionTest.java
+++ b/validation/citrus-validation-json/src/test/java/org/citrusframework/validation/json/SendMessageActionTest.java
@@ -145,5 +145,4 @@ public class SendMessageActionTest extends AbstractTestNGUnitTest {
         DefaultMessageHeaderValidator validator = new DefaultMessageHeaderValidator();
         validator.validateMessage(toSend, controlMessage, context, new HeaderValidationContext());
     }
-
 }

--- a/validation/citrus-validation-text/src/main/java/org/citrusframework/validation/text/PlainTextMessageValidator.java
+++ b/validation/citrus-validation-text/src/main/java/org/citrusframework/validation/text/PlainTextMessageValidator.java
@@ -75,7 +75,7 @@ public class PlainTextMessageValidator extends DefaultMessageValidator {
             throw new ValidationException("Failed to validate text content", e);
         }
 
-        logger.info("Text validation successful: All values OK");
+        logger.debug("Text validation successful: All values OK");
     }
 
     /**

--- a/validation/citrus-validation-xml/src/main/java/org/citrusframework/endpoint/adapter/mapping/XPathPayloadMappingKeyExtractor.java
+++ b/validation/citrus-validation-xml/src/main/java/org/citrusframework/endpoint/adapter/mapping/XPathPayloadMappingKeyExtractor.java
@@ -60,5 +60,4 @@ public class XPathPayloadMappingKeyExtractor extends AbstractMappingKeyExtractor
     public void setNamespaceContextBuilder(NamespaceContextBuilder namespaceContextBuilder) {
         this.namespaceContextBuilder = namespaceContextBuilder;
     }
-
 }

--- a/validation/citrus-validation-xml/src/main/java/org/citrusframework/functions/core/CreateCDataSectionFunction.java
+++ b/validation/citrus-validation-xml/src/main/java/org/citrusframework/functions/core/CreateCDataSectionFunction.java
@@ -44,5 +44,4 @@ public class CreateCDataSectionFunction implements Function {
 
         return CDATA_START + parameterList.get(0) + CDATA_END;
     }
-
 }

--- a/validation/citrus-validation-xml/src/main/java/org/citrusframework/functions/core/EscapeXmlFunction.java
+++ b/validation/citrus-validation-xml/src/main/java/org/citrusframework/functions/core/EscapeXmlFunction.java
@@ -39,5 +39,4 @@ public class EscapeXmlFunction implements Function {
 
         return escapeXml(parameterList.get(0));
     }
-
 }

--- a/validation/citrus-validation-xml/src/main/java/org/citrusframework/message/builder/MarshallingPayloadBuilder.java
+++ b/validation/citrus-validation-xml/src/main/java/org/citrusframework/message/builder/MarshallingPayloadBuilder.java
@@ -155,5 +155,4 @@ public class MarshallingPayloadBuilder extends DefaultPayloadBuilder {
         }
 
     }
-
 }

--- a/validation/citrus-validation-xml/src/main/java/org/citrusframework/message/selector/RootQNameMessageSelector.java
+++ b/validation/citrus-validation-xml/src/main/java/org/citrusframework/message/selector/RootQNameMessageSelector.java
@@ -94,5 +94,4 @@ public class RootQNameMessageSelector extends AbstractMessageSelector {
             return new RootQNameMessageSelector(key, value, context);
         }
     }
-
 }

--- a/validation/citrus-validation-xml/src/main/java/org/citrusframework/message/selector/XpathPayloadMessageSelector.java
+++ b/validation/citrus-validation-xml/src/main/java/org/citrusframework/message/selector/XpathPayloadMessageSelector.java
@@ -102,5 +102,4 @@ public class XpathPayloadMessageSelector extends AbstractMessageSelector {
             return new XpathPayloadMessageSelector(key, value, context);
         }
     }
-
 }

--- a/validation/citrus-validation-xml/src/main/java/org/citrusframework/validation/matcher/core/XmlValidationMatcher.java
+++ b/validation/citrus-validation-xml/src/main/java/org/citrusframework/validation/matcher/core/XmlValidationMatcher.java
@@ -108,5 +108,4 @@ public class XmlValidationMatcher implements ValidationMatcher {
 
         return data;
     }
-
 }

--- a/validation/citrus-validation-xml/src/main/java/org/citrusframework/validation/xhtml/XhtmlMessageConverter.java
+++ b/validation/citrus-validation-xml/src/main/java/org/citrusframework/validation/xhtml/XhtmlMessageConverter.java
@@ -110,5 +110,4 @@ public class XhtmlMessageConverter implements InitializingPhase {
     public void setTidyConfiguration(Resource tidyConfiguration) {
         this.tidyConfiguration = tidyConfiguration;
     }
-
 }

--- a/validation/citrus-validation-xml/src/main/java/org/citrusframework/validation/xml/DomXmlMessageValidator.java
+++ b/validation/citrus-validation-xml/src/main/java/org/citrusframework/validation/xml/DomXmlMessageValidator.java
@@ -101,11 +101,11 @@ public class DomXmlMessageValidator extends AbstractMessageValidator<XmlMessageV
 
             }
 
-            logger.info("XML message validation successful: All values OK");
+            logger.debug("XML message validation successful: All values OK");
         } catch (ClassCastException | DOMException | LSException e) {
             throw new CitrusRuntimeException(e);
         } catch (ValidationException ex) {
-            logger.error("Failed to validate:\n" + XMLUtils.prettyPrint(receivedMessage.getPayload(String.class)));
+            logger.error("Failed to validate:\n{}", XMLUtils.prettyPrint(receivedMessage.getPayload(String.class)));
             throw ex;
         }
     }
@@ -150,9 +150,7 @@ public class DomXmlMessageValidator extends AbstractMessageValidator<XmlMessageV
                             "' expected '" + url + "' in reference node " +
                             XMLUtils.getNodesPathName(received.getFirstChild()));
                 } else {
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("Validating namespace " + namespace + " value as expected " + url + " - value OK");
-                    }
+                    logger.debug("Validating namespace {} value as expected {} - value OK", namespace, url);
                 }
             } else {
                 throw new ValidationException("Missing namespace " + namespace + "(" + url + ") in node " +
@@ -160,14 +158,12 @@ public class DomXmlMessageValidator extends AbstractMessageValidator<XmlMessageV
             }
         }
 
-        logger.info("XML namespace validation successful: All values OK");
+        logger.debug("XML namespace validation successful: All values OK");
     }
 
     private void doElementNameValidation(Node received, Node source) {
         //validate element name
-        if (logger.isDebugEnabled()) {
-            logger.debug("Validating element: " + received.getLocalName() + " (" + received.getNamespaceURI() + ")");
-        }
+        logger.debug("Validating element: {} ({})", received.getLocalName(), received.getNamespaceURI());
 
         if (!received.getLocalName().equals(source.getLocalName())) {
             throw new ValidationException(ValidationUtils.buildValueMismatchErrorMessage("Element names not equal", source.getLocalName(), received.getLocalName()));
@@ -176,9 +172,7 @@ public class DomXmlMessageValidator extends AbstractMessageValidator<XmlMessageV
 
     private void doElementNamespaceValidation(Node received, Node source) {
         //validate element namespace
-        if (logger.isDebugEnabled()) {
-            logger.debug("Validating namespace for element: " + received.getLocalName());
-        }
+        logger.debug("Validating namespace for element: {}", received.getLocalName());
 
         if (received.getNamespaceURI() != null) {
             if (source.getNamespaceURI() == null) {
@@ -257,10 +251,8 @@ public class DomXmlMessageValidator extends AbstractMessageValidator<XmlMessageV
         XMLUtils.stripWhitespaceNodes(received);
         XMLUtils.stripWhitespaceNodes(source);
 
-        if (logger.isDebugEnabled()) {
-            logger.debug("Received header data:\n" + XMLUtils.serialize(received));
-            logger.debug("Control header data:\n" + XMLUtils.serialize(source));
-        }
+        logger.debug("Received header data:\n{}", XMLUtils.serialize(received));
+        logger.debug("Control header data:\n{}", XMLUtils.serialize(source));
 
         validateXmlTree(received, source, validationContext,
                 getNamespaceContextBuilder(context)
@@ -316,10 +308,7 @@ public class DomXmlMessageValidator extends AbstractMessageValidator<XmlMessageV
 
         DocumentType receivedDTD = (DocumentType) received;
 
-        if (logger.isDebugEnabled()) {
-            logger.debug("Validating document type definition: " +
-                    receivedDTD.getPublicId() + " (" + receivedDTD.getSystemId() + ")");
-        }
+        logger.debug("Validating document type definition: {} ({})", receivedDTD.getPublicId(), receivedDTD.getSystemId());
 
         if (!hasText(sourceDTD.getPublicId())) {
             if (receivedDTD.getPublicId() != null) {
@@ -327,10 +316,7 @@ public class DomXmlMessageValidator extends AbstractMessageValidator<XmlMessageV
                         sourceDTD.getPublicId(), receivedDTD.getPublicId()));
             }
         } else if (sourceDTD.getPublicId().trim().equals(CitrusSettings.IGNORE_PLACEHOLDER)) {
-            if (logger.isDebugEnabled()) {
-                logger.debug("Document type public id: '" + receivedDTD.getPublicId() +
-                        "' is ignored by placeholder '" + CitrusSettings.IGNORE_PLACEHOLDER + "'");
-            }
+            logger.debug("Document type public id: '{}' is ignored by placeholder '{}'", receivedDTD.getPublicId(), CitrusSettings.IGNORE_PLACEHOLDER);
         } else if (!hasText(receivedDTD.getPublicId()) || !receivedDTD.getPublicId().equals(sourceDTD.getPublicId())) {
             throw new ValidationException(ValidationUtils.buildValueMismatchErrorMessage("Document type public id not equal",
                     sourceDTD.getPublicId(), receivedDTD.getPublicId()));
@@ -342,10 +328,7 @@ public class DomXmlMessageValidator extends AbstractMessageValidator<XmlMessageV
                         sourceDTD.getSystemId(), receivedDTD.getSystemId()));
             }
         } else if (sourceDTD.getSystemId().trim().equals(CitrusSettings.IGNORE_PLACEHOLDER)) {
-            if (logger.isDebugEnabled()) {
-                logger.debug("Document type system id: '" + receivedDTD.getSystemId() +
-                        "' is ignored by placeholder '" + CitrusSettings.IGNORE_PLACEHOLDER + "'");
-            }
+            logger.debug("Document type system id: '{} ' is ignored by placeholder '{}'", receivedDTD.getSystemId(), CitrusSettings.IGNORE_PLACEHOLDER);
         } else if (!hasText(receivedDTD.getSystemId()) || !receivedDTD.getSystemId().equals(sourceDTD.getSystemId())) {
             throw new ValidationException(ValidationUtils.buildValueMismatchErrorMessage("Document type system id not equal",
                     sourceDTD.getSystemId(), receivedDTD.getSystemId()));
@@ -375,9 +358,7 @@ public class DomXmlMessageValidator extends AbstractMessageValidator<XmlMessageV
         }
 
         //work on attributes
-        if (logger.isDebugEnabled()) {
-            logger.debug("Validating attributes for element: " + received.getLocalName());
-        }
+        logger.debug("Validating attributes for element: {}", received.getLocalName());
         NamedNodeMap receivedAttr = received.getAttributes();
         NamedNodeMap sourceAttr = source.getAttributes();
 
@@ -415,10 +396,7 @@ public class DomXmlMessageValidator extends AbstractMessageValidator<XmlMessageV
                     validationContext, namespaceContext, context);
         }
 
-        if (logger.isDebugEnabled()) {
-            logger.debug("Validation successful for element: " + received.getLocalName() +
-                    " (" + received.getNamespaceURI() + ")");
-        }
+        logger.debug("Validation successful for element: {} ({})", received.getLocalName(), received.getNamespaceURI());
     }
 
     /**
@@ -428,9 +406,7 @@ public class DomXmlMessageValidator extends AbstractMessageValidator<XmlMessageV
      * @param source
      */
     private void doText(Element received, Element source) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Validating node value for element: " + received.getLocalName());
-        }
+        logger.debug("Validating node value for element: {}", received.getLocalName());
 
         String receivedText = DomUtils.getTextValue(received);
         String sourceText = DomUtils.getTextValue(source);
@@ -440,9 +416,7 @@ public class DomXmlMessageValidator extends AbstractMessageValidator<XmlMessageV
                         + received.getLocalName() + "'", sourceText.trim(), receivedText.trim()));
         }
 
-        if (logger.isDebugEnabled()) {
-            logger.debug("Node value '" + receivedText.trim() + "': OK");
-        }
+        logger.debug("Node value '{}': OK", receivedText.trim());
     }
 
     /**
@@ -459,9 +433,7 @@ public class DomXmlMessageValidator extends AbstractMessageValidator<XmlMessageV
 
         String receivedAttributeName = receivedAttribute.getLocalName();
 
-        if (logger.isDebugEnabled()) {
-            logger.debug("Validating attribute: " + receivedAttributeName + " (" + receivedAttribute.getNamespaceURI() + ")");
-        }
+        logger.debug("Validating attribute: {} ({})", receivedAttributeName, receivedAttribute.getNamespaceURI());
 
         NamedNodeMap sourceAttributes = sourceElement.getAttributes();
         Node sourceAttribute = sourceAttributes.getNamedItemNS(receivedAttribute.getNamespaceURI(), receivedAttributeName);
@@ -492,9 +464,7 @@ public class DomXmlMessageValidator extends AbstractMessageValidator<XmlMessageV
             }
         }
 
-        if (logger.isDebugEnabled()) {
-            logger.debug("Attribute '" + receivedAttributeName + "'='" + receivedValue + "': OK");
-        }
+        logger.debug("Attribute '{}'='{}': OK", receivedAttributeName, receivedValue);
     }
 
     /**
@@ -549,9 +519,7 @@ public class DomXmlMessageValidator extends AbstractMessageValidator<XmlMessageV
      * @param received
      */
     private void doPI(Node received) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Ignored processing instruction (" + received.getLocalName() + "=" + received.getNodeValue() + ")");
-        }
+        logger.debug("Ignored processing instruction ({}={})", received.getLocalName(), received.getNodeValue());
     }
 
     /**

--- a/validation/citrus-validation-xml/src/main/java/org/citrusframework/validation/xml/XpathMessageValidator.java
+++ b/validation/citrus-validation-xml/src/main/java/org/citrusframework/validation/xml/XpathMessageValidator.java
@@ -116,12 +116,10 @@ public class XpathMessageValidator extends AbstractMessageValidator<XpathMessage
             //do the validation of actual and expected value for element
             ValidationUtils.validateValues(xPathResult, expectedValue, xPathExpression, context);
 
-            if (logger.isDebugEnabled()) {
-                logger.debug("Validating element: " + xPathExpression + "='" + expectedValue + "': OK.");
-            }
+            logger.debug("Validating element: {}='{}': OK", xPathExpression, expectedValue);
         }
 
-        logger.info("XPath element validation successful: All elements OK");
+        logger.debug("XPath element validation successful: All elements OK");
     }
 
     @Override
@@ -134,9 +132,9 @@ public class XpathMessageValidator extends AbstractMessageValidator<XpathMessage
         List<XpathMessageValidationContext> xpathMessageValidationContexts = validationContexts.stream()
                 .filter(XpathMessageValidationContext.class::isInstance)
                 .map(XpathMessageValidationContext.class::cast)
-                .collect(Collectors.toList());
+                .toList();
 
-        if (xpathMessageValidationContexts.size() > 1) {
+        if (!xpathMessageValidationContexts.isEmpty()) {
             XpathMessageValidationContext xpathMessageValidationContext = xpathMessageValidationContexts.get(0);
 
             // Collect all xpath expressions and combine into one single validation context

--- a/validation/citrus-validation-xml/src/main/java/org/citrusframework/validation/xml/schema/XmlSchemaValidation.java
+++ b/validation/citrus-validation-xml/src/main/java/org/citrusframework/validation/xml/schema/XmlSchemaValidation.java
@@ -165,12 +165,12 @@ public class XmlSchemaValidation implements SchemaValidator<XmlMessageValidation
 
             SAXParseException[] results = validator.validate(new DOMSource(doc));
             if (results.length == 0) {
-                logger.info("XML schema validation successful: All values OK");
+                logger.debug("XML schema validation successful: All values OK");
             } else {
-                logger.error("XML schema validation failed for message:\n" + XMLUtils.prettyPrint(message.getPayload(String.class)));
+                logger.error("XML schema validation failed for message:\n{}", XMLUtils.prettyPrint(message.getPayload(String.class)));
 
                 // Report all parsing errors
-                logger.debug("Found " + results.length + " schema validation errors");
+                logger.debug("Found {} schema validation errors", results.length);
                 StringBuilder errors = new StringBuilder();
                 for (SAXParseException e : results) {
                     errors.append(e.toString());

--- a/validation/citrus-validation-xml/src/main/java/org/citrusframework/xml/XsdSchemaRepository.java
+++ b/validation/citrus-validation-xml/src/main/java/org/citrusframework/xml/XsdSchemaRepository.java
@@ -215,5 +215,4 @@ public class XsdSchemaRepository implements Named, InitializingPhase {
     public void setLocations(List<String> locations) {
         this.locations = locations;
     }
-
 }

--- a/validation/citrus-validation-xml/src/main/java/org/citrusframework/xml/schema/SchemaMappingStrategyChain.java
+++ b/validation/citrus-validation-xml/src/main/java/org/citrusframework/xml/schema/SchemaMappingStrategyChain.java
@@ -56,5 +56,4 @@ public class SchemaMappingStrategyChain implements XsdSchemaMappingStrategy {
     public void setStrategies(List<XsdSchemaMappingStrategy> strategies) {
         this.strategies = strategies;
     }
-
 }

--- a/validation/citrus-validation-xml/src/main/java/org/citrusframework/xml/schema/WsdlXsdSchema.java
+++ b/validation/citrus-validation-xml/src/main/java/org/citrusframework/xml/schema/WsdlXsdSchema.java
@@ -226,5 +226,4 @@ public class WsdlXsdSchema extends AbstractSchemaCollection {
     public void setWsdl(Resource wsdl) {
         this.wsdl = wsdl;
     }
-
 }

--- a/validation/citrus-validation-xml/src/main/java/org/citrusframework/xml/xpath/XPathUtils.java
+++ b/validation/citrus-validation-xml/src/main/java/org/citrusframework/xml/xpath/XPathUtils.java
@@ -348,5 +348,4 @@ public abstract class XPathUtils {
 
         return factory;
     }
-
 }

--- a/validation/citrus-validation-xml/src/test/java/org/citrusframework/actions/dsl/SendMessageActionBuilderTest.java
+++ b/validation/citrus-validation-xml/src/test/java/org/citrusframework/actions/dsl/SendMessageActionBuilderTest.java
@@ -285,5 +285,4 @@ public class SendMessageActionBuilderTest extends UnitTestSupport {
         Assert.assertEquals(action.getSchema(), "fooSchema");
         Assert.assertEquals(action.getSchemaRepository(), "fooRepository");
     }
-
 }

--- a/validation/citrus-validation-xml/src/test/java/org/citrusframework/message/selector/RootQNameMessageSelectorTest.java
+++ b/validation/citrus-validation-xml/src/test/java/org/citrusframework/message/selector/RootQNameMessageSelectorTest.java
@@ -76,5 +76,4 @@ public class RootQNameMessageSelectorTest extends UnitTestSupport {
             Assert.assertTrue(e.getMessage().startsWith("Invalid root QName"));
         }
     }
-
 }

--- a/validation/citrus-validation-xml/src/test/java/org/citrusframework/validation/xhtml/XhtmlMessageValidatorTest.java
+++ b/validation/citrus-validation-xml/src/test/java/org/citrusframework/validation/xhtml/XhtmlMessageValidatorTest.java
@@ -142,5 +142,4 @@ public class XhtmlMessageValidatorTest extends UnitTestSupport {
                 .build();
         receiveAction.execute(context);
     }
-
 }

--- a/validation/citrus-validation-xml/src/test/java/org/citrusframework/validation/xml/DomXmlMessageValidatorTest.java
+++ b/validation/citrus-validation-xml/src/test/java/org/citrusframework/validation/xml/DomXmlMessageValidatorTest.java
@@ -1090,5 +1090,4 @@ public class DomXmlMessageValidatorTest extends UnitTestSupport {
     public void testTestLookup() {
         Assert.assertTrue(SchemaValidator.lookup("xml").isPresent());
     }
-
 }

--- a/validation/citrus-validation-xml/src/test/java/org/citrusframework/xml/schema/SchemaMappingStrategyChainTest.java
+++ b/validation/citrus-validation-xml/src/test/java/org/citrusframework/xml/schema/SchemaMappingStrategyChainTest.java
@@ -102,5 +102,4 @@ public class SchemaMappingStrategyChainTest {
         Assert.assertEquals(strategy.getSchema(schemas, doc), schemaMock);
 
     }
-
 }

--- a/validation/citrus-validation-xml/src/test/java/org/citrusframework/xml/schema/locator/JarWSDLLocatorTest.java
+++ b/validation/citrus-validation-xml/src/test/java/org/citrusframework/xml/schema/locator/JarWSDLLocatorTest.java
@@ -43,5 +43,4 @@ public class JarWSDLLocatorTest {
         JarWSDLLocator locator = new JarWSDLLocator(wsdl);
         locator.getImportInputSource(locator.getBaseURI(), "invalid.xsd");
     }
-
 }


### PR DESCRIPTION
I found the validation log levels to be rather annoying. I only want to know about this if something goes wrong, not if something passes. that should imo be something for a report, but not for a log.