### PR TITLE
enable parallel maven build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,5 +56,4 @@ jobs:
           java -version
           ./mvnw -version
       - name: Build Citrus
-        run: |
-          ./mvnw --no-transfer-progress install
+        run: ./mvnw --no-transfer-progress -T1C install

--- a/.github/workflows/lts.yml
+++ b/.github/workflows/lts.yml
@@ -48,5 +48,4 @@ jobs:
           java -version
           ./mvnw -version
       - name: Build Citrus
-        run: |
-          ./mvnw --no-transfer-progress -Djava.version=${{ matrix.version }} install
+        run: ./mvnw --no-transfer-progress -T1C -Djava.version=${{ matrix.version }} install


### PR DESCRIPTION
enabled parallel build using the "threads per core" flag: `-T1C`. build ens up being pretty stable running around 12 minutes.

closes #943.