### PR TITLE
backport[`v3.4.0`]: update testng to v7.10.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ name: build_jdk11
 on:
   pull_request:
     branches:
-      - main
+      - support/3.0.0
     paths-ignore:
       - '**.adoc'
       - '**.md'
@@ -29,7 +29,7 @@ on:
       - 'NOTICE'
   push:
     branches:
-      - main
+      - support/3.0.0
     paths-ignore:
       - '**.adoc'
       - '**.md'

--- a/.github/workflows/lts.yml
+++ b/.github/workflows/lts.yml
@@ -20,7 +20,7 @@ name: build_jdk17
 on:
   pull_request:
     branches:
-      - main
+      - support/3.0.0
     paths-ignore:
       - '**.adoc'
       - '**.md'
@@ -29,7 +29,7 @@ on:
       - 'NOTICE'
   push:
     branches:
-      - main
+      - support/3.0.0
     paths-ignore:
       - '**.adoc'
       - '**.md'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,14 +21,14 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+      - support/3.0.0
     paths:
       - '.github/project.yml'
 
 jobs:
   release:
     runs-on: ubuntu-20.04
-    if: github.ref == 'refs/heads/main' && github.repository == 'citrusframework/citrus'
+    if: github.ref == 'refs/heads/support/3.0.0' && github.repository == 'citrusframework/citrus'
 
     steps:
     - name: Checkout code

--- a/core/citrus-spring/src/test/java/com/consol/citrus/BeanDefinitionParserTestSupport.java
+++ b/core/citrus-spring/src/test/java/com/consol/citrus/BeanDefinitionParserTestSupport.java
@@ -10,10 +10,12 @@ import com.consol.citrus.report.JUnitReporter;
 import com.consol.citrus.testng.AbstractBeanDefinitionParserTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
-import org.testng.ITestContext;
+import org.testng.Reporter;
 import org.testng.annotations.AfterSuite;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeSuite;
+
+import static java.util.Objects.nonNull;
 
 /**
  * @author Christoph Deppisch
@@ -21,7 +23,9 @@ import org.testng.annotations.BeforeSuite;
 @ContextConfiguration(classes = CitrusSpringConfig.class)
 public class BeanDefinitionParserTestSupport extends AbstractBeanDefinitionParserTest {
 
-    /** Factory bean for test context */
+    /**
+     * Factory bean for test context
+     */
     @Autowired
     protected TestContextFactoryBean testContextFactory;
 
@@ -31,26 +35,28 @@ public class BeanDefinitionParserTestSupport extends AbstractBeanDefinitionParse
     @Autowired
     private JUnitReporter jUnitReporter;
 
-    /** Citrus instance */
+    /**
+     * Citrus instance
+     */
     protected Citrus citrus;
 
-    @BeforeSuite(alwaysRun = true)
     @Override
-    public void beforeSuite(ITestContext testContext) throws Exception {
-        super.beforeSuite(testContext);
+    @BeforeSuite(alwaysRun = true)
+    public void beforeSuite() throws Exception {
+        super.beforeSuite();
 
         citrus = Citrus.newInstance(new CitrusSpringContextProvider(applicationContext));
-        citrus.beforeSuite(testContext.getSuite().getName(), testContext.getIncludedGroups());
+        citrus.beforeSuite(
+                Reporter.getCurrentTestResult().getTestContext().getSuite().getName(),
+                Reporter.getCurrentTestResult().getTestContext().getIncludedGroups());
     }
 
-    /**
-     * Runs tasks after test suite.
-     * @param testContext the test context.
-     */
     @AfterSuite(alwaysRun = true)
-    public void afterSuite(ITestContext testContext) {
-        if (citrus != null) {
-            citrus.afterSuite(testContext.getSuite().getName(), testContext.getIncludedGroups());
+    public void afterSuite() {
+        if (nonNull(citrus)) {
+            citrus.afterSuite(
+                    Reporter.getCurrentTestResult().getTestContext().getSuite().getName(),
+                    Reporter.getCurrentTestResult().getTestContext().getIncludedGroups());
         }
     }
 

--- a/core/citrus-spring/src/test/java/com/consol/citrus/UnitTestSupport.java
+++ b/core/citrus-spring/src/test/java/com/consol/citrus/UnitTestSupport.java
@@ -10,10 +10,12 @@ import com.consol.citrus.report.JUnitReporter;
 import com.consol.citrus.testng.AbstractTestNGUnitTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
-import org.testng.ITestContext;
+import org.testng.Reporter;
 import org.testng.annotations.AfterSuite;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeSuite;
+
+import static java.util.Objects.nonNull;
 
 /**
  * @author Christoph Deppisch
@@ -21,7 +23,9 @@ import org.testng.annotations.BeforeSuite;
 @ContextConfiguration(classes = CitrusSpringConfig.class)
 public class UnitTestSupport extends AbstractTestNGUnitTest {
 
-    /** Factory bean for test context */
+    /**
+     * Factory bean for test context
+     */
     @Autowired
     protected TestContextFactoryBean testContextFactory;
 
@@ -31,26 +35,27 @@ public class UnitTestSupport extends AbstractTestNGUnitTest {
     @Autowired
     private JUnitReporter jUnitReporter;
 
-    /** Citrus instance */
+    /**
+     * Citrus instance
+     */
     protected Citrus citrus;
 
-    @BeforeSuite(alwaysRun = true)
     @Override
-    public void beforeSuite(ITestContext testContext) throws Exception {
-        super.beforeSuite(testContext);
+    @BeforeSuite(alwaysRun = true)
+    public void beforeSuite() throws Exception {
+        super.beforeSuite();
 
         citrus = Citrus.newInstance(new CitrusSpringContextProvider(applicationContext));
-        citrus.beforeSuite(testContext.getSuite().getName(), testContext.getIncludedGroups());
+        citrus.beforeSuite(
+                Reporter.getCurrentTestResult().getTestContext().getSuite().getName(),
+                Reporter.getCurrentTestResult().getTestContext().getIncludedGroups());
     }
 
-    /**
-     * Runs tasks after test suite.
-     * @param testContext the test context.
-     */
     @AfterSuite(alwaysRun = true)
-    public void afterSuite(ITestContext testContext) {
-        if (citrus != null) {
-            citrus.afterSuite(testContext.getSuite().getName(), testContext.getIncludedGroups());
+    public void afterSuite() {
+        if (nonNull(citrus)) {
+            citrus.afterSuite(Reporter.getCurrentTestResult().getTestContext().getSuite().getName(),
+                    Reporter.getCurrentTestResult().getTestContext().getIncludedGroups());
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@
     <spring.restdocs.version>2.0.7.RELEASE</spring.restdocs.version>
     <sshd.version>2.9.2</sshd.version>
     <subethasmtp.version>3.1.7</subethasmtp.version>
-    <testng.version>7.7.1</testng.version>
+    <testng.version>7.10.1</testng.version>
     <vertx.version>3.9.14</vertx.version>
     <wsdl4j.version>1.6.3</wsdl4j.version>
     <xalan.version>2.7.2</xalan.version>

--- a/runtime/citrus-cucumber/src/test/java/com/consol/citrus/cucumber/UnitTestSupport.java
+++ b/runtime/citrus-cucumber/src/test/java/com/consol/citrus/cucumber/UnitTestSupport.java
@@ -12,10 +12,12 @@ import com.consol.citrus.report.JUnitReporter;
 import com.consol.citrus.testng.AbstractTestNGUnitTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
-import org.testng.ITestContext;
+import org.testng.Reporter;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
+
+import static java.util.Objects.nonNull;
 
 /**
  * @author Christoph Deppisch
@@ -23,7 +25,9 @@ import org.testng.annotations.BeforeMethod;
 @ContextConfiguration(classes = CitrusSpringConfig.class)
 public class UnitTestSupport extends AbstractTestNGUnitTest {
 
-    /** Factory bean for test context */
+    /**
+     * Factory bean for test context
+     */
     @Autowired
     protected TestContextFactoryBean testContextFactory;
 
@@ -33,23 +37,23 @@ public class UnitTestSupport extends AbstractTestNGUnitTest {
     @Autowired
     private JUnitReporter jUnitReporter;
 
-    /** Citrus instance */
+    /**
+     * Citrus instance
+     */
     protected Citrus citrus;
 
     @BeforeClass(alwaysRun = true)
-    public void beforeSuite(ITestContext testContext) throws Exception {
+    public void beforeSuite() {
         citrus = Citrus.newInstance(new CitrusSpringContextProvider(applicationContext));
-        citrus.beforeSuite(testContext.getSuite().getName(), testContext.getIncludedGroups());
+        citrus.beforeSuite(Reporter.getCurrentTestResult().getTestContext().getSuite().getName(),
+                Reporter.getCurrentTestResult().getTestContext().getIncludedGroups());
     }
 
-    /**
-     * Runs tasks after test suite.
-     * @param testContext the test context.
-     */
     @AfterClass(alwaysRun = true)
-    public void afterSuite(ITestContext testContext) {
-        if (citrus != null) {
-            citrus.afterSuite(testContext.getSuite().getName(), testContext.getIncludedGroups());
+    public void afterSuite() {
+        if (nonNull(citrus)) {
+            citrus.afterSuite(Reporter.getCurrentTestResult().getTestContext().getSuite().getName(),
+                    Reporter.getCurrentTestResult().getTestContext().getIncludedGroups());
         }
     }
 

--- a/runtime/citrus-testng/src/main/java/com/consol/citrus/testng/TestNGCitrusSupport.java
+++ b/runtime/citrus-testng/src/main/java/com/consol/citrus/testng/TestNGCitrusSupport.java
@@ -19,10 +19,6 @@
 
 package com.consol.citrus.testng;
 
-import java.lang.reflect.Method;
-import java.util.Date;
-import java.util.List;
-
 import com.consol.citrus.Citrus;
 import com.consol.citrus.CitrusContext;
 import com.consol.citrus.GherkinTestActionRunner;
@@ -45,13 +41,19 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.IHookCallBack;
 import org.testng.IHookable;
-import org.testng.ITestContext;
 import org.testng.ITestResult;
+import org.testng.Reporter;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterSuite;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Listeners;
+
+import java.lang.reflect.Method;
+import java.util.Date;
+import java.util.List;
+
+import static java.util.Objects.nonNull;
 
 /**
  * Basic Citrus TestNG support base class automatically handles test case runner creation. Also provides method parameter resolution
@@ -60,16 +62,22 @@ import org.testng.annotations.Listeners;
  *
  * @author Christoph Deppisch
  */
-@Listeners( { TestNGCitrusMethodInterceptor.class } )
+@Listeners({TestNGCitrusMethodInterceptor.class})
 public class TestNGCitrusSupport implements IHookable, GherkinTestActionRunner {
 
-    /** Logger */
+    /**
+     * Logger
+     */
     protected final Logger log = LoggerFactory.getLogger(getClass());
 
-    /** Citrus instance */
+    /**
+     * Citrus instance
+     */
     protected Citrus citrus;
 
-    /** Test builder delegate */
+    /**
+     * Test builder delegate
+     */
     private TestCaseRunner delegate;
 
     @Override
@@ -108,6 +116,7 @@ public class TestNGCitrusSupport implements IHookable, GherkinTestActionRunner {
 
     /**
      * Run method prepares and executes test case.
+     *
      * @param testResult
      * @param method
      * @param methodTestLoaders
@@ -172,6 +181,7 @@ public class TestNGCitrusSupport implements IHookable, GherkinTestActionRunner {
 
     /**
      * Subclasses may add before test actions on the provided context.
+     *
      * @param context the Citrus context.
      */
     protected void before(CitrusContext context) {
@@ -186,36 +196,41 @@ public class TestNGCitrusSupport implements IHookable, GherkinTestActionRunner {
 
     /**
      * Subclasses may add after test actions on the provided context.
+     *
      * @param context the Citrus context.
      */
     protected void after(CitrusContext context) {
     }
 
     @BeforeSuite(alwaysRun = true)
-    public final void beforeSuite(ITestContext testContext) {
+    public final void beforeSuite() {
         citrus = Citrus.newInstance();
         CitrusAnnotations.injectCitrusFramework(this, citrus);
         beforeSuite(citrus.getCitrusContext());
-        citrus.beforeSuite(testContext.getSuite().getName(), testContext.getIncludedGroups());
+        citrus.beforeSuite(Reporter.getCurrentTestResult().getTestContext().getSuite().getName(),
+                Reporter.getCurrentTestResult().getTestContext().getIncludedGroups());
     }
 
     /**
      * Subclasses may add before suite actions on the provided context.
+     *
      * @param context the Citrus context.
      */
     protected void beforeSuite(CitrusContext context) {
     }
 
     @AfterSuite(alwaysRun = true)
-    public final void afterSuite(ITestContext testContext) {
-        if (citrus != null) {
+    public final void afterSuite() {
+        if (nonNull(citrus)) {
             afterSuite(citrus.getCitrusContext());
-            citrus.afterSuite(testContext.getSuite().getName(), testContext.getIncludedGroups());
+            citrus.afterSuite(Reporter.getCurrentTestResult().getTestContext().getSuite().getName(),
+                    Reporter.getCurrentTestResult().getTestContext().getIncludedGroups());
         }
     }
 
     /**
      * Subclasses may add after suite actions on the provided context.
+     *
      * @param context the Citrus context.
      */
     protected void afterSuite(CitrusContext context) {
@@ -223,7 +238,7 @@ public class TestNGCitrusSupport implements IHookable, GherkinTestActionRunner {
 
     /**
      * Prepares the test context.
-     *
+     * <p>
      * Provides a hook for test context modifications before the test gets executed.
      *
      * @param testContext the test context.
@@ -237,6 +252,7 @@ public class TestNGCitrusSupport implements IHookable, GherkinTestActionRunner {
      * Creates new test loader which has TestNG test annotations set for test execution. Only
      * suitable for tests that get created at runtime through factory method. Subclasses
      * may overwrite this in order to provide custom test loader with custom test annotations set.
+     *
      * @param testName
      * @param packageName
      * @return

--- a/runtime/citrus-testng/src/main/java/com/consol/citrus/testng/spring/TestNGCitrusSpringSupport.java
+++ b/runtime/citrus-testng/src/main/java/com/consol/citrus/testng/spring/TestNGCitrusSpringSupport.java
@@ -19,11 +19,6 @@
 
 package com.consol.citrus.testng.spring;
 
-import java.lang.reflect.Method;
-import java.util.Date;
-import java.util.List;
-import java.util.Optional;
-
 import com.consol.citrus.Citrus;
 import com.consol.citrus.CitrusContext;
 import com.consol.citrus.CitrusSpringContext;
@@ -53,13 +48,20 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
 import org.springframework.util.Assert;
 import org.testng.IHookCallBack;
-import org.testng.ITestContext;
 import org.testng.ITestResult;
+import org.testng.Reporter;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterSuite;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Listeners;
+
+import java.lang.reflect.Method;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Objects.nonNull;
 
 /**
  * Basic Citrus TestNG support base class with Spring support automatically handles test case runner creation. Also provides method parameter resolution
@@ -70,17 +72,22 @@ import org.testng.annotations.Listeners;
  * @author Christoph Deppisch
  */
 @ContextConfiguration(classes = CitrusSpringConfig.class)
-@Listeners( { TestNGCitrusSpringMethodInterceptor.class } )
-public class TestNGCitrusSpringSupport extends AbstractTestNGSpringContextTests
-        implements GherkinTestActionRunner {
+@Listeners({TestNGCitrusSpringMethodInterceptor.class})
+public class TestNGCitrusSpringSupport extends AbstractTestNGSpringContextTests implements GherkinTestActionRunner {
 
-    /** Logger */
+    /**
+     * Logger
+     */
     protected final Logger log = LoggerFactory.getLogger(getClass());
 
-    /** Citrus instance */
+    /**
+     * Citrus instance
+     */
     protected Citrus citrus;
 
-    /** Test builder delegate */
+    /**
+     * Test builder delegate
+     */
     private TestCaseRunner delegate;
     private TestCase testCase;
 
@@ -121,6 +128,7 @@ public class TestNGCitrusSpringSupport extends AbstractTestNGSpringContextTests
 
     /**
      * Run method prepares and executes test case.
+     *
      * @param testResult
      * @param method
      * @param methodTestLoaders
@@ -159,7 +167,7 @@ public class TestNGCitrusSpringSupport extends AbstractTestNGSpringContextTests
 
                 CitrusAnnotations.injectAll(this, citrus, ctx);
 
-                TestLoader testLoader ;
+                TestLoader testLoader;
                 if (method.getAnnotation(CitrusTestSource.class) != null && !methodTestLoaders.isEmpty()) {
                     testLoader = methodTestLoaders.get(invocationCount % methodTestLoaders.size());
 
@@ -201,6 +209,7 @@ public class TestNGCitrusSpringSupport extends AbstractTestNGSpringContextTests
 
     /**
      * Subclasses may add before test actions on the provided context.
+     *
      * @param context the Citrus context.
      */
     protected void before(CitrusContext context) {
@@ -215,13 +224,14 @@ public class TestNGCitrusSpringSupport extends AbstractTestNGSpringContextTests
 
     /**
      * Subclasses may add after test actions on the provided context.
+     *
      * @param context the Citrus context.
      */
     protected void after(CitrusContext context) {
     }
 
     @BeforeSuite(alwaysRun = true)
-    public final void beforeSuite(ITestContext testContext) {
+    public final void beforeSuite() {
         try {
             springTestContextPrepareTestInstance();
         } catch (Exception e) {
@@ -232,26 +242,30 @@ public class TestNGCitrusSpringSupport extends AbstractTestNGSpringContextTests
         citrus = Citrus.newInstance(new CitrusSpringContextProvider(applicationContext));
         CitrusAnnotations.injectCitrusFramework(this, citrus);
         beforeSuite(citrus.getCitrusContext());
-        citrus.beforeSuite(testContext.getSuite().getName(), testContext.getIncludedGroups());
+        citrus.beforeSuite(Reporter.getCurrentTestResult().getTestContext().getSuite().getName(),
+                Reporter.getCurrentTestResult().getTestContext().getIncludedGroups());
     }
 
     /**
      * Subclasses may add before suite actions on the provided context.
+     *
      * @param context the Citrus context.
      */
     protected void beforeSuite(CitrusContext context) {
     }
 
     @AfterSuite(alwaysRun = true)
-    public final void afterSuite(ITestContext testContext) {
-        if (citrus != null) {
+    public final void afterSuite() {
+        if (nonNull(citrus)) {
             afterSuite(citrus.getCitrusContext());
-            citrus.afterSuite(testContext.getSuite().getName(), testContext.getIncludedGroups());
+            citrus.afterSuite(Reporter.getCurrentTestResult().getTestContext().getSuite().getName(),
+                    Reporter.getCurrentTestResult().getTestContext().getIncludedGroups());
         }
     }
 
     /**
      * Subclasses may add after suite actions on the provided context.
+     *
      * @param context the Citrus context.
      */
     protected void afterSuite(CitrusContext context) {
@@ -259,7 +273,7 @@ public class TestNGCitrusSpringSupport extends AbstractTestNGSpringContextTests
 
     /**
      * Prepares the test context.
-     *
+     * <p>
      * Provides a hook for test context modifications before the test gets executed.
      *
      * @param testContext the test context.
@@ -273,6 +287,7 @@ public class TestNGCitrusSpringSupport extends AbstractTestNGSpringContextTests
      * Creates new test loader which has TestNG test annotations set for test execution. Only
      * suitable for tests that get created at runtime through factory method. Subclasses
      * may overwrite this in order to provide custom test loader with custom test annotations set.
+     *
      * @param testName
      * @param packageName
      * @return
@@ -293,6 +308,7 @@ public class TestNGCitrusSpringSupport extends AbstractTestNGSpringContextTests
 
     /**
      * Constructs the test case to execute.
+     *
      * @return
      */
     protected TestCase getTestCase() {

--- a/utils/citrus-test-support/src/main/java/com/consol/citrus/testng/AbstractTestNGUnitTest.java
+++ b/utils/citrus-test-support/src/main/java/com/consol/citrus/testng/AbstractTestNGUnitTest.java
@@ -23,7 +23,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
 import org.springframework.util.Assert;
-import org.testng.ITestContext;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeSuite;
 
@@ -47,11 +46,10 @@ public abstract class AbstractTestNGUnitTest extends AbstractTestNGSpringContext
 
     /**
      * Runs tasks before test suite.
-     * @param testContext the test context.
      * @throws Exception on error.
      */
     @BeforeSuite(alwaysRun = true)
-    public void beforeSuite(ITestContext testContext) throws Exception {
+    public void beforeSuite() throws Exception {
         springTestContextPrepareTestInstance();
         Assert.notNull(applicationContext, "Missing proper application context in before suite initialization");
     }

--- a/vintage/citrus-java-dsl/src/test/java/com/consol/citrus/dsl/UnitTestSupport.java
+++ b/vintage/citrus-java-dsl/src/test/java/com/consol/citrus/dsl/UnitTestSupport.java
@@ -13,10 +13,12 @@ import com.consol.citrus.report.JUnitReporter;
 import com.consol.citrus.testng.AbstractTestNGUnitTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
-import org.testng.ITestContext;
+import org.testng.Reporter;
 import org.testng.annotations.AfterSuite;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeSuite;
+
+import static java.util.Objects.nonNull;
 
 /**
  * @author Christoph Deppisch
@@ -41,23 +43,23 @@ public class UnitTestSupport extends AbstractTestNGUnitTest {
     /** Citrus instance */
     protected Citrus citrus;
 
-    @BeforeSuite(alwaysRun = true)
     @Override
-    public void beforeSuite(ITestContext testContext) throws Exception {
-        super.beforeSuite(testContext);
+    @BeforeSuite(alwaysRun = true)
+    public void beforeSuite() throws Exception {
+        super.beforeSuite();
 
         citrus = Citrus.newInstance(new CitrusSpringContextProvider(applicationContext));
-        citrus.beforeSuite(testContext.getSuite().getName(), testContext.getIncludedGroups());
+        citrus.beforeSuite(
+                Reporter.getCurrentTestResult().getTestContext().getSuite().getName(),
+                Reporter.getCurrentTestResult().getTestContext().getIncludedGroups());
     }
 
-    /**
-     * Runs tasks after test suite.
-     * @param testContext the test context.
-     */
     @AfterSuite(alwaysRun = true)
-    public void afterSuite(ITestContext testContext) {
-        if (citrus != null) {
-            citrus.afterSuite(testContext.getSuite().getName(), testContext.getIncludedGroups());
+    public void afterSuite() {
+        if (nonNull(citrus)) {
+            citrus.afterSuite(
+                    Reporter.getCurrentTestResult().getTestContext().getSuite().getName(),
+                    Reporter.getCurrentTestResult().getTestContext().getIncludedGroups());
         }
     }
 


### PR DESCRIPTION
backport fix of a4a1a5daec800cfc070c9df1135db958df31e1ad for citrus `v3.4.0`. bug has originally been reported in #1090.

closes #1146.

[`support/3.0.0`](https://github.com/citrusframework/citrus/tree/support/3.0.0) is at e8382c98e49b3d14476f31ae5aa7980161d150f6, which is [`v3.4.0`](https://github.com/citrusframework/citrus/releases/tag/v3.4.0)