### PR TITLE
fix: Make tests loadable even from within jar (needed for citrus-remote update to Citrus version 4)

### DIFF
--- a/core/citrus-base/src/main/java/org/citrusframework/main/scan/AbstractTestScanner.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/main/scan/AbstractTestScanner.java
@@ -16,8 +16,10 @@
 
 package org.citrusframework.main.scan;
 
+import java.util.Arrays;
+import java.util.Set;
 import java.util.regex.Pattern;
-import java.util.stream.Stream;
+import java.util.stream.Collectors;
 
 /**
  * @author Christoph Deppisch
@@ -27,6 +29,7 @@ public abstract class AbstractTestScanner implements TestScanner {
 
     /** Test name patterns to include */
     private final String[] includes;
+    private final Set<Pattern> includePatterns;
 
     public AbstractTestScanner(String... includes) {
         if (includes.length > 0) {
@@ -34,12 +37,14 @@ public abstract class AbstractTestScanner implements TestScanner {
         } else {
             this.includes = new String[] { "^.*IT$", "^.*ITCase$", "^IT.*$" };
         }
+        includePatterns = Arrays.stream(includes)
+            .map(Pattern::compile)
+            .collect(Collectors.toSet());
     }
 
     protected boolean isIncluded(String className) {
-        return Stream.of(getIncludes())
+        return getIncludePatterns().stream()
                 .parallel()
-                .map(Pattern::compile)
                 .anyMatch(pattern -> pattern.matcher(className).matches());
     }
 
@@ -50,5 +55,14 @@ public abstract class AbstractTestScanner implements TestScanner {
      */
     public String[] getIncludes() {
         return includes;
+    }
+
+    /**
+     * Gets the include patterns.
+     *
+     * @return
+     */
+    public Set<Pattern> getIncludePatterns() {
+        return includePatterns;
     }
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/main/scan/JarFileTestScanner.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/main/scan/JarFileTestScanner.java
@@ -49,14 +49,19 @@ public class JarFileTestScanner extends AbstractTestScanner {
 
     @Override
     public List<TestClass> findTestsInPackage(String packageToScan) {
+        boolean packageIsEmpty = packageToScan.isEmpty();
+        String packageAsPath = packageToScan.replace(".", "/");
         List<TestClass> testClasses = new ArrayList<>();
         if (artifact != null && artifact.isFile()) {
             try (JarFile jar = new JarFile(artifact)) {
                 for (Enumeration<JarEntry> entries = jar.entries(); entries.hasMoreElements();) {
                     JarEntry entry = entries.nextElement();
                     String className = FileUtils.getBaseName(entry.getName()).replace( "/", "." );
-                    if (packageToScan.replace( ".", "/" ).startsWith(entry.getName()) && isIncluded(className)) {
-                        logger.info("Found test class candidate in test jar file: " +  entry.getName());
+                    boolean isTestClass = (packageIsEmpty || packageAsPath.startsWith(entry.getName()))
+                        && entry.getName().endsWith(".class")
+                        && isIncluded(className);
+                    if (isTestClass) {
+                        logger.info("Found test class candidate in test jar file: {}",  entry.getName());
                         testClasses.add(TestClass.fromString(className));
                     }
                 }


### PR DESCRIPTION
While updating `citrus-remote` to Citrus version 4 (https://github.com/citrusframework/citrus-remote/issues/5), we encountered the problem of test classes within a JAR not being loaded.

These changes have been tested by:

1. Installing: https://github.com/maletic/citrus/tree/fix-test-classes-not-found-in-jar
2. Installing: https://github.com/maletic/citrus-remote/tree/update-citrus-remote-to-newest
3. Running: https://github.com/maletic/citrus-playground/tree/update-citrus-remote