### PR TITLE
improved kafka actions reading

### DIFF
--- a/core/citrus-api/src/main/java/org/citrusframework/messaging/AbstractMessageConsumer.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/messaging/AbstractMessageConsumer.java
@@ -34,8 +34,6 @@ public abstract class AbstractMessageConsumer implements Consumer {
 
     /**
      * Default constructor using receive timeout setting.
-     * @param name
-     * @param endpointConfiguration
      */
     public AbstractMessageConsumer(String name, EndpointConfiguration endpointConfiguration) {
         this.name = name;
@@ -47,7 +45,12 @@ public abstract class AbstractMessageConsumer implements Consumer {
         return name;
     }
 
+    @Override
     public Message receive(TestContext context) {
         return receive(context, endpointConfiguration.getTimeout());
+    }
+
+    protected EndpointConfiguration getEndpointConfiguration() {
+        return endpointConfiguration;
     }
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/actions/PurgeEndpointAction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/actions/PurgeEndpointAction.java
@@ -16,12 +16,6 @@
 
 package org.citrusframework.actions;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.citrusframework.AbstractTestActionBuilder;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.endpoint.Endpoint;
@@ -34,7 +28,14 @@ import org.citrusframework.spi.ReferenceResolver;
 import org.citrusframework.spi.ReferenceResolverAware;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.citrusframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.citrusframework.util.StringUtils.hasText;
 
 /**
  * Action purges all messages from a message endpoint. Action receives
@@ -118,8 +119,8 @@ public class PurgeEndpointAction extends AbstractTestAction {
         do {
             try {
                 String selector = MessageSelectorBuilder.build(messageSelector, messageSelectorMap, context);
-                if (StringUtils.hasText(selector) && messageConsumer instanceof SelectiveConsumer) {
-                    message = (receiveTimeout >= 0) ? ((SelectiveConsumer) messageConsumer).receive(selector, context, receiveTimeout) : ((SelectiveConsumer) messageConsumer).receive(selector, context);
+                if (hasText(selector) && messageConsumer instanceof SelectiveConsumer selectiveConsumer) {
+                    message = (receiveTimeout >= 0) ? selectiveConsumer.receive(selector, context, receiveTimeout) : selectiveConsumer.receive(selector, context);
                 } else {
                     message = (receiveTimeout >= 0) ? messageConsumer.receive(context, receiveTimeout) : messageConsumer.receive(context);
                 }

--- a/core/citrus-base/src/main/java/org/citrusframework/message/MessageSelectorBuilder.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/message/MessageSelectorBuilder.java
@@ -24,6 +24,8 @@ import java.util.Map.Entry;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.util.StringUtils;
 
+import static org.citrusframework.util.StringUtils.hasText;
+
 /**
  * Constructs message selectors either from string value or from key value maps. Currently only AND logical combination
  * of multiple expressions is supported.
@@ -51,7 +53,7 @@ public class MessageSelectorBuilder {
      * @return
      */
     public static String build(String messageSelector, Map<String, Object> messageSelectorMap, TestContext context) {
-        if (StringUtils.hasText(messageSelector)) {
+        if (hasText(messageSelector)) {
             return context.replaceDynamicContentInString(messageSelector);
         } else if (messageSelectorMap != null && !messageSelectorMap.isEmpty()) {
             return MessageSelectorBuilder.fromKeyValueMap(
@@ -113,7 +115,7 @@ public class MessageSelectorBuilder {
                 tokens = escapeEqualsFromXpathNodeTest(chunk).split("=");
                 valueMap.put(unescapeEqualsFromXpathNodeTest(tokens[0].trim()), tokens[1].trim().substring(1, tokens[1].trim().length() -1));
             }
-        } else {
+        } else if (hasText(selectorString)) {
             tokens = escapeEqualsFromXpathNodeTest(selectorString).split("=");
             valueMap.put(unescapeEqualsFromXpathNodeTest(tokens[0].trim()), tokens[1].trim().substring(1, tokens[1].trim().length() -1));
         }

--- a/core/citrus-base/src/main/java/org/citrusframework/util/StringUtils.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/util/StringUtils.java
@@ -27,8 +27,6 @@ public class StringUtils {
 
     /**
      * Helper method checks for non-null and non-blank String.
-     * @param str
-     * @return
      */
     public static boolean hasText(String str) {
         return str != null && !str.isBlank();
@@ -36,8 +34,6 @@ public class StringUtils {
 
     /**
      * String helper checking for isEmpty String and adds null check on given parameter.
-     * @param str
-     * @return
      */
     public static boolean isEmpty(String str) {
         return str == null || str.isEmpty();

--- a/core/citrus-base/src/test/java/org/citrusframework/util/StringUtilsTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/util/StringUtilsTest.java
@@ -1,0 +1,56 @@
+package org.citrusframework.util;
+
+import static org.citrusframework.util.StringUtils.hasText;
+import static org.citrusframework.util.StringUtils.isEmpty;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class StringUtilsTest {
+
+    @DataProvider
+    public static Object[][] text() {
+        return new Object[][]{{"foo"}};
+    }
+
+    @DataProvider
+    public static Object[][] blankText() {
+        return new Object[][]{{" "}};
+    }
+
+    @DataProvider
+    public static Object[][] emptyText() {
+        return new Object[][]{{null}, {""}};
+    }
+
+    @Test(dataProvider = "text")
+    public void hasText_returnsTrue(String str) {
+        assertTrue(hasText(str));
+    }
+
+    @Test(dataProvider = "blankText")
+    public void hasText_returnsFalse_forBlankText(String str) {
+        assertFalse(hasText(str));
+    }
+    @Test(dataProvider = "emptyText")
+    public void hasText_returnsFalse_forEmptyText(String str) {
+        assertFalse(hasText(str));
+    }
+
+    @Test(dataProvider = "emptyText")
+    public void isEmpty_returnsTrue(String str) {
+        assertTrue(isEmpty(str));
+    }
+
+    @Test(dataProvider = "text")
+    public void isEmpty_returnsFalse_forText(String str) {
+        assertFalse(isEmpty(str));
+    }
+
+    @Test(dataProvider = "blankText")
+    public void isEmpty_returnsFalse_forBlankText(String str) {
+        assertFalse(isEmpty(str));
+    }
+}

--- a/endpoints/citrus-kafka/pom.xml
+++ b/endpoints/citrus-kafka/pom.xml
@@ -79,21 +79,8 @@
     </dependency>
     
     <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-handler</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-transport-native-epoll</artifactId>
-      <classifier>linux-x86_64</classifier>
-    </dependency>
-    <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.dropwizard.metrics</groupId>
-      <artifactId>metrics-core</artifactId>
     </dependency>
 
     <dependency>
@@ -127,5 +114,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
 </project>

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/config/annotation/KafkaEndpointConfig.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/config/annotation/KafkaEndpointConfig.java
@@ -16,17 +16,17 @@
 
 package org.citrusframework.kafka.config.annotation;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-
-import org.citrusframework.annotations.CitrusEndpointConfig;
-import org.citrusframework.kafka.message.KafkaMessageHeaders;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.citrusframework.annotations.CitrusEndpointConfig;
+import org.citrusframework.kafka.message.KafkaMessageHeaders;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * @author Christoph Deppisch

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/config/annotation/KafkaEndpointConfigParser.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/config/annotation/KafkaEndpointConfigParser.java
@@ -16,8 +16,6 @@
 
 package org.citrusframework.kafka.config.annotation;
 
-import java.util.Map;
-
 import org.citrusframework.TestActor;
 import org.citrusframework.config.annotation.AnnotationConfigParser;
 import org.citrusframework.exceptions.CitrusRuntimeException;
@@ -27,6 +25,8 @@ import org.citrusframework.kafka.message.KafkaMessageConverter;
 import org.citrusframework.kafka.message.KafkaMessageHeaderMapper;
 import org.citrusframework.spi.ReferenceResolver;
 import org.citrusframework.util.StringUtils;
+
+import java.util.Map;
 
 /**
  * @author Christoph Deppisch

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/config/handler/CitrusKafkaConfigNamespaceHandler.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/config/handler/CitrusKafkaConfigNamespaceHandler.java
@@ -16,7 +16,8 @@
 
 package org.citrusframework.kafka.config.handler;
 
-import org.citrusframework.kafka.config.xml.*;
+import org.citrusframework.kafka.config.xml.KafkaEmbeddedServerParser;
+import org.citrusframework.kafka.config.xml.KafkaEndpointParser;
 import org.springframework.beans.factory.xml.NamespaceHandlerSupport;
 
 /**

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/config/xml/KafkaEndpointParser.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/config/xml/KafkaEndpointParser.java
@@ -16,7 +16,7 @@
 
 package org.citrusframework.kafka.config.xml;
 
-import org.citrusframework.config.util.BeanDefinitionParserUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.citrusframework.config.xml.AbstractEndpointParser;
 import org.citrusframework.endpoint.Endpoint;
 import org.citrusframework.endpoint.EndpointConfiguration;
@@ -26,10 +26,14 @@ import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.w3c.dom.Element;
 
+import static java.lang.Boolean.parseBoolean;
+import static org.citrusframework.config.util.BeanDefinitionParserUtils.setPropertyReference;
+import static org.citrusframework.config.util.BeanDefinitionParserUtils.setPropertyValue;
+import static org.citrusframework.kafka.message.KafkaMessageHeaders.KAFKA_PREFIX;
+
 /**
  * Bean definition parser for Kafka endpoint component.
  *
- * @author Christoph Deppisch
  * @since 2.8
  */
 public class KafkaEndpointParser extends AbstractEndpointParser {
@@ -38,25 +42,30 @@ public class KafkaEndpointParser extends AbstractEndpointParser {
     protected void parseEndpointConfiguration(BeanDefinitionBuilder endpointConfiguration, Element element, ParserContext parserContext) {
         super.parseEndpointConfiguration(endpointConfiguration, element, parserContext);
 
-        BeanDefinitionParserUtils.setPropertyValue(endpointConfiguration, element.getAttribute("client-id"), "clientId");
-        BeanDefinitionParserUtils.setPropertyValue(endpointConfiguration, element.getAttribute("server"), "server");
-        BeanDefinitionParserUtils.setPropertyValue(endpointConfiguration, element.getAttribute("topic"), "topic");
-        BeanDefinitionParserUtils.setPropertyValue(endpointConfiguration, element.getAttribute("partition"), "partition");
+        setPropertyValue(endpointConfiguration, element.getAttribute("client-id"), "clientId");
+        setPropertyValue(endpointConfiguration, element.getAttribute("server"), "server");
+        setPropertyValue(endpointConfiguration, element.getAttribute("topic"), "topic");
+        setPropertyValue(endpointConfiguration, element.getAttribute("partition"), "partition");
 
-        BeanDefinitionParserUtils.setPropertyReference(endpointConfiguration, element.getAttribute("message-converter"), "messageConverter");
-        BeanDefinitionParserUtils.setPropertyReference(endpointConfiguration, element.getAttribute("header-mapper"), "headerMapper");
-        BeanDefinitionParserUtils.setPropertyReference(endpointConfiguration, element.getAttribute("producer-properties"), "producerProperties");
-        BeanDefinitionParserUtils.setPropertyReference(endpointConfiguration, element.getAttribute("consumer-properties"), "consumerProperties");
+        setPropertyReference(endpointConfiguration, element.getAttribute("message-converter"), "messageConverter");
+        setPropertyReference(endpointConfiguration, element.getAttribute("header-mapper"), "headerMapper");
+        setPropertyReference(endpointConfiguration, element.getAttribute("producer-properties"), "producerProperties");
+        setPropertyReference(endpointConfiguration, element.getAttribute("consumer-properties"), "consumerProperties");
 
-        BeanDefinitionParserUtils.setPropertyValue(endpointConfiguration, element.getAttribute("auto-commit"), "autoCommit");
-        BeanDefinitionParserUtils.setPropertyValue(endpointConfiguration, element.getAttribute("auto-commit-interval"), "autoCommitInterval");
-        BeanDefinitionParserUtils.setPropertyValue(endpointConfiguration, element.getAttribute("offset-reset"), "offsetReset");
-        BeanDefinitionParserUtils.setPropertyValue(endpointConfiguration, element.getAttribute("consumer-group"), "consumerGroup");
+        setPropertyValue(endpointConfiguration, element.getAttribute("auto-commit"), "autoCommit");
+        setPropertyValue(endpointConfiguration, element.getAttribute("auto-commit-interval"), "autoCommitInterval");
+        setPropertyValue(endpointConfiguration, element.getAttribute("offset-reset"), "offsetReset");
 
-        BeanDefinitionParserUtils.setPropertyValue(endpointConfiguration, element.getAttribute("key-serializer"), "keySerializer");
-        BeanDefinitionParserUtils.setPropertyValue(endpointConfiguration, element.getAttribute("key-deserializer"), "keyDeserializer");
-        BeanDefinitionParserUtils.setPropertyValue(endpointConfiguration, element.getAttribute("value-serializer"), "valueSerializer");
-        BeanDefinitionParserUtils.setPropertyValue(endpointConfiguration, element.getAttribute("value-deserializer"), "valueDeserializer");
+        if (parseBoolean(element.getAttribute("random-consumer-group"))) {
+            setPropertyValue(endpointConfiguration, KAFKA_PREFIX + RandomStringUtils.insecure().nextAlphabetic(10).toLowerCase(), "consumerGroup");
+        }else {
+            setPropertyValue(endpointConfiguration, element.getAttribute("consumer-group"), "consumerGroup");
+        }
+
+        setPropertyValue(endpointConfiguration, element.getAttribute("key-serializer"), "keySerializer");
+        setPropertyValue(endpointConfiguration, element.getAttribute("key-deserializer"), "keyDeserializer");
+        setPropertyValue(endpointConfiguration, element.getAttribute("value-serializer"), "valueSerializer");
+        setPropertyValue(endpointConfiguration, element.getAttribute("value-deserializer"), "valueDeserializer");
     }
 
     @Override

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/embedded/EmbeddedKafkaServerApp.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/embedded/EmbeddedKafkaServerApp.java
@@ -17,7 +17,9 @@
 package org.citrusframework.kafka.embedded;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.*;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.PropertySource;
 
 /**
  * Standalone application provides a main cli entry for running an embedded Kafka server with embedded Zookeeper.

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaEndpointBuilder.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaEndpointBuilder.java
@@ -16,11 +16,11 @@
 
 package org.citrusframework.kafka.endpoint;
 
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serializer;
 import org.citrusframework.endpoint.AbstractEndpointBuilder;
 import org.citrusframework.kafka.message.KafkaMessageConverter;
 import org.citrusframework.kafka.message.KafkaMessageHeaderMapper;
-import org.apache.kafka.common.serialization.Deserializer;
-import org.apache.kafka.common.serialization.Serializer;
 
 import java.util.Map;
 

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaEndpointComponent.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaEndpointComponent.java
@@ -16,11 +16,11 @@
 
 package org.citrusframework.kafka.endpoint;
 
-import java.util.Map;
-
 import org.citrusframework.context.TestContext;
 import org.citrusframework.endpoint.AbstractEndpointComponent;
 import org.citrusframework.endpoint.Endpoint;
+
+import java.util.Map;
 
 /**
  * Kafka endpoint component is able to create kafka endpoint from endpoint uri with parameters. Depending on uri creates a

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaEndpointConfiguration.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaEndpointConfiguration.java
@@ -16,340 +16,85 @@
 
 package org.citrusframework.kafka.endpoint;
 
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.citrusframework.endpoint.AbstractPollableEndpointConfiguration;
-import org.citrusframework.kafka.message.*;
-import org.apache.kafka.common.serialization.*;
+import org.citrusframework.kafka.message.KafkaMessageConverter;
+import org.citrusframework.kafka.message.KafkaMessageHeaderMapper;
+import org.citrusframework.kafka.message.KafkaMessageHeaders;
 
 import java.util.HashMap;
 import java.util.Map;
 
-/**
- * @author Christoph Deppisch
- * @since 2.8
- */
+@Getter
+@Setter
 public class KafkaEndpointConfiguration extends AbstractPollableEndpointConfiguration {
 
-    /** Client id */
+    /**
+     * Client id
+     */
     private String clientId;
 
-    /** Consumer group id */
+    /**
+     * Consumer group id
+     */
     private String consumerGroup = KafkaMessageHeaders.KAFKA_PREFIX + "group";
 
-    /** The topic name */
+    /**
+     * The topic name
+     */
     private String topic;
 
-    /** List of server to connect with */
+    /**
+     * List of server to connect with
+     */
     private String server = "localhost:9092";
 
-    /** The header mapper */
+    /**
+     * The header mapper
+     */
     private KafkaMessageHeaderMapper headerMapper = new KafkaMessageHeaderMapper();
 
-    /** The message converter */
+    /**
+     * The message converter
+     */
     private KafkaMessageConverter messageConverter = new KafkaMessageConverter();
 
-    /** Key and value serializer types */
+    /**
+     * Key and value serializer types
+     */
     private Class<? extends Serializer> keySerializer = StringSerializer.class;
     private Class<? extends Serializer> valueSerializer = StringSerializer.class;
 
-    /** Key and value deserializer types */
+    /**
+     * Key and value deserializer types
+     */
     private Class<? extends Deserializer> keyDeserializer = StringDeserializer.class;
     private Class<? extends Deserializer> valueDeserializer = StringDeserializer.class;
 
-    /** Consumer/producer properties */
+    /**
+     * Consumer/producer properties
+     */
     private Map<String, Object> consumerProperties = new HashMap<>();
     private Map<String, Object> producerProperties = new HashMap<>();
 
-    /** Auto commit setting for consumer */
+    /**
+     * Auto commit setting for consumer
+     */
     private boolean autoCommit = true;
     private int autoCommitInterval = 1000;
 
-    /** Offset reset setting for consumer  */
+    /**
+     * Offset reset setting for consumer
+     */
     private String offsetReset = "earliest";
 
-    /** Topic partition */
+    /**
+     * Topic partition
+     */
     private int partition = 0;
-
-    /**
-     * Gets the topic name.
-     * @return the topic
-     */
-    public String getTopic() {
-        return topic;
-    }
-
-    /**
-     * Sets the topic name.
-     * @param topic the topic to set
-     */
-    public void setTopic(String topic) {
-        this.topic = topic;
-    }
-
-    /**
-     * Gets the message converter.
-     * @return
-     */
-    public KafkaMessageConverter getMessageConverter() {
-        return messageConverter;
-    }
-
-    /**
-     * Sets the message converter.
-     * @param messageConverter
-     */
-    public void setMessageConverter(KafkaMessageConverter messageConverter) {
-        this.messageConverter = messageConverter;
-    }
-
-    /**
-     * Gets the headerMapper.
-     *
-     * @return
-     */
-    public KafkaMessageHeaderMapper getHeaderMapper() {
-        return headerMapper;
-    }
-
-    /**
-     * Sets the headerMapper.
-     *
-     * @param headerMapper
-     */
-    public void setHeaderMapper(KafkaMessageHeaderMapper headerMapper) {
-        this.headerMapper = headerMapper;
-    }
-
-    /**
-     * Sets the server.
-     *
-     * @param server
-     */
-    public void setServer(String server) {
-        this.server = server;
-    }
-
-    /**
-     * Gets the server.
-     *
-     * @return
-     */
-    public String getServer() {
-        return server;
-    }
-
-    /**
-     * Gets the group.
-     *
-     * @return
-     */
-    public String getConsumerGroup() {
-        return consumerGroup;
-    }
-
-    /**
-     * Sets the group.
-     *
-     * @param consumerGroup
-     */
-    public void setConsumerGroup(String consumerGroup) {
-        this.consumerGroup = consumerGroup;
-    }
-
-    /**
-     * Gets the keySerializer.
-     *
-     * @return
-     */
-    public Class<? extends Serializer> getKeySerializer() {
-        return keySerializer;
-    }
-
-    /**
-     * Sets the keySerializer.
-     *
-     * @param keySerializer
-     */
-    public void setKeySerializer(Class<? extends Serializer> keySerializer) {
-        this.keySerializer = keySerializer;
-    }
-
-    /**
-     * Gets the valueSerializer.
-     *
-     * @return
-     */
-    public Class<? extends Serializer> getValueSerializer() {
-        return valueSerializer;
-    }
-
-    /**
-     * Sets the valueSerializer.
-     *
-     * @param valueSerializer
-     */
-    public void setValueSerializer(Class<? extends Serializer> valueSerializer) {
-        this.valueSerializer = valueSerializer;
-    }
-
-    /**
-     * Gets the keyDeserializer.
-     *
-     * @return
-     */
-    public Class<? extends Deserializer> getKeyDeserializer() {
-        return keyDeserializer;
-    }
-
-    /**
-     * Sets the keyDeserializer.
-     *
-     * @param keyDeserializer
-     */
-    public void setKeyDeserializer(Class<? extends Deserializer> keyDeserializer) {
-        this.keyDeserializer = keyDeserializer;
-    }
-
-    /**
-     * Gets the valueDeserializer.
-     *
-     * @return
-     */
-    public Class<? extends Deserializer> getValueDeserializer() {
-        return valueDeserializer;
-    }
-
-    /**
-     * Sets the valueDeserializer.
-     *
-     * @param valueDeserializer
-     */
-    public void setValueDeserializer(Class<? extends Deserializer> valueDeserializer) {
-        this.valueDeserializer = valueDeserializer;
-    }
-
-    /**
-     * Gets the consumerProperties.
-     *
-     * @return
-     */
-    public Map<String, Object> getConsumerProperties() {
-        return consumerProperties;
-    }
-
-    /**
-     * Sets the consumerProperties.
-     *
-     * @param consumerProperties
-     */
-    public void setConsumerProperties(Map<String, Object> consumerProperties) {
-        this.consumerProperties = consumerProperties;
-    }
-
-    /**
-     * Gets the producerProperties.
-     *
-     * @return
-     */
-    public Map<String, Object> getProducerProperties() {
-        return producerProperties;
-    }
-
-    /**
-     * Sets the producerProperties.
-     *
-     * @param producerProperties
-     */
-    public void setProducerProperties(Map<String, Object> producerProperties) {
-        this.producerProperties = producerProperties;
-    }
-
-    /**
-     * Gets the clientId.
-     *
-     * @return
-     */
-    public String getClientId() {
-        return clientId;
-    }
-
-    /**
-     * Sets the clientId.
-     *
-     * @param clientId
-     */
-    public void setClientId(String clientId) {
-        this.clientId = clientId;
-    }
-
-    /**
-     * Gets the offsetReset.
-     *
-     * @return
-     */
-    public String getOffsetReset() {
-        return offsetReset;
-    }
-
-    /**
-     * Sets the offsetReset.
-     *
-     * @param offsetReset
-     */
-    public void setOffsetReset(String offsetReset) {
-        this.offsetReset = offsetReset;
-    }
-
-    /**
-     * Gets the autoCommit.
-     *
-     * @return
-     */
-    public boolean isAutoCommit() {
-        return autoCommit;
-    }
-
-    /**
-     * Sets the autoCommit.
-     *
-     * @param autoCommit
-     */
-    public void setAutoCommit(boolean autoCommit) {
-        this.autoCommit = autoCommit;
-    }
-
-    /**
-     * Gets the autoCommitInterval.
-     *
-     * @return
-     */
-    public int getAutoCommitInterval() {
-        return autoCommitInterval;
-    }
-
-    /**
-     * Sets the autoCommitInterval.
-     *
-     * @param autoCommitInterval
-     */
-    public void setAutoCommitInterval(int autoCommitInterval) {
-        this.autoCommitInterval = autoCommitInterval;
-    }
-
-    /**
-     * Gets the partition.
-     *
-     * @return
-     */
-    public int getPartition() {
-        return partition;
-    }
-
-    /**
-     * Sets the partition.
-     *
-     * @param partition
-     */
-    public void setPartition(int partition) {
-        this.partition = partition;
-    }
 }

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaMessageConsumerUtils.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaMessageConsumerUtils.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.kafka.endpoint;
+
+import lombok.NoArgsConstructor;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.message.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Optional;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@NoArgsConstructor(access = PRIVATE)
+final class KafkaMessageConsumerUtils {
+
+    private static final Logger logger = LoggerFactory.getLogger(KafkaMessageConsumerUtils.class);
+
+    static String resolveTopic(
+            KafkaEndpointConfiguration kafkaEndpointConfiguration,
+            TestContext testContext
+    ) {
+        return testContext.replaceDynamicContentInString(
+                Optional.ofNullable(kafkaEndpointConfiguration.getTopic())
+                        .orElseThrow(() -> new CitrusRuntimeException(
+                                "Missing Kafka topic to receive messages from - add topic to endpoint configuration")));
+    }
+
+    static Message parseConsumerRecordsToMessage(
+            List<ConsumerRecord<Object, Object>> consumerRecords,
+            KafkaEndpointConfiguration endpointConfiguration,
+            TestContext testContext
+    ) {
+         if (consumerRecords.size() > 1) {
+            throw new CitrusRuntimeException("More than one matching record found in topic " + resolveTopic(endpointConfiguration, testContext));
+        }
+
+        if (logger.isDebugEnabled()) {
+            consumerRecords.forEach(
+                    record -> logger.debug("Received message: ({}, {}) at offset {}", record.key(), record.value(), record.offset()));
+        }
+
+        Message received = endpointConfiguration.getMessageConverter()
+                .convertInbound(
+                        consumerRecords.iterator().next(),
+                        endpointConfiguration,
+                        testContext);
+        testContext.onInboundMessage(received);
+
+        return received;
+    }
+}

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaMessageFilter.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaMessageFilter.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.kafka.endpoint;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.kafka.endpoint.selector.KafkaMessageSelector;
+import org.citrusframework.kafka.endpoint.selector.KafkaMessageSelectorFactory;
+import org.citrusframework.message.MessageSelectorBuilder;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+import static lombok.AccessLevel.PACKAGE;
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter(PACKAGE)
+@AllArgsConstructor(access = PRIVATE)
+@RequiredArgsConstructor(access = PRIVATE)
+@Builder(buildMethodName = "buildFilter")
+@ToString(exclude = {"kafkaMessageSelectorFactory"})
+public final class KafkaMessageFilter {
+
+    /**
+     * @see KafkaMessageFilter#eventLookbackWindow
+     */
+    static final String EVENT_LOOKBACK_WINDOW = "event-lookback-window";
+
+    /**
+     * @see KafkaMessageFilter#pollTimeout
+     */
+    static final String POLL_TIMEOUT = "poll-timeout";
+
+    private static final String EVENT_LOOKBACK_WINDOW_EXCEPTION = "Cannot find Kafka messages without offset limitation";
+
+    private final KafkaMessageSelectorFactory kafkaMessageSelectorFactory;
+
+    /**
+     * Defines the time window to look back for events in the Kafka topic. This duration is subtracted from the current
+     * time to determine the starting point for consuming messages.
+     * <p>
+     * Because finding messages in a Kafka topic is relatively complicated, message consumption starts at an
+     * offset {@code Ox = OT-n}. Where {@code T} is the current timestamp and {@code n} is the maximum timespan in which
+     * the wanted event is expected to have been published.
+     * <p>
+     * The timespan {@code n} should also be as small as possible, because the amount of consumed messages is
+     * potentially very high.
+     */
+    private Duration eventLookbackWindow;
+
+    /**
+     * The timeout duration for each poll operation when consuming messages from Kafka. This value determines how long
+     * the consumer will wait for new records in each poll cycle.
+     */
+    @Builder.Default
+    private Duration pollTimeout = Duration.ofMillis(100);
+
+    /**
+     * A custom matcher implementing {@link KafkaMessageSelector}. This matcher is used to determine whether a
+     * consumed record meets specific criteria defined by the user.
+     */
+    private KafkaMessageSelector kafkaMessageSelector;
+
+    public static KafkaMessageFilterBuilder kafkaMessageFilter() {
+        return KafkaMessageFilter.builder()
+                .kafkaMessageSelectorFactory(new KafkaMessageSelectorFactory());
+    }
+
+    static KafkaMessageFilter kafkaMessageFilter(String selector) {
+        return kafkaMessageFilter(selector, new KafkaMessageSelectorFactory());
+    }
+
+    static KafkaMessageFilter kafkaMessageFilter(String selector, KafkaMessageSelectorFactory kafkaMessageSelectorFactory) {
+        return new KafkaMessageFilter(kafkaMessageSelectorFactory)
+                .fromSelectorString(selector);
+    }
+
+    private KafkaMessageFilter fromSelectorString(String selector) {
+        var messageSelectors = MessageSelectorBuilder.withString(selector).toKeyValueMap();
+
+        eventLookbackWindow = Duration.parse(
+                Optional.ofNullable(messageSelectors.get(EVENT_LOOKBACK_WINDOW))
+                        .orElseThrow(() -> new CitrusRuntimeException(EVENT_LOOKBACK_WINDOW_EXCEPTION))
+        );
+
+        pollTimeout = Duration.parse(
+                Optional.ofNullable(messageSelectors.get(POLL_TIMEOUT))
+                        .orElse("PT0.100S") // 100 ms
+        );
+
+        kafkaMessageSelector = kafkaMessageSelectorFactory.parseFromSelector(messageSelectors);
+
+        return this;
+    }
+
+    @SuppressWarnings({"unchecked"})
+    private <T> Map<String, T> asSelector() {
+        Map<String, T> selector = new HashMap<>();
+
+        if (nonNull(eventLookbackWindow)) {
+            selector.put(EVENT_LOOKBACK_WINDOW, (T) eventLookbackWindow.toString());
+        }
+        if (nonNull(pollTimeout)) {
+            selector.put(POLL_TIMEOUT, (T) pollTimeout.toString());
+        }
+        if (nonNull(kafkaMessageSelector)) {
+            selector.putAll(kafkaMessageSelector.asSelector());
+        }
+
+        return selector;
+    }
+
+    void sanitize() {
+        if (isNull(eventLookbackWindow)) {
+            throw new CitrusRuntimeException(EVENT_LOOKBACK_WINDOW_EXCEPTION);
+        } else if (isNull(pollTimeout)) {
+            throw new CitrusRuntimeException("No poll timeout defined when looking for Kafka messages");
+        } else if (isNull(kafkaMessageSelector)) {
+            throw new CitrusRuntimeException("No matcher specified when looking for Kafka messages");
+        }
+    }
+
+    // Custom builder is compatible with lombok:
+    // * make factory only accessible in package
+    // * custom `build` method returns `Map<String, T>`
+    public static class KafkaMessageFilterBuilder {
+
+        KafkaMessageFilterBuilder kafkaMessageSelectorFactory(KafkaMessageSelectorFactory kafkaMessageSelectorFactory) {
+            this.kafkaMessageSelectorFactory = kafkaMessageSelectorFactory;
+            return this;
+        }
+
+        public <T> Map<String, T> build() {
+            return buildFilter()
+                    .asSelector();
+        }
+    }
+}

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaMessageFilteringConsumer.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaMessageFilteringConsumer.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.kafka.endpoint;
+
+import jakarta.annotation.Nullable;
+import lombok.Builder;
+import lombok.Getter;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.exceptions.MessageTimeoutException;
+import org.citrusframework.kafka.endpoint.selector.KafkaMessageSelector;
+import org.citrusframework.message.Message;
+import org.citrusframework.messaging.AbstractSelectiveMessageConsumer;
+import org.slf4j.Logger;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+
+import static java.lang.String.format;
+import static java.time.Instant.now;
+import static java.util.Collections.singletonList;
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+import static java.util.concurrent.Executors.newSingleThreadExecutor;
+import static java.util.stream.Collectors.toMap;
+import static org.apache.commons.lang3.exception.ExceptionUtils.getRootCause;
+import static org.citrusframework.kafka.endpoint.KafkaMessageConsumerUtils.parseConsumerRecordsToMessage;
+import static org.citrusframework.kafka.endpoint.KafkaMessageConsumerUtils.resolveTopic;
+import static org.citrusframework.util.StringUtils.hasText;
+import static org.citrusframework.util.StringUtils.isEmpty;
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * A specialized Kafka message consumer that filters messages based on specified criteria.
+ * <p>
+ * This consumer provides functionality to receive Kafka messages that match given selectors or matchers within a
+ * specified time window.
+ *
+ * @see KafkaMessageSelector
+ */
+@Getter
+class KafkaMessageFilteringConsumer extends AbstractSelectiveMessageConsumer {
+
+    private static final Logger logger = getLogger(KafkaMessageFilteringConsumer.class);
+
+    private final ExecutorService executor = newSingleThreadExecutor();
+
+    private final org.apache.kafka.clients.consumer.KafkaConsumer<Object, Object> consumer;
+
+    private KafkaMessageFilter kafkaMessageFilter;
+
+    @Builder
+    private KafkaMessageFilteringConsumer(
+            KafkaEndpointConfiguration endpointConfiguration,
+            org.apache.kafka.clients.consumer.KafkaConsumer<Object, Object> consumer,
+            @Nullable Duration eventLookbackWindow,
+            @Nullable Duration pollTimeout,
+            @Nullable KafkaMessageSelector kafkaMessageSelector
+    ) {
+        super(KafkaMessageSingleConsumer.class.getSimpleName(), endpointConfiguration);
+
+        this.consumer = consumer;
+
+        if (nonNull(eventLookbackWindow) || nonNull(kafkaMessageSelector) || nonNull(pollTimeout)) {
+            kafkaMessageFilter = KafkaMessageFilter.kafkaMessageFilter()
+                    .eventLookbackWindow(eventLookbackWindow)
+                    .kafkaMessageSelector(kafkaMessageSelector)
+                    .pollTimeout(pollTimeout)
+                    .buildFilter();
+        }
+    }
+
+    @Override
+    public Message receive(String selector, TestContext testContext, long timeout) {
+        if (isEmpty(selector) && (isNull(kafkaMessageFilter))) {
+            throw new CitrusRuntimeException("Cannot invoke filtering kafka message consumer without selectors");
+        } else if (hasText(selector)) {
+            kafkaMessageFilter = KafkaMessageFilter.kafkaMessageFilter(selector);
+        }
+
+        kafkaMessageFilter.sanitize();
+
+        String topic = resolveTopic(getEndpointConfiguration(), testContext);
+
+        logger.debug("Receiving Kafka message on topic '{}' using selector: {}", topic, kafkaMessageFilter);
+
+        if (!consumer.subscription().isEmpty()) {
+            logger.warn("Cancelling active subscriptions of consumer before looking for Kafka events, because subscription to topics, partitions and pattern are mutually exclusive");
+            consumer.unsubscribe();
+        }
+
+        var consumerRecords = findMessageWithTimeout(topic, timeout);
+        if (consumerRecords.isEmpty()) {
+            throw new CitrusRuntimeException("Failed to resolve Kafka message using selector: " + selector);
+        }
+
+        var received = parseConsumerRecordsToMessage(
+                consumerRecords,
+                getEndpointConfiguration(),
+                testContext);
+
+        logger.info("Received Kafka message on topic: '{}", topic);
+
+        return received;
+    }
+
+    private List<ConsumerRecord<Object, Object>> findMessageWithTimeout(String topic, long timeout) {
+        logger.trace("Applied timeout is {} ms", timeout);
+
+        final Future<List<ConsumerRecord<Object, Object>>> handler = executor.submit(() -> findMessagesSatisfyingMatcher(topic));
+
+        try {
+            return handler.get(timeout, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new CitrusRuntimeException("Thread was interrupted while waiting for Kafka message", e);
+        } catch (ExecutionException e) {
+            throw new CitrusRuntimeException(format("Failed to receive message on Kafka topic '%s'", topic), e);
+        } catch (TimeoutException e) {
+            logger.error("Failed to receive message on  Kafka topic '{}': {}", topic, getRootCause(e).getMessage());
+
+            handler.cancel(true);
+
+            throw new MessageTimeoutException(timeout, topic, e);
+        } finally {
+            executor.shutdownNow();
+            consumer.unsubscribe();
+        }
+    }
+
+    @Override
+    protected KafkaEndpointConfiguration getEndpointConfiguration() {
+        return (KafkaEndpointConfiguration) super.getEndpointConfiguration();
+    }
+
+    private List<ConsumerRecord<Object, Object>> findMessagesSatisfyingMatcher(String topic) {
+        List<TopicPartition> partitions = consumer.partitionsFor(topic).stream()
+                .map(partitionInfo -> new TopicPartition(topic, partitionInfo.partition()))
+                .toList();
+
+        consumer.assign(partitions);
+
+        offsetConsumerOnTopicByLookbackWindow(partitions);
+
+        var endTime = Instant.now();
+        var startTime = endTime.minus(kafkaMessageFilter.getEventLookbackWindow());
+
+        var matchingConsumerRecords = new ArrayList<ConsumerRecord<Object, Object>>();
+
+        while (true) {
+            var consumerRecords = consumer.poll(kafkaMessageFilter.getPollTimeout());
+            if (consumerRecords.isEmpty()) {
+                break;  // No more records to process
+            }
+
+            for (ConsumerRecord<Object, Object> consumerRecord : consumerRecords) {
+                if (isConsumerRecordNewerThanEndTime(consumerRecord, endTime)) {
+                    return matchingConsumerRecords;
+                } else if (!isConsumerRecordOlderThanStartTime(consumerRecord, startTime)
+                        && kafkaMessageFilter.getKafkaMessageSelector().matches(consumerRecord)) {
+                    matchingConsumerRecords.add(consumerRecord);
+                }
+            }
+        }
+
+        return matchingConsumerRecords;
+    }
+
+    private void offsetConsumerOnTopicByLookbackWindow(List<TopicPartition> partitions) {
+        Map<TopicPartition, Long> partitionsWithTimestamps = partitions.stream().collect(toMap(
+                Function.identity(),
+                partition -> now().minusMillis(kafkaMessageFilter.getEventLookbackWindow().toMillis()).toEpochMilli()
+        ));
+
+        var newOffsets = consumer.offsetsForTimes(partitionsWithTimestamps);
+
+        logger.trace("Applying new offsets: {}", newOffsets);
+
+        newOffsets.forEach((partition, partitionOffset) -> {
+            if (nonNull(partitionOffset)) {
+                consumer.seek(partition, partitionOffset.offset());
+            } else {
+                consumer.seekToEnd(singletonList(partition));
+            }
+        });
+    }
+
+    private static boolean isConsumerRecordNewerThanEndTime(
+            ConsumerRecord<Object, Object> consumerRecord,
+            Instant endTime
+    ) {
+        return consumerRecord.timestamp() > endTime.toEpochMilli();
+    }
+
+    private static boolean isConsumerRecordOlderThanStartTime(
+            ConsumerRecord<Object, Object> consumerRecord,
+            Instant startTime
+    ) {
+        return consumerRecord.timestamp() < startTime.toEpochMilli();
+    }
+}

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaMessageSingleConsumer.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaMessageSingleConsumer.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.kafka.endpoint;
+
+import lombok.Builder;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.exceptions.MessageTimeoutException;
+import org.citrusframework.message.Message;
+import org.citrusframework.messaging.AbstractMessageConsumer;
+import org.slf4j.Logger;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.stream.StreamSupport;
+
+import static org.citrusframework.kafka.endpoint.KafkaMessageConsumerUtils.parseConsumerRecordsToMessage;
+import static org.citrusframework.kafka.endpoint.KafkaMessageConsumerUtils.resolveTopic;
+import static org.slf4j.LoggerFactory.getLogger;
+
+class KafkaMessageSingleConsumer extends AbstractMessageConsumer {
+
+    private static final Logger logger = getLogger(KafkaMessageSingleConsumer.class);
+
+    private final org.apache.kafka.clients.consumer.KafkaConsumer<Object, Object> consumer;
+
+    @Builder
+    private KafkaMessageSingleConsumer(
+            KafkaEndpointConfiguration endpointConfiguration,
+            org.apache.kafka.clients.consumer.KafkaConsumer<Object, Object> consumer
+    ) {
+        super(KafkaMessageSingleConsumer.class.getSimpleName(), endpointConfiguration);
+        this.consumer = consumer;
+    }
+
+    @Override
+    public Message receive(TestContext testContext, long timeout) {
+        String topic = resolveTopic(getEndpointConfiguration(), testContext);
+
+        logger.debug("Receiving Kafka message on topic: '{}'", topic);
+
+        if (consumer.subscription() == null || consumer.subscription().isEmpty()) {
+            consumer.subscribe(Arrays.stream(topic.split(",")).toList());
+        }
+
+        ConsumerRecords<Object, Object> consumerRecords = consumer.poll(Duration.ofMillis(timeout));
+        if (consumerRecords.isEmpty()) {
+            throw new MessageTimeoutException(timeout, topic);
+        }
+
+        var received = parseConsumerRecordsToMessage(
+                StreamSupport.stream(consumerRecords.spliterator(), false).toList(),
+                getEndpointConfiguration(),
+                testContext);
+
+        consumer.commitSync(Duration.ofMillis(getEndpointConfiguration().getTimeout()));
+
+        logger.info("Received Kafka message on topic: '{}", topic);
+        return received;
+    }
+
+    @Override
+    protected KafkaEndpointConfiguration getEndpointConfiguration() {
+        return (KafkaEndpointConfiguration) super.getEndpointConfiguration();
+    }
+}

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/selector/KafkaMessageByHeaderSelector.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/selector/KafkaMessageByHeaderSelector.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.kafka.endpoint.selector;
+
+import jakarta.annotation.Nullable;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Header;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+import static lombok.AccessLevel.PACKAGE;
+import static lombok.AccessLevel.PRIVATE;
+import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.ValueMatchingStrategy.CONTAINS;
+import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.ValueMatchingStrategy.EQUALS;
+import static org.citrusframework.util.StringUtils.isEmpty;
+
+/**
+ * A matcher for Kafka {@link ConsumerRecord}, based on header key-value pairs. This class implements
+ * the {@link KafkaMessageSelector} interface and provides flexible matching capabilities for Kafka message
+ * headers.
+ *
+ * <p>The matching mechanism works as follows:</p>
+ * <ul>
+ *   <li>If the <code>key</code> is <code>null</code>, it matches against all headers in the record.</li>
+ *   <li>If the <code>key</code> is specified, it matches only headers with that exact key.</li>
+ *   <li>
+ *       If the <code>value</code> is <code>null</code>, it matches any value for the specified key (or any header if
+ *       key is {@code null}).
+ *   </li>
+ *   <li>
+ *       If both <code>key</code> and <code>value</code> are specified, it matches headers with the exact key and
+ *       applies the specified matching mechanism to the value.
+ *   </li>
+ * </ul>
+ *
+ * <p>The 'matchingMechanism' applies only to the <code>value</code> and can be one of the following:</p>
+ * <ul>
+ *   <li><code>EQUALS</code>: The header value must exactly match the specified value.</li>
+ *   <li><code>CONTAINS</code>: The header value must contain the specified value as a substring.</li>
+ *   <li><code>STARTS_WITH</code>: The header value must start with the specified value.</li>
+ *   <li><code>ENDS_WITH</code>: The header value must end with the specified value.</li>
+ * </ul>
+ *
+ * <p>If no matching mechanism is specified, <code>EQUALS</code> is used by default.</p>
+ *
+ * @see ValueMatchingStrategy
+ */
+@Builder
+@ToString
+@Getter(PACKAGE)
+@AllArgsConstructor(access = PRIVATE)
+public class KafkaMessageByHeaderSelector implements KafkaMessageSelector {
+
+    /**
+     * @see KafkaMessageByHeaderSelector#key
+     */
+    static final String HEADER_FILTER_KEY = "header-filter-key";
+
+    /**
+     * @see KafkaMessageByHeaderSelector#value
+     */
+    static final String HEADER_FILTER_VALUE = "header-filter-value";
+
+    /**
+     * @see KafkaMessageByHeaderSelector#valueMatchingStrategy
+     */
+    static final String HEADER_FILTER_COMPARATOR = "header-filter-comparator";
+
+    /**
+     * Key-filter being applied to Kafka messages. Matches exact if specified, all keys if {@code null}.
+     */
+    private @Nullable String key;
+
+    /**
+     * Value-filter being applied to Kafka messages. Matches all values if {@code null}. Otherwise, matches as specified
+     * in the {@link KafkaMessageByHeaderSelector#valueMatchingStrategy}.
+     */
+    private @Nullable String value;
+
+    /**
+     * Specifies how the {@link KafkaMessageByHeaderSelector#value} should be matched.
+     */
+    private @Nullable ValueMatchingStrategy valueMatchingStrategy;
+
+    /**
+     * Creates a {@link KafkaMessageByHeaderSelector} that checks if a header with the specified key contains the given
+     * value.
+     * <p>
+     * This method is a convenient shortcut for creating a matcher with the {@link ValueMatchingStrategy#CONTAINS} matching
+     * mechanism.
+     *
+     * @param key   The header key to match. If {@code null}, all header keys will be checked.
+     * @param value The value to search for within the header value. If {@code null}, any value will match.
+     * @return A {@link KafkaMessageByHeaderSelector} configured to use the {@link ValueMatchingStrategy#CONTAINS} matching mechanism.
+     */
+    public static KafkaMessageByHeaderSelector kafkaHeaderContains(String key, String value) {
+        return keyValueBuilder(key, value)
+                .valueMatchingStrategy(CONTAINS)
+                .build();
+    }
+
+    /**
+     * Creates a {@link KafkaMessageByHeaderSelector} that checks if a header with the specified key exactly equals the
+     * given value.
+     * <p>
+     * This method is a convenient shortcut for creating a matcher with the {@link ValueMatchingStrategy#EQUALS} matching
+     * mechanism.
+     *
+     * @param key   The header key to match. If {@code null}, all header keys will be checked.
+     * @param value The exact value to match in the header. If {@code null}, any value will match.
+     * @return A {@link KafkaMessageByHeaderSelector} configured to use the {@link ValueMatchingStrategy#EQUALS} matching mechanism.
+     */
+    public static KafkaMessageByHeaderSelector kafkaHeaderEquals(String key, String value) {
+        return keyValueBuilder(key, value)
+                .valueMatchingStrategy(EQUALS)
+                .build();
+    }
+
+    static <T> KafkaMessageByHeaderSelector fromSelector(Map<String, T> messageSelectors) {
+        var keyFilter = Optional.ofNullable(messageSelectors.get(HEADER_FILTER_KEY)).map(Object::toString).orElse("");
+        var valueFilter = Optional.ofNullable(messageSelectors.get(HEADER_FILTER_VALUE)).map(Objects::toString).orElse(null);
+        var comparator = Optional.ofNullable(messageSelectors.get(HEADER_FILTER_COMPARATOR)).map(Object::toString).orElse(EQUALS.toString());
+
+        if (isEmpty(keyFilter) && isEmpty(valueFilter)) {
+            throw new CitrusRuntimeException("No matcher specified when looking for Kafka messages");
+        }
+
+        return KafkaMessageByHeaderSelector.builder()
+                .key(keyFilter)
+                .value(valueFilter)
+                .valueMatchingStrategy(ValueMatchingStrategy.valueOf(comparator.toUpperCase()))
+                .build();
+    }
+
+    private static KafkaMessageByHeaderSelectorBuilder keyValueBuilder(String key, String value) {
+        return KafkaMessageByHeaderSelector.builder()
+                .key(key)
+                .value(value);
+    }
+
+    @Override
+    public boolean matches(ConsumerRecord<Object, Object> consumerRecord) {
+        var headers = consumerRecord.headers();
+
+        for (Header header : headers) {
+            if ((isEmpty(key) || header.key().equals(key))
+                    && matchesValue(header.value())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    public <T> Map<String, T> asSelector() {
+        Map<String, T> selector = new HashMap<>();
+
+        if (nonNull(key)) {
+            selector.put(HEADER_FILTER_KEY, (T) key);
+        }
+        if (nonNull(value)) {
+            selector.put(HEADER_FILTER_VALUE, (T) value);
+        }
+
+        selector.put(HEADER_FILTER_COMPARATOR, (T) Optional.ofNullable(valueMatchingStrategy).orElse(EQUALS).toString());
+
+        return selector;
+    }
+
+    private boolean matchesValue(byte[] headerValue) {
+        if (isNull(value)) {
+            return true; // If value is not defined, consider it a match
+        }
+
+        var headerValueString = new String(headerValue, UTF_8);
+
+        if (isNull(valueMatchingStrategy)) {
+            return headerValueString.equals(value);
+        }
+
+        return switch (valueMatchingStrategy) {
+            case EQUALS -> headerValueString.equals(value);
+            case CONTAINS -> headerValueString.contains(value);
+            case STARTS_WITH -> headerValueString.startsWith(value);
+            case ENDS_WITH -> headerValueString.endsWith(value);
+        };
+    }
+
+    public enum ValueMatchingStrategy {
+        EQUALS,
+        CONTAINS,
+        STARTS_WITH,
+        ENDS_WITH
+    }
+
+    // Lombok will complete this class; declaration required to build the javadocs
+    public static class KafkaMessageByHeaderSelectorBuilder {}
+}

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/selector/KafkaMessageSelector.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/selector/KafkaMessageSelector.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.kafka.endpoint.selector;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+import java.util.Map;
+
+/**
+ * Defines custom matching logic for filtering {@link ConsumerRecord} instances in Kafka. Implementations of this
+ * interface can define specific criteria for matching Kafka messages based on their content, headers, or any other
+ * attributes.
+ *
+ * @see org.citrusframework.kafka.endpoint.KafkaMessageFilteringConsumer
+ */
+public interface KafkaMessageSelector {
+
+    /**
+     * Determines whether a given ConsumerRecord matches specific criteria.
+     *
+     * @param consumerRecord The ConsumerRecord to be evaluated.
+     * @return true if the record matches the defined criteria, false otherwise.
+     */
+    boolean matches(ConsumerRecord<Object, Object> consumerRecord);
+
+    /**
+     * Transforms the current matcher into its key-value representation, a so-called "selector" in the citrus context.
+     *
+     * @return Selector representation of the matcher.
+     */
+    <T> Map<String, T> asSelector();
+}

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/selector/KafkaMessageSelectorFactory.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/selector/KafkaMessageSelectorFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.kafka.endpoint.selector;
+
+import org.citrusframework.exceptions.CitrusRuntimeException;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.HEADER_FILTER_KEY;
+import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.HEADER_FILTER_VALUE;
+
+public class KafkaMessageSelectorFactory {
+
+    private static final Map<Predicate<Map<String, Object>>, Function<Map<String, Object>, KafkaMessageSelector>> strategies = new HashMap<>();
+
+    static {
+        strategies.put(messageSelectors -> messageSelectors.containsKey(HEADER_FILTER_KEY) || messageSelectors.containsKey(HEADER_FILTER_VALUE), KafkaMessageByHeaderSelector::fromSelector);
+    }
+
+    @SuppressWarnings({"unchecked"})
+    public <T> KafkaMessageSelector parseFromSelector(Map<String, T> messageSelectors) {
+        return strategies.entrySet().stream()
+                .filter(strategy -> strategy.getKey().test((Map<String, Object>) messageSelectors))
+                .findFirst()
+                .map(Map.Entry::getValue)
+                .map(supplier -> supplier.apply((Map<String, Object>) messageSelectors))
+                .orElseThrow(() -> new CitrusRuntimeException("Cannot instantiate Kafka matcher from selectors: " + messageSelectors));
+    }
+}

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/message/KafkaMessage.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/message/KafkaMessage.java
@@ -16,13 +16,14 @@
 
 package org.citrusframework.kafka.message;
 
-import java.util.Map;
-
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.message.DefaultMessage;
 
+import java.util.Map;
+
+import static java.lang.String.format;
+
 /**
- * @author Christoph Deppisch
  * @since 2.8
  */
 public class KafkaMessage extends DefaultMessage {
@@ -36,8 +37,6 @@ public class KafkaMessage extends DefaultMessage {
 
     /**
      * Default constructor using payload and headers.
-     * @param payload
-     * @param headers
      */
     public KafkaMessage(Object payload, Map<String, Object> headers) {
         super(payload, headers);
@@ -45,7 +44,6 @@ public class KafkaMessage extends DefaultMessage {
 
     /**
      * Default constructor using message payload.
-     * @param payload
      */
     public KafkaMessage(Object payload) {
         super(payload);
@@ -53,7 +51,6 @@ public class KafkaMessage extends DefaultMessage {
 
     /**
      * Sets the Kafka partition id header.
-     * @param partition
      */
     public KafkaMessage partition(int partition) {
         setHeader(KafkaMessageHeaders.PARTITION, partition);
@@ -62,7 +59,6 @@ public class KafkaMessage extends DefaultMessage {
 
     /**
      * Sets the Kafka timestamp header.
-     * @param timestamp
      */
     public KafkaMessage timestamp(Long timestamp) {
         setHeader(KafkaMessageHeaders.TIMESTAMP, timestamp);
@@ -71,7 +67,6 @@ public class KafkaMessage extends DefaultMessage {
 
     /**
      * Sets the Kafka offset header.
-     * @param offset
      */
     public KafkaMessage offset(long offset) {
         setHeader(KafkaMessageHeaders.OFFSET, offset);
@@ -80,7 +75,6 @@ public class KafkaMessage extends DefaultMessage {
 
     /**
      * Sets the Kafka message key header.
-     * @param key
      */
     public KafkaMessage messageKey(Object key) {
         setHeader(KafkaMessageHeaders.MESSAGE_KEY, key);
@@ -89,7 +83,6 @@ public class KafkaMessage extends DefaultMessage {
 
     /**
      * Sets the Kafka topic key header.
-     * @param topic
      */
     public KafkaMessage topic(String topic) {
         setHeader(KafkaMessageHeaders.TOPIC, topic);
@@ -98,19 +91,18 @@ public class KafkaMessage extends DefaultMessage {
 
     /**
      * Gets the Kafka partition header.
-     * @return
      */
     public Integer getPartition() {
         Object partition = getHeader(KafkaMessageHeaders.PARTITION);
 
         if (partition != null) {
-            if (partition instanceof Integer) {
-                return (Integer) partition;
-            } else if (partition instanceof String) {
-                return Integer.parseInt((String) partition);
+            if (partition instanceof Integer partitionInteger) {
+                return partitionInteger;
+            } else if (partition instanceof String partitionString) {
+                return Integer.parseInt(partitionString);
             }
 
-            throw new CitrusRuntimeException(String.format("Failed to convert partition header to proper Integer value: %s", partition.getClass()));
+            throw new CitrusRuntimeException(format("Failed to convert partition header to proper Integer value: %s", partition.getClass()));
         }
 
         return null;
@@ -118,7 +110,6 @@ public class KafkaMessage extends DefaultMessage {
 
     /**
      * Gets the Kafka timestamp header.
-     * @return
      */
     public Long getTimestamp() {
         Object timestamp = getHeader(KafkaMessageHeaders.TIMESTAMP);
@@ -132,19 +123,18 @@ public class KafkaMessage extends DefaultMessage {
 
     /**
      * Gets the Kafka offset header.
-     * @return
      */
     public Long getOffset() {
         Object offset = getHeader(KafkaMessageHeaders.OFFSET);
 
         if (offset != null) {
-            if (offset instanceof Long) {
-                return (Long) offset;
-            } else if (offset instanceof String) {
-                return Long.parseLong((String) offset);
+            if (offset instanceof Long longOffset) {
+                return longOffset;
+            } else if (offset instanceof String stringOffset) {
+                return Long.parseLong(stringOffset);
             }
 
-            throw new CitrusRuntimeException(String.format("Failed to convert partition header to proper Long value: %s", offset.getClass()));
+            throw new CitrusRuntimeException(format("Failed to convert partition header to proper Long value: %s", offset.getClass()));
         }
 
         return 0L;
@@ -152,21 +142,13 @@ public class KafkaMessage extends DefaultMessage {
 
     /**
      * Gets the Kafka message key header.
-     * @return
      */
     public Object getMessageKey() {
-        Object key = getHeader(KafkaMessageHeaders.MESSAGE_KEY);
-
-        if (key != null) {
-            return key;
-        }
-
-        return null;
+        return getHeader(KafkaMessageHeaders.MESSAGE_KEY);
     }
 
     /**
      * Gets the Kafka topic header.
-     * @return
      */
     public String getTopic() {
         Object topic = getHeader(KafkaMessageHeaders.TOPIC);

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/message/KafkaMessageConverter.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/message/KafkaMessageConverter.java
@@ -16,9 +16,6 @@
 
 package org.citrusframework.kafka.message;
 
-import java.io.IOException;
-import java.util.Optional;
-
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.citrusframework.context.TestContext;
@@ -28,6 +25,9 @@ import org.citrusframework.message.Message;
 import org.citrusframework.message.MessageConverter;
 import org.citrusframework.spi.Resource;
 import org.citrusframework.util.FileUtils;
+
+import java.io.IOException;
+import java.util.Optional;
 
 /**
  * Basic message converter for converting Spring Integration message implementations to Kafka

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/message/KafkaMessageHeaderMapper.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/message/KafkaMessageHeaderMapper.java
@@ -16,13 +16,13 @@
 
 package org.citrusframework.kafka.message;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import org.citrusframework.context.TestContext;
-import org.citrusframework.message.MessageHeaders;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.message.MessageHeaders;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Citrus Kafka header mapper translates internal message headers to Spring integration message headers and

--- a/endpoints/citrus-kafka/src/main/resources/org/citrusframework/schema/citrus-kafka-config.xsd
+++ b/endpoints/citrus-kafka/src/main/resources/org/citrusframework/schema/citrus-kafka-config.xsd
@@ -45,6 +45,7 @@
       <xs:attribute name="id" type="xs:ID"/>
       <xs:attribute name="client-id" type="xs:string"/>
       <xs:attribute name="consumer-group" type="xs:string"/>
+      <xs:attribute name="random-consumer-group" type="xs:boolean" default="false"/>
       <xs:attribute name="auto-commit" type="xs:string"/>
       <xs:attribute name="auto-commit-interval" type="xs:int"/>
       <xs:attribute name="server" type="xs:string"/>

--- a/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/config/annotation/KafkaEndpointConfigParserTest.java
+++ b/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/config/annotation/KafkaEndpointConfigParserTest.java
@@ -16,8 +16,12 @@
 
 package org.citrusframework.kafka.config.annotation;
 
-import java.util.Map;
-
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.citrusframework.TestActor;
 import org.citrusframework.annotations.CitrusAnnotations;
 import org.citrusframework.annotations.CitrusEndpoint;
@@ -30,18 +34,14 @@ import org.citrusframework.kafka.message.KafkaMessageHeaderMapper;
 import org.citrusframework.kafka.message.KafkaMessageHeaders;
 import org.citrusframework.spi.ReferenceResolver;
 import org.citrusframework.testng.AbstractTestNGUnitTest;
-import org.apache.kafka.common.serialization.ByteArrayDeserializer;
-import org.apache.kafka.common.serialization.ByteArraySerializer;
-import org.apache.kafka.common.serialization.IntegerDeserializer;
-import org.apache.kafka.common.serialization.IntegerSerializer;
-import org.apache.kafka.common.serialization.StringDeserializer;
-import org.apache.kafka.common.serialization.StringSerializer;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import java.util.Map;
 
 import static org.mockito.Mockito.when;
 

--- a/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/config/xml/KafkaEndpointParserTest.java
+++ b/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/config/xml/KafkaEndpointParserTest.java
@@ -16,14 +16,6 @@
 
 package org.citrusframework.kafka.config.xml;
 
-import java.util.Map;
-
-import org.citrusframework.TestActor;
-import org.citrusframework.kafka.endpoint.KafkaEndpoint;
-import org.citrusframework.kafka.message.KafkaMessageConverter;
-import org.citrusframework.kafka.message.KafkaMessageHeaderMapper;
-import org.citrusframework.kafka.message.KafkaMessageHeaders;
-import org.citrusframework.testng.AbstractBeanDefinitionParserTest;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
@@ -32,8 +24,22 @@ import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.testng.Assert;
+import org.citrusframework.TestActor;
+import org.citrusframework.kafka.endpoint.KafkaEndpoint;
+import org.citrusframework.kafka.message.KafkaMessageConverter;
+import org.citrusframework.kafka.message.KafkaMessageHeaderMapper;
+import org.citrusframework.testng.AbstractBeanDefinitionParserTest;
 import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.citrusframework.kafka.message.KafkaMessageHeaders.KAFKA_PREFIX;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 /**
  * @author Christoph Deppisch
@@ -44,60 +50,67 @@ public class KafkaEndpointParserTest extends AbstractBeanDefinitionParserTest {
     public void testKafkaEndpointParser() {
         Map<String, KafkaEndpoint> endpoints = beanDefinitionContext.getBeansOfType(KafkaEndpoint.class);
 
-        Assert.assertEquals(endpoints.size(), 3);
+        assertThat(endpoints)
+            .hasSize(4);
 
         // 1st message receiver
         KafkaEndpoint kafkaEndpoint = endpoints.get("kafkaEndpoint1");
-        Assert.assertNull(kafkaEndpoint.getEndpointConfiguration().getClientId());
-        Assert.assertNotNull(kafkaEndpoint.getEndpointConfiguration().getServer());
-        Assert.assertEquals(kafkaEndpoint.getEndpointConfiguration().getServer(), "localhost:9091");
-        Assert.assertEquals(kafkaEndpoint.getEndpointConfiguration().getHeaderMapper().getClass(), KafkaMessageHeaderMapper.class);
-        Assert.assertEquals(kafkaEndpoint.getEndpointConfiguration().getMessageConverter().getClass(), KafkaMessageConverter.class);
-        Assert.assertEquals(kafkaEndpoint.getEndpointConfiguration().isAutoCommit(), true);
-        Assert.assertEquals(kafkaEndpoint.getEndpointConfiguration().getAutoCommitInterval(), 1000L);
-        Assert.assertEquals(kafkaEndpoint.getEndpointConfiguration().getOffsetReset(), "earliest");
-        Assert.assertEquals(kafkaEndpoint.getEndpointConfiguration().getTopic(), "test");
-        Assert.assertEquals(kafkaEndpoint.getEndpointConfiguration().getPartition(), 0);
-        Assert.assertEquals(kafkaEndpoint.getEndpointConfiguration().getTimeout(), 5000L);
-        Assert.assertEquals(kafkaEndpoint.getEndpointConfiguration().getConsumerGroup(), KafkaMessageHeaders.KAFKA_PREFIX + "group");
-        Assert.assertEquals(kafkaEndpoint.getEndpointConfiguration().getConsumerProperties().size(), 0);
-        Assert.assertEquals(kafkaEndpoint.getEndpointConfiguration().getProducerProperties().size(), 0);
-        Assert.assertEquals(kafkaEndpoint.getEndpointConfiguration().getKeySerializer(), StringSerializer.class);
-        Assert.assertEquals(kafkaEndpoint.getEndpointConfiguration().getValueSerializer(), StringSerializer.class);
-        Assert.assertEquals(kafkaEndpoint.getEndpointConfiguration().getKeyDeserializer(), StringDeserializer.class);
-        Assert.assertEquals(kafkaEndpoint.getEndpointConfiguration().getValueDeserializer(), StringDeserializer.class);
+        assertNull(kafkaEndpoint.getEndpointConfiguration().getClientId());
+        assertNotNull(kafkaEndpoint.getEndpointConfiguration().getServer());
+        assertEquals(kafkaEndpoint.getEndpointConfiguration().getServer(), "localhost:9091");
+        assertEquals(kafkaEndpoint.getEndpointConfiguration().getHeaderMapper().getClass(), KafkaMessageHeaderMapper.class);
+        assertEquals(kafkaEndpoint.getEndpointConfiguration().getMessageConverter().getClass(), KafkaMessageConverter.class);
+        assertTrue(kafkaEndpoint.getEndpointConfiguration().isAutoCommit());
+        assertEquals(kafkaEndpoint.getEndpointConfiguration().getAutoCommitInterval(), 1000L);
+        assertEquals(kafkaEndpoint.getEndpointConfiguration().getOffsetReset(), "earliest");
+        assertEquals(kafkaEndpoint.getEndpointConfiguration().getTopic(), "test");
+        assertEquals(kafkaEndpoint.getEndpointConfiguration().getPartition(), 0);
+        assertEquals(kafkaEndpoint.getEndpointConfiguration().getTimeout(), 5000L);
+        assertEquals(kafkaEndpoint.getEndpointConfiguration().getConsumerGroup(), KAFKA_PREFIX + "group");
+        assertEquals(kafkaEndpoint.getEndpointConfiguration().getConsumerProperties().size(), 0);
+        assertEquals(kafkaEndpoint.getEndpointConfiguration().getProducerProperties().size(), 0);
+        assertEquals(kafkaEndpoint.getEndpointConfiguration().getKeySerializer(), StringSerializer.class);
+        assertEquals(kafkaEndpoint.getEndpointConfiguration().getValueSerializer(), StringSerializer.class);
+        assertEquals(kafkaEndpoint.getEndpointConfiguration().getKeyDeserializer(), StringDeserializer.class);
+        assertEquals(kafkaEndpoint.getEndpointConfiguration().getValueDeserializer(), StringDeserializer.class);
 
         // 2nd message receiver
         kafkaEndpoint = endpoints.get("kafkaEndpoint2");
-        Assert.assertNotNull(kafkaEndpoint.getEndpointConfiguration().getClientId());
-        Assert.assertEquals(kafkaEndpoint.getEndpointConfiguration().getClientId(), "kafkaEndpoint2");
-        Assert.assertNotNull(kafkaEndpoint.getEndpointConfiguration().getServer());
-        Assert.assertEquals(kafkaEndpoint.getEndpointConfiguration().getServer(), "localhost:9092");
-        Assert.assertEquals(kafkaEndpoint.getEndpointConfiguration().getHeaderMapper(), beanDefinitionContext.getBean("headerMapper"));
-        Assert.assertEquals(kafkaEndpoint.getEndpointConfiguration().getMessageConverter(), beanDefinitionContext.getBean("messageConverter"));
-        Assert.assertEquals(kafkaEndpoint.getEndpointConfiguration().isAutoCommit(), false);
-        Assert.assertEquals(kafkaEndpoint.getEndpointConfiguration().getAutoCommitInterval(), 500L);
-        Assert.assertEquals(kafkaEndpoint.getEndpointConfiguration().getOffsetReset(), "latest");
-        Assert.assertEquals(kafkaEndpoint.getEndpointConfiguration().getTopic(), "test");
-        Assert.assertEquals(kafkaEndpoint.getEndpointConfiguration().getPartition(), 1);
-        Assert.assertEquals(kafkaEndpoint.getEndpointConfiguration().getConsumerGroup(), "citrus_group");
-        Assert.assertEquals(kafkaEndpoint.getEndpointConfiguration().getTimeout(), 10000L);
-        Assert.assertEquals(kafkaEndpoint.getEndpointConfiguration().getKeySerializer(), IntegerSerializer.class);
-        Assert.assertEquals(kafkaEndpoint.getEndpointConfiguration().getValueSerializer(), ByteArraySerializer.class);
-        Assert.assertEquals(kafkaEndpoint.getEndpointConfiguration().getKeyDeserializer(), IntegerDeserializer.class);
-        Assert.assertEquals(kafkaEndpoint.getEndpointConfiguration().getValueDeserializer(), ByteArrayDeserializer.class);
+        assertNotNull(kafkaEndpoint.getEndpointConfiguration().getClientId());
+        assertEquals(kafkaEndpoint.getEndpointConfiguration().getClientId(), "kafkaEndpoint2");
+        assertNotNull(kafkaEndpoint.getEndpointConfiguration().getServer());
+        assertEquals(kafkaEndpoint.getEndpointConfiguration().getServer(), "localhost:9092");
+        assertEquals(kafkaEndpoint.getEndpointConfiguration().getHeaderMapper(), beanDefinitionContext.getBean("headerMapper"));
+        assertEquals(kafkaEndpoint.getEndpointConfiguration().getMessageConverter(), beanDefinitionContext.getBean("messageConverter"));
+        assertFalse(kafkaEndpoint.getEndpointConfiguration().isAutoCommit());
+        assertEquals(kafkaEndpoint.getEndpointConfiguration().getAutoCommitInterval(), 500L);
+        assertEquals(kafkaEndpoint.getEndpointConfiguration().getOffsetReset(), "latest");
+        assertEquals(kafkaEndpoint.getEndpointConfiguration().getTopic(), "test");
+        assertEquals(kafkaEndpoint.getEndpointConfiguration().getPartition(), 1);
+        assertEquals(kafkaEndpoint.getEndpointConfiguration().getConsumerGroup(), "citrus_group");
+        assertEquals(kafkaEndpoint.getEndpointConfiguration().getTimeout(), 10000L);
+        assertEquals(kafkaEndpoint.getEndpointConfiguration().getKeySerializer(), IntegerSerializer.class);
+        assertEquals(kafkaEndpoint.getEndpointConfiguration().getValueSerializer(), ByteArraySerializer.class);
+        assertEquals(kafkaEndpoint.getEndpointConfiguration().getKeyDeserializer(), IntegerDeserializer.class);
+        assertEquals(kafkaEndpoint.getEndpointConfiguration().getValueDeserializer(), ByteArrayDeserializer.class);
 
         // 3rd message receiver
         kafkaEndpoint = endpoints.get("kafkaEndpoint3");
-        Assert.assertNotNull(kafkaEndpoint.getEndpointConfiguration().getServer());
-        Assert.assertEquals(kafkaEndpoint.getEndpointConfiguration().getServer(), "localhost:9093");
-        Assert.assertNull(kafkaEndpoint.getEndpointConfiguration().getTopic());
-        Assert.assertNotNull(kafkaEndpoint.getActor());
-        Assert.assertEquals(kafkaEndpoint.getActor(), beanDefinitionContext.getBean("testActor", TestActor.class));
-        Assert.assertEquals(kafkaEndpoint.getEndpointConfiguration().getConsumerProperties().size(), 1);
-        Assert.assertEquals(kafkaEndpoint.getEndpointConfiguration().getConsumerProperties().get(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG), true);
-        Assert.assertEquals(kafkaEndpoint.getEndpointConfiguration().getProducerProperties().size(), 1);
-        Assert.assertEquals(kafkaEndpoint.getEndpointConfiguration().getProducerProperties().get(ProducerConfig.MAX_REQUEST_SIZE_CONFIG), 1024);
+        assertNotNull(kafkaEndpoint.getEndpointConfiguration().getServer());
+        assertEquals(kafkaEndpoint.getEndpointConfiguration().getServer(), "localhost:9093");
+        assertNull(kafkaEndpoint.getEndpointConfiguration().getTopic());
+        assertNotNull(kafkaEndpoint.getActor());
+        assertEquals(kafkaEndpoint.getActor(), beanDefinitionContext.getBean("testActor", TestActor.class));
+        assertEquals(kafkaEndpoint.getEndpointConfiguration().getConsumerProperties().size(), 1);
+        assertEquals(kafkaEndpoint.getEndpointConfiguration().getConsumerProperties().get(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG), true);
+        assertEquals(kafkaEndpoint.getEndpointConfiguration().getProducerProperties().size(), 1);
+        assertEquals(kafkaEndpoint.getEndpointConfiguration().getProducerProperties().get(ProducerConfig.MAX_REQUEST_SIZE_CONFIG), 1024);
 
+        // 4th message receiver
+        kafkaEndpoint = endpoints.get("kafkaEndpoint4");
+        assertThat(kafkaEndpoint.getEndpointConfiguration().getConsumerGroup())
+            .startsWith(KAFKA_PREFIX)
+            .hasSize(23)
+            .containsPattern(".*[a-z]{10}$");
     }
 }

--- a/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/KafkaConsumerTest.java
+++ b/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/KafkaConsumerTest.java
@@ -16,147 +16,181 @@
 
 package org.citrusframework.kafka.endpoint;
 
-import java.time.Duration;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import org.citrusframework.exceptions.ActionTimeoutException;
-import org.citrusframework.message.DefaultMessage;
-import org.citrusframework.message.Message;
-import org.citrusframework.testng.AbstractTestNGUnitTest;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.internals.RecordHeader;
-import org.mockito.Mockito;
-import org.testng.Assert;
+import org.citrusframework.exceptions.ActionTimeoutException;
+import org.citrusframework.message.DefaultMessage;
+import org.citrusframework.message.Message;
+import org.citrusframework.testng.AbstractTestNGUnitTest;
 import org.testng.annotations.Test;
 
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
-/**
- * @author Christoph Deppisch
- */
 public class KafkaConsumerTest extends AbstractTestNGUnitTest {
 
-    private org.apache.kafka.clients.consumer.KafkaConsumer<Object, Object> kafkaConsumer = Mockito.mock(KafkaConsumer.class);
+    private final org.apache.kafka.clients.consumer.KafkaConsumer<Object, Object> kafkaConsumerMock = mock(KafkaConsumer.class);
 
     @Test
     public void testReceiveMessage() {
         String topic = "default";
 
-        KafkaEndpoint endpoint = new KafkaEndpoint();
-        endpoint.createConsumer().setConsumer(kafkaConsumer);
-
-        endpoint.getEndpointConfiguration().setTopic(topic);
+        KafkaEndpoint endpoint = KafkaEndpoint.builder()
+                .kafkaConsumer(kafkaConsumerMock)
+                .topic(topic)
+                .build();
 
         TopicPartition partition = new TopicPartition(topic, 0);
 
-        reset(kafkaConsumer);
+        reset(kafkaConsumerMock);
 
-        when(kafkaConsumer.subscription()).thenReturn(Collections.emptySet());
+        when(kafkaConsumerMock.subscription()).thenReturn(emptySet());
         doAnswer(invocation -> {
             List<String> topics = invocation.getArgument(0);
-            Assert.assertEquals(topics.size(), 1L);
-            Assert.assertEquals(topics.get(0), topic);
+            assertEquals(topics.size(), 1L);
+            assertEquals(topics.get(0), topic);
 
             return null;
-        }).when(kafkaConsumer).subscribe(anyList());
+        }).when(kafkaConsumerMock).subscribe(anyList());
 
         ConsumerRecord<Object, Object> consumerRecord = new ConsumerRecord<>(topic, 0, 0, 1, "<TestRequest><Message>Hello World!</Message></TestRequest>");
-        ConsumerRecords<Object, Object> records = new ConsumerRecords<>(Collections.singletonMap(partition, Collections.singletonList(consumerRecord)));
-        when(kafkaConsumer.poll(Duration.ofMillis(5000L))).thenReturn(records);
+        ConsumerRecords<Object, Object> records = new ConsumerRecords<>(singletonMap(partition, singletonList(consumerRecord)));
+        when(kafkaConsumerMock.poll(Duration.ofMillis(5000L))).thenReturn(records);
 
         final Message controlMessage = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>");
 
         Message receivedMessage = endpoint.createConsumer().receive(context);
-        Assert.assertEquals(receivedMessage.getPayload(), controlMessage.getPayload());
+        assertEquals(receivedMessage.getPayload(), controlMessage.getPayload());
+    }
+
+    @Test
+    public void testReceiveMessage_inRandomConsumerGroup() {
+        String topic = "default";
+
+        KafkaEndpoint endpoint = KafkaEndpoint.builder()
+                .kafkaConsumer(kafkaConsumerMock)
+                .topic(topic)
+                .build();
+
+        TopicPartition partition = new TopicPartition(topic, 0);
+
+        reset(kafkaConsumerMock);
+
+        when(kafkaConsumerMock.subscription()).thenReturn(emptySet());
+        doAnswer(invocation -> {
+            List<String> topics = invocation.getArgument(0);
+            assertEquals(topics.size(), 1L);
+            assertEquals(topics.get(0), topic);
+
+            return null;
+        }).when(kafkaConsumerMock).subscribe(anyList());
+
+        ConsumerRecord<Object, Object> consumerRecord = new ConsumerRecord<>(topic, 0, 0, 1, "<TestRequest><Message>Hello World!</Message></TestRequest>");
+        ConsumerRecords<Object, Object> records = new ConsumerRecords<>(singletonMap(partition, singletonList(consumerRecord)));
+        when(kafkaConsumerMock.poll(Duration.ofMillis(5000L))).thenReturn(records);
+
+        final Message controlMessage = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>");
+
+        Message receivedMessage = endpoint.createConsumer().receive(context);
+        assertEquals(receivedMessage.getPayload(), controlMessage.getPayload());
     }
 
     @Test
     public void testReceiveMessageTimeout() {
         String topic = "test";
 
-        KafkaEndpoint endpoint = new KafkaEndpoint();
-        endpoint.createConsumer().setConsumer(kafkaConsumer);
+        KafkaEndpoint endpoint = KafkaEndpoint.builder()
+                .kafkaConsumer(kafkaConsumerMock)
+                .server("localhost:9092")
+                .topic(topic)
+                .build();
 
-        endpoint.getEndpointConfiguration().setServer("localhost:9092");
-        endpoint.getEndpointConfiguration().setTopic(topic);
+        reset(kafkaConsumerMock);
+        when(kafkaConsumerMock.subscription()).thenReturn(singleton(topic));
 
-        reset(kafkaConsumer);
-        when(kafkaConsumer.subscription()).thenReturn(Collections.singleton(topic));
-
-        when(kafkaConsumer.poll(Duration.ofMillis(10000L))).thenReturn(ConsumerRecords.EMPTY);
+        when(kafkaConsumerMock.poll(Duration.ofMillis(10000L))).thenReturn(ConsumerRecords.EMPTY);
 
         try {
             endpoint.createConsumer().receive(context, 10000L);
-        } catch(ActionTimeoutException e) {
-            Assert.assertTrue(e.getMessage().startsWith("Action timeout after 10000 milliseconds. Failed to receive message on endpoint: 'test'"));
+        } catch (ActionTimeoutException e) {
+            assertTrue(e.getMessage().startsWith("Action timeout after 10000 milliseconds. Failed to receive message on endpoint: 'test'"));
             return;
         }
 
-        Assert.fail("Missing " + ActionTimeoutException.class + " because of receiving message timeout");
+        fail("Missing " + ActionTimeoutException.class + " because of receiving message timeout");
     }
 
     @Test
     public void testWithCustomTimeout() {
         String topic = "timeout";
 
-        KafkaEndpoint endpoint = new KafkaEndpoint();
-        endpoint.createConsumer().setConsumer(kafkaConsumer);
-
-        endpoint.getEndpointConfiguration().setTopic(topic);
-
-        endpoint.getEndpointConfiguration().setTimeout(10000L);
+        KafkaEndpoint endpoint = KafkaEndpoint.builder()
+                .kafkaConsumer(kafkaConsumerMock)
+                .timeout(10_000L)
+                .topic(topic)
+                .build();
 
         TopicPartition partition = new TopicPartition(topic, 0);
 
-        reset(kafkaConsumer);
-        when(kafkaConsumer.subscription()).thenReturn(Collections.singleton(topic));
+        reset(kafkaConsumerMock);
+        when(kafkaConsumerMock.subscription()).thenReturn(singleton(topic));
 
         ConsumerRecord<Object, Object> consumerRecord = new ConsumerRecord<>(topic, 0, 0, 1, "<TestRequest><Message>Hello World!</Message></TestRequest>");
-        ConsumerRecords<Object, Object> records = new ConsumerRecords<>(Collections.singletonMap(partition, Collections.singletonList(consumerRecord)));
-        when(kafkaConsumer.poll(Duration.ofMillis(10000L))).thenReturn(records);
+        ConsumerRecords<Object, Object> records = new ConsumerRecords<>(singletonMap(partition, singletonList(consumerRecord)));
+        when(kafkaConsumerMock.poll(Duration.ofMillis(10000L))).thenReturn(records);
 
         final Message controlMessage = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>");
 
         Message receivedMessage = endpoint.createConsumer().receive(context);
-        Assert.assertEquals(receivedMessage.getPayload(), controlMessage.getPayload());
+        assertEquals(receivedMessage.getPayload(), controlMessage.getPayload());
     }
 
     @Test
     public void testWithMessageHeaders() {
         String topic = "headers";
 
-        KafkaEndpoint endpoint = new KafkaEndpoint();
-        endpoint.createConsumer().setConsumer(kafkaConsumer);
-
-        endpoint.getEndpointConfiguration().setServer("localhost:9092");
-        endpoint.getEndpointConfiguration().setTopic(topic);
+        KafkaEndpoint endpoint = KafkaEndpoint.builder()
+                .kafkaConsumer(kafkaConsumerMock)
+                .server("localhost:9092")
+                .topic(topic)
+                .build();
 
         TopicPartition partition = new TopicPartition(topic, 0);
 
-        reset(kafkaConsumer);
-        when(kafkaConsumer.subscription()).thenReturn(Collections.singleton(topic));
+        reset(kafkaConsumerMock);
+        when(kafkaConsumerMock.subscription()).thenReturn(singleton(topic));
 
         ConsumerRecord<Object, Object> consumerRecord = new ConsumerRecord<>(topic, 0, 0, 1, "<TestRequest><Message>Hello World!</Message></TestRequest>");
         consumerRecord.headers().add(new RecordHeader("Operation", "sayHello".getBytes()));
-        ConsumerRecords<Object, Object> records = new ConsumerRecords<>(Collections.singletonMap(partition, Collections.singletonList(consumerRecord)));
-        when(kafkaConsumer.poll(Duration.ofMillis(5000L))).thenReturn(records);
+        ConsumerRecords<Object, Object> records = new ConsumerRecords<>(singletonMap(partition, singletonList(consumerRecord)));
+        when(kafkaConsumerMock.poll(Duration.ofMillis(5000L))).thenReturn(records);
 
         Map<String, Object> controlHeaders = new HashMap<>();
         controlHeaders.put("Operation", "sayHello");
         final Message controlMessage = new DefaultMessage("<TestRequest><Message>Hello World!</Message></TestRequest>", controlHeaders);
 
         Message receivedMessage = endpoint.createConsumer().receive(context);
-        Assert.assertEquals(receivedMessage.getPayload(), controlMessage.getPayload());
-        Assert.assertNotNull(receivedMessage.getHeader("Operation"));
-        Assert.assertTrue(receivedMessage.getHeader("Operation").equals("sayHello"));
+        assertEquals(receivedMessage.getPayload(), controlMessage.getPayload());
+        assertNotNull(receivedMessage.getHeader("Operation"));
+        assertEquals(receivedMessage.getHeader("Operation"), "sayHello");
     }
 }

--- a/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/KafkaEndpointComponentTest.java
+++ b/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/KafkaEndpointComponentTest.java
@@ -16,8 +16,6 @@
 
 package org.citrusframework.kafka.endpoint;
 
-import java.util.Map;
-
 import org.citrusframework.context.TestContext;
 import org.citrusframework.endpoint.Endpoint;
 import org.citrusframework.endpoint.EndpointComponent;
@@ -25,6 +23,8 @@ import org.citrusframework.endpoint.direct.DirectEndpointComponent;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import java.util.Map;
 
 /**
  * @author Christoph Deppisch

--- a/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/KafkaEndpointTest.java
+++ b/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/KafkaEndpointTest.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.kafka.endpoint;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.OPTIONAL;
+import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
+import static org.citrusframework.kafka.message.KafkaMessageHeaders.KAFKA_PREFIX;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+public class KafkaEndpointTest {
+
+    @Test
+    public void classHasBuilder() {
+        assertThat(KafkaEndpoint.builder().build())
+                .isInstanceOf(KafkaEndpoint.class);
+    }
+
+    @Test
+    public void defaultConstructor_initializesKafkaEndpointConfiguration() {
+        var fixture = new KafkaEndpoint();
+
+        assertThat(fixture)
+                .extracting(KafkaEndpoint::getEndpointConfiguration)
+                .isNotNull();
+    }
+
+    @Test
+    public void newKafkaEndpoint_acceptsKafkaConsumer() {
+        var kafkaConsumerMock = mock(org.apache.kafka.clients.consumer.KafkaConsumer.class);
+
+        var fixture = KafkaEndpoint.newKafkaEndpoint(
+                kafkaConsumerMock,
+                null, null, null, null, null
+        );
+
+        assertThat(fixture)
+                .isNotNull()
+                .extracting(KafkaEndpoint::getKafkaConsumer)
+                .isNotNull()
+                .extracting(org.citrusframework.kafka.endpoint.KafkaConsumer::getConsumer)
+                .isEqualTo(kafkaConsumerMock);
+    }
+
+    @Test
+    public void newKafkaEndpoint_acceptsKafkaProducer() {
+        var kafkaProducerMock = mock(org.apache.kafka.clients.producer.KafkaProducer.class);
+
+        var fixture = KafkaEndpoint.newKafkaEndpoint(
+                null,
+                kafkaProducerMock,
+                null, null, null, null
+        );
+
+        assertThat(fixture)
+                .isNotNull()
+                .extracting(KafkaEndpoint::getKafkaProducer)
+                .isNotNull()
+                .extracting(org.citrusframework.kafka.endpoint.KafkaProducer::getProducer)
+                .isEqualTo(kafkaProducerMock);
+    }
+
+    @DataProvider
+    public static Object[][] defaultConsumerGroups() {
+        return new Object[][]{{null}, {FALSE}};
+    }
+
+    @Test(dataProvider = "defaultConsumerGroups")
+    public void newKafkaEndpoint_usesDefaultConsumerGroup(Boolean useRandomConsumerGroup) {
+        var fixture = KafkaEndpoint.newKafkaEndpoint(
+                null, null,
+                useRandomConsumerGroup,
+                null, null, null
+        );
+
+        assertThat(fixture)
+                .isNotNull()
+                .extracting(KafkaEndpoint::getEndpointConfiguration)
+                .isNotNull()
+                .extracting(KafkaEndpointConfiguration::getConsumerGroup)
+                .asInstanceOf(STRING)
+                .isNotEmpty()
+                .isEqualTo("citrus_kafka_group");
+    }
+
+    @Test
+    public void newKafkaEndpoint_isAbleToCreateRandomConsumerGroup() {
+        var fixture = KafkaEndpoint.newKafkaEndpoint(
+                null, null,
+                TRUE,
+                null, null, null
+        );
+
+        assertThat(fixture)
+                .isNotNull()
+                .extracting(KafkaEndpoint::getEndpointConfiguration)
+                .isNotNull()
+                .extracting(KafkaEndpointConfiguration::getConsumerGroup)
+                .asInstanceOf(STRING)
+                .isNotEmpty()
+                .startsWith(KAFKA_PREFIX)
+                .hasSize(23)
+                .containsPattern(".*[a-z]{10}$")
+                .satisfies(
+                        // Additionally make sure that gets passed downstream
+                        groupId -> assertThat(fixture.createConsumer().getConsumer())
+                                .extracting("delegate")
+                                .extracting("groupId")
+                                .asInstanceOf(OPTIONAL)
+                                .hasValue(groupId)
+                );
+    }
+
+    @Test
+    public void newKafkaEndpoint_acceptsServer() {
+        var server = "localhost";
+
+        var fixture = KafkaEndpoint.newKafkaEndpoint(
+                null, null, null,
+                server,
+                null, null
+        );
+
+        assertThat(fixture)
+                .isNotNull()
+                .extracting(KafkaEndpoint::getEndpointConfiguration)
+                .isNotNull()
+                .extracting(KafkaEndpointConfiguration::getServer)
+                .isEqualTo(server);
+    }
+
+    @Test
+    public void newKafkaEndpoint_acceptsTimeout() {
+        var timeout = 1234L;
+
+        var fixture = KafkaEndpoint.newKafkaEndpoint(
+                null, null, null, null,
+                timeout,
+                null
+        );
+
+        assertThat(fixture)
+                .isNotNull()
+                .extracting(KafkaEndpoint::getEndpointConfiguration)
+                .isNotNull()
+                .extracting(KafkaEndpointConfiguration::getTimeout)
+                .isEqualTo(timeout);
+    }
+
+    @Test
+    public void newKafkaEndpoint_acceptsTopic() {
+        var topic = "citrus";
+
+        var fixture = KafkaEndpoint.newKafkaEndpoint(
+                null, null, null, null, null,
+                topic
+        );
+
+        assertThat(fixture)
+                .isNotNull()
+                .extracting(KafkaEndpoint::getEndpointConfiguration)
+                .isNotNull()
+                .extracting(KafkaEndpointConfiguration::getTopic)
+                .isEqualTo(topic);
+    }
+
+    @Test
+    public void createConsumer_isMultipleInvocationAware() {
+        var fixture = new KafkaEndpoint();
+
+        var firstConsumer = fixture.createConsumer();
+        var secondConsumer = fixture.createConsumer();
+
+        assertThat(firstConsumer).isNotNull();
+        assertThat(secondConsumer).isNotNull();
+        assertThat(firstConsumer).isSameAs(secondConsumer);
+    }
+
+    @Test
+    public void createProducer_isMultipleInvocationAware() {
+        var fixture = new KafkaEndpoint();
+
+        var firstConsumer = fixture.createProducer();
+        var secondConsumer = fixture.createProducer();
+
+        assertThat(firstConsumer).isNotNull();
+        assertThat(secondConsumer).isNotNull();
+        assertThat(firstConsumer).isSameAs(secondConsumer);
+    }
+
+    @Test
+    public void getEndpointConfiguration_returnsInitialEndpointConfiguration() {
+        var kafkaEndpointConfigurationMock = mock(KafkaEndpointConfiguration.class);
+
+        var fixture = new KafkaEndpoint(kafkaEndpointConfigurationMock);
+
+        assertThat(fixture)
+                .extracting(KafkaEndpoint::getEndpointConfiguration)
+                .isEqualTo(kafkaEndpointConfigurationMock);
+    }
+
+    @Test
+    public void destroy_stopsKafkaConsumer() {
+        var kafkaConsumerMock = mock(KafkaConsumer.class);
+
+        var fixture = new KafkaEndpoint();
+        setField(fixture, "kafkaConsumer", kafkaConsumerMock, KafkaConsumer.class);
+
+        fixture.destroy();
+
+        verify(kafkaConsumerMock).stop();
+    }
+}

--- a/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/KafkaMessageConsumerUtilsTest.java
+++ b/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/KafkaMessageConsumerUtilsTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.kafka.endpoint;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.kafka.message.KafkaMessageConverter;
+import org.citrusframework.message.Message;
+import org.mockito.Mock;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+public class KafkaMessageConsumerUtilsTest {
+
+    @Mock
+    private TestContext testContextMock;
+
+    private AutoCloseable mockitoContext;
+
+    @BeforeMethod
+    public void beforeMethodSetup() {
+        mockitoContext = openMocks(this);
+    }
+
+    @Test
+    public void resolveTopic() {
+        var kafkaEndpointConfiguration = new KafkaEndpointConfiguration();
+
+        var topic = "earth";
+        kafkaEndpointConfiguration.setTopic(topic);
+
+        var resolvedTopic = "vogon";
+        doReturn(resolvedTopic).when(testContextMock).replaceDynamicContentInString(topic);
+
+        assertThat(KafkaMessageConsumerUtils.resolveTopic(kafkaEndpointConfiguration, testContextMock))
+                .isEqualTo(resolvedTopic);
+
+        verify(testContextMock).replaceDynamicContentInString(topic);
+    }
+
+    @Test
+    public void resolveTopic_throwsException_ifTopicIsNull() {
+        var kafkaEndpointConfiguration = new KafkaEndpointConfiguration();
+
+        assertThatThrownBy(() -> KafkaMessageConsumerUtils.resolveTopic(kafkaEndpointConfiguration, testContextMock))
+                .isInstanceOf(CitrusRuntimeException.class)
+                .hasMessage("Missing Kafka topic to receive messages from - add topic to endpoint configuration");
+
+        verifyNoInteractions(testContextMock);
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked"})
+    public void parseConsumerRecordsToMessage() {
+        var consumerRecordMock = mock(ConsumerRecord.class);
+        List<ConsumerRecord<Object, Object>> consumerRecords = singletonList(consumerRecordMock);
+
+        var kafkaEndpointConfiguration = new KafkaEndpointConfiguration();
+
+        var messageConverterMock = mock(KafkaMessageConverter.class);
+        kafkaEndpointConfiguration.setMessageConverter(messageConverterMock);
+
+        var messageMock = mock(Message.class);
+        doReturn(messageMock).when(messageConverterMock).convertInbound(consumerRecordMock, kafkaEndpointConfiguration, testContextMock);
+
+        var result = KafkaMessageConsumerUtils.parseConsumerRecordsToMessage(consumerRecords, kafkaEndpointConfiguration, testContextMock);
+
+        assertThat(result)
+                .isEqualTo(messageMock);
+
+        verify(testContextMock).onInboundMessage(messageMock);
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked"})
+    public void parseConsumerRecordsToMessage_throwsException_ifNonUniqueResultMapped() {
+        List<ConsumerRecord<Object, Object>> consumerRecords = List.of(
+                mock(ConsumerRecord.class),
+                mock(ConsumerRecord.class)
+        );
+
+        var kafkaEndpointConfiguration = new KafkaEndpointConfiguration();
+
+        var topic = "Mars";
+        kafkaEndpointConfiguration.setTopic(topic);
+        doReturn(topic).when(testContextMock).replaceDynamicContentInString(topic);
+
+        assertThatThrownBy(() -> KafkaMessageConsumerUtils.parseConsumerRecordsToMessage(consumerRecords, kafkaEndpointConfiguration, testContextMock))
+                .isInstanceOf(CitrusRuntimeException.class)
+                .hasMessage("More than one matching record found in topic " + topic);
+    }
+
+    @AfterMethod
+    public void afterMethodTeardown() throws Exception {
+        mockitoContext.close();
+    }
+}

--- a/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/KafkaMessageFilterTest.java
+++ b/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/KafkaMessageFilterTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.kafka.endpoint;
+
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.kafka.endpoint.selector.KafkaMessageSelector;
+import org.citrusframework.kafka.endpoint.selector.KafkaMessageSelectorFactory;
+import org.citrusframework.message.MessageSelectorBuilder;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.time.Duration;
+
+import static java.util.Collections.singletonMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.citrusframework.kafka.endpoint.KafkaMessageFilter.EVENT_LOOKBACK_WINDOW;
+import static org.citrusframework.kafka.endpoint.KafkaMessageFilter.POLL_TIMEOUT;
+import static org.citrusframework.kafka.endpoint.KafkaMessageFilter.kafkaMessageFilter;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class KafkaMessageFilterTest {
+
+    private KafkaMessageFilter fixture;
+
+    @BeforeMethod
+    public void beforeMethodSetup() {
+        fixture = KafkaMessageFilter.kafkaMessageFilter().buildFilter();
+    }
+
+    @Test
+    public void hasKafkaConsumerRecordMatcherFactory() {
+        assertThat(fixture.getKafkaMessageSelectorFactory())
+                .isNotNull();
+    }
+
+    @Test
+    public void defaultPollTimeout() {
+        assertThat(fixture.getPollTimeout())
+                .isEqualTo(Duration.ofMillis(100));
+    }
+
+    @Test
+    public void kafkaMessageFilter_throwsException_whenNoOffsetConfigured() {
+        assertThatThrownBy(() -> KafkaMessageFilter.kafkaMessageFilter(""))
+                .isInstanceOf(CitrusRuntimeException.class)
+                .hasMessage("Cannot find Kafka messages without offset limitation");
+    }
+
+    @Test
+    public void kafkaMessageFilter_extractsOffset() {
+        var eventLookbackWindow = Duration.ofSeconds(1);
+
+        var keyValueMap = KafkaMessageFilter.kafkaMessageFilter()
+                .eventLookbackWindow(eventLookbackWindow)
+                .build();
+        var messageSelector = MessageSelectorBuilder.fromKeyValueMap(keyValueMap).build();
+
+        var kafkaConsumerRecordMatcherFactoryMock = mock(KafkaMessageSelectorFactory.class);
+        var fixture = kafkaMessageFilter(messageSelector, kafkaConsumerRecordMatcherFactoryMock);
+
+        assertThat(fixture.getEventLookbackWindow())
+                .isEqualTo(eventLookbackWindow);
+
+        verify(kafkaConsumerRecordMatcherFactoryMock).parseFromSelector(keyValueMap);
+    }
+
+    @Test
+    public void kafkaMessageFilter_usesDefaultPollTimeout_whenNotGiven() {
+        var eventLookbackWindow = Duration.ofSeconds(1);
+
+        var keyValueMap = KafkaMessageFilter.kafkaMessageFilter()
+                .eventLookbackWindow(eventLookbackWindow)
+                .build();
+        var messageSelector = MessageSelectorBuilder.fromKeyValueMap(keyValueMap).build();
+
+        var kafkaConsumerRecordMatcherFactoryMock = mock(KafkaMessageSelectorFactory.class);
+        var fixture = kafkaMessageFilter(messageSelector, kafkaConsumerRecordMatcherFactoryMock);
+
+        assertThat(fixture.getPollTimeout())
+                .isEqualTo(Duration.ofMillis(100));
+
+        verify(kafkaConsumerRecordMatcherFactoryMock).parseFromSelector(keyValueMap);
+    }
+
+    @Test
+    public void kafkaMessageFilter_extractsPollTimeout() {
+        var eventLookbackWindow = Duration.ofSeconds(5);
+        var pollTimeout = Duration.ofSeconds(1);
+
+        var keyValueMap = KafkaMessageFilter.kafkaMessageFilter()
+                .eventLookbackWindow(eventLookbackWindow)
+                .pollTimeout(pollTimeout)
+                .build();
+        var messageSelector = MessageSelectorBuilder.fromKeyValueMap(keyValueMap).build();
+
+        var kafkaConsumerRecordMatcherFactoryMock = mock(KafkaMessageSelectorFactory.class);
+        var fixture = kafkaMessageFilter(messageSelector, kafkaConsumerRecordMatcherFactoryMock);
+
+        assertThat(fixture.getPollTimeout())
+                .isEqualTo(pollTimeout);
+
+        verify(kafkaConsumerRecordMatcherFactoryMock).parseFromSelector(keyValueMap);
+    }
+
+    @Test
+    public void kafkaMessageSelector_extractsKafkaConsumerRecordMatcher() {
+        var eventLookbackWindow = Duration.ofSeconds(5);
+        var pollTimeout = Duration.ofSeconds(1);
+
+        var keyValueMap = KafkaMessageFilter.kafkaMessageFilter()
+                .eventLookbackWindow(eventLookbackWindow)
+                .pollTimeout(pollTimeout)
+                .build();
+        var messageSelector = MessageSelectorBuilder.fromKeyValueMap(keyValueMap).build();
+
+        var kafkaConsumerRecordMatcherFactoryMock = mock(KafkaMessageSelectorFactory.class);
+
+        var kafkaConsumerRecordMatcher = mock(KafkaMessageSelector.class);
+        doReturn(kafkaConsumerRecordMatcher).when(kafkaConsumerRecordMatcherFactoryMock).parseFromSelector(keyValueMap);
+
+        var fixture = kafkaMessageFilter(messageSelector, kafkaConsumerRecordMatcherFactoryMock);
+
+        assertThat(fixture.getKafkaMessageSelector())
+                .isEqualTo(kafkaConsumerRecordMatcher);
+
+        verify(kafkaConsumerRecordMatcherFactoryMock).parseFromSelector(keyValueMap);
+    }
+
+    @Test
+    public void build_ignoresNullValues() {
+        var selector = KafkaMessageFilter.kafkaMessageFilter()
+                .eventLookbackWindow(null)
+                .kafkaMessageSelector(null)
+                .pollTimeout(null)
+                .build();
+
+        assertThat(selector)
+                .isEmpty();
+    }
+
+    @Test
+    public void build_exportsAllNonNullValues() {
+        var eventLookbackWindow = Duration.ofSeconds(5);
+        var kafkaConsumerRecordMatcherMock = mock(KafkaMessageSelector.class);
+        var pollTimeout = Duration.ofSeconds(1);
+
+        var kafkaConsumerRecordMatcherSelector = singletonMap("foo", "bar");
+        doReturn(kafkaConsumerRecordMatcherSelector).when(kafkaConsumerRecordMatcherMock).asSelector();
+
+        var selector = KafkaMessageFilter.kafkaMessageFilter()
+                .eventLookbackWindow(eventLookbackWindow)
+                .kafkaMessageSelector(kafkaConsumerRecordMatcherMock)
+                .pollTimeout(pollTimeout)
+                .build();
+
+        assertThat(selector)
+                .hasEntrySatisfying(EVENT_LOOKBACK_WINDOW, r -> assertThat(r).isEqualTo(eventLookbackWindow.toString()))
+                .hasEntrySatisfying(POLL_TIMEOUT, r -> assertThat(r).isEqualTo(pollTimeout.toString()))
+                .containsAllEntriesOf(selector);
+
+        verify(kafkaConsumerRecordMatcherMock).asSelector();
+    }
+
+    @Test
+    public void sanitize_throwsNothing_whenSelectorValid() {
+        var eventLookbackWindow = Duration.ofSeconds(1);
+        var kafkaConsumerRecordMatcherMock = mock(KafkaMessageSelector.class);
+
+        // Explicitly configure selector, but no lookback window, to minimize side effects
+        fixture = KafkaMessageFilter.kafkaMessageFilter()
+                .eventLookbackWindow(eventLookbackWindow)
+                .kafkaMessageSelector(kafkaConsumerRecordMatcherMock)
+                .buildFilter();
+
+        assertThatNoException().isThrownBy(() -> fixture.sanitize());
+    }
+
+    @Test
+    public void sanitize_throwsException_whenNoOffsetConfigured() {
+        var kafkaConsumerRecordMatcherMock = mock(KafkaMessageSelector.class);
+
+        // Explicitly configure selector, but no lookback window, to minimize side effects
+        fixture = KafkaMessageFilter.kafkaMessageFilter()
+                .kafkaMessageSelector(kafkaConsumerRecordMatcherMock)
+                .buildFilter();
+
+        assertThatThrownBy(() -> fixture.sanitize())
+                .isInstanceOf(CitrusRuntimeException.class)
+                .hasMessage("Cannot find Kafka messages without offset limitation");
+    }
+
+    @Test
+    public void sanitize_throwsException_whenNoPollTimeoutConfigured() {
+        var eventLookbackWindow = Duration.ofSeconds(1);
+        var kafkaConsumerRecordMatcherMock = mock(KafkaMessageSelector.class);
+
+        // Explicitly configure selector, but nullish poll timeout, to minimize side effects
+        fixture = KafkaMessageFilter.kafkaMessageFilter()
+                .eventLookbackWindow(eventLookbackWindow)
+                .kafkaMessageSelector(kafkaConsumerRecordMatcherMock)
+                .pollTimeout(null)
+                .buildFilter();
+
+        assertThatThrownBy(() -> fixture.sanitize())
+                .isInstanceOf(CitrusRuntimeException.class)
+                .hasMessage("No poll timeout defined when looking for Kafka messages");
+    }
+
+    @Test
+    public void sanitize_throwsException_whenNoMatcherConfigured() {
+        var eventLookbackWindow = Duration.ofSeconds(1);
+
+        // Explicitly configure selector, but no record matcher, to minimize side effects
+        fixture = KafkaMessageFilter.kafkaMessageFilter()
+                .eventLookbackWindow(eventLookbackWindow)
+                .buildFilter();
+
+        assertThatThrownBy(() -> fixture.sanitize())
+                .isInstanceOf(CitrusRuntimeException.class)
+                .hasMessage("No matcher specified when looking for Kafka messages");
+    }
+}

--- a/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/KafkaMessageFilteringConsumerTest.java
+++ b/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/KafkaMessageFilteringConsumerTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.kafka.endpoint;
+
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.kafka.endpoint.selector.KafkaMessageSelector;
+import org.citrusframework.message.MessageSelectorBuilder;
+import org.mockito.Mock;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.Duration;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.kafkaHeaderEquals;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.MockitoAnnotations.openMocks;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+public class KafkaMessageFilteringConsumerTest {
+
+    private static final Long TIMEOUT = 10_000L;
+
+    @Mock
+    private TestContext testContextMock;
+
+    private AutoCloseable mockitoContext;
+
+    @BeforeMethod
+    public void beforeMethodSetup() {
+        mockitoContext = openMocks(this);
+    }
+
+    @Test
+    public void builder() {
+        var eventLookbackWindow = Duration.ofSeconds(5);
+        var kafkaConsumer = mock(KafkaConsumer.class);
+        var kafkaMessageSelectorMock = mock(KafkaMessageSelector.class);
+        var pollTimeout = Duration.ofSeconds(1);
+
+        var fixture = KafkaMessageFilteringConsumer.builder()
+                .consumer(kafkaConsumer)
+                .eventLookbackWindow(eventLookbackWindow)
+                .kafkaMessageSelector(kafkaMessageSelectorMock)
+                .pollTimeout(pollTimeout)
+                .build();
+
+        assertThat(fixture).satisfies(
+                c -> assertThat(c.getConsumer()).isEqualTo(kafkaConsumer),
+                c -> assertThat(c.getKafkaMessageFilter())
+                        .satisfies(
+                                s -> assertThat(s.getEventLookbackWindow()).isEqualTo(eventLookbackWindow),
+                                s -> assertThat(s.getKafkaMessageSelector()).isEqualTo(kafkaMessageSelectorMock),
+                                s -> assertThat(s.getPollTimeout()).isEqualTo(pollTimeout)
+                        )
+        );
+    }
+
+    @DataProvider
+    public static Object[][] nullishConsumerSelector() {
+        return new Object[][]{
+                {Duration.ofSeconds(5), mock(KafkaMessageSelector.class), null},
+                {Duration.ofSeconds(5), null, Duration.ofSeconds(1)},
+                {null, mock(KafkaMessageSelector.class), Duration.ofSeconds(1)},
+        };
+    }
+
+    @Test(dataProvider = "nullishConsumerSelector")
+    public void builder_requiresOneNonNullArgument_toBuildKafkaConsumerSelector(
+            Duration eventLookbackWindow,
+            KafkaMessageSelector kafkaMessageSelector,
+            Duration pollTimeout) {
+        var fixture = KafkaMessageFilteringConsumer.builder()
+                .eventLookbackWindow(eventLookbackWindow)
+                .kafkaMessageSelector(kafkaMessageSelector)
+                .pollTimeout(pollTimeout)
+                .build();
+
+        assertThat(fixture.getKafkaMessageFilter())
+                .satisfies(
+                        s -> assertThat(s.getEventLookbackWindow()).isEqualTo(eventLookbackWindow),
+                        s -> assertThat(s.getKafkaMessageSelector()).isEqualTo(kafkaMessageSelector),
+                        s -> assertThat(s.getPollTimeout()).isEqualTo(pollTimeout)
+                );
+    }
+
+    @DataProvider
+    public static Object[][] emptyStrings() {
+        return new Object[][]{{null}, {""}};
+    }
+
+    @Test(dataProvider = "emptyStrings")
+    public void receive_throwsException_whenNoSelectorGiven(String selector) {
+        var fixture = KafkaMessageFilteringConsumer.builder()
+                .build();
+
+        assertThatThrownBy(() -> fixture.receive(selector, testContextMock, TIMEOUT))
+                .isInstanceOf(CitrusRuntimeException.class)
+                .hasMessage("Cannot invoke filtering kafka message consumer without selectors");
+    }
+
+    @Test(dataProvider = "emptyStrings")
+    public void receive_doesNotThrowException_whenNoSelectorGiven_butKafkaConsumerSelectorPresent(String selector) {
+        var kafkaMessageFilterTest = mock(KafkaMessageFilter.class);
+
+        var randomUUID = UUID.randomUUID().toString();
+        doThrow(new CitrusRuntimeException(randomUUID)).when(kafkaMessageFilterTest).sanitize();
+
+        var fixture = KafkaMessageFilteringConsumer.builder()
+                .build();
+
+        setField(fixture, "kafkaMessageFilter", kafkaMessageFilterTest, KafkaMessageFilter.class);
+
+        assertThatThrownBy(() -> fixture.receive(selector, testContextMock, TIMEOUT))
+                .isInstanceOf(CitrusRuntimeException.class)
+                .hasMessage(randomUUID);
+    }
+
+    @Test
+    public void receive_parsesSelectorString() {
+        var kafkaMessageFilterMock = mock(KafkaMessageFilter.class);
+
+        var fixture = KafkaMessageFilteringConsumer.builder()
+                .build();
+
+        setField(fixture, "kafkaMessageFilter", kafkaMessageFilterMock, KafkaMessageFilter.class);
+
+        var kafkaMessageSelector = KafkaMessageFilter.kafkaMessageFilter()
+                .eventLookbackWindow(Duration.ofSeconds(1L))
+                .kafkaMessageSelector(kafkaHeaderEquals("foo", "bar"))
+                .build();
+        var selector = MessageSelectorBuilder.fromKeyValueMap(kafkaMessageSelector).build();
+
+        assertThatThrownBy(() -> fixture.receive(selector, testContextMock, TIMEOUT))
+                // Resolving the topic is the next step, but it isn't specified
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("Cannot invoke", "kafkaEndpointConfiguration", "is null");
+
+        assertThat(fixture.getKafkaMessageFilter())
+                .isNotNull()
+                .isNotEqualTo(kafkaMessageFilterMock)
+                .isNotSameAs(kafkaMessageFilterMock);
+    }
+
+    @AfterMethod
+    public void afterMethodTeardown() throws Exception {
+        mockitoContext.close();
+    }
+}

--- a/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/KafkaProducerTest.java
+++ b/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/KafkaProducerTest.java
@@ -16,14 +16,6 @@
 
 package org.citrusframework.kafka.endpoint;
 
-import java.util.Collections;
-import java.util.concurrent.Future;
-
-import org.citrusframework.exceptions.CitrusRuntimeException;
-import org.citrusframework.kafka.message.KafkaMessage;
-import org.citrusframework.message.Message;
-import org.citrusframework.testng.AbstractTestNGUnitTest;
-import org.citrusframework.util.SocketUtils;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -32,10 +24,18 @@ import org.apache.kafka.clients.producer.internals.FutureRecordMetadata;
 import org.apache.kafka.clients.producer.internals.ProduceRequestResult;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.Time;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.kafka.message.KafkaMessage;
+import org.citrusframework.message.Message;
+import org.citrusframework.testng.AbstractTestNGUnitTest;
+import org.citrusframework.util.SocketUtils;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.concurrent.Future;
 
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.reset;

--- a/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/builder/KafkaEndpointsTest.java
+++ b/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/builder/KafkaEndpointsTest.java
@@ -16,12 +16,12 @@
 
 package org.citrusframework.kafka.endpoint.builder;
 
-import java.util.Map;
-
 import org.citrusframework.endpoint.EndpointBuilder;
 import org.citrusframework.kafka.endpoint.KafkaEndpointBuilder;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import java.util.Map;
 
 /**
  * @author Christoph Deppisch

--- a/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/selector/KafkaMessageByHeaderSelectorTest.java
+++ b/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/selector/KafkaMessageByHeaderSelectorTest.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.kafka.endpoint.selector;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.ValueMatchingStrategy;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Arrays.stream;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.HEADER_FILTER_COMPARATOR;
+import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.HEADER_FILTER_KEY;
+import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.HEADER_FILTER_VALUE;
+import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.ValueMatchingStrategy.CONTAINS;
+import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.ValueMatchingStrategy.EQUALS;
+import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.ValueMatchingStrategy.STARTS_WITH;
+import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.kafkaHeaderContains;
+import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.kafkaHeaderEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class KafkaMessageByHeaderSelectorTest {
+
+    @Test
+    public void builder() {
+        var key = "key";
+        var value = "value";
+
+        var fixture = KafkaMessageByHeaderSelector.builder()
+                .key(key)
+                .value(value)
+                .valueMatchingStrategy(EQUALS)
+                .build();
+
+        assertThat(fixture)
+                .satisfies(
+                        m -> assertThat(m.getKey()).isEqualTo(key),
+                        m -> assertThat(m.getValue()).isEqualTo(value),
+                        m -> assertThat(m.getValueMatchingStrategy()).isEqualTo(EQUALS)
+                );
+    }
+
+    @Test
+    public void kafkaHeaderContains_returns_CONTAINS_matcher() {
+        var key = "key";
+        var value = "value";
+
+        var fixture = kafkaHeaderContains(key, value);
+
+        assertThat(fixture)
+                .satisfies(
+                        m -> assertThat(m.getKey()).isEqualTo(key),
+                        m -> assertThat(m.getValue()).isEqualTo(value),
+                        m -> assertThat(m.getValueMatchingStrategy()).isEqualTo(CONTAINS)
+                );
+    }
+
+    @Test
+    public void kafkaHeaderEquals_returns_EQUALS_matcher() {
+        var key = "key";
+        var value = "value";
+
+        var fixture = kafkaHeaderEquals(key, value);
+
+        assertThat(fixture)
+                .satisfies(
+                        m -> assertThat(m.getKey()).isEqualTo(key),
+                        m -> assertThat(m.getValue()).isEqualTo(value),
+                        m -> assertThat(m.getValueMatchingStrategy()).isEqualTo(EQUALS)
+                );
+    }
+
+    @Test
+    public void fromSelector_throwsException_whenNeitherKeyNorValuePresent() {
+        var messageSelectors = new HashMap<String, Object>();
+
+        assertThatThrownBy(() -> KafkaMessageByHeaderSelector.fromSelector(messageSelectors))
+                .isInstanceOf(CitrusRuntimeException.class)
+                .hasMessage("No matcher specified when looking for Kafka messages");
+    }
+
+    @Test
+    public void fromSelector_createsKafkaMessageByHeaderSelector() {
+        var key = "key";
+        var value = "value";
+
+        var messageSelectors = Map.of(
+                HEADER_FILTER_KEY, key,
+                HEADER_FILTER_VALUE, value,
+                HEADER_FILTER_COMPARATOR, STARTS_WITH.toString()
+        );
+
+        var result = KafkaMessageByHeaderSelector.fromSelector(messageSelectors);
+
+        assertThat(result)
+                .satisfies(
+                        m -> assertThat(m.getKey()).isEqualTo(key),
+                        m -> assertThat(m.getValue()).isEqualTo(value),
+                        m -> assertThat(m.getValueMatchingStrategy()).isEqualTo(STARTS_WITH)
+                );
+    }
+
+    @Test
+    public void matches_AnyHeaderWhenKeyIsNull() {
+        var matcher = KafkaMessageByHeaderSelector.builder()
+                .value("test")
+                .build();
+
+        var record = createRecordWithHeaders(
+                new RecordHeader("header1", "test".getBytes()),
+                new RecordHeader("header2", "other".getBytes())
+        );
+
+        assertTrue(matcher.matches(record));
+    }
+
+    @Test
+    public void matches_specificHeaderWhenKeyIsDefined() {
+        var matcher = KafkaMessageByHeaderSelector.builder()
+                .key("header1")
+                .value("test")
+                .build();
+
+        var record = createRecordWithHeaders(
+                new RecordHeader("header1", "test".getBytes()),
+                new RecordHeader("header2", "test".getBytes())
+        );
+
+        assertTrue(matcher.matches(record));
+    }
+
+    @Test
+    public void matches_doesNotMatchWhenKeyIsDefinedButNotPresent() {
+        var matcher = KafkaMessageByHeaderSelector.builder()
+                .key("header3")
+                .value("test")
+                .build();
+
+        var record = createRecordWithHeaders(
+                new RecordHeader("header1", "test".getBytes()),
+                new RecordHeader("header2", "test".getBytes())
+        );
+
+        assertFalse(matcher.matches(record));
+    }
+
+    @Test
+    public void matches_anyValueWhenValueIsNull() {
+        var matcher = KafkaMessageByHeaderSelector.builder()
+                .key("header1")
+                .build();
+
+        var record = createRecordWithHeaders(new RecordHeader("header1", "anything".getBytes()));
+
+        assertTrue(matcher.matches(record));
+    }
+
+    @DataProvider
+    public static Object[][] matchingMechanism() {
+        return stream(ValueMatchingStrategy.values())
+                .map(m -> new Object[]{m})
+                .toArray(Object[][]::new);
+    }
+
+    @Test(dataProvider = "matchingMechanism")
+    public void matches_usingSpecifiedMechanism(ValueMatchingStrategy mechanism) {
+        String headerValue = "testValue";
+        String matchValue = switch (mechanism) {
+            case EQUALS -> "testValue";
+            case CONTAINS -> "stVal";
+            case STARTS_WITH -> "test";
+            case ENDS_WITH -> "Value";
+        };
+
+        var matcher = KafkaMessageByHeaderSelector.builder()
+                .key("header")
+                .value(matchValue)
+                .valueMatchingStrategy(mechanism)
+                .build();
+
+        var record = createRecordWithHeaders(new RecordHeader("header", headerValue.getBytes()));
+
+        assertTrue(matcher.matches(record));
+    }
+
+    @Test
+    public void matches_emptyValueWithEquality() {
+        var matcher = KafkaMessageByHeaderSelector.builder()
+                .key("header1")
+                .value("")
+                .build();
+
+        var record = createRecordWithHeaders(new RecordHeader("header1", "".getBytes()));
+
+        assertTrue(matcher.matches(record));
+    }
+
+    @Test
+    public void matches_doesNotMatchWhenValueDoesNotMatchUsingSpecifiedMechanism() {
+        var matcher = KafkaMessageByHeaderSelector.builder()
+                .key("header")
+                .value("different")
+                .valueMatchingStrategy(EQUALS)
+                .build();
+
+        var record = createRecordWithHeaders(new RecordHeader("header", "testValue".getBytes()));
+
+        assertFalse(matcher.matches(record));
+    }
+
+    @Test
+    public void asSelector_ignoresNullValues() {
+        var fixture = KafkaMessageByHeaderSelector.builder().build();
+
+        var result = fixture.asSelector();
+
+        assertThat(result)
+                .doesNotContainKey(HEADER_FILTER_KEY)
+                .doesNotContainKey(HEADER_FILTER_VALUE);
+    }
+
+    @Test
+    public void asSelector_exportsKey() {
+        var key = "key";
+
+        var fixture = KafkaMessageByHeaderSelector.builder()
+                .key(key)
+                .build();
+
+        var result = fixture.asSelector();
+
+        assertThat(result)
+                .containsEntry(HEADER_FILTER_KEY, key);
+    }
+
+    @Test
+    public void asSelector_exportsValue() {
+        var value = "value";
+
+        var fixture = KafkaMessageByHeaderSelector.builder()
+                .value(value)
+                .build();
+
+        var result = fixture.asSelector();
+
+        assertThat(result)
+                .containsEntry(HEADER_FILTER_VALUE, value);
+    }
+
+    @Test
+    public void asSelector_containsEqualsMatcherPerDefault() {
+        var fixture = KafkaMessageByHeaderSelector.builder().build();
+
+        var result = fixture.asSelector();
+
+        assertThat(result)
+                .containsEntry(HEADER_FILTER_COMPARATOR, EQUALS.toString());
+    }
+
+    private ConsumerRecord<Object, Object> createRecordWithHeaders(RecordHeader... headers) {
+        var consumerRecord = new ConsumerRecord<>("topic", 0, 0, null, null);
+        stream(headers).forEach(header -> consumerRecord.headers().add(header));
+        return consumerRecord;
+    }
+}

--- a/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/selector/KafkaMessageSelectorFactoryTest.java
+++ b/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/selector/KafkaMessageSelectorFactoryTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.kafka.endpoint.selector;
+
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.HEADER_FILTER_KEY;
+import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.HEADER_FILTER_VALUE;
+
+public class KafkaMessageSelectorFactoryTest {
+
+    private KafkaMessageSelectorFactory fixture;
+
+    @BeforeMethod
+    public void beforeMethodSetup() {
+        fixture = new KafkaMessageSelectorFactory();
+    }
+
+    @Test
+    public void parseFromSelector_throwsException_whenNoIdentifierPresent() {
+        var messageSelectors = new HashMap<String, Object>();
+
+        assertThatThrownBy(() -> fixture.parseFromSelector(messageSelectors))
+                .isInstanceOf(CitrusRuntimeException.class)
+                .hasMessage("Cannot instantiate Kafka matcher from selectors: " + messageSelectors);
+    }
+
+    @Test
+    public void parseFromSelector_returnsKafkaMessageByHeaderSelector_ifKeyIsPresent() {
+        var messageSelectors = Map.of(
+                HEADER_FILTER_KEY, "foo");
+
+        var result = fixture.parseFromSelector(messageSelectors);
+
+        assertThat(result)
+                .isInstanceOf(KafkaMessageByHeaderSelector.class)
+                .isNotNull();
+    }
+
+    @Test
+    public void parseFromSelector_returnsKafkaMessageByHeaderSelector_ifValueIsPresent() {
+        var messageSelectors = Map.of(
+                HEADER_FILTER_VALUE, "bar");
+
+        var result = fixture.parseFromSelector(messageSelectors);
+
+        assertThat(result)
+                .isInstanceOf(KafkaMessageByHeaderSelector.class)
+                .isNotNull();
+    }
+}

--- a/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/integration/KafkaEndpointJavaIT.java
+++ b/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/integration/KafkaEndpointJavaIT.java
@@ -1,0 +1,299 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.kafka.integration;
+
+import org.assertj.core.api.ThrowableAssert;
+import org.citrusframework.annotations.CitrusTest;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.exceptions.TestCaseFailedException;
+import org.citrusframework.kafka.endpoint.KafkaEndpoint;
+import org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector;
+import org.citrusframework.kafka.message.KafkaMessage;
+import org.citrusframework.testng.spring.TestNGCitrusSpringSupport;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.testng.annotations.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.citrusframework.actions.ReceiveMessageAction.Builder.receive;
+import static org.citrusframework.actions.SendMessageAction.Builder.send;
+import static org.citrusframework.actions.SleepAction.Builder.sleep;
+import static org.citrusframework.kafka.endpoint.KafkaMessageFilter.kafkaMessageFilter;
+import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.ValueMatchingStrategy.ENDS_WITH;
+import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.ValueMatchingStrategy.STARTS_WITH;
+import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.kafkaHeaderContains;
+import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.kafkaHeaderEquals;
+
+@Test
+@DirtiesContext
+@ContextConfiguration(classes = {KafkaEndpointJavaIT.KafkaEndpointConfiguration.class})
+public class KafkaEndpointJavaIT extends TestNGCitrusSpringSupport {
+
+    @Autowired
+    private KafkaEndpoint kafkaWithRandomConsumerGroupEndpoint;
+
+    @Test
+    @CitrusTest
+    public void findKafkaEvent_headerEquals_citrus_DSL() {
+        var body = "findKafkaEvent_headerEquals_citrus_DSL";
+
+        var key = "Name";
+        var value = "Bilbo";
+
+        when(
+                send(kafkaWithRandomConsumerGroupEndpoint)
+                        .message(new KafkaMessage(body).setHeader(key, value))
+        );
+
+        then(
+                receive(kafkaWithRandomConsumerGroupEndpoint)
+                        .selector(
+                                kafkaMessageFilter()
+                                        .eventLookbackWindow(Duration.ofSeconds(1L))
+                                        .kafkaMessageSelector(kafkaHeaderEquals(key, value))
+                                        .build()
+                        )
+                        .getMessageBuilderSupport()
+                        .body(body)
+        );
+    }
+
+    @Test
+    @CitrusTest
+    public void findKafkaEvent_headerContains_citrus_DSL() {
+        var body = "findKafkaEvent_headerContains_citrus_DSL";
+
+        var key = "Name";
+        var value = "Frodo";
+
+        when(
+                send(kafkaWithRandomConsumerGroupEndpoint)
+                        .message(new KafkaMessage(body).setHeader(key, value))
+        );
+
+        then(
+                receive(kafkaWithRandomConsumerGroupEndpoint)
+                        .selector(
+                                kafkaMessageFilter()
+                                        .eventLookbackWindow(Duration.ofSeconds(1L))
+                                        .kafkaMessageSelector(kafkaHeaderContains(key, "odo"))
+                                        .build()
+                        )
+                        .getMessageBuilderSupport()
+                        .body(body)
+        );
+    }
+
+    @Test
+    @CitrusTest
+    public void findKafkaEvent_headerStartsWith_citrus_DSL() {
+        var body = "findKafkaEvent_headerStartsWith_citrus_DSL";
+
+        var key = "Name";
+        var value = "Galadriel";
+
+        when(
+                send(kafkaWithRandomConsumerGroupEndpoint)
+                        .message(new KafkaMessage(body).setHeader(key, value))
+        );
+
+        then(
+                receive(kafkaWithRandomConsumerGroupEndpoint)
+                        .selector(
+                                kafkaMessageFilter()
+                                        .eventLookbackWindow(Duration.ofSeconds(1L))
+                                        .kafkaMessageSelector(
+                                                KafkaMessageByHeaderSelector.builder()
+                                                        .key(key)
+                                                        .value("Gala")
+                                                        .valueMatchingStrategy(STARTS_WITH)
+                                                        .build()
+                                        )
+                                        .build()
+                        )
+                        .getMessageBuilderSupport()
+                        .body(body)
+        );
+    }
+
+    @Test
+    @CitrusTest
+    public void findKafkaEvent_headerEndsWith_citrus_DSL() {
+        var body = "findKafkaEvent_headerEndsWith_citrus_DSL";
+
+        var key = "Name";
+        var value = "Celeborn";
+
+        when(
+                send(kafkaWithRandomConsumerGroupEndpoint)
+                        .message(new KafkaMessage(body).setHeader(key, value))
+        );
+
+        then(
+                receive(kafkaWithRandomConsumerGroupEndpoint)
+                        .selector(
+                                kafkaMessageFilter()
+                                        .eventLookbackWindow(Duration.ofSeconds(1L))
+                                        .kafkaMessageSelector(
+                                                KafkaMessageByHeaderSelector.builder()
+                                                        .key(key)
+                                                        .value("born")
+                                                        .valueMatchingStrategy(ENDS_WITH)
+                                                        .build()
+                                        )
+                                        .build()
+                        )
+                        .getMessageBuilderSupport()
+                        .body(body)
+        );
+    }
+
+    @Test
+    @CitrusTest
+    public void findKafkaEvent_nothingFound_noMatch_citrus_DSL() {
+        var body = "findKafkaEvent_nothingFound_noMatch_citrus_DSL";
+
+        var key = "Name";
+        var value = "Elrond";
+
+        when(
+                send(kafkaWithRandomConsumerGroupEndpoint)
+                        .message(new KafkaMessage(body).setHeader(key, value))
+        );
+
+        ThrowableAssert.ThrowingCallable receiver = () -> then(
+                receive(kafkaWithRandomConsumerGroupEndpoint)
+                        .selector(
+                                kafkaMessageFilter()
+                                        .eventLookbackWindow(Duration.ofSeconds(1L))
+                                        .kafkaMessageSelector(kafkaHeaderEquals(key, "Arwen"))
+                                        .build()
+                        )
+                        .getMessageBuilderSupport()
+                        .body(body)
+        );
+
+        assertThatThrownBy(receiver)
+                .isInstanceOf(TestCaseFailedException.class)
+                .hasRootCauseInstanceOf(CitrusRuntimeException.class)
+                .hasMessageContaining("Failed to resolve Kafka message using selector");
+    }
+
+    @Test
+    @CitrusTest
+    public void findKafkaEvent_nothingFound_outsideLookbackWindow_citrus_DSL() {
+        var body = "findKafkaEvent_nothingFound_outsideLookbackWindow_citrus_DSL";
+
+        var key = "Name";
+        var value = "Gimli";
+
+        given(
+                send(kafkaWithRandomConsumerGroupEndpoint)
+                        .message(new KafkaMessage(body).setHeader(key, value))
+        );
+
+        when(sleep().seconds(2));
+
+        ThrowableAssert.ThrowingCallable receiver = () -> then(
+                receive(kafkaWithRandomConsumerGroupEndpoint)
+                        .selector(
+                                kafkaMessageFilter()
+                                        .eventLookbackWindow(Duration.ofSeconds(1L))
+                                        .kafkaMessageSelector(kafkaHeaderEquals(key, value))
+                                        .build()
+                        )
+                        .getMessageBuilderSupport()
+                        .body(body)
+        );
+
+        assertThatThrownBy(receiver)
+                .isInstanceOf(TestCaseFailedException.class)
+                .hasRootCauseInstanceOf(CitrusRuntimeException.class)
+                .hasMessageContaining("Failed to resolve Kafka message using selector");
+    }
+
+    @Test
+    @CitrusTest
+    public void findKafkaEvent_duplicateEntriesFound_citrus_DSL() {
+        var body = "findKafkaEvent_duplicateEntriesFound_citrus_DSL";
+
+        var key = "Name";
+
+        given(
+                send(kafkaWithRandomConsumerGroupEndpoint)
+                        .message(new KafkaMessage(body).setHeader(key, "Gandalf the Grey"))
+        );
+
+        when(
+                send(kafkaWithRandomConsumerGroupEndpoint)
+                        .message(new KafkaMessage(body).setHeader(key, "Gandalf the White"))
+        );
+
+        ThrowableAssert.ThrowingCallable receiver = () -> then(
+                receive(kafkaWithRandomConsumerGroupEndpoint)
+                        .selector(
+                                kafkaMessageFilter()
+                                        .eventLookbackWindow(Duration.ofSeconds(1L))
+                                        .kafkaMessageSelector(kafkaHeaderContains(key, "Gandalf"))
+                                        .build()
+                        )
+                        .getMessageBuilderSupport()
+                        .body(body)
+        );
+
+        assertThatThrownBy(receiver)
+                .isInstanceOf(TestCaseFailedException.class)
+                .hasRootCauseInstanceOf(CitrusRuntimeException.class)
+                .hasMessageContaining("More than one matching record found in topic");
+    }
+
+    @Test
+    @CitrusTest
+    public void findKafkaEvent_headerEquals_java_DSL() {
+        var body = "findKafkaEvent_headerEquals_java_DSL";
+
+        var key = "Name";
+        var value = "Gollum";
+
+        when(
+                send(kafkaWithRandomConsumerGroupEndpoint)
+                        .message(new KafkaMessage(body).setHeader(key, value))
+        );
+
+        then(
+                kafkaWithRandomConsumerGroupEndpoint.findKafkaEventHeaderEquals(Duration.ofSeconds(1L), key, value)
+                        .body(body)
+        );
+    }
+
+    @TestConfiguration
+    static class KafkaEndpointConfiguration {
+
+        @Bean
+        public KafkaEndpoint kafkaWithRandomConsumerGroupEndpoint() {
+            return KafkaEndpoint.builder()
+                    .randomConsumerGroup(true)
+                    .topic("hello")
+                    .build();
+        }
+    }
+}

--- a/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/integration/KafkaEndpointXmlIT.java
+++ b/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/integration/KafkaEndpointXmlIT.java
@@ -19,14 +19,18 @@ package org.citrusframework.kafka.integration;
 import org.citrusframework.annotations.CitrusTestSource;
 import org.citrusframework.common.TestLoader;
 import org.citrusframework.testng.spring.TestNGCitrusSpringSupport;
+import org.springframework.test.annotation.DirtiesContext;
 import org.testng.annotations.Test;
 
-/**
- * @author Christoph Deppisch
- */
 @Test
-public class KafkaEndpointIT extends TestNGCitrusSpringSupport {
+@DirtiesContext
+public class KafkaEndpointXmlIT extends TestNGCitrusSpringSupport {
 
-    @CitrusTestSource(type = TestLoader.SPRING, name = "KafkaEndpointIT")
-    public void testKafkaEndpoint() {}
+    @CitrusTestSource(type = TestLoader.SPRING, name = "KafkaEndpointIT_singleMessage")
+    public void singleKafkaMessage() {
+    }
+
+    @CitrusTestSource(type = TestLoader.SPRING, name = "KafkaEndpointIT_selectiveMessage")
+    public void selectiveKafkaMessage() {
+    }
 }

--- a/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/message/KafkaMessageTest.java
+++ b/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/message/KafkaMessageTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.kafka.message;
+
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.MAP;
+
+public class KafkaMessageTest {
+
+    @Test
+    public void hasEmptyConstructor() {
+        assertThat(new KafkaMessage())
+                .isNotNull();
+    }
+
+    @Test
+    public void hasConstructorWithPayload() {
+        var payload = "payload";
+
+        assertThat(new KafkaMessage(payload))
+                .hasFieldOrPropertyWithValue("payload", payload);
+    }
+
+    @Test
+    public void hasConstructorWithPayloadAndHeaders() {
+        var payload = "payload";
+        Map<String,Object> headers = Map.of("foo", "bar");
+
+        assertThat(new KafkaMessage(payload, headers))
+                .hasFieldOrPropertyWithValue("payload", payload)
+                .extracting(KafkaMessage::getHeaders)
+                .asInstanceOf(MAP)
+                .hasEntrySatisfying("foo", e -> assertThat(e).isEqualTo("bar"));
+    }
+}

--- a/endpoints/citrus-kafka/src/test/resources/org/citrusframework/kafka/config/xml/KafkaEndpointParserTest-context.xml
+++ b/endpoints/citrus-kafka/src/test/resources/org/citrusframework/kafka/config/xml/KafkaEndpointParserTest-context.xml
@@ -36,6 +36,9 @@
                                producer-properties="producerProps"
                                actor="testActor"/>
 
+  <citrus-kafka:endpoint id="kafkaEndpoint4"
+                               random-consumer-group="true" />
+
   <citrus:actor id="testActor" name="TESTACTOR" disabled="false"/>
 
   <util:map id="producerProps">

--- a/endpoints/citrus-kafka/src/test/resources/org/citrusframework/kafka/integration/KafkaEndpointIT_selectiveMessage.xml
+++ b/endpoints/citrus-kafka/src/test/resources/org/citrusframework/kafka/integration/KafkaEndpointIT_selectiveMessage.xml
@@ -7,27 +7,33 @@
                                   http://www.citrusframework.org/schema/testcase 
                                   http://www.citrusframework.org/schema/testcase/citrus-testcase.xsd">
 
-  <testcase name="KafkaEndpointIT">
+  <testcase name="KafkaEndpointIT_selectiveMessage">
     <meta-info>
-      <author>Christoph Deppisch</author>
-      <creationdate>2018-09-10</creationdate>
+      <author>bbortt</author>
+      <creationdate>2024-09-30</creationdate>
       <status>FINAL</status>
-      <last-updated-by>Christoph Deppisch</last-updated-by>
-      <last-updated-on>2018-09-10T00:00:00</last-updated-on>
+      <last-updated-by>bbortt</last-updated-by>
+      <last-updated-on>2014-09-30T00:00:00</last-updated-on>
     </meta-info>
 
-    <description>Test sends and receives messages on Kafka topic endpoint.</description>
+    <description>Test sends and receives a specific message identified by header key and value on Kafka topic endpoint.</description>
 
     <variables>
       <variable name="correlationId" value="citrus:randomNumber(10)"/>
       <variable name="messageId" value="citrus:randomNumber(10)"/>
-      <variable name="user" value="Christoph"/>
+      <variable name="traceId" value="citrus:randomString(32)"/>
+      <variable name="spanId" value="citrus:randomString(16)"/>
+      <variable name="user" value="bbortt"/>
     </variables>
 
     <actions>
       <echo>
-        <message>Test 1: Send Kafka message and receive that message on the same topic (inline CDATA payload)</message>
+        <message>Test 1: Send Kafka message and receive that message based on header equality</message>
       </echo>
+
+      <purge-endpoint>
+        <endpoint name="helloKafkaEndpoint"/>
+      </purge-endpoint>
 
       <send endpoint="helloKafkaEndpoint">
         <description>Send Kafka request: Citrus -> Kafka broker</description>
@@ -40,16 +46,23 @@
                  <User>${user}</User>
                  <Text>Hello Citrus</Text>
                </HelloRequest>								
-						]]>
+            ]]>
           </data>
         </message>
         <header>
+          <element name="traceparent" value="01-${traceId}-${spanId}-00"/>
           <element name="Operation" value="sayHello"/>
         </header>
       </send>
 
       <receive endpoint="helloKafkaEndpoint">
         <description>Receive Kafka request: Kafka broker -> Citrus</description>
+        <selector>
+          <element name="header-filter-key" value="traceparent"/>
+          <element name="header-filter-value" value="${traceId}"/>
+          <element name="header-filter-comparator" value="CONTAINS"/>
+          <element name="event-lookback-window" value="PT1S"/>
+        </selector>
         <message>
           <data>
             <![CDATA[

--- a/endpoints/citrus-kafka/src/test/resources/org/citrusframework/kafka/integration/KafkaEndpointIT_singleMessage.xml
+++ b/endpoints/citrus-kafka/src/test/resources/org/citrusframework/kafka/integration/KafkaEndpointIT_singleMessage.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<spring:beans xmlns="http://www.citrusframework.org/schema/testcase"
+              xmlns:spring="http://www.springframework.org/schema/beans"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://www.springframework.org/schema/beans 
+                                  http://www.springframework.org/schema/beans/spring-beans.xsd 
+                                  http://www.citrusframework.org/schema/testcase 
+                                  http://www.citrusframework.org/schema/testcase/citrus-testcase.xsd">
+
+  <testcase name="KafkaEndpointIT_singleMessage">
+    <meta-info>
+      <author>Christoph Deppisch</author>
+      <creationdate>2018-09-10</creationdate>
+      <status>FINAL</status>
+      <last-updated-by>bbortt</last-updated-by>
+      <last-updated-on>2014-09-30T00:00:00</last-updated-on>
+    </meta-info>
+
+    <description>Test sends and receives messages on Kafka topic endpoint.</description>
+
+    <variables>
+      <variable name="correlationId" value="citrus:randomNumber(10)"/>
+      <variable name="messageId" value="citrus:randomNumber(10)"/>
+      <variable name="user" value="Christoph"/>
+    </variables>
+
+    <actions>
+      <echo>
+        <message>Test 1: Send Kafka message and receive that message on the same topic (inline CDATA payload)</message>
+      </echo>
+
+      <purge-endpoint>
+        <endpoint name="helloKafkaEndpoint"/>
+      </purge-endpoint>
+
+      <send endpoint="helloKafkaEndpoint">
+        <description>Send Kafka request: Citrus -> Kafka broker</description>
+        <message>
+          <data>
+            <![CDATA[
+               <HelloRequest xmlns="http://citrusframework.org/schemas/samples/HelloService.xsd">
+                 <MessageId>${messageId}</MessageId>
+                 <CorrelationId>${correlationId}</CorrelationId>
+                 <User>${user}</User>
+                 <Text>Hello Citrus</Text>
+               </HelloRequest>								
+						]]>
+          </data>
+        </message>
+        <header>
+          <element name="Operation" value="sayHello"/>
+          <element name="CorrelationId" value="${correlationId}"/>
+        </header>
+      </send>
+
+      <create-variables>
+        <variable name="extractedCorrelationId"></variable>
+      </create-variables>
+
+      <repeat-onerror-until-true condition="@assertThat('${extractedCorrelationId}', 'equalTo(${correlationId})')@">
+        <receive endpoint="helloKafkaEndpoint">
+          <description>Receive Kafka request: Kafka broker -> Citrus</description>
+          <message>
+            <data>
+              <![CDATA[
+                <HelloRequest xmlns="http://citrusframework.org/schemas/samples/HelloService.xsd">
+                   <MessageId>${messageId}</MessageId>
+                   <CorrelationId>${correlationId}</CorrelationId>
+                   <User>${user}</User>
+                   <Text>Hello Citrus</Text>
+                 </HelloRequest>
+              ]]>
+            </data>
+          </message>
+          <header>
+            <element name="Operation" value="sayHello"/>
+            <element name="citrus_kafka_topic" value="hello"/>
+            <element name="citrus_kafka_partition" value="0"/>
+            <element name="citrus_kafka_offset" value="@assertThat(greaterThanOrEqualTo(0))@"/>
+          </header>
+          <extract>
+              <header name="CorrelationId" variable="${extractedCorrelationId}"/>
+          </extract>
+        </receive>
+      </repeat-onerror-until-true>
+    </actions>
+  </testcase>
+</spring:beans>

--- a/pom.xml
+++ b/pom.xml
@@ -1141,16 +1141,29 @@
 
   <!-- Global dependencies -->
   <dependencies>
-    <!-- Compile scope -->
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>1.18.34</version>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- Test scoped dependencies -->
     <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-test</artifactId>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>${assertj.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <version>3.3.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/manual/endpoint-kafka.adoc
+++ b/src/manual/endpoint-kafka.adoc
@@ -1,5 +1,5 @@
 [[kafka]]
-= Apache Kafka support
+= Apache Kafka Support
 
 Kafka is a distributed streaming platform that enables you to publish and subscribe to streams of records, similar to a
 message queue or enterprise messaging system. Citrus provides support for publishing/consuming records to/from a Kafka topic.
@@ -44,7 +44,7 @@ Now you are able to use customized Citrus XML elements in order to define the Ka
 using the Spring Java configuration with `@Bean` annotations you do not require this step.
 
 [[kafka-endpoint]]
-== Kafka endpoint
+== Kafka Endpoint
 
 By default, Citrus Kafka endpoints are asynchronous. Asynchronous messaging means that the endpoint will not wait for any
 response message after sending or receiving a message.
@@ -103,20 +103,22 @@ public KafkaEndpoint helloKafkaEndpoint() {
           consumer-group="citrus_group"/>
 ----
 
-The endpoint is now ready to be used inside a test case. The test simply references the endpoint by its name when sending
-or receiving.
+Note that for effective message consumption it is advisable to use random consumer groups.
+Both the Java and XML DSL support random consumer groups, when enabled: `randomConsumerGroup(true)` or `random-consumer-group="true"`.
 
-In case of a send operation the endpoint creates a Kafka producer and will simply publish the records to the defined Kafka
-topic. As the communication is asynchronous by default producer does not wait for a synchronous response.
+The endpoint is now ready to be used inside a test case.
+The test simply references the endpoint by its name when sending or receiving.
 
-In case of a receive operation the endpoint creates a Kafka consumer instance in the defined consumer group. The consumer
-starts a subscription on the given topic and acts as a polling listener. This means that the message consumer connects
-to the given topic and polls for records. As soon as a record has been received the action is ready to perform the validation
-process that verifies the record.
+In case of a send operation the endpoint creates a Kafka producer and will simply publish the records to the defined Kafka topic.
+As the communication is asynchronous by default, the producer does not wait for a response.
 
-NOTE: By default, the consumer polls for a single record per receive operation (`max.poll.records=1`). You can change this
-setting within the consumer properties on the Citrus Kafka endpoint. The property `max.poll.records` that sets the number
-of records in a single poll.
+In case of a receive operation the endpoint creates a Kafka consumer instance in the defined (possibly random) consumer group.
+
+NOTE: By default, the consumer starts a subscription on the given topic and acts as a polling listener.
+This means that the message consumer connects to the given topic and polls one single record at a time.
+The action is the ready to perform the validation process that verifies the record, once it has been received.
+This approach requires looping to find specific Kafka messages, which can be highly inefficient, especially when the Kafka topic experiences high traffic.
+See <<kafka-message-selector,Kafka message selectors>> for a more effective Kafka message selection.
 
 [[kafka-endpoint-configuration]]
 === Configuration
@@ -127,114 +129,124 @@ The following table shows all available settings on a Kafka endpoint in Citrus:
 |===
 | Property | Mandatory | Default | Description
 
-| id
+| `id`
 | Yes
 | -
 | Identifying name of the endpoint. Only required for XML configuration.
 
-| topic
+| `topic`
 | No
 | -
 | Default topic to use with this endpoint. Multiple topics are supported by using a comma delimited list of names (e.g. `topic1,topic2,topicN`).
   If not specified the test case send operation needs to set the topic as message header information.
 
-| server
+| `server`
 | No
-| localhost:9092
-| A comma delimited list of host/port pairs to use for establishing the initial connection to the Kafka cluster. Usually
-  it is only required to connect to one Kafka server instance in the cluster. Kafka then makes sure that the endpoint is
-  automatically introduced to all other servers in the cluster. This list only impacts the initial hosts used to discover
-  the full set of servers.
+| `localhost:9092`
+| A comma delimited list of host/port pairs to use for establishing the initial connection to the Kafka cluster.
+  Usually it is only required to connect to one Kafka server instance in the cluster.
+  Kafka then makes sure that the endpoint is automatically introduced to all other servers in the cluster.
+  This list only impacts the initial hosts used to discover the full set of servers.
 
-| timeout
+| `timeout`
 | No
-| 5000
-| Timeout in milliseconds. For producers the timeout is set as time to wait for the message to be accepted by the cluster.
+| `5000`
+| Timeout in milliseconds.
+  For producers the timeout is set as time to wait for the message to be accepted by the cluster.
   For consumers the timeout is used for polling records on a specific topic.
 
-| message-converter
+| `message-converter`
 | No
 | `org.citrusframework.kafka.message.KafkaMessageConverter`
-| Converter maps internal Citrus message objects to ProducerRecord/ConsumerRecord objects. The converter implementation takes
-  care of message key, value, timestamp and special message headers.
+| Converter maps internal Citrus message objects to `ProducerRecord`/`ConsumerRecord` objects.
+  The converter implementation takes care of message key, value, timestamp and special message headers.
 
-| header-mapper
+| `header-mapper`
 | No
 | `org.citrusframework.kafka.message.KafkaMessageHeaderMapper`
-| Header mapper maps Kafka record information (e.g. topic name, timestamp, message key) to internal message headers
-  (`org.citrusframework.kafka.message.KafkaMessageHeaders`) and vice versa.
+| Header mapper maps Kafka record information (e.g. topic name, timestamp, message key) to internal message headers (`org.citrusframework.kafka.message.KafkaMessageHeaders`) and vice versa.
 
-| auto-commit
+| `auto-commit`
 | No
-| true
-| When this setting is enabled the consumer will automatically commit consumed records so the offset pointer on the Kafka
-  topic is set to the next record.
+| `true`
+| When this setting is enabled the consumer will automatically commit consumed records so the offset pointer on the Kafka topic is set to the next record.
 
-| auto-commit-interval
+| `auto-commit-interval`
 | No
-| 1000
+| `1000`
 | Interval in milliseconds the auto commit operation on consumed records is performed.
 
 | offset-reset
 | No
-| earliest
-| When consuming records from a topic partition and the current offset does not exist on that partition Kafka will automatically
-  seek to a valid offset position on that partition. The `offset-reset` setting sets where to find the new position (latest, earliest,
-  none). If `none` is set the consumer will receive an exception instead of resetting the offset to a valid position.
+| `earliest`
+| When consuming records from a topic partition and the current offset does not exist on that partition Kafka will automatically seek to a valid offset position on that partition.
+  The `offset-reset` setting sets where to find the new position (`latest`, `earliest`, `none`).
+  If `none` is set the consumer will receive an exception instead of resetting the offset to a valid position.
 
-| partition
+| `partition`
 | No
-| 0
+| `0`
 | Partition id that the consumer will be assigned to.
 
-| consumer-group
+| `consumer-group`
 | No
-| citrus_kafka_group
-| Consumer group name. Please keep in mind that records are load balanced across consumer instances with the same consumer
-  group name set. So you might run into message timeouts when using multiple Kafka endpoints with the same consumer group name.
+| `citrus_kafka_group`
+| Consumer group name.
+Please keep in mind that records are load balanced across consumer instances with the same consumer group name set.
+So you might run into message timeouts when using multiple Kafka endpoints with the same consumer group name.
 
-| key-serializer
+| `random-consumer-group`
 | No
-| org.apache.kafka.common.serialization.StringSerializer
-| Serializer implementation that converts message key values. By default keys are serialized to String values.
+| `false`
+| Whether to use random consumer gorup names.
+  Note that these will all be prefixed by `citrus_kafka_` and end with a random 10 characters alphabetic suffix.
 
-| key-deserializer
+| `key-serializer`
 | No
-| org.apache.kafka.common.serialization.StringDeserializer
-| Deserializer implementation that converts message key values. By default keys are deserialized as String values.
+| `org.apache.kafka.common.serialization.StringSerializer`
+| Serializer implementation that converts message key values.
+  By default, keys are serialized to String values.
 
-| value-serializer
+| `key-deserializer`
 | No
-| org.apache.kafka.common.serialization.StringSerializer
-| Serializer implementation that converts record values. By default values are serialized to String values.
+| `org.apache.kafka.common.serialization.StringDeserializer`
+| Deserializer implementation that converts message key values.
+  By default, keys are deserialized as String values.
 
-| value-deserializer
+| `value-serializer`
 | No
-| org.apache.kafka.common.serialization.StringDeserializer
-| Deserializer implementation that converts record values. By default values are deserialized as String values.
+| `org.apache.kafka.common.serialization.StringSerializer`
+| Serializer implementation that converts record values.
+  By default values are serialized to String values.
 
-| client-id
+| `value-deserializer`
 | No
-| citrus_kafka_[producer/consumer]_{randomUUID}
-| An id string to pass to the server when producing/consuming records. Used as logical application name to be included in
-  server-side request logging.
+| `org.apache.kafka.common.serialization.StringDeserializer`
+| Deserializer implementation that converts record values.
+  By default, values are deserialized as String values.
 
-| consumer-properties
+| `client-id`
+| No
+| `citrus_kafka_[producer/consumer]_{randomUUID}`
+| An id string to pass to the server when producing/consuming records.
+  Used as logical application name to be included in server-side request logging.
+
+| `consumer-properties`
 | No
 | -
-| Map of consumer property settings to apply to the Kafka consumer configuration. This enables you to overwrite any consumer
-  setting with respective property key value pairs.
+| Map of consumer property settings to apply to the Kafka consumer configuration.
+  This enables you to overwrite any consumer setting with respective property key value pairs.
 
-| producer-properties
+| `producer-properties`
 | No
 | -
-| Map of producer property settings to apply to the Kafka producer configuration. This enables you to overwrite any producer
-  setting with respective property key value pairs.
+| Map of producer property settings to apply to the Kafka producer configuration.
+  This enables you to overwrite any producer setting with respective property key value pairs.
 
 |===
 
 [[kafka-endpoint-properties]]
-=== Producer and consumer properties
+=== Producer and Consumer Properties
 
 The Citrus Kafka endpoint component is also able to receive a map of Kafka producer and consumer properties. These property
 settings overwrite any predefined setting on the producer/consumer instance created by the endpoint. You can use the Kafka
@@ -287,12 +299,12 @@ private Map<String, Object> getConsumerProps() {
 ----
 
 [[kafka-synchronous-endpoints]]
-== Kafka synchronous endpoints
+== Kafka Synchronous Endpoints
 
 Not implemented yet.
 
 [[kafka-message-headers]]
-== Kafka message headers
+== Kafka Message Headers
 
 The Kafka Citrus integration defines a set of special message header entries that are either used to manipulate the endpoint
 behavior or as validation object. These Kafka specific headers are stored with a header key prefix `citrus_kafka_*`. You
@@ -404,7 +416,7 @@ These are the available Kafka message headers in Citrus:
 |===
 
 [[kafka-message]]
-== Kafka message
+== Kafka Message
 
 Citrus also provides a Kafka message implementation that you can use on any send and receive operation. This enables you
 to set special message headers in a more comfortable way when using the Java fluent API:
@@ -421,8 +433,154 @@ send(helloKafkaEndpoint)
 
 The message implementation provides fluent API builder methods for each Kafka specific header.
 
+Additionally, when receiving messages, you might want to use <<kafka-message-selector,Kafka message selectors>>.
+
+[[kafka-message-selector]]
+== Kafka Message Selector
+
+The Kafka Message Selector feature allows you to selectively receive messages from a Kafka topic based on specific criteria.
+This powerful functionality enables you to filter Kafka messages by different criteria, e.g. <<kafka-message-selector-types,based on headers>>.
+Additionally, the defined time window for message retrieval significantly improves the performance.
+Imagine a large Kafka topic with thousands of events.
+Looking through all of these would require an immense amount of resources and time.
+Instead, selective message consumption starts at an offset `Ox = OT-n`.
+Where `T` is the current timestamp and `n` is the maximum timespan in which the wanted event is expected to have been published.
+
+=== Basic Usage
+
+The Kafka Message Selector can be used in various ways, depending on your preferred syntax and test framework.
+
+.Java
+[source,java,indent=0,role="primary"]
+----
+then(
+    receive(kafkaEndpoint)
+        .selector(
+            kafkaMessageFilter()
+                .eventLookbackWindow(Duration.ofSeconds(1L))
+                .kafkaMessageSelector(kafkaHeaderEquals("key", "value"))
+                .build()
+        )
+);
+----
+
+.Java 2
+[source,java,indent=0,role="secondary"]
+----
+then(
+    kafkaEndpoint.findKafkaEventHeaderEquals(Duration.ofSeconds(1L), "key", "value")
+);
+----
+
+.XML
+[source,xml,indent=0,role="secondary"]
+----
+<receive endpoint="helloKafkaEndpoint">
+    <description>Receive selective Kafka message</description>
+    <selector>
+      <element name="header-filter-key" value="key"/>
+      <element name="header-filter-value" value="value"/>
+      <element name="event-lookback-window" value="PT1S"/>
+    </selector>
+</receive>
+----
+
+=== Configuration
+
+[cols="2,2,2"]
+|===
+| Java DSL | XML DSL | Description
+
+| `eventLookbackWindow`
+| `event-lookback-window`
+| This defines how far back in time the selector should search for messages.
+  When using XML configuration, the event lookback window must be specified as an <<https://en.wikipedia.org/wiki/ISO_8601,ISO-8601 duration string>>.
+  For example, `PT1S` represents a duration of 1 second.
+
+| `kafkaMessageSelector`
+| See <<kafka-message-selector-types,Selector Types
+| This specifies the criteria for message selection.
+  In the examples, we're using `kafkaHeaderEquals("key", "value")`, which selects messages where a header with the `key` "key" exactly matches the `value` "value".
+
+| `pollTimeout`
+| `poll-timeout`
+| The timeout duration for each poll operation when consuming messages from Kafka.
+  This value determines how long the consumer will wait for new records in each poll cycle.
+  It is not the overall receive action timeout!
+  When using XML configuration, the poll timeout must be specified as an <<https://en.wikipedia.org/wiki/ISO_8601,ISO-8601 duration string>>.
+  For example, `PT0.100S` represents a duration of 1 millisecond.
+
+|===
+
+[[kafka-message-selector-types]]
+=== Selector Types
+
+.Message Header
+
+The framework provides two main types of message header selectors.
+From within the Java DSL, these two can be easily invoked using statically provided methods:
+
+1. `kafkaHeaderEquals`: Matches messages where the specified header `key` exactly equals the given `value`.
+2. `kafkaHeaderContains`: Matches messages where the specified header `key` contains the given `value` as a substring.
+
+More advanced users might want to do pre- or suffix matching.
+That is also possible.
+
+.Java
+[source,java,indent=0,role="primary"]
+----
+then(
+    receive(kafkaWithRandomConsumerGroupEndpoint)
+        .selector(
+            kafkaMessageFilter()
+                .eventLookbackWindow(Duration.ofSeconds(1L))
+                .kafkaMessageSelector(
+                    KafkaMessageByHeaderSelector.builder()
+                        .key("key")
+                        .value("prefix")
+                        .matchingMechanism(STARTS_WITH)
+                        .build()
+                )
+                .build()
+        )
+);
+----
+
+Note that if the specified `key` is `null`, all headers in the record will be matched against the `value`.
+If the `value` is `null` however, all headers with the exact `key` match.
+
+[cols="2,2,2"]
+|===
+| Java DSL | XML DSL | Description
+
+| `key`
+| `header-filter-key`
+| Key-filter being applied to Kafka messages.
+  Matches exact if specified, all keys if `null` or empty.
+
+| `value`
+| `header-filter-value`
+| Value-filter being applied to Kafka messages.
+  Matches all values if `null` or empty.
+  Otherwise matches as specified by strategy.
+
+| `valueMatchingStrategy`
+| `header-filter-comparator`
+| Specifies how the `value` is being matched.
+  Must be one of `EQUALS`, `CONTAINS`, `STARTS_WITH` or `ENDS_WITH`.
+  It defaults to `EQUALS`, if not specified.
+
+|===
+
+=== Best Practices
+
+*Set Appropriate Lookback Window:* Choose a lookback window that balances between finding the desired message and performance.
+A larger window might find older messages but could impact performance.
+
+*Combine with Other Citrus Features:* The Kafka Message Selector can be combined with other Citrus testing features for comprehensive Kafka integration testing.
+
 [[dynamic-kafka-endpoints]]
-== Dynamic Kafka endpoints
+== Dynamic Kafka Endpoints
 
 As we have seen before the topic name can be overwritten in each send and receive operation by specifying the `citrus_kafka_topic`
 message header. In addition to that you can make use of completely dynamic Kafka endpoints, too.
@@ -477,7 +635,7 @@ You can add multiple parameters to the endpoint url in order to set properties o
 about dynamic endpoints in chapter link:#dynamic-endpoint-components[dynamic endpoints].
 
 [[embedded-kafka-server]]
-== Embedded Kafka server
+== Embedded Kafka Server
 
 The Kafka message broker is composed of a Zookeeper server and a Kafka server. Citrus provides an embedded server (*for testing purpose only!*)
 that is able to be started within your integration test environment. The server cluster is configured with one single Zookeeper
@@ -526,7 +684,7 @@ The embedded server component provides following properties to set:
 
 | zookeeper-port
 | java.lang.Integer
-| Zookeeper server port. By default a random port is used.
+| Zookeeper server port. By default, a random port is used.
 
 | broker-properties
 | java.util.Map

--- a/validation/citrus-validation-json/pom.xml
+++ b/validation/citrus-validation-json/pom.xml
@@ -72,11 +72,5 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <version>${assertj.version}</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/validation/citrus-validation-xml/src/test/java/org/citrusframework/xml/XsdSchemaRepositoryTest.java
+++ b/validation/citrus-validation-xml/src/test/java/org/citrusframework/xml/XsdSchemaRepositoryTest.java
@@ -16,11 +16,12 @@
 
 package org.citrusframework.xml;
 
+import org.citrusframework.xml.schema.WsdlXsdSchema;
 import org.springframework.xml.xsd.SimpleXsdSchema;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import org.citrusframework.xml.schema.WsdlXsdSchema;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 /**
  * @author Christoph Deppisch
@@ -35,8 +36,8 @@ public class XsdSchemaRepositoryTest {
 
         schemaRepository.initialize();
 
-        Assert.assertEquals(schemaRepository.getSchemas().size(), 1);
-        Assert.assertEquals(schemaRepository.getSchemas().get(0).getClass(), SimpleXsdSchema.class);
+        assertEquals(schemaRepository.getSchemas().size(), 1);
+        assertEquals(schemaRepository.getSchemas().get(0).getClass(), SimpleXsdSchema.class);
     }
 
     @Test
@@ -46,7 +47,7 @@ public class XsdSchemaRepositoryTest {
         schemaRepository.getLocations().add("classpath:org/citrusframework/unknown/unknown.xsd");
 
         schemaRepository.initialize();
-        Assert.assertEquals(schemaRepository.getSchemas().size(), 0);
+        assertEquals(schemaRepository.getSchemas().size(), 0);
     }
 
     @Test
@@ -57,11 +58,8 @@ public class XsdSchemaRepositoryTest {
 
         schemaRepository.initialize();
 
-        Assert.assertEquals(schemaRepository.getSchemas().size(), 4);
-        Assert.assertEquals(schemaRepository.getSchemas().get(0).getClass(), SimpleXsdSchema.class);
-        Assert.assertEquals(schemaRepository.getSchemas().get(1).getClass(), SimpleXsdSchema.class);
-        Assert.assertEquals(schemaRepository.getSchemas().get(2).getClass(), SimpleXsdSchema.class);
-        Assert.assertEquals(schemaRepository.getSchemas().get(3).getClass(), SimpleXsdSchema.class);
+        assertTrue(schemaRepository.getSchemas().size() == 4 || schemaRepository.getSchemas().size() == 6, "Expecting schema repository size to be either 4 or 6");
+        schemaRepository.getSchemas().forEach(xsdSchema -> assertEquals(xsdSchema.getClass(), SimpleXsdSchema.class));
     }
 
     @Test
@@ -72,7 +70,7 @@ public class XsdSchemaRepositoryTest {
 
         schemaRepository.initialize();
 
-        Assert.assertEquals(schemaRepository.getSchemas().size(), 0);
+        assertEquals(schemaRepository.getSchemas().size(), 0);
     }
 
     @Test
@@ -82,33 +80,33 @@ public class XsdSchemaRepositoryTest {
 
         schemaRepository.initialize();
 
-        Assert.assertEquals(schemaRepository.getSchemas().size(), 15);
+        assertEquals(schemaRepository.getSchemas().size(), 15);
 
         schemaRepository = new XsdSchemaRepository();
         schemaRepository.getLocations().add("classpath:org/citrusframework/validation/*.xsd");
 
         schemaRepository.initialize();
 
-        Assert.assertEquals(schemaRepository.getSchemas().size(), 6);
-        Assert.assertEquals(schemaRepository.getSchemas().get(0).getClass(), SimpleXsdSchema.class);
-        Assert.assertEquals(schemaRepository.getSchemas().get(1).getClass(), SimpleXsdSchema.class);
-        Assert.assertEquals(schemaRepository.getSchemas().get(2).getClass(), SimpleXsdSchema.class);
+        assertEquals(schemaRepository.getSchemas().size(), 6);
+        assertEquals(schemaRepository.getSchemas().get(0).getClass(), SimpleXsdSchema.class);
+        assertEquals(schemaRepository.getSchemas().get(1).getClass(), SimpleXsdSchema.class);
+        assertEquals(schemaRepository.getSchemas().get(2).getClass(), SimpleXsdSchema.class);
 
         schemaRepository = new XsdSchemaRepository();
         schemaRepository.getLocations().add("classpath:org/citrusframework/validation/*.wsdl");
 
         schemaRepository.initialize();
 
-        Assert.assertEquals(schemaRepository.getSchemas().size(), 9);
-        Assert.assertEquals(schemaRepository.getSchemas().get(0).getClass(), WsdlXsdSchema.class);
-        Assert.assertEquals(schemaRepository.getSchemas().get(1).getClass(), WsdlXsdSchema.class);
-        Assert.assertEquals(schemaRepository.getSchemas().get(2).getClass(), WsdlXsdSchema.class);
-        Assert.assertEquals(schemaRepository.getSchemas().get(3).getClass(), WsdlXsdSchema.class);
-        Assert.assertEquals(schemaRepository.getSchemas().get(4).getClass(), WsdlXsdSchema.class);
-        Assert.assertEquals(schemaRepository.getSchemas().get(5).getClass(), WsdlXsdSchema.class);
-        Assert.assertEquals(schemaRepository.getSchemas().get(6).getClass(), WsdlXsdSchema.class);
-        Assert.assertEquals(schemaRepository.getSchemas().get(7).getClass(), WsdlXsdSchema.class);
-        Assert.assertEquals(schemaRepository.getSchemas().get(8).getClass(), WsdlXsdSchema.class);
+        assertEquals(schemaRepository.getSchemas().size(), 9);
+        assertEquals(schemaRepository.getSchemas().get(0).getClass(), WsdlXsdSchema.class);
+        assertEquals(schemaRepository.getSchemas().get(1).getClass(), WsdlXsdSchema.class);
+        assertEquals(schemaRepository.getSchemas().get(2).getClass(), WsdlXsdSchema.class);
+        assertEquals(schemaRepository.getSchemas().get(3).getClass(), WsdlXsdSchema.class);
+        assertEquals(schemaRepository.getSchemas().get(4).getClass(), WsdlXsdSchema.class);
+        assertEquals(schemaRepository.getSchemas().get(5).getClass(), WsdlXsdSchema.class);
+        assertEquals(schemaRepository.getSchemas().get(6).getClass(), WsdlXsdSchema.class);
+        assertEquals(schemaRepository.getSchemas().get(7).getClass(), WsdlXsdSchema.class);
+        assertEquals(schemaRepository.getSchemas().get(8).getClass(), WsdlXsdSchema.class);
     }
 
     @Test
@@ -119,8 +117,8 @@ public class XsdSchemaRepositoryTest {
 
         schemaRepository.initialize();
 
-        Assert.assertEquals(schemaRepository.getSchemas().size(), 1);
-        Assert.assertEquals(schemaRepository.getSchemas().get(0).getClass(), WsdlXsdSchema.class);
+        assertEquals(schemaRepository.getSchemas().size(), 1);
+        assertEquals(schemaRepository.getSchemas().get(0).getClass(), WsdlXsdSchema.class);
     }
 
     @Test
@@ -129,11 +127,11 @@ public class XsdSchemaRepositoryTest {
 
         schemaRepository.addCitrusSchema("citrus-unknown-config");
 
-        Assert.assertEquals(schemaRepository.getSchemas().size(), 0);
+        assertEquals(schemaRepository.getSchemas().size(), 0);
 
         schemaRepository.addCitrusSchema("citrus-config");
 
-        Assert.assertEquals(schemaRepository.getSchemas().size(), 1);
-        Assert.assertEquals(schemaRepository.getSchemas().get(0).getClass(), SimpleXsdSchema.class);
+        assertEquals(schemaRepository.getSchemas().size(), 1);
+        assertEquals(schemaRepository.getSchemas().get(0).getClass(), SimpleXsdSchema.class);
     }
 }


### PR DESCRIPTION
improved the `receive` action for Kafka with selectors. that makes it possible to look out for specific events. sample in java:

```java
public class KafkaConsumerIT extends TestNGCitrusSpringSupport {

    @Autowired
    private KafkaEndpoint helloKafkaEndpoint;

    @Test
    @CitrusTest
    public void findKafkaEvent_headerEquals_citrus_DSL() {
        var body = "findKafkaEvent_headerEquals_citrus_DSL";

        var key = "Name";
        var value = "Bilbo";

        when(
                send(helloKafkaEndpoint)
                        .message(new KafkaMessage(body).setHeader(key, value))
        );

        then(
                receive(helloKafkaEndpoint)
                        .selector(
                                kafkaConsumerSelector()
                                        .eventLookbackWindow(Duration.ofSeconds(1L))
                                        .kafkaConsumerRecordMatcher(kafkaHeaderEquals(key, value))
                                        .build()
                        )
                        .getMessageBuilderSupport()
                        .body(body)
        );
    }
}
```

xml sample:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<spring:beans xmlns="http://www.citrusframework.org/schema/testcase"
              xmlns:spring="http://www.springframework.org/schema/beans"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xsi:schemaLocation="http://www.springframework.org/schema/beans 
                                  http://www.springframework.org/schema/beans/spring-beans.xsd 
                                  http://www.citrusframework.org/schema/testcase 
                                  http://www.citrusframework.org/schema/testcase/citrus-testcase.xsd">
    <variables>
      <variable name="correlationId" value="citrus:randomNumber(10)"/>
      <variable name="messageId" value="citrus:randomNumber(10)"/>
      <variable name="traceId" value="citrus:randomString(32)"/>
      <variable name="spanId" value="citrus:randomString(16)"/>
      <variable name="user" value="bbortt"/>
    </variables>

    <actions>
      <receive endpoint="helloKafkaEndpoint">
        <description>Receive Kafka request: Kafka broker -> Citrus</description>
        <selector>
          <element name="filter-identifier" value="KafkaConsumerRecordHeaderMatcher"/>
          <element name="header-filter-key" value="traceparent"/>
          <element name="header-filter-value" value="${traceId}"/>
          <element name="header-filter-comparator" value="CONTAINS"/>
          <element name="event-lookback-window" value="PT1S"/>
        </selector>
        <message>
          <data>
            <![CDATA[
              <HelloRequest xmlns="http://citrusframework.org/schemas/samples/HelloService.xsd">
                 <MessageId>${messageId}</MessageId>
                 <CorrelationId>${correlationId}</CorrelationId>
                 <User>${user}</User>
                 <Text>Hello Citrus</Text>
               </HelloRequest>
            ]]>
          </data>
        </message>
        <header>
          <element name="Operation" value="sayHello"/>
          <element name="citrus_kafka_topic" value="hello"/>
          <element name="citrus_kafka_partition" value="0"/>
          <element name="citrus_kafka_offset" value="@assertThat(greaterThanOrEqualTo(0))@"/>
        </header>
      </receive>
    </actions>
  </testcase>
</spring:beans>
```

coverage on code:

![2024-09-30-101131_3840x2160_scrot](https://github.com/user-attachments/assets/cdc11d32-99a2-448c-b8f9-7b870d15a685)

closes #1215.

**edit:** updated the coverage report. I forgot that TestNG requires tests to be `public` 😉 
**edit 2:** added xml sample.