### PR TITLE
fix(citrus-http): accept status code interface

### DIFF
--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/actions/HttpClientActionBuilder.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/actions/HttpClientActionBuilder.java
@@ -24,7 +24,7 @@ import org.citrusframework.spi.ReferenceResolverAware;
 import org.citrusframework.util.ObjectHelper;
 import org.citrusframework.util.StringUtils;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 
 /**
  * Action executes http client operations such as sending requests and receiving responses.
@@ -250,7 +250,7 @@ public class HttpClientActionBuilder implements TestActionBuilder.DelegatingTest
          * Generic response builder for expecting response messages on client with response status code.
          * @return
          */
-        public HttpClientResponseActionBuilder response(HttpStatus status) {
+        public HttpClientResponseActionBuilder response(HttpStatusCode status) {
             HttpClientResponseActionBuilder builder = new HttpClientResponseActionBuilder();
             if (httpClient != null) {
                 builder.endpoint(httpClient);

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/actions/HttpClientResponseActionBuilder.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/actions/HttpClientResponseActionBuilder.java
@@ -16,8 +16,6 @@
 
 package org.citrusframework.http.actions;
 
-import java.util.Optional;
-
 import jakarta.servlet.http.Cookie;
 import org.citrusframework.actions.ReceiveMessageAction;
 import org.citrusframework.http.message.HttpMessage;
@@ -26,8 +24,9 @@ import org.citrusframework.http.message.HttpMessageUtils;
 import org.citrusframework.message.Message;
 import org.citrusframework.message.MessageBuilder;
 import org.citrusframework.message.builder.ReceiveMessageBuilderSupport;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
+
+import java.util.Optional;
 
 /**
  * @author Christoph Deppisch
@@ -98,7 +97,7 @@ public class HttpClientResponseActionBuilder extends ReceiveMessageAction.Receiv
          * @param status
          * @return
          */
-        public HttpMessageBuilderSupport status(HttpStatus status) {
+        public HttpMessageBuilderSupport status(HttpStatusCode status) {
             httpMessage.status(status);
             return this;
         }

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/actions/HttpClientActionBuilderTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/actions/HttpClientActionBuilderTest.java
@@ -1,0 +1,58 @@
+package org.citrusframework.http.actions;
+
+import org.citrusframework.http.client.HttpClient;
+import org.citrusframework.http.message.HttpMessage;
+import org.springframework.http.HttpStatusCode;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.http.message.HttpMessageHeaders.HTTP_REASON_PHRASE;
+import static org.citrusframework.http.message.HttpMessageHeaders.HTTP_STATUS_CODE;
+import static org.mockito.Mockito.mock;
+import static org.springframework.http.HttpStatus.OK;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertNotNull;
+
+public class HttpClientActionBuilderTest {
+
+    private HttpClient httpClientMock;
+
+    @BeforeMethod
+    void beforeMethodSetup() {
+        httpClientMock = mock(HttpClient.class);
+    }
+
+    @Test
+    public void responseWithHttpStatus() {
+        var fixture = new HttpClientActionBuilder(httpClientMock)
+                .receive()
+                .response(OK) // Method under test
+                .message();
+
+        var httpMessage = (HttpMessage) getField(fixture, HttpClientResponseActionBuilder.HttpMessageBuilderSupport.class, "httpMessage");
+        assertNotNull(httpMessage);
+
+        var headers = httpMessage.getHeaders();
+        assertEquals(OK.value(), headers.get(HTTP_STATUS_CODE));
+        assertEquals(OK.name(), headers.get(HTTP_REASON_PHRASE));
+    }
+
+    @Test
+    public void responseWithHttpStatusCode() {
+        var code = 123;
+
+        var fixture = new HttpClientActionBuilder(httpClientMock)
+                .receive()
+                .response(HttpStatusCode.valueOf(code)) // Method under test
+                .message();
+
+        var httpMessage = (HttpMessage) getField(fixture, HttpClientResponseActionBuilder.HttpMessageBuilderSupport.class, "httpMessage");
+        assertNotNull(httpMessage);
+
+        var headers = httpMessage.getHeaders();
+        assertEquals(code, headers.get(HTTP_STATUS_CODE));
+        assertFalse(headers.containsKey(HTTP_REASON_PHRASE));
+    }
+}

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/actions/HttpClientResponseActionBuilderTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/actions/HttpClientResponseActionBuilderTest.java
@@ -1,0 +1,43 @@
+package org.citrusframework.http.actions;
+
+import org.citrusframework.http.message.HttpMessage;
+import org.citrusframework.message.MessageBuilder;
+import org.springframework.http.HttpStatusCode;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.springframework.http.HttpStatus.OK;
+
+public class HttpClientResponseActionBuilderTest {
+
+    private HttpMessage httpMessageMock;
+    private MessageBuilder messageBuilderMock;
+
+    @BeforeMethod
+    void beforeMethodSetup() {
+        httpMessageMock = mock(HttpMessage.class);
+        messageBuilderMock = mock(MessageBuilder.class);
+    }
+
+    @Test
+    public void statusFromHttpStatus() {
+        new HttpClientResponseActionBuilder(messageBuilderMock, httpMessageMock)
+                .message()
+                .status(OK); // Method under test
+
+        verify(httpMessageMock).status(OK);
+    }
+
+    @Test
+    public void statusFromHttpStatusCode() {
+        var httpStatusCode = HttpStatusCode.valueOf(123);
+
+        new HttpClientResponseActionBuilder(messageBuilderMock, httpMessageMock)
+                .message()
+                .status(httpStatusCode); // Method under test
+
+        verify(httpMessageMock).status(httpStatusCode);
+    }
+}


### PR DESCRIPTION
Http Message actions should use interface `HttpStatusCode` instead of concrete implementation `HttpStatus`. otherwise, custom response codes are not allowed.