### PR TITLE
fix quarkus-jacoco

### DIFF
--- a/runtime/citrus-quarkus/citrus-quarkus-it/pom.xml
+++ b/runtime/citrus-quarkus/citrus-quarkus-it/pom.xml
@@ -13,6 +13,10 @@
   <name>Citrus :: Runtime :: Quarkus Integration Tests</name>
   <description>Citrus Quarkus Integration Test</description>
 
+  <properties>
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -36,6 +40,11 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-jacoco</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/runtime/citrus-quarkus/pom.xml
+++ b/runtime/citrus-quarkus/pom.xml
@@ -15,7 +15,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <quarkus.platform.version>3.13.1</quarkus.platform.version>
+    <quarkus.platform.version>3.14.1</quarkus.platform.version>
   </properties>
 
   <dependencyManagement>
@@ -35,10 +35,15 @@
         <artifactId>quarkus-junit5</artifactId>
         <version>${quarkus.platform.version}</version>
       </dependency>
-
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-test-common</artifactId>
+        <version>${quarkus.platform.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-jacoco</artifactId>
         <version>${quarkus.platform.version}</version>
       </dependency>
     </dependencies>


### PR DESCRIPTION
Align `quarkus-jacoco` with the platform version. I've also included it in the `citrus-quarkus-it` project in order to verify the integration.