### PR TITLE
Fix: Use ISO date format for random JSON property values (OpenAPI)

### DIFF
--- a/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/OpenApiTestDataGenerator.java
+++ b/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/OpenApiTestDataGenerator.java
@@ -32,6 +32,7 @@ import org.springframework.util.StringUtils;
  * enforce the specification rules.
  *
  * @author Christoph Deppisch
+ * @author Ralf Ueberfuhr
  */
 public class OpenApiTestDataGenerator {
 
@@ -119,7 +120,7 @@ public class OpenApiTestDataGenerator {
             }
 
             if (schema.format != null && schema.format.equals("date")) {
-                payload.append("citrus:currentDate()");
+                payload.append("citrus:currentDate('yyyy-MM-dd')");
             } else if (schema.format != null && schema.format.equals("date-time")) {
                 payload.append("citrus:currentDate('yyyy-MM-dd'T'hh:mm:ss')");
             } else if (StringUtils.hasText(schema.pattern)) {


### PR DESCRIPTION
The `OpenApiTestDataGenerator` creates random values for JOSN properties. When a property has format `date`, the function `citrus:currentDate()` was used, which is wrong, because it leads to an invalid date pattern. I fixed this by specifying the correct pattern.

Resolves #1166 