### PR TITLE
fix(#1199): respect custom mailserver on startup

### DIFF
--- a/endpoints/citrus-mail/src/test/java/org/citrusframework/mail/server/MailServerTest.java
+++ b/endpoints/citrus-mail/src/test/java/org/citrusframework/mail/server/MailServerTest.java
@@ -16,12 +16,9 @@
 
 package org.citrusframework.mail.server;
 
-import java.io.IOException;
-import java.text.SimpleDateFormat;
-import java.util.Collections;
-import java.util.Date;
-
+import com.icegreen.greenmail.Managers;
 import com.icegreen.greenmail.mail.MailAddress;
+import com.icegreen.greenmail.util.GreenMail;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import org.citrusframework.endpoint.EndpointAdapter;
@@ -33,15 +30,18 @@ import org.citrusframework.spi.Resources;
 import org.citrusframework.util.FileUtils;
 import org.citrusframework.util.TestUtils;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.when;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Collections;
+import java.util.Date;
+
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.openMocks;
+import static org.testng.Assert.*;
 
 /**
  * @author Christoph Deppisch
@@ -53,39 +53,52 @@ public class MailServerTest {
     @Mock
     private EndpointAdapter endpointAdapterMock;
 
+    @Mock
+    private GreenMail greenMailMock;
+
     private MailServer fixture;
 
     @BeforeMethod
     void beforeMethodSetup() {
-        mockitoContext = MockitoAnnotations.openMocks(this);
+        mockitoContext = openMocks(this);
 
         fixture = new MailServer();
         fixture.setEndpointAdapter(endpointAdapterMock);
     }
 
     @Test
-    void testTextMessage() throws IOException, MessagingException {
+    void startupRespectsCustomGreenMail() {
+        doReturn(new Managers()).when(greenMailMock).getManagers();
+        fixture.setSmtpServer(greenMailMock);
+
+        fixture.startup();
+
+        assertEquals(fixture.getSmtpServer(), greenMailMock);
+    }
+
+    @Test
+    void testTextMessage() throws MessagingException {
         doAnswer(invocation -> {
             Message message = (Message) invocation.getArguments()[0];
 
-            Assert.assertNotNull(message.getPayload());
-            Assert.assertNull(message.getHeader(CitrusMailMessageHeaders.MAIL_MESSAGE_ID));
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_FROM), "foo@mail.com");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_TO), "bar@mail.com,copy@mail.com");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_CC), "foobar@mail.com");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_BCC), "secret@mail.com");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_REPLY_TO), "reply@mail.com");
-            Assert.assertNull(message.getHeader(CitrusMailMessageHeaders.MAIL_DATE));
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_SUBJECT), "Testmail");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_CONTENT_TYPE), "text/plain");
+            assertNotNull(message.getPayload());
+            assertNull(message.getHeader(CitrusMailMessageHeaders.MAIL_MESSAGE_ID));
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_FROM), "foo@mail.com");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_TO), "bar@mail.com,copy@mail.com");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_CC), "foobar@mail.com");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_BCC), "secret@mail.com");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_REPLY_TO), "reply@mail.com");
+            assertNull(message.getHeader(CitrusMailMessageHeaders.MAIL_DATE));
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_SUBJECT), "Testmail");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_CONTENT_TYPE), "text/plain");
 
             try {
-                Assert.assertEquals(
-                    message.getPayload(String.class).replaceAll("\\s", ""),
-                    FileUtils.readToString(Resources.create("text_mail.xml", MailServer.class)).replaceAll("\\s", "")
+                assertEquals(
+                        message.getPayload(String.class).replaceAll("\\s", ""),
+                        FileUtils.readToString(Resources.create("text_mail.xml", MailServer.class)).replaceAll("\\s", "")
                 );
             } catch (IOException e) {
-                Assert.fail(e.getMessage());
+                fail(e.getMessage());
             }
 
             return null;
@@ -96,43 +109,43 @@ public class MailServerTest {
         fixture.deliver(message);
 
         // Because of autoAccept = true
-        Assert.assertTrue(fixture.accept("foo@mail.com", Collections.singletonList(new MailAddress("bar@mail.com"))));
+        assertTrue(fixture.accept("foo@mail.com", Collections.singletonList(new MailAddress("bar@mail.com"))));
     }
 
     @Test
-    void testMultipartMessage() throws IOException, MessagingException {
+    void testMultipartMessage() throws MessagingException {
         final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
 
         doAnswer(invocation -> {
             Message message = (Message) invocation.getArguments()[0];
 
-            Assert.assertNotNull(message.getPayload());
-            Assert.assertNull(message.getHeader(CitrusMailMessageHeaders.MAIL_MESSAGE_ID));
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_FROM), "foo@mail.com");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_TO), "bar@mail.com");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_CC), "");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_BCC), "");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_REPLY_TO), "foo@mail.com");
+            assertNotNull(message.getPayload());
+            assertNull(message.getHeader(CitrusMailMessageHeaders.MAIL_MESSAGE_ID));
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_FROM), "foo@mail.com");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_TO), "bar@mail.com");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_CC), "");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_BCC), "");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_REPLY_TO), "foo@mail.com");
 
             // compare the Date as a Date rather than a String, otherwise this test fails outside the "+1" timezone
-            Date actualDate = dateFormat.parse((String)message.getHeader(CitrusMailMessageHeaders.MAIL_DATE));
+            Date actualDate = dateFormat.parse((String) message.getHeader(CitrusMailMessageHeaders.MAIL_DATE));
             Date expectedDateDate = dateFormat.parse("2006-10-26T13:10:50+0200");
-            Assert.assertEquals(actualDate, expectedDateDate);
+            assertEquals(actualDate, expectedDateDate);
 
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_SUBJECT), "Multipart Testmail");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_CONTENT_TYPE), "multipart/mixed");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_SUBJECT), "Multipart Testmail");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_CONTENT_TYPE), "multipart/mixed");
 
             try {
-                Assert.assertEquals(
+                assertEquals(
                         TestUtils.normalizeLineEndings(
-                            message.getPayload(String.class).replaceAll("\\s", "")
+                                message.getPayload(String.class).replaceAll("\\s", "")
                         ),
                         TestUtils.normalizeLineEndings(
-                            FileUtils.readToString(Resources.create("multipart_mail.xml", MailServer.class)).replaceAll("\\s", "")
+                                FileUtils.readToString(Resources.create("multipart_mail.xml", MailServer.class)).replaceAll("\\s", "")
                         )
                 );
             } catch (IOException e) {
-                Assert.fail(e.getMessage());
+                fail(e.getMessage());
             }
 
             return null;
@@ -142,39 +155,39 @@ public class MailServerTest {
         fixture.deliver(message);
 
         // Because of autoAccept = true
-        Assert.assertTrue(fixture.accept("foo@mail.com", Collections.singletonList(new MailAddress("bar@mail.com"))));
+        assertTrue(fixture.accept("foo@mail.com", Collections.singletonList(new MailAddress("bar@mail.com"))));
     }
 
     @Test
-    void testBinaryMessage() throws IOException, MessagingException {
+    void testBinaryMessage() throws MessagingException {
         final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
 
         doAnswer(invocation -> {
             Message message = (Message) invocation.getArguments()[0];
 
-            Assert.assertNotNull(message.getPayload());
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_MESSAGE_ID), "<52A1988D.2060403@foo.bar>");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_FROM), "Foo <foo@mail.com>");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_TO), "bar@mail.com");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_CC), "FooBar <foobar@mail.com>");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_BCC), "");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_REPLY_TO), "Foo <foo@mail.com>");
+            assertNotNull(message.getPayload());
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_MESSAGE_ID), "<52A1988D.2060403@foo.bar>");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_FROM), "Foo <foo@mail.com>");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_TO), "bar@mail.com");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_CC), "FooBar <foobar@mail.com>");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_BCC), "");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_REPLY_TO), "Foo <foo@mail.com>");
 
             // compare the Date as a Date rather than a String, otherwsie this test fails outside the "+1" timezone
-            Date actualDate = dateFormat.parse((String)message.getHeader(CitrusMailMessageHeaders.MAIL_DATE));
+            Date actualDate = dateFormat.parse((String) message.getHeader(CitrusMailMessageHeaders.MAIL_DATE));
             Date expectedDateDate = dateFormat.parse("2013-12-06T10:27:41+0100");
-            Assert.assertEquals(actualDate, expectedDateDate);
+            assertEquals(actualDate, expectedDateDate);
 
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_SUBJECT), "This is brand_logo.png");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_CONTENT_TYPE), "multipart/mixed");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_SUBJECT), "This is brand_logo.png");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_CONTENT_TYPE), "multipart/mixed");
 
             try {
-                Assert.assertEquals(
+                assertEquals(
                         message.getPayload(String.class).replaceAll("\\s", ""),
                         FileUtils.readToString(Resources.create("binary_mail.xml", MailServer.class)).replaceAll("\\s", "")
                 );
             } catch (IOException e) {
-                Assert.fail(e.getMessage());
+                fail(e.getMessage());
             }
 
             return null;
@@ -184,7 +197,7 @@ public class MailServerTest {
         fixture.deliver(message);
 
         // Because of autoAccept = true
-        Assert.assertTrue(fixture.accept("foo@mail.com", Collections.singletonList(new MailAddress("bar@mail.com"))));
+        assertTrue(fixture.accept("foo@mail.com", Collections.singletonList(new MailAddress("bar@mail.com"))));
     }
 
     @Test
@@ -192,24 +205,24 @@ public class MailServerTest {
         doAnswer(invocation -> {
             Message message = (Message) invocation.getArguments()[0];
 
-            Assert.assertNotNull(message.getPayload());
+            assertNotNull(message.getPayload());
 
             try {
-                Assert.assertEquals(
-                    message.getPayload(String.class).replaceAll("\\s", ""),
-                    FileUtils.readToString(Resources.create("accept-request.xml", MailServer.class)).replaceAll("\\s", "")
+                assertEquals(
+                        message.getPayload(String.class).replaceAll("\\s", ""),
+                        FileUtils.readToString(Resources.create("accept-request.xml", MailServer.class)).replaceAll("\\s", "")
                 );
             } catch (IOException e) {
-                Assert.fail(e.getMessage());
+                fail(e.getMessage());
             }
 
             return new DefaultMessage(
-                FileUtils.readToString(Resources.create("accept-response.xml",MailServer.class))
+                    FileUtils.readToString(Resources.create("accept-response.xml", MailServer.class))
             );
         }).when(endpointAdapterMock).handleMessage(any(Message.class));
 
         fixture.setAutoAccept(false);
-        Assert.assertTrue(fixture.accept("foo@mail.com", Collections.singletonList(new MailAddress("bar@mail.com"))));
+        assertTrue(fixture.accept("foo@mail.com", Collections.singletonList(new MailAddress("bar@mail.com"))));
     }
 
     @Test
@@ -219,9 +232,9 @@ public class MailServerTest {
 
         try {
             fixture.accept("foo@mail.com", Collections.singletonList(new MailAddress("bar@mail.com")));
-            Assert.fail("Missing runtime exception due to missing accept response");
+            fail("Missing runtime exception due to missing accept response");
         } catch (CitrusRuntimeException e) {
-            Assert.assertTrue(e.getMessage().startsWith("Did not receive accept response"));
+            assertTrue(e.getMessage().startsWith("Did not receive accept response"));
         }
     }
 
@@ -232,37 +245,37 @@ public class MailServerTest {
 
         try {
             fixture.accept("foo@mail.com", Collections.singletonList(new MailAddress("bar@mail.com")));
-            Assert.fail("Missing runtime exception due to invalid accept response");
+            fail("Missing runtime exception due to invalid accept response");
         } catch (CitrusRuntimeException e) {
-            Assert.assertTrue(e.getMessage().startsWith("Unable to read accept response"));
+            assertTrue(e.getMessage().startsWith("Unable to read accept response"));
         }
     }
 
     @Test
-    void testTextMessageSplitting() throws IOException, MessagingException {
+    void testTextMessageSplitting() throws MessagingException {
         fixture.setSplitMultipart(true);
 
         doAnswer(invocation -> {
             Message message = (Message) invocation.getArguments()[0];
 
-            Assert.assertNotNull(message.getPayload());
-            Assert.assertNull(message.getHeader(CitrusMailMessageHeaders.MAIL_MESSAGE_ID));
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_FROM), "foo@mail.com");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_TO), "bar@mail.com,copy@mail.com");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_CC), "foobar@mail.com");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_BCC), "secret@mail.com");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_REPLY_TO), "reply@mail.com");
-            Assert.assertNull(message.getHeader(CitrusMailMessageHeaders.MAIL_DATE));
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_SUBJECT), "Testmail");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_CONTENT_TYPE), "text/plain");
+            assertNotNull(message.getPayload());
+            assertNull(message.getHeader(CitrusMailMessageHeaders.MAIL_MESSAGE_ID));
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_FROM), "foo@mail.com");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_TO), "bar@mail.com,copy@mail.com");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_CC), "foobar@mail.com");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_BCC), "secret@mail.com");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_REPLY_TO), "reply@mail.com");
+            assertNull(message.getHeader(CitrusMailMessageHeaders.MAIL_DATE));
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_SUBJECT), "Testmail");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_CONTENT_TYPE), "text/plain");
 
             try {
-                Assert.assertEquals(
-                    message.getPayload(String.class).replaceAll("\\s", ""),
-                    FileUtils.readToString(Resources.create("text_mail.xml", MailServer.class)).replaceAll("\\s", "")
+                assertEquals(
+                        message.getPayload(String.class).replaceAll("\\s", ""),
+                        FileUtils.readToString(Resources.create("text_mail.xml", MailServer.class)).replaceAll("\\s", "")
                 );
             } catch (IOException e) {
-                Assert.fail(e.getMessage());
+                fail(e.getMessage());
             }
 
             return null;
@@ -272,11 +285,11 @@ public class MailServerTest {
         fixture.deliver(message);
 
         // Because of autoAccept = true
-        Assert.assertTrue(fixture.accept("foo@mail.com", Collections.singletonList(new MailAddress("bar@mail.com"))));
+        assertTrue(fixture.accept("foo@mail.com", Collections.singletonList(new MailAddress("bar@mail.com"))));
     }
 
     @Test
-    void testMultipartMessageSplitting() throws IOException, MessagingException {
+    void testMultipartMessageSplitting() throws MessagingException {
         final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
 
         fixture.setSplitMultipart(true);
@@ -284,63 +297,63 @@ public class MailServerTest {
         doAnswer(invocation -> {
             Message message = (Message) invocation.getArguments()[0];
 
-            Assert.assertNotNull(message.getPayload());
-            Assert.assertNull(message.getHeader(CitrusMailMessageHeaders.MAIL_MESSAGE_ID));
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_FROM), "foo@mail.com");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_TO), "bar@mail.com");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_CC), "");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_BCC), "");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_REPLY_TO), "foo@mail.com");
+            assertNotNull(message.getPayload());
+            assertNull(message.getHeader(CitrusMailMessageHeaders.MAIL_MESSAGE_ID));
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_FROM), "foo@mail.com");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_TO), "bar@mail.com");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_CC), "");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_BCC), "");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_REPLY_TO), "foo@mail.com");
 
             // compare dates as Date rather than String otherwise this test fails outside the "+1" timezone
-            Date actualDate = dateFormat.parse((String)message.getHeader(CitrusMailMessageHeaders.MAIL_DATE));
+            Date actualDate = dateFormat.parse((String) message.getHeader(CitrusMailMessageHeaders.MAIL_DATE));
             Date expectedDateDate = dateFormat.parse("2006-10-26T13:10:50+0200");
-            Assert.assertEquals(actualDate, expectedDateDate);
+            assertEquals(actualDate, expectedDateDate);
 
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_SUBJECT), "Multipart Testmail");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_CONTENT_TYPE), "text/plain; charset=utf-8");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_SUBJECT), "Multipart Testmail");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_CONTENT_TYPE), "text/plain; charset=utf-8");
 
             try {
-                Assert.assertEquals(
-                    message.getPayload(String.class).replaceAll("\\s", ""),
-                    FileUtils.readToString(Resources.create("multipart_mail_1.xml", MailServer.class)).replaceAll("\\s", "")
+                assertEquals(
+                        message.getPayload(String.class).replaceAll("\\s", ""),
+                        FileUtils.readToString(Resources.create("multipart_mail_1.xml", MailServer.class)).replaceAll("\\s", "")
                 );
             } catch (IOException e) {
-                Assert.fail(e.getMessage());
+                fail(e.getMessage());
             }
 
             return null;
         }).doAnswer(invocation -> {
             Message message = (Message) invocation.getArguments()[0];
 
-            Assert.assertNotNull(message.getPayload());
-            Assert.assertNull(message.getHeader(CitrusMailMessageHeaders.MAIL_MESSAGE_ID));
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_FROM), "foo@mail.com");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_TO), "bar@mail.com");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_CC), "");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_BCC), "");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_REPLY_TO), "foo@mail.com");
+            assertNotNull(message.getPayload());
+            assertNull(message.getHeader(CitrusMailMessageHeaders.MAIL_MESSAGE_ID));
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_FROM), "foo@mail.com");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_TO), "bar@mail.com");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_CC), "");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_BCC), "");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_REPLY_TO), "foo@mail.com");
 
             // compare dates as Date rather than String otherwise this test fails outside the "+1" timezone
-            Date actualDate = dateFormat.parse((String)message.getHeader(CitrusMailMessageHeaders.MAIL_DATE));
+            Date actualDate = dateFormat.parse((String) message.getHeader(CitrusMailMessageHeaders.MAIL_DATE));
             Date expectedDateDate = dateFormat.parse("2006-10-26T13:10:50+0200");
-            Assert.assertEquals(actualDate, expectedDateDate);
+            assertEquals(actualDate, expectedDateDate);
 
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_SUBJECT), "Multipart Testmail");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_CONTENT_TYPE), "text/html; charset=utf-8");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_FILENAME), "index.html");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_SUBJECT), "Multipart Testmail");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_CONTENT_TYPE), "text/html; charset=utf-8");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_FILENAME), "index.html");
 
             try {
-                Assert.assertEquals(
+                assertEquals(
                         TestUtils.normalizeLineEndings(
-                            message.getPayload(String.class).replaceAll("\\s", "")
+                                message.getPayload(String.class).replaceAll("\\s", "")
                         ),
                         TestUtils.normalizeLineEndings(
-                            FileUtils.readToString(Resources.create("multipart_mail_2.xml", MailServer.class)).replaceAll("\\s", "")
+                                FileUtils.readToString(Resources.create("multipart_mail_2.xml", MailServer.class)).replaceAll("\\s", "")
                         )
                 );
             } catch (IOException e) {
-                Assert.fail(e.getMessage());
+                fail(e.getMessage());
             }
 
             return null;
@@ -350,11 +363,11 @@ public class MailServerTest {
         fixture.deliver(message);
 
         // Because of autoAccept = true
-        Assert.assertTrue(fixture.accept("foo@mail.com", Collections.singletonList(new MailAddress("bar@mail.com"))));
+        assertTrue(fixture.accept("foo@mail.com", Collections.singletonList(new MailAddress("bar@mail.com"))));
     }
 
     @Test
-    void testBinaryMessageSplitting() throws IOException, MessagingException {
+    void testBinaryMessageSplitting() throws MessagingException {
         final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
 
         fixture.setSplitMultipart(true);
@@ -362,59 +375,59 @@ public class MailServerTest {
         doAnswer(invocation -> {
             Message message = (Message) invocation.getArguments()[0];
 
-            Assert.assertNotNull(message.getPayload());
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_MESSAGE_ID), "<52A1988D.2060403@foo.bar>");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_FROM), "Foo <foo@mail.com>");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_TO), "bar@mail.com");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_CC), "FooBar <foobar@mail.com>");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_BCC), "");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_REPLY_TO), "Foo <foo@mail.com>");
+            assertNotNull(message.getPayload());
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_MESSAGE_ID), "<52A1988D.2060403@foo.bar>");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_FROM), "Foo <foo@mail.com>");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_TO), "bar@mail.com");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_CC), "FooBar <foobar@mail.com>");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_BCC), "");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_REPLY_TO), "Foo <foo@mail.com>");
 
             // compare dates as Date rather than String otherwise this test fails outside the "+1" timezone
-            Date actualDate = dateFormat.parse((String)message.getHeader(CitrusMailMessageHeaders.MAIL_DATE));
+            Date actualDate = dateFormat.parse((String) message.getHeader(CitrusMailMessageHeaders.MAIL_DATE));
             Date expectedDateDate = dateFormat.parse("2013-12-06T10:27:41+0100");
-            Assert.assertEquals(actualDate, expectedDateDate);
+            assertEquals(actualDate, expectedDateDate);
 
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_SUBJECT), "This is brand_logo.png");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_CONTENT_TYPE), "text/plain; charset=ISO-8859-15; format=flowed");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_SUBJECT), "This is brand_logo.png");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_CONTENT_TYPE), "text/plain; charset=ISO-8859-15; format=flowed");
 
             try {
-                Assert.assertEquals(
-                    message.getPayload(String.class).replaceAll("\\s", ""),
-                    FileUtils.readToString(Resources.create("binary_mail_1.xml", MailServer.class)).replaceAll("\\s", "")
+                assertEquals(
+                        message.getPayload(String.class).replaceAll("\\s", ""),
+                        FileUtils.readToString(Resources.create("binary_mail_1.xml", MailServer.class)).replaceAll("\\s", "")
                 );
             } catch (IOException e) {
-                Assert.fail(e.getMessage());
+                fail(e.getMessage());
             }
 
             return null;
         }).doAnswer(invocation -> {
             Message message = (Message) invocation.getArguments()[0];
 
-            Assert.assertNotNull(message.getPayload());
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_MESSAGE_ID), "<52A1988D.2060403@foo.bar>");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_FROM), "Foo <foo@mail.com>");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_TO), "bar@mail.com");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_CC), "FooBar <foobar@mail.com>");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_BCC), "");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_REPLY_TO), "Foo <foo@mail.com>");
+            assertNotNull(message.getPayload());
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_MESSAGE_ID), "<52A1988D.2060403@foo.bar>");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_FROM), "Foo <foo@mail.com>");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_TO), "bar@mail.com");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_CC), "FooBar <foobar@mail.com>");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_BCC), "");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_REPLY_TO), "Foo <foo@mail.com>");
 
             // compare dates as Date rather than String otherwise this test fails outside the "+1" timezone
-            Date actualDate = dateFormat.parse((String)message.getHeader(CitrusMailMessageHeaders.MAIL_DATE));
+            Date actualDate = dateFormat.parse((String) message.getHeader(CitrusMailMessageHeaders.MAIL_DATE));
             Date expectedDateDate = dateFormat.parse("2013-12-06T10:27:41+0100");
-            Assert.assertEquals(actualDate, expectedDateDate);
+            assertEquals(actualDate, expectedDateDate);
 
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_SUBJECT), "This is brand_logo.png");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_CONTENT_TYPE), "image/png");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_FILENAME), "brand_logo.png");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_SUBJECT), "This is brand_logo.png");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_CONTENT_TYPE), "image/png");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_FILENAME), "brand_logo.png");
 
             try {
-                Assert.assertEquals(
-                    message.getPayload(String.class).replaceAll("\\s", ""),
-                    FileUtils.readToString(Resources.create("binary_mail_2.xml", MailServer.class)).replaceAll("\\s", "")
+                assertEquals(
+                        message.getPayload(String.class).replaceAll("\\s", ""),
+                        FileUtils.readToString(Resources.create("binary_mail_2.xml", MailServer.class)).replaceAll("\\s", "")
                 );
             } catch (IOException e) {
-                Assert.fail(e.getMessage());
+                fail(e.getMessage());
             }
 
             return null;
@@ -424,32 +437,32 @@ public class MailServerTest {
         fixture.deliver(message);
 
         // Because of autoAccept = true
-        Assert.assertTrue(fixture.accept("foo@mail.com", Collections.singletonList(new MailAddress("bar@mail.com"))));
+        assertTrue(fixture.accept("foo@mail.com", Collections.singletonList(new MailAddress("bar@mail.com"))));
     }
 
     @Test
-    void testSimulateError() throws IOException, MessagingException {
+    void testSimulateError() throws MessagingException {
         doAnswer(invocation -> {
             Message message = (Message) invocation.getArguments()[0];
 
-            Assert.assertNotNull(message.getPayload());
-            Assert.assertNull(message.getHeader(CitrusMailMessageHeaders.MAIL_MESSAGE_ID));
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_FROM), "foo@mail.com");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_TO), "bar@mail.com,copy@mail.com");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_CC), "foobar@mail.com");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_BCC), "secret@mail.com");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_REPLY_TO), "reply@mail.com");
-            Assert.assertNull(message.getHeader(CitrusMailMessageHeaders.MAIL_DATE));
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_SUBJECT), "Testmail");
-            Assert.assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_CONTENT_TYPE), "text/plain");
+            assertNotNull(message.getPayload());
+            assertNull(message.getHeader(CitrusMailMessageHeaders.MAIL_MESSAGE_ID));
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_FROM), "foo@mail.com");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_TO), "bar@mail.com,copy@mail.com");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_CC), "foobar@mail.com");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_BCC), "secret@mail.com");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_REPLY_TO), "reply@mail.com");
+            assertNull(message.getHeader(CitrusMailMessageHeaders.MAIL_DATE));
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_SUBJECT), "Testmail");
+            assertEquals(message.getHeader(CitrusMailMessageHeaders.MAIL_CONTENT_TYPE), "text/plain");
 
             try {
-                Assert.assertEquals(
-                    message.getPayload(String.class).replaceAll("\\s", ""),
-                    FileUtils.readToString(Resources.create("text_mail.xml", MailServer.class)).replaceAll("\\s", "")
+                assertEquals(
+                        message.getPayload(String.class).replaceAll("\\s", ""),
+                        FileUtils.readToString(Resources.create("text_mail.xml", MailServer.class)).replaceAll("\\s", "")
                 );
             } catch (IOException e) {
-                Assert.fail(e.getMessage());
+                fail(e.getMessage());
             }
 
             return new DefaultMessage(
@@ -457,13 +470,13 @@ public class MailServerTest {
         }).when(endpointAdapterMock).handleMessage(any(Message.class));
 
         MimeMessage message = new MimeMessage(fixture.getSession(), Resources.create("text_mail.txt", MailServer.class).getInputStream());
-        Assert.assertTrue(fixture.accept("foo@mail.com", Collections.singletonList(new MailAddress("bar@mail.com"))));
+        assertTrue(fixture.accept("foo@mail.com", Collections.singletonList(new MailAddress("bar@mail.com"))));
 
         try {
             fixture.deliver(message);
             throw new CitrusRuntimeException("Missing reject exception due to simulated error");
         } catch (CitrusRuntimeException e) {
-            Assert.assertEquals(e.getMessage(), "443 Failed!");
+            assertEquals(e.getMessage(), "443 Failed!");
         }
     }
 


### PR DESCRIPTION
closes #1199.

@e17gpy I wen't for this implementation and will skip this part (as reported):

> As the Citrus MailServerBuilder does not have functions to set the host manually, and the MailServer initialises the GreenMail server with a hardcoded host value of null, the Citrus MailServer will only bind to the loopback interface and not receive Mails from another interfaces.

I think for security reasons this is ok. whoever want's to bind to a specific interface should create a custom `MailServer` and use that - with the provided fix this is now possible. does this fit your needs?