### PR TITLE
fix(#1143): let HttpMessageBuilder create messages with unique ids

### DIFF
--- a/core/citrus-api/src/main/java/org/citrusframework/CitrusSettings.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/CitrusSettings.java
@@ -16,24 +16,28 @@
 
 package org.citrusframework;
 
+import org.citrusframework.common.TestLoader;
 import org.citrusframework.message.MessageType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.InputStream;
-import java.nio.charset.Charset;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.logging.LogManager;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.lang.Boolean.parseBoolean;
+import static java.lang.System.getProperty;
+import static java.lang.System.getenv;
+import static java.lang.System.setProperty;
+import static java.nio.charset.Charset.defaultCharset;
 import static java.util.Collections.emptySet;
+import static java.util.logging.LogManager.getLogManager;
+import static java.util.stream.Collectors.toSet;
 import static org.citrusframework.common.TestLoader.GROOVY;
 import static org.citrusframework.common.TestLoader.SPRING;
-import static org.citrusframework.common.TestLoader.XML;
 import static org.citrusframework.common.TestLoader.YAML;
 
 /**
@@ -41,26 +45,31 @@ import static org.citrusframework.common.TestLoader.YAML;
  */
 public final class CitrusSettings {
 
-    /** Logger */
+    /**
+     * Logger
+     */
     private static final Logger logger = LoggerFactory.getLogger(CitrusSettings.class);
 
     private CitrusSettings() {
         // prevent instantiation
     }
 
-    /** Optional application property file */
+    /**
+     * Optional application property file
+     */
     private static final String APPLICATION_PROPERTY_FILE_PROPERTY = "citrus.application.properties";
     private static final String APPLICATION_PROPERTY_FILE_ENV = "CITRUS_APPLICATION_PROPERTIES";
-    private static final String APPLICATION_PROPERTY_FILE = System.getProperty(APPLICATION_PROPERTY_FILE_PROPERTY, System.getenv(APPLICATION_PROPERTY_FILE_ENV) != null ?
-            System.getenv(APPLICATION_PROPERTY_FILE_ENV) : "citrus-application.properties");
+    private static final String APPLICATION_PROPERTY_FILE = getProperty(
+            APPLICATION_PROPERTY_FILE_PROPERTY,
+            getenv(APPLICATION_PROPERTY_FILE_ENV) != null ? getenv(APPLICATION_PROPERTY_FILE_ENV) : "citrus-application.properties");
 
-    public  static final String OUTBOUND_SCHEMA_VALIDATION_ENABLED_PROPERTY = "citrus.validation.outbound.schema.enabled";
+    public static final String OUTBOUND_SCHEMA_VALIDATION_ENABLED_PROPERTY = "citrus.validation.outbound.schema.enabled";
     public static final String OUTBOUND_SCHEMA_VALIDATION_ENABLED_ENV = "CITRUS_VALIDATION_OUTBOUND_SCHEMA_ENABLED";
 
-    public  static final String OUTBOUND_JSON_SCHEMA_VALIDATION_ENABLED_PROPERTY = "citrus.validation.outbound.json.schema.enabled";
+    public static final String OUTBOUND_JSON_SCHEMA_VALIDATION_ENABLED_PROPERTY = "citrus.validation.outbound.json.schema.enabled";
     public static final String OUTBOUND_JSON_SCHEMA_VALIDATION_ENABLED_ENV = "CITRUS_VALIDATION_OUTBOUND_JSON_SCHEMA_ENABLED";
 
-    public  static final String OUTBOUND_XML_SCHEMA_VALIDATION_ENABLED_PROPERTY = "citrus.validation.outbound.xml.schema.enabled";
+    public static final String OUTBOUND_XML_SCHEMA_VALIDATION_ENABLED_PROPERTY = "citrus.validation.outbound.xml.schema.enabled";
     public static final String OUTBOUND_XML_SCHEMA_VALIDATION_ENABLED_ENV = "CITRUS_VALIDATION_OUTBOUND_XML_SCHEMA_ENABLED";
 
     /* Load application properties */
@@ -77,9 +86,9 @@ public final class CitrusSettings {
             logger.debug("Loading Citrus application properties");
 
             for (Map.Entry<Object, Object> property : applicationProperties.entrySet()) {
-                if (System.getProperty(property.getKey().toString(), "").isEmpty()) {
-                    logger.debug(String.format("Setting application property %s=%s", property.getKey(), property.getValue()));
-                    System.setProperty(property.getKey().toString(), property.getValue().toString());
+                if (getProperty(property.getKey().toString(), "").isEmpty()) {
+                    logger.debug("Setting application property {}={}", property.getKey(), property.getValue());
+                    setProperty(property.getKey().toString(), property.getValue().toString());
                 }
             }
         } catch (Exception e) {
@@ -92,7 +101,7 @@ public final class CitrusSettings {
 
         try (InputStream is = CitrusSettings.class.getClassLoader().getResourceAsStream("logging.properties")) {
             if (is != null) {
-                LogManager.getLogManager().readConfiguration(is);
+                getLogManager().readConfiguration(is);
             }
         } catch (Exception e) {
             if (logger.isTraceEnabled()) {
@@ -103,215 +112,325 @@ public final class CitrusSettings {
         }
     }
 
-    /** Default variable names */
+    /**
+     * Default variable names
+     */
     public static final String TEST_NAME_VARIABLE_PROPERTY = "citrus.test.name.variable";
     public static final String TEST_NAME_VARIABLE_ENV = "CITRUS_TEST_NAME_VARIABLE";
-    public static final String TEST_NAME_VARIABLE = System.getProperty(TEST_NAME_VARIABLE_PROPERTY, System.getenv(TEST_NAME_VARIABLE_ENV) != null ?
-            System.getenv(TEST_NAME_VARIABLE_ENV) : "citrus.test.name");
+    public static final String TEST_NAME_VARIABLE = getPropertyEnvOrDefault(
+            TEST_NAME_VARIABLE_PROPERTY,
+            TEST_NAME_VARIABLE_ENV,
+            "citrus.test.name");
 
     public static final String TEST_PACKAGE_VARIABLE_PROPERTY = "citrus.test.package.variable";
     public static final String TEST_PACKAGE_VARIABLE_ENV = "CITRUS_TEST_PACKAGE_VARIABLE";
-    public static final String TEST_PACKAGE_VARIABLE = System.getProperty(TEST_PACKAGE_VARIABLE_PROPERTY, System.getenv(TEST_PACKAGE_VARIABLE_ENV) != null ?
-            System.getenv(TEST_PACKAGE_VARIABLE_ENV) : "citrus.test.package");
+    public static final String TEST_PACKAGE_VARIABLE = getPropertyEnvOrDefault(
+            TEST_PACKAGE_VARIABLE_PROPERTY,
+            TEST_PACKAGE_VARIABLE_ENV,
+            "citrus.test.package");
 
-    /** File encoding system property */
+    /**
+     * File encoding system property
+     */
     public static final String CITRUS_FILE_ENCODING_PROPERTY = "citrus.file.encoding";
     public static final String CITRUS_FILE_ENCODING_ENV = "CITRUS_FILE_ENCODING";
-    public static final String CITRUS_FILE_ENCODING = System.getProperty(CITRUS_FILE_ENCODING_PROPERTY, System.getenv(CITRUS_FILE_ENCODING_ENV) != null ?
-            System.getenv(CITRUS_FILE_ENCODING_ENV) : Charset.defaultCharset().displayName());
+    public static final String CITRUS_FILE_ENCODING = getPropertyEnvOrDefault(
+            CITRUS_FILE_ENCODING_PROPERTY,
+            CITRUS_FILE_ENCODING_ENV,
+            defaultCharset().displayName());
 
-    /** Prefix/sufix used to identify variable expressions */
+    /**
+     * Prefix/sufix used to identify variable expressions
+     */
     public static final String VARIABLE_PREFIX = "${";
     public static final String VARIABLE_SUFFIX = "}";
     public static final String VARIABLE_ESCAPE = "//";
 
-    /** Default application context class */
+    /**
+     * Default application context class
+     */
     public static final String DEFAULT_CONFIG_CLASS_PROPERTY = "citrus.java.config";
     public static final String DEFAULT_CONFIG_CLASS_ENV = "CITRUS_JAVA_CONFIG";
-    public static final String DEFAULT_CONFIG_CLASS = System.getProperty(DEFAULT_CONFIG_CLASS_PROPERTY, System.getenv(DEFAULT_CONFIG_CLASS_ENV));
+    public static final String DEFAULT_CONFIG_CLASS = getPropertyEnvOrDefault(
+            DEFAULT_CONFIG_CLASS_PROPERTY,
+            DEFAULT_CONFIG_CLASS_ENV,
+            null);
 
-    /** Default test directories */
+    /**
+     * Default test directories
+     */
     public static final String DEFAULT_TEST_SRC_DIRECTORY_PROPERTY = "citrus.default.src.directory";
     public static final String DEFAULT_TEST_SRC_DIRECTORY_ENV = "CITRUS_DEFAULT_SRC_DIRECTORY";
-    public static final String DEFAULT_TEST_SRC_DIRECTORY = System.getProperty(DEFAULT_TEST_SRC_DIRECTORY_PROPERTY, System.getenv(DEFAULT_TEST_SRC_DIRECTORY_ENV) != null ?
-            System.getenv(DEFAULT_TEST_SRC_DIRECTORY_ENV) : "src" + File.separator + "test" + File.separator);
+    public static final String DEFAULT_TEST_SRC_DIRECTORY = getPropertyEnvOrDefault(
+            DEFAULT_TEST_SRC_DIRECTORY_PROPERTY,
+            DEFAULT_TEST_SRC_DIRECTORY_ENV,
+            "src" + File.separator + "test" + File.separator);
 
-    /** Placeholder used in messages to ignore elements */
+    /**
+     * Placeholder used in messages to ignore elements
+     */
     public static final String IGNORE_PLACEHOLDER = "@ignore@";
 
-    /** Prefix/suffix used to identify validation matchers */
+    /**
+     * Prefix/suffix used to identify validation matchers
+     */
     public static final String VALIDATION_MATCHER_PREFIX = "@";
     public static final String VALIDATION_MATCHER_SUFFIX = "@";
 
     public static final String GROOVY_TEST_FILE_NAME_PATTERN_PROPERTY = "citrus.groovy.file.name.pattern";
     public static final String GROOVY_TEST_FILE_NAME_PATTERN_ENV = "CITRUS_GROOVY_FILE_NAME_PATTERN";
-    public static final String GROOVY_TEST_FILE_NAME_PATTERN = System.getProperty(GROOVY_TEST_FILE_NAME_PATTERN_PROPERTY, System.getenv(GROOVY_TEST_FILE_NAME_PATTERN_ENV) != null ?
-            System.getenv(GROOVY_TEST_FILE_NAME_PATTERN_ENV) : ".*test\\.groovy,.*it\\.groovy");
+    public static final String GROOVY_TEST_FILE_NAME_PATTERN = getPropertyEnvOrDefault(
+            GROOVY_TEST_FILE_NAME_PATTERN_PROPERTY,
+            GROOVY_TEST_FILE_NAME_PATTERN_ENV,
+            ".*test\\.groovy,.*it\\.groovy");
 
     public static final String YAML_TEST_FILE_NAME_PATTERN_PROPERTY = "citrus.yaml.file.name.pattern";
     public static final String YAML_TEST_FILE_NAME_PATTERN_ENV = "CITRUS_YAML_FILE_NAME_PATTERN";
-    public static final String YAML_TEST_FILE_NAME_PATTERN = System.getProperty(YAML_TEST_FILE_NAME_PATTERN_PROPERTY, System.getenv(YAML_TEST_FILE_NAME_PATTERN_ENV) != null ?
-            System.getenv(YAML_TEST_FILE_NAME_PATTERN_ENV) : ".*test\\.yaml,.*it\\.yaml");
+    public static final String YAML_TEST_FILE_NAME_PATTERN = getPropertyEnvOrDefault(
+            YAML_TEST_FILE_NAME_PATTERN_PROPERTY,
+            YAML_TEST_FILE_NAME_PATTERN_ENV,
+            ".*test\\.yaml,.*it\\.yaml");
 
     public static final String XML_TEST_FILE_NAME_PATTERN_PROPERTY = "citrus.xml.file.name.pattern";
     public static final String XML_TEST_FILE_NAME_PATTERN_ENV = "CITRUS_XML_FILE_NAME_PATTERN";
-    public static final String XML_TEST_FILE_NAME_PATTERN = System.getProperty(XML_TEST_FILE_NAME_PATTERN_PROPERTY, System.getenv(XML_TEST_FILE_NAME_PATTERN_ENV) != null ?
-            System.getenv(XML_TEST_FILE_NAME_PATTERN_ENV) : ".*Test\\.xml,.*IT\\.xml,.*test\\.xml,.*it\\.xml");
+    public static final String XML_TEST_FILE_NAME_PATTERN = getPropertyEnvOrDefault(
+            XML_TEST_FILE_NAME_PATTERN_PROPERTY,
+            XML_TEST_FILE_NAME_PATTERN_ENV,
+            ".*Test\\.xml,.*IT\\.xml,.*test\\.xml,.*it\\.xml");
 
     public static final String JAVA_TEST_FILE_NAME_PATTERN_PROPERTY = "citrus.java.file.name.pattern";
     public static final String JAVA_TEST_FILE_NAME_PATTERN_ENV = "CITRUS_JAVA_FILE_NAME_PATTERN";
-    public static final String JAVA_TEST_FILE_NAME_PATTERN = System.getProperty(JAVA_TEST_FILE_NAME_PATTERN_PROPERTY, System.getenv(JAVA_TEST_FILE_NAME_PATTERN_ENV) != null ?
-            System.getenv(JAVA_TEST_FILE_NAME_PATTERN_ENV) : ".*Test\\.java,.*IT\\.java");
+    public static final String JAVA_TEST_FILE_NAME_PATTERN = getPropertyEnvOrDefault(
+            JAVA_TEST_FILE_NAME_PATTERN_PROPERTY,
+            JAVA_TEST_FILE_NAME_PATTERN_ENV,
+            ".*Test\\.java,.*IT\\.java");
 
-    /** Default message type used in message validation mechanism */
+    /**
+     * Default message type used in message validation mechanism
+     */
     public static final String DEFAULT_MESSAGE_TYPE_PROPERTY = "citrus.default.message.type";
     public static final String DEFAULT_MESSAGE_TYPE_ENV = "CITRUS_DEFAULT_MESSAGE_TYPE";
-    public static final String DEFAULT_MESSAGE_TYPE = System.getProperty(DEFAULT_MESSAGE_TYPE_PROPERTY,  System.getenv(DEFAULT_MESSAGE_TYPE_ENV) != null ?
-            System.getenv(DEFAULT_MESSAGE_TYPE_ENV) : MessageType.XML.toString());
+    public static final String DEFAULT_MESSAGE_TYPE = getPropertyEnvOrDefault(
+            DEFAULT_MESSAGE_TYPE_PROPERTY,
+            DEFAULT_MESSAGE_TYPE_ENV,
+            MessageType.XML.toString());
 
-    /** Default message trace output directory */
+    /**
+     * Flag to allow deactivation of the http message builder citrus header update. See <a href="https://github.com/citrusframework/citrus/issues/1143">ISSUE-1143</a> for details.
+     */
+    public static final String HTTP_MESSAGE_BUILDER_FORCE_CITRUS_HEADER_UPDATE_ENABLED_PROPERTY = "citrus.http.message.builder.force.citrus.header.update.enabled";
+    public static final String HTTP_MESSAGE_BUILDER_FORCE_CITRUS_HEADER_UPDATE_ENABLED_ENV = "CITRUS_HTTP_MESSAGE_BUILDER_FORCE_CITRUS_HEADER_UPDATE_ENABLED";
+    public static final String HTTP_MESSAGE_BUILDER_FORCE_CITRUS_HEADER_UPDATE_ENABLED_DEFAULT = "true";
+
+    /**
+     * Default message trace output directory
+     */
     public static final String MESSAGE_TRACE_DIRECTORY_PROPERTY = "citrus.message.trace.directory";
     public static final String MESSAGE_TRACE_DIRECTORY_ENV = "CITRUS_MESSAGE_TRACE_DIRECTORY";
     public static final String MESSAGE_TRACE_DIRECTORY_DEFAULT = "target/citrus-logs/trace/messages";
 
-    /** Default type converter */
+    /**
+     * Default type converter
+     */
     public static final String TYPE_CONVERTER_PROPERTY = "citrus.type.converter";
     public static final String TYPE_CONVERTER_ENV = "CITRUS_TYPE_CONVERTER";
     public static final String TYPE_CONVERTER_DEFAULT = "default";
 
-    /** Flag to enable/disable message pretty print */
+    /**
+     * Flag to enable/disable message pretty print
+     */
     public static final String PRETTY_PRINT_PROPERTY = "citrus.message.pretty.print";
     public static final String PRETTY_PRINT_ENV = "CITRUS_MESSAGE_PRETTY_PRINT";
     public static final String PRETTY_PRINT_DEFAULT = Boolean.TRUE.toString();
 
-    /** Flag to enable/disable logger modifier */
+    /**
+     * Flag to enable/disable logger modifier
+     */
     public static final String LOG_MODIFIER_PROPERTY = "citrus.logger.modifier";
     public static final String LOG_MODIFIER_ENV = "CITRUS_LOG_MODIFIER";
     public static final String LOG_MODIFIER_DEFAULT = Boolean.TRUE.toString();
 
-    /** Default logger modifier mask value */
+    /**
+     * Default logger modifier mask value
+     */
     public static final String LOG_MASK_VALUE_PROPERTY = "citrus.logger.mask.value";
     public static final String LOG_MASK_VALUE_ENV = "CITRUS_LOG_MASK_VALUE";
     public static final String LOG_MASK_VALUE_DEFAULT = "****";
 
-    /** Default logger modifier keywords */
+    /**
+     * Default logger modifier keywords
+     */
     public static final String LOG_MASK_KEYWORDS_PROPERTY = "citrus.logger.mask.keywords";
     public static final String LOG_MASK_KEYWORDS_ENV = "CITRUS_LOG_MASK_KEYWORDS";
     public static final String LOG_MASK_KEYWORDS_DEFAULT = "password,secret,secretKey";
 
-    /** File path charset parameter */
+    /**
+     * File path charset parameter
+     */
     public static final String FILE_PATH_CHARSET_PARAMETER_PROPERTY = "citrus.file.path.charset.parameter";
     public static final String FILE_PATH_CHARSET_PARAMETER_ENV = "CITRUS_FILE_PATH_CHARSET_PARAMETER";
     public static final String FILE_PATH_CHARSET_PARAMETER_DEFAULT = "; charset=";
 
     /**
      * Gets set of file name patterns for Groovy test files.
+     *
      * @return
      */
     public static Set<String> getGroovyTestFileNamePattern() {
-        return Stream.of(GROOVY_TEST_FILE_NAME_PATTERN.split(",")).collect(Collectors.toSet());
+        return Stream.of(GROOVY_TEST_FILE_NAME_PATTERN.split(",")).collect(toSet());
     }
 
     /**
      * Gets set of file name patterns for YAML test files.
+     *
      * @return
      */
     public static Set<String> getYamlTestFileNamePattern() {
-        return Stream.of(YAML_TEST_FILE_NAME_PATTERN.split(",")).collect(Collectors.toSet());
+        return Stream.of(YAML_TEST_FILE_NAME_PATTERN.split(",")).collect(toSet());
     }
 
     /**
      * Gets set of file name patterns for XML test files.
+     *
      * @return
      */
     public static Set<String> getXmlTestFileNamePattern() {
-        return Stream.of(XML_TEST_FILE_NAME_PATTERN.split(",")).collect(Collectors.toSet());
+        return Stream.of(XML_TEST_FILE_NAME_PATTERN.split(",")).collect(toSet());
     }
 
     /**
      * Gets set of file name patterns for Java test files.
+     *
      * @return
      */
     public static Set<String> getJavaTestFileNamePattern() {
-        return Stream.of(JAVA_TEST_FILE_NAME_PATTERN.split(",")).collect(Collectors.toSet());
+        return Stream.of(JAVA_TEST_FILE_NAME_PATTERN.split(",")).collect(toSet());
     }
 
     /**
      * Gets the directory where to put message trace files.
+     *
      * @return
      */
     public static String getMessageTraceDirectory() {
-        return System.getProperty(MESSAGE_TRACE_DIRECTORY_PROPERTY,  System.getenv(MESSAGE_TRACE_DIRECTORY_ENV) != null ?
-                System.getenv(MESSAGE_TRACE_DIRECTORY_ENV) : MESSAGE_TRACE_DIRECTORY_DEFAULT);
+        return getPropertyEnvOrDefault(
+                MESSAGE_TRACE_DIRECTORY_PROPERTY,
+                MESSAGE_TRACE_DIRECTORY_ENV,
+                MESSAGE_TRACE_DIRECTORY_DEFAULT);
     }
 
     /**
      * Gets the type converter to use by default.
+     *
      * @return
      */
     public static String getTypeConverter() {
-        return System.getProperty(TYPE_CONVERTER_PROPERTY,  System.getenv(TYPE_CONVERTER_ENV) != null ?
-                System.getenv(TYPE_CONVERTER_ENV) : TYPE_CONVERTER_DEFAULT);
+        return getPropertyEnvOrDefault(
+                TYPE_CONVERTER_PROPERTY,
+                TYPE_CONVERTER_ENV,
+                TYPE_CONVERTER_DEFAULT);
     }
 
     /**
      * Gets the message payload pretty print enabled/disabled setting.
+     *
      * @return
      */
     public static boolean isPrettyPrintEnabled() {
-        return Boolean.parseBoolean(System.getProperty(PRETTY_PRINT_PROPERTY,  System.getenv(PRETTY_PRINT_ENV) != null ?
-                System.getenv(PRETTY_PRINT_ENV) : PRETTY_PRINT_DEFAULT));
+        return parseBoolean(getPropertyEnvOrDefault(
+                PRETTY_PRINT_PROPERTY,
+                PRETTY_PRINT_ENV,
+                PRETTY_PRINT_DEFAULT));
     }
 
     /**
      * Gets the logger modifier enabled/disabled setting.
+     *
      * @return
      */
     public static boolean isLogModifierEnabled() {
-        return Boolean.parseBoolean(System.getProperty(LOG_MODIFIER_PROPERTY,  System.getenv(LOG_MODIFIER_ENV) != null ?
-                System.getenv(LOG_MODIFIER_ENV) : LOG_MODIFIER_DEFAULT));
+        return parseBoolean(getPropertyEnvOrDefault(
+                LOG_MODIFIER_PROPERTY,
+                LOG_MODIFIER_ENV,
+                LOG_MODIFIER_DEFAULT));
     }
 
     /**
      * Get logger mask value.
+     *
      * @return
      */
     public static String getLogMaskValue() {
-        return System.getProperty(LOG_MASK_VALUE_PROPERTY,  System.getenv(LOG_MASK_VALUE_ENV) != null ?
-                System.getenv(LOG_MASK_VALUE_ENV) : LOG_MASK_VALUE_DEFAULT);
+        return getPropertyEnvOrDefault(
+                LOG_MASK_VALUE_PROPERTY,
+                LOG_MASK_VALUE_ENV,
+                LOG_MASK_VALUE_DEFAULT);
     }
 
     /**
      * Get the file path charset parameter.
+     *
      * @return
      */
     public static String getFilePathCharsetParameter() {
-        return System.getProperty(FILE_PATH_CHARSET_PARAMETER_PROPERTY,  System.getenv(FILE_PATH_CHARSET_PARAMETER_ENV) != null ?
-                System.getenv(FILE_PATH_CHARSET_PARAMETER_ENV) : FILE_PATH_CHARSET_PARAMETER_DEFAULT);
+        return getPropertyEnvOrDefault(
+                FILE_PATH_CHARSET_PARAMETER_PROPERTY,
+                FILE_PATH_CHARSET_PARAMETER_ENV,
+                FILE_PATH_CHARSET_PARAMETER_DEFAULT);
     }
 
     /**
      * Get logger mask keywords.
+     *
      * @return
      */
     public static Set<String> getLogMaskKeywords() {
-        return Stream.of(System.getProperty(LOG_MASK_KEYWORDS_PROPERTY,  System.getenv(LOG_MASK_KEYWORDS_ENV) != null ?
-                System.getenv(LOG_MASK_KEYWORDS_ENV) : LOG_MASK_KEYWORDS_DEFAULT).split(","))
-                    .map(String::trim)
-                    .collect(Collectors.toSet());
+        return Stream.of(getPropertyEnvOrDefault(
+                        LOG_MASK_KEYWORDS_PROPERTY,
+                        LOG_MASK_KEYWORDS_ENV,
+                        LOG_MASK_KEYWORDS_DEFAULT)
+                        .split(","))
+                .map(String::trim)
+                .collect(toSet());
+    }
+
+    /**
+     * Gets the http message builder force citrus header update enabled/disabled setting, which controls
+     * whether the citrus message builder always creates messages with unique ids.
+     *
+     * @return
+     */
+    public static boolean isHttpMessageBuilderForceCitrusHeaderUpdateEnabled() {
+        return parseBoolean(getPropertyEnvOrDefault(
+                HTTP_MESSAGE_BUILDER_FORCE_CITRUS_HEADER_UPDATE_ENABLED_PROPERTY,
+                HTTP_MESSAGE_BUILDER_FORCE_CITRUS_HEADER_UPDATE_ENABLED_ENV,
+                HTTP_MESSAGE_BUILDER_FORCE_CITRUS_HEADER_UPDATE_ENABLED_DEFAULT));
     }
 
     /**
      * Gets the test file name pattern for given type or empty patterns for unknown type.
+     *
      * @param type
      * @return
      */
     public static Set<String> getTestFileNamePattern(String type) {
         return switch (type) {
-            case XML, SPRING -> getXmlTestFileNamePattern();
+            case TestLoader.XML, SPRING -> getXmlTestFileNamePattern();
             case GROOVY -> getGroovyTestFileNamePattern();
             case YAML -> getYamlTestFileNamePattern();
             default -> emptySet();
         };
+    }
+
+    /**
+     * Gets in the respective order, a system property, an environment variable or the default
+     *
+     * @param prop the name of the system property to get
+     * @param env  the name of the environment variable to get
+     * @param def  the default value
+     * @return first value encountered, which is not null. May return null, if default value is null.
+     */
+    private static String getPropertyEnvOrDefault(String prop, String env, String def) {
+        return getProperty(prop, getenv(env) != null ? getenv(env) : def);
     }
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/message/DefaultMessage.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/message/DefaultMessage.java
@@ -16,16 +16,18 @@
 
 package org.citrusframework.message;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
 import org.citrusframework.CitrusSettings;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.util.MessageUtils;
 import org.citrusframework.util.TypeConversionUtils;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.lang.System.currentTimeMillis;
+import static java.util.UUID.randomUUID;
 
 /**
  * Default message implementation holds message payload and message headers. Also provides access methods for special
@@ -74,6 +76,22 @@ public class DefaultMessage implements Message {
     }
 
     /**
+     * Constructs a new DefaultMessage based on the provided Message object, with an option to force Citrus header update.
+     * If forceCitrusHeaderUpdate is true, it overwrites existing values for ID and TIMESTAMP headers with new values.
+     * If forceCitrusHeaderUpdate is false, it updates the ID and TIMESTAMP headers only if they are absent in the provided headers.
+     *
+     * @param message the Message object to copy
+     * @param forceCitrusHeaderUpdate flag indicating whether to force Citrus header update
+     */
+    public DefaultMessage(Message message, boolean forceCitrusHeaderUpdate) {
+        this(message.getPayload(), message.getHeaders(), forceCitrusHeaderUpdate);
+
+        this.setName(message.getName());
+        this.setType(message.getType());
+        this.headerData.addAll(message.getHeaderData());
+    }
+
+    /**
      * Default constructor using just message payload.
      * @param payload
      */
@@ -87,11 +105,29 @@ public class DefaultMessage implements Message {
      * @param headers
      */
     public DefaultMessage(Object payload, Map<String, Object> headers) {
+        this(payload, headers, false);
+    }
+
+    /**
+     * Constructs a new DefaultMessage with the given payload, headers, and an option to force Citrus header update.
+     * If forceCitrusHeaderUpdate is true, it updates the ID and TIMESTAMP headers with new values.
+     * If forceCitrusHeaderUpdate is false, it updates the ID and TIMESTAMP headers only if they are absent in the provided headers.
+     *
+     * @param payload the message payload
+     * @param headers the message headers
+     * @param forceCitrusHeaderUpdate flag indicating whether to force Citrus header update
+     */
+    private DefaultMessage(Object payload, Map<String, Object> headers, boolean forceCitrusHeaderUpdate) {
         this.payload = payload;
         this.headers.putAll(headers);
 
-        this.headers.putIfAbsent(MessageHeaders.ID, UUID.randomUUID().toString());
-        this.headers.putIfAbsent(MessageHeaders.TIMESTAMP, System.currentTimeMillis());
+        if (forceCitrusHeaderUpdate) {
+            this.headers.put(MessageHeaders.ID, randomUUID().toString());
+            this.headers.put(MessageHeaders.TIMESTAMP, currentTimeMillis());
+        } else {
+            this.headers.putIfAbsent(MessageHeaders.ID, randomUUID().toString());
+            this.headers.putIfAbsent(MessageHeaders.TIMESTAMP, currentTimeMillis());
+        }
     }
 
     @Override

--- a/core/citrus-base/src/test/java/org/citrusframework/message/DefaultMessageTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/message/DefaultMessageTest.java
@@ -16,8 +16,11 @@
 
 package org.citrusframework.message;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+
+import java.util.Map;
 import org.citrusframework.UnitTestSupport;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 /**
@@ -33,7 +36,7 @@ public class DefaultMessageTest extends UnitTestSupport {
         message.setHeader("password", "foo");
 
         String output = message.print();
-        Assert.assertEquals(output, String.format("DEFAULTMESSAGE [" +
+        assertEquals(output, String.format("DEFAULTMESSAGE [" +
                     "id: %s, " +
                     "payload: <credentials>%n  <password>foo</password>%n</credentials>%n" +
                 "][headers: {" +
@@ -50,7 +53,7 @@ public class DefaultMessageTest extends UnitTestSupport {
         message.setHeader("secret", "bar");
 
         String output = message.print(context);
-        Assert.assertEquals(output, String.format("DEFAULTMESSAGE [" +
+        assertEquals(output, String.format("DEFAULTMESSAGE [" +
                     "id: %s, " +
                     "payload: password=****,secret=****" +
                 "][headers: {" +
@@ -67,7 +70,7 @@ public class DefaultMessageTest extends UnitTestSupport {
         message.setHeader("secret", "bar");
 
         String output = message.print(context);
-        Assert.assertEquals(output, String.format("DEFAULTMESSAGE [" +
+        assertEquals(output, String.format("DEFAULTMESSAGE [" +
                     "id: %s, " +
                     "payload: password=****&secret=****" +
                 "][headers: {" +
@@ -83,7 +86,7 @@ public class DefaultMessageTest extends UnitTestSupport {
         message.setHeader("password", "foo");
 
         String output = message.print(context);
-        Assert.assertEquals(output, String.format("DEFAULTMESSAGE [" +
+        assertEquals(output, String.format("DEFAULTMESSAGE [" +
                     "id: %s, " +
                     "payload: <credentials>%n  <password>****</password>%n</credentials>%n" +
                 "][headers: {" +
@@ -100,11 +103,46 @@ public class DefaultMessageTest extends UnitTestSupport {
         message.setHeader("secretKey", "bar");
 
         String output = message.print(context);
-        Assert.assertEquals(output, String.format("DEFAULTMESSAGE [" +
+        assertEquals(output, String.format("DEFAULTMESSAGE [" +
                     "id: %s, " +
                     "payload: {%n  \"credentials\": {%n    \"password\": \"****\",%n    \"secretKey\": \"****\"%n  }%n}" +
                 "][headers: {" +
                     "citrus_message_id=%s, citrus_message_timestamp=%s, operation=getCredentials, password=****, secretKey=****" +
                 "}]", message.getId(), message.getId(), message.getTimestamp()));
+    }
+
+    @Test
+    public void testCopyConstructorPreservesIdAndTimestamp() {
+
+        // Given
+        DefaultMessage originalMessage = new DefaultMessage("myPayload", Map.of("k1","v1"));
+
+        // When
+        DefaultMessage copiedMessage = new DefaultMessage(originalMessage);
+
+        // Then
+        assertEquals(originalMessage.getHeader(MessageHeaders.ID), copiedMessage.getHeader(MessageHeaders.ID));
+        assertEquals(originalMessage.getHeader(MessageHeaders.TIMESTAMP), copiedMessage.getHeader(MessageHeaders.TIMESTAMP));
+        assertEquals(originalMessage.getHeader("k1"), copiedMessage.getHeader("k1"));
+        assertEquals(originalMessage.getPayload(), copiedMessage.getPayload());
+
+    }
+
+    @Test
+    public void testCopyConstructorWithCitrusOverwriteDoesNotPreserveIdAndTimestamp() {
+
+        // Given
+        DefaultMessage originalMessage = new DefaultMessage("myPayload", Map.of("k1","v1"));
+        originalMessage.setHeader(MessageHeaders.TIMESTAMP, System.currentTimeMillis() - 1);
+
+        // When
+        DefaultMessage copiedMessage = new DefaultMessage(originalMessage, true);
+
+        // Then
+        assertNotEquals(originalMessage.getHeader(MessageHeaders.ID), copiedMessage.getHeader(MessageHeaders.ID));
+        assertNotEquals(originalMessage.getHeader(MessageHeaders.TIMESTAMP), copiedMessage.getHeader(MessageHeaders.TIMESTAMP));
+        assertEquals(originalMessage.getHeader("k1"), copiedMessage.getHeader("k1"));
+        assertEquals(originalMessage.getPayload(), copiedMessage.getPayload());
+
     }
 }

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/message/HttpMessageBuilder.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/message/HttpMessageBuilder.java
@@ -16,15 +16,20 @@
 
 package org.citrusframework.http.message;
 
+import static org.citrusframework.CitrusSettings.isHttpMessageBuilderForceCitrusHeaderUpdateEnabled;
+
 import jakarta.servlet.http.Cookie;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-
 import org.citrusframework.context.TestContext;
 import org.citrusframework.message.Message;
 import org.citrusframework.validation.builder.StaticMessageBuilder;
 
+/**
+ * Builder class for creating HTTP messages with default settings, ensuring that each message has a unique
+ * ID and a timestamp that corresponds to the time, the build method was called.
+ */
 public class HttpMessageBuilder extends StaticMessageBuilder {
 
     private final CookieEnricher cookieEnricher;
@@ -52,7 +57,7 @@ public class HttpMessageBuilder extends StaticMessageBuilder {
     @Override
     public Message build(final TestContext context, final String messageType) {
         //Copy the initial message, so that it is not manipulated during the test.
-        final HttpMessage message = new HttpMessage(super.getMessage());
+        final HttpMessage message = new HttpMessage(super.getMessage(), isHttpMessageBuilderForceCitrusHeaderUpdateEnabled());
 
         final Message constructed = super.build(context, messageType);
 
@@ -92,6 +97,7 @@ public class HttpMessageBuilder extends StaticMessageBuilder {
         return cookies.toArray(new Cookie[0]);
     }
 
+    @Override
     public HttpMessage getMessage() {
         return (HttpMessage) super.getMessage();
     }

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/message/HttpMessageBuilderTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/message/HttpMessageBuilderTest.java
@@ -18,8 +18,6 @@
 package org.citrusframework.http.message;
 
 import jakarta.servlet.http.Cookie;
-import java.util.Collections;
-
 import org.citrusframework.context.TestContext;
 import org.citrusframework.message.Message;
 import org.citrusframework.message.MessageHeaders;
@@ -27,10 +25,16 @@ import org.citrusframework.message.MessageType;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static org.mockito.ArgumentMatchers.eq;
+import static java.lang.System.currentTimeMillis;
+import static java.lang.System.setProperty;
+import static java.util.Collections.singletonList;
+import static org.citrusframework.CitrusSettings.HTTP_MESSAGE_BUILDER_FORCE_CITRUS_HEADER_UPDATE_ENABLED_DEFAULT;
+import static org.citrusframework.CitrusSettings.HTTP_MESSAGE_BUILDER_FORCE_CITRUS_HEADER_UPDATE_ENABLED_PROPERTY;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 public class HttpMessageBuilderTest {
@@ -38,13 +42,13 @@ public class HttpMessageBuilderTest {
     private HttpMessage message;
 
     @BeforeMethod
-    public void setUp(){
+    public void setUp() {
         message = new HttpMessage("");
+        message.setHeader(MessageHeaders.TIMESTAMP, currentTimeMillis() - 1);
     }
 
     @Test
     public void testDefaultMessageHeader() {
-
         //GIVEN
         final HttpMessageBuilder builder = getBuilder();
 
@@ -53,14 +57,38 @@ public class HttpMessageBuilderTest {
 
         //THEN
         assertEquals(builtMessage.getHeaders().entrySet().size(), 3);
-        assertEquals(message.getHeader(MessageHeaders.ID), builtMessage.getHeader(MessageHeaders.ID));
-        assertEquals(message.getHeader(MessageHeaders.TIMESTAMP), builtMessage.getHeader(MessageHeaders.TIMESTAMP));
+        assertNotNull(message.getHeader(MessageHeaders.ID));
+        assertNotNull(message.getHeader(MessageHeaders.TIMESTAMP));
+        assertNotEquals(message.getHeader(MessageHeaders.ID), builtMessage.getHeader(MessageHeaders.ID));
+        assertNotEquals(message.getHeader(MessageHeaders.TIMESTAMP), builtMessage.getHeader(MessageHeaders.TIMESTAMP));
         assertEquals(builtMessage.getType(), MessageType.XML.toString());
     }
 
     @Test
-    public void testHeaderVariableSubstitution() {
+    public void testDefaultMessageHeaderWithNoForceUpdate() {
+        try {
+            setProperty(HTTP_MESSAGE_BUILDER_FORCE_CITRUS_HEADER_UPDATE_ENABLED_PROPERTY, "false");
 
+            //GIVEN
+            final HttpMessageBuilder builder = getBuilder();
+
+            //WHEN
+            final Message builtMessage = builder.build(new TestContext(), MessageType.XML.name());
+
+            //THEN
+            assertEquals(builtMessage.getHeaders().entrySet().size(), 3);
+            assertNotNull(message.getHeader(MessageHeaders.ID));
+            assertNotNull(message.getHeader(MessageHeaders.TIMESTAMP));
+            assertEquals(message.getHeader(MessageHeaders.ID), builtMessage.getHeader(MessageHeaders.ID));
+            assertEquals(message.getHeader(MessageHeaders.TIMESTAMP), builtMessage.getHeader(MessageHeaders.TIMESTAMP));
+            assertEquals(builtMessage.getType(), MessageType.XML.toString());
+        } finally {
+            setProperty(HTTP_MESSAGE_BUILDER_FORCE_CITRUS_HEADER_UPDATE_ENABLED_PROPERTY, HTTP_MESSAGE_BUILDER_FORCE_CITRUS_HEADER_UPDATE_ENABLED_DEFAULT);
+        }
+    }
+
+    @Test
+    public void testHeaderVariableSubstitution() {
         //GIVEN
         final HttpMessageBuilder builder = getBuilder();
 
@@ -78,8 +106,7 @@ public class HttpMessageBuilderTest {
     }
 
     @Test
-    public void testTemplateHeadersArePreserved(){
-
+    public void testTemplateHeadersArePreserved() {
         //GIVEN
         final HttpMessageBuilder builder = getBuilder();
         message.setHeader("foo", "bar");
@@ -94,8 +121,7 @@ public class HttpMessageBuilderTest {
     }
 
     @Test
-    public void testCookieEnricherIsCalledForTemplateCookies(){
-
+    public void testCookieEnricherIsCalledForTemplateCookies() {
         //GIVEN
         final CookieEnricher cookieEnricherMock = mock(CookieEnricher.class);
         final TestContext testContextMock = mock(TestContext.class);
@@ -105,17 +131,14 @@ public class HttpMessageBuilderTest {
         final Cookie enrichedCookie = mock(Cookie.class);
 
         when(cookieEnricherMock.enrich(
-                eq(Collections.singletonList(templateCookie)),
-                eq(testContextMock)))
-                .thenReturn(Collections.singletonList(enrichedCookie));
+                singletonList(templateCookie),
+                testContextMock))
+                .thenReturn(singletonList(enrichedCookie));
 
-        final HttpMessageBuilder builder = new HttpMessageBuilder(
-                message,
-                cookieEnricherMock);
+        final HttpMessageBuilder builder = new HttpMessageBuilder(message, cookieEnricherMock);
 
         //WHEN
-        final HttpMessage message = (HttpMessage) builder.build(
-                testContextMock, String.valueOf(MessageType.XML));
+        final HttpMessage message = (HttpMessage) builder.build(testContextMock, String.valueOf(MessageType.XML));
 
         //THEN
         assertEquals(message.getCookies().size(), 1);
@@ -123,8 +146,6 @@ public class HttpMessageBuilderTest {
     }
 
     private HttpMessageBuilder getBuilder() {
-        return new HttpMessageBuilder(
-                message,
-                mock(CookieEnricher.class));
+        return new HttpMessageBuilder(message, mock(CookieEnricher.class));
     }
 }

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/message/HttpMessageTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/message/HttpMessageTest.java
@@ -16,18 +16,20 @@
 
 package org.citrusframework.http.message;
 
+import jakarta.servlet.http.Cookie;
 import org.citrusframework.endpoint.resolver.EndpointUriResolver;
+import org.citrusframework.message.MessageHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import jakarta.servlet.http.Cookie;
 import java.util.Collection;
 import java.util.Map;
 
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
@@ -36,13 +38,12 @@ public class HttpMessageTest {
     private HttpMessage httpMessage;
 
     @BeforeMethod
-    public void setUp(){
+    public void setUp() {
         httpMessage = new HttpMessage();
     }
 
     @Test
     public void testSetCookies() {
-
         //GIVEN
         final Cookie cookie = mock(Cookie.class);
         final Cookie[] cookies = new Cookie[]{cookie};
@@ -55,11 +56,10 @@ public class HttpMessageTest {
     }
 
     /**
-     * Required by https://tools.ietf.org/html/rfc6265#section-4.1.1
+     * Required by <a href="https://tools.ietf.org/html/rfc6265#section-4.1.1">rfc6265-section-4.1.1</a>
      */
     @Test
     public void testCookiesWithSameNamesAreOverwritten() {
-
         //GIVEN
         final Cookie cookie = new Cookie("foo", "bar");
         httpMessage.cookie(cookie);
@@ -76,7 +76,6 @@ public class HttpMessageTest {
 
     @Test
     public void testSetCookiesOverwritesOldCookies() {
-
         //GIVEN
         httpMessage.setCookies(new Cookie[]{
                 mock(Cookie.class),
@@ -95,7 +94,6 @@ public class HttpMessageTest {
 
     @Test
     public void testCopyConstructorPreservesCookies() {
-
         //GIVEN
         final Cookie expectedCookie = mock(Cookie.class);
         final HttpMessage originalMessage = new HttpMessage();
@@ -110,7 +108,6 @@ public class HttpMessageTest {
 
     @Test
     public void testParseQueryParamsAreParsedCorrectly() {
-
         //GIVEN
         final String queryParamString = "foo=foobar,bar=barbar";
 
@@ -125,7 +122,6 @@ public class HttpMessageTest {
 
     @Test
     public void testParseQueryParamsSetsQueryParamsHeader() {
-
         //GIVEN
         final String queryParamString = "foo=foobar,bar=barbar";
 
@@ -138,7 +134,6 @@ public class HttpMessageTest {
 
     @Test
     public void testParseQueryParamsSetsQueryParamHeaderName() {
-
         //GIVEN
         final String queryParamString = "foo=foobar,bar=barbar";
 
@@ -151,7 +146,6 @@ public class HttpMessageTest {
 
     @Test
     public void testQueryParamWithoutValueContainsNull() {
-
         //GIVEN
         final String queryParam = "foo";
 
@@ -164,7 +158,6 @@ public class HttpMessageTest {
 
     @Test
     public void testQueryParamWithValueIsSetCorrectly() {
-
         //GIVEN
         final String key = "foo";
         final String value = "foo";
@@ -178,7 +171,6 @@ public class HttpMessageTest {
 
     @Test
     public void testNewQueryParamIsAddedToExistingParams() {
-
         //GIVEN
         final String existingKey = "foo";
         final String existingValue = "foobar";
@@ -197,7 +189,6 @@ public class HttpMessageTest {
 
     @Test
     public void testNewQueryParamIsAddedQueryParamsHeader() {
-
         //GIVEN
         httpMessage.queryParam("foo", "foobar");
 
@@ -212,7 +203,6 @@ public class HttpMessageTest {
 
     @Test
     public void testNewQueryParamIsAddedQueryParamHeaderName() {
-
         //GIVEN
         httpMessage.queryParam("foo", "foobar");
 
@@ -227,9 +217,7 @@ public class HttpMessageTest {
 
     @Test
     public void testDefaultStatusCodeIsNull() {
-
         //GIVEN
-
 
         //WHEN
         final HttpStatusCode statusCode = httpMessage.getStatusCode();
@@ -240,7 +228,6 @@ public class HttpMessageTest {
 
     @Test
     public void testStringStatusCodeIsParsed() {
-
         //GIVEN
         httpMessage.header(HttpMessageHeaders.HTTP_STATUS_CODE, "404");
 
@@ -253,7 +240,6 @@ public class HttpMessageTest {
 
     @Test
     public void testIntegerStatusCodeIsParsed() {
-
         //GIVEN
         httpMessage.header(HttpMessageHeaders.HTTP_STATUS_CODE, 403);
 
@@ -266,7 +252,6 @@ public class HttpMessageTest {
 
     @Test
     public void testStatusCodeObjectIsPreserved() {
-
         //GIVEN
         httpMessage.header(HttpMessageHeaders.HTTP_STATUS_CODE, HttpStatus.I_AM_A_TEAPOT);
 
@@ -279,7 +264,6 @@ public class HttpMessageTest {
 
     @Test
     public void testCanHandleCustomStatusCode() {
-
         //GIVEN
         httpMessage.header(HttpMessageHeaders.HTTP_STATUS_CODE, 555);
 
@@ -292,16 +276,49 @@ public class HttpMessageTest {
 
     @Test
     public void testQueryParamWithMultipleParams() {
-
         //GIVEN
         httpMessage.queryParam("foo", "bar");
 
         final String expectedHeaderValue = "foo=bar,foo=foobar";
 
         //WHEN
-        final HttpMessage resultMessage= httpMessage.queryParam("foo", "foobar");
+        final HttpMessage resultMessage = httpMessage.queryParam("foo", "foobar");
 
         //THEN
         assertEquals(resultMessage.getHeader(EndpointUriResolver.QUERY_PARAM_HEADER_NAME), expectedHeaderValue);
+    }
+
+    @Test
+    public void testCopyConstructorPreservesIdAndTimestamp() {
+        // Given
+        httpMessage.setPayload("myPayload");
+        httpMessage.setHeader("k1", "v1");
+
+        // When
+        HttpMessage copiedMessage = new HttpMessage(httpMessage);
+
+        // Then
+        assertEquals(httpMessage.getHeader(MessageHeaders.ID), copiedMessage.getHeader(MessageHeaders.ID));
+        assertEquals(httpMessage.getHeader(MessageHeaders.TIMESTAMP), copiedMessage.getHeader(MessageHeaders.TIMESTAMP));
+        assertEquals(httpMessage.getHeader("k1"), copiedMessage.getHeader("k1"));
+        assertEquals(httpMessage.getPayload(), copiedMessage.getPayload());
+
+    }
+
+    @Test
+    public void testCopyConstructorWithCitrusOverwriteDoesNotPreserveIdAndTimestamp() {
+        // Given
+        httpMessage.setPayload("myPayload");
+        httpMessage.setHeader("k1", "v1");
+        httpMessage.setHeader(MessageHeaders.TIMESTAMP, System.currentTimeMillis() - 1);
+
+        // When
+        HttpMessage copiedMessage = new HttpMessage(httpMessage, true);
+
+        // Then
+        assertNotEquals(httpMessage.getHeader(MessageHeaders.ID), copiedMessage.getHeader(MessageHeaders.ID));
+        assertNotEquals(httpMessage.getHeader(MessageHeaders.TIMESTAMP), copiedMessage.getHeader(MessageHeaders.TIMESTAMP));
+        assertEquals(httpMessage.getHeader("k1"), copiedMessage.getHeader("k1"));
+        assertEquals(httpMessage.getPayload(), copiedMessage.getPayload());
     }
 }


### PR DESCRIPTION
I've updated the HttpMessageBuilder to consistently generate messages with new IDs and timestamps. As a result, messages created by the builder will always have unique identifiers and may differ in their timestamps. I haven't identified any scenarios where this change would cause any issues.

I would appreciate Christoph's thorough review and expert opinion on this matter, considering the potential for unforeseen side effects.