### PR TITLE
fix(citrus-kafka): delombok module

### DIFF
--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaConsumer.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaConsumer.java
@@ -16,8 +16,6 @@
 
 package org.citrusframework.kafka.endpoint;
 
-import lombok.Getter;
-import lombok.Setter;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.message.Message;
 import org.citrusframework.messaging.AbstractSelectiveMessageConsumer;
@@ -41,8 +39,6 @@ import static org.apache.kafka.clients.consumer.ConsumerConfig.MAX_POLL_RECORDS_
 import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
 import static org.citrusframework.kafka.message.KafkaMessageHeaders.KAFKA_PREFIX;
 
-@Setter
-@Getter
 public class KafkaConsumer extends AbstractSelectiveMessageConsumer {
 
     private static final Logger logger = LoggerFactory.getLogger(KafkaConsumer.class);
@@ -55,6 +51,14 @@ public class KafkaConsumer extends AbstractSelectiveMessageConsumer {
     public KafkaConsumer(String name, KafkaEndpointConfiguration endpointConfiguration) {
         super(name, endpointConfiguration);
         this.consumer = createConsumer();
+    }
+
+    public org.apache.kafka.clients.consumer.KafkaConsumer<Object, Object> getConsumer() {
+        return consumer;
+    }
+
+    public void setConsumer(org.apache.kafka.clients.consumer.KafkaConsumer<Object, Object> consumer) {
+        this.consumer = consumer;
     }
 
     @Override

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaEndpoint.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaEndpoint.java
@@ -16,10 +16,7 @@
 
 package org.citrusframework.kafka.endpoint;
 
-import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
-import lombok.Builder;
-import lombok.Getter;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.citrusframework.actions.ReceiveMessageAction;
 import org.citrusframework.common.ShutdownPhase;
@@ -29,7 +26,6 @@ import java.time.Duration;
 
 import static java.lang.Boolean.TRUE;
 import static java.util.Objects.nonNull;
-import static lombok.AccessLevel.PACKAGE;
 import static org.citrusframework.actions.ReceiveMessageAction.Builder.receive;
 import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.kafkaHeaderEquals;
 import static org.citrusframework.kafka.message.KafkaMessageHeaders.KAFKA_PREFIX;
@@ -42,7 +38,6 @@ import static org.citrusframework.util.StringUtils.hasText;
  *
  * @since 2.8
  */
-@Getter(PACKAGE)
 public class KafkaEndpoint extends AbstractEndpoint implements ShutdownPhase {
 
     /**
@@ -50,6 +45,10 @@ public class KafkaEndpoint extends AbstractEndpoint implements ShutdownPhase {
      */
     private @Nullable KafkaProducer kafkaProducer;
     private @Nullable KafkaConsumer kafkaConsumer;
+
+    public static SimpleKafkaEndpointBuilder builder() {
+        return new SimpleKafkaEndpointBuilder();
+    }
 
     /**
      * Default constructor initializing endpoint configuration.
@@ -65,8 +64,7 @@ public class KafkaEndpoint extends AbstractEndpoint implements ShutdownPhase {
         super(endpointConfiguration);
     }
 
-    @Builder
-    public static @Nonnull KafkaEndpoint newKafkaEndpoint(
+    static KafkaEndpoint newKafkaEndpoint(
             @Nullable org.apache.kafka.clients.consumer.KafkaConsumer<Object, Object> kafkaConsumer,
             @Nullable org.apache.kafka.clients.producer.KafkaProducer<Object, Object> kafkaProducer,
             @Nullable Boolean randomConsumerGroup,
@@ -99,6 +97,16 @@ public class KafkaEndpoint extends AbstractEndpoint implements ShutdownPhase {
         }
 
         return kafkaEndpoint;
+    }
+
+    @Nullable
+    KafkaProducer getKafkaProducer() {
+        return kafkaProducer;
+    }
+
+    @Nullable
+    KafkaConsumer getKafkaConsumer() {
+        return kafkaConsumer;
     }
 
     @Override
@@ -140,5 +148,49 @@ public class KafkaEndpoint extends AbstractEndpoint implements ShutdownPhase {
                                 .build()
                 )
                 .getMessageBuilderSupport();
+    }
+
+    public static class SimpleKafkaEndpointBuilder {
+
+        private org.apache.kafka.clients.consumer.KafkaConsumer<Object, Object> kafkaConsumer;
+        private org.apache.kafka.clients.producer.KafkaProducer<Object, Object> kafkaProducer;
+        private Boolean randomConsumerGroup;
+        private String server;
+        private Long timeout;
+        private String topic;
+
+        public SimpleKafkaEndpointBuilder kafkaConsumer(org.apache.kafka.clients.consumer.KafkaConsumer<Object, Object> kafkaConsumer) {
+            this.kafkaConsumer = kafkaConsumer;
+            return this;
+        }
+
+        public SimpleKafkaEndpointBuilder kafkaProducer(org.apache.kafka.clients.producer.KafkaProducer<Object, Object> kafkaProducer) {
+            this.kafkaProducer = kafkaProducer;
+            return this;
+        }
+
+        public SimpleKafkaEndpointBuilder randomConsumerGroup(Boolean randomConsumerGroup) {
+            this.randomConsumerGroup = randomConsumerGroup;
+            return this;
+        }
+
+        public SimpleKafkaEndpointBuilder server(String server) {
+            this.server = server;
+            return this;
+        }
+
+        public SimpleKafkaEndpointBuilder timeout(Long timeout) {
+            this.timeout = timeout;
+            return this;
+        }
+
+        public SimpleKafkaEndpointBuilder topic(String topic) {
+            this.topic = topic;
+            return this;
+        }
+
+        public KafkaEndpoint build() {
+            return KafkaEndpoint.newKafkaEndpoint(kafkaConsumer, kafkaProducer, randomConsumerGroup, server, timeout, topic);
+        }
     }
 }

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaEndpointConfiguration.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaEndpointConfiguration.java
@@ -16,8 +16,6 @@
 
 package org.citrusframework.kafka.endpoint;
 
-import lombok.Getter;
-import lombok.Setter;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -30,8 +28,6 @@ import org.citrusframework.kafka.message.KafkaMessageHeaders;
 import java.util.HashMap;
 import java.util.Map;
 
-@Getter
-@Setter
 public class KafkaEndpointConfiguration extends AbstractPollableEndpointConfiguration {
 
     /**
@@ -97,4 +93,132 @@ public class KafkaEndpointConfiguration extends AbstractPollableEndpointConfigur
      * Topic partition
      */
     private int partition = 0;
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public String getConsumerGroup() {
+        return consumerGroup;
+    }
+
+    public void setConsumerGroup(String consumerGroup) {
+        this.consumerGroup = consumerGroup;
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public void setTopic(String topic) {
+        this.topic = topic;
+    }
+
+    public String getServer() {
+        return server;
+    }
+
+    public void setServer(String server) {
+        this.server = server;
+    }
+
+    public KafkaMessageHeaderMapper getHeaderMapper() {
+        return headerMapper;
+    }
+
+    public void setHeaderMapper(KafkaMessageHeaderMapper headerMapper) {
+        this.headerMapper = headerMapper;
+    }
+
+    public KafkaMessageConverter getMessageConverter() {
+        return messageConverter;
+    }
+
+    public void setMessageConverter(KafkaMessageConverter messageConverter) {
+        this.messageConverter = messageConverter;
+    }
+
+    public Class<? extends Serializer> getKeySerializer() {
+        return keySerializer;
+    }
+
+    public void setKeySerializer(Class<? extends Serializer> keySerializer) {
+        this.keySerializer = keySerializer;
+    }
+
+    public Class<? extends Serializer> getValueSerializer() {
+        return valueSerializer;
+    }
+
+    public void setValueSerializer(Class<? extends Serializer> valueSerializer) {
+        this.valueSerializer = valueSerializer;
+    }
+
+    public Class<? extends Deserializer> getKeyDeserializer() {
+        return keyDeserializer;
+    }
+
+    public void setKeyDeserializer(Class<? extends Deserializer> keyDeserializer) {
+        this.keyDeserializer = keyDeserializer;
+    }
+
+    public Class<? extends Deserializer> getValueDeserializer() {
+        return valueDeserializer;
+    }
+
+    public void setValueDeserializer(Class<? extends Deserializer> valueDeserializer) {
+        this.valueDeserializer = valueDeserializer;
+    }
+
+    public Map<String, Object> getConsumerProperties() {
+        return consumerProperties;
+    }
+
+    public void setConsumerProperties(Map<String, Object> consumerProperties) {
+        this.consumerProperties = consumerProperties;
+    }
+
+    public Map<String, Object> getProducerProperties() {
+        return producerProperties;
+    }
+
+    public void setProducerProperties(Map<String, Object> producerProperties) {
+        this.producerProperties = producerProperties;
+    }
+
+    public boolean isAutoCommit() {
+        return autoCommit;
+    }
+
+    public void setAutoCommit(boolean autoCommit) {
+        this.autoCommit = autoCommit;
+    }
+
+    public int getAutoCommitInterval() {
+        return autoCommitInterval;
+    }
+
+    public void setAutoCommitInterval(int autoCommitInterval) {
+        this.autoCommitInterval = autoCommitInterval;
+    }
+
+    public String getOffsetReset() {
+        return offsetReset;
+    }
+
+    public void setOffsetReset(String offsetReset) {
+        this.offsetReset = offsetReset;
+    }
+
+    public int getPartition() {
+        return partition;
+    }
+
+    public void setPartition(int partition) {
+        this.partition = partition;
+    }
 }

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaMessageConsumerUtils.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaMessageConsumerUtils.java
@@ -16,7 +16,6 @@
 
 package org.citrusframework.kafka.endpoint;
 
-import lombok.NoArgsConstructor;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;
@@ -27,9 +26,6 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 import java.util.Optional;
 
-import static lombok.AccessLevel.PRIVATE;
-
-@NoArgsConstructor(access = PRIVATE)
 final class KafkaMessageConsumerUtils {
 
     private static final Logger logger = LoggerFactory.getLogger(KafkaMessageConsumerUtils.class);
@@ -66,5 +62,9 @@ final class KafkaMessageConsumerUtils {
         testContext.onInboundMessage(received);
 
         return received;
+    }
+
+    private KafkaMessageConsumerUtils() {
+        // Static utility class
     }
 }

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaMessageSingleConsumer.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaMessageSingleConsumer.java
@@ -16,8 +16,8 @@
 
 package org.citrusframework.kafka.endpoint;
 
-import lombok.Builder;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.MessageTimeoutException;
 import org.citrusframework.message.Message;
@@ -38,7 +38,10 @@ class KafkaMessageSingleConsumer extends AbstractMessageConsumer {
 
     private final org.apache.kafka.clients.consumer.KafkaConsumer<Object, Object> consumer;
 
-    @Builder
+    public static KafkaMessageSingleConsumerBuilder builder() {
+        return new KafkaMessageSingleConsumerBuilder();
+    }
+
     private KafkaMessageSingleConsumer(
             KafkaEndpointConfiguration endpointConfiguration,
             org.apache.kafka.clients.consumer.KafkaConsumer<Object, Object> consumer
@@ -76,5 +79,25 @@ class KafkaMessageSingleConsumer extends AbstractMessageConsumer {
     @Override
     protected KafkaEndpointConfiguration getEndpointConfiguration() {
         return (KafkaEndpointConfiguration) super.getEndpointConfiguration();
+    }
+
+    public static class KafkaMessageSingleConsumerBuilder {
+
+        private KafkaEndpointConfiguration endpointConfiguration;
+        private org.apache.kafka.clients.consumer.KafkaConsumer<Object, Object> consumer;
+
+        public KafkaMessageSingleConsumerBuilder endpointConfiguration(KafkaEndpointConfiguration endpointConfiguration) {
+            this.endpointConfiguration = endpointConfiguration;
+            return this;
+        }
+
+        public KafkaMessageSingleConsumerBuilder consumer(KafkaConsumer<Object, Object> consumer) {
+            this.consumer = consumer;
+            return this;
+        }
+
+        public KafkaMessageSingleConsumer build() {
+            return new KafkaMessageSingleConsumer(endpointConfiguration, consumer);
+        }
     }
 }

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaProducer.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaProducer.java
@@ -16,8 +16,6 @@
 
 package org.citrusframework.kafka.endpoint;
 
-import lombok.Getter;
-import lombok.Setter;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;
@@ -52,7 +50,6 @@ public class KafkaProducer implements Producer {
     /**
      * The producer name.
      */
-    @Getter
     private final String name;
 
     /**
@@ -63,8 +60,6 @@ public class KafkaProducer implements Producer {
     /**
      * Kafka producer.
      */
-    @Getter
-    @Setter
     private org.apache.kafka.clients.producer.KafkaProducer<Object, Object> producer;
 
     /**
@@ -74,6 +69,19 @@ public class KafkaProducer implements Producer {
         this.name = name;
         this.endpointConfiguration = endpointConfiguration;
         this.producer = createKafkaProducer();
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public org.apache.kafka.clients.producer.KafkaProducer<Object, Object> getProducer() {
+        return producer;
+    }
+
+    public void setProducer(org.apache.kafka.clients.producer.KafkaProducer<Object, Object> producer) {
+        this.producer = producer;
     }
 
     @Override

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/selector/KafkaMessageByHeaderSelector.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/selector/KafkaMessageByHeaderSelector.java
@@ -17,10 +17,6 @@
 package org.citrusframework.kafka.endpoint.selector;
 
 import jakarta.annotation.Nullable;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.ToString;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Header;
 import org.citrusframework.exceptions.CitrusRuntimeException;
@@ -33,8 +29,6 @@ import java.util.Optional;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
-import static lombok.AccessLevel.PACKAGE;
-import static lombok.AccessLevel.PRIVATE;
 import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.ValueMatchingStrategy.CONTAINS;
 import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.ValueMatchingStrategy.EQUALS;
 import static org.citrusframework.util.StringUtils.isEmpty;
@@ -70,10 +64,6 @@ import static org.citrusframework.util.StringUtils.isEmpty;
  *
  * @see ValueMatchingStrategy
  */
-@Builder
-@ToString
-@Getter(PACKAGE)
-@AllArgsConstructor(access = PRIVATE)
 public class KafkaMessageByHeaderSelector implements KafkaMessageSelector {
 
     /**
@@ -106,6 +96,10 @@ public class KafkaMessageByHeaderSelector implements KafkaMessageSelector {
      * Specifies how the {@link KafkaMessageByHeaderSelector#value} should be matched.
      */
     private @Nullable ValueMatchingStrategy valueMatchingStrategy;
+
+    public static KafkaMessageByHeaderSelectorBuilder builder() {
+        return new KafkaMessageByHeaderSelectorBuilder();
+    }
 
     /**
      * Creates a {@link KafkaMessageByHeaderSelector} that checks if a header with the specified key contains the given
@@ -161,6 +155,27 @@ public class KafkaMessageByHeaderSelector implements KafkaMessageSelector {
         return KafkaMessageByHeaderSelector.builder()
                 .key(key)
                 .value(value);
+    }
+
+    private KafkaMessageByHeaderSelector(@Nullable String key, @Nullable String value, @Nullable ValueMatchingStrategy valueMatchingStrategy) {
+        this.key = key;
+        this.value = value;
+        this.valueMatchingStrategy = valueMatchingStrategy;
+    }
+
+    @Nullable
+    String getKey() {
+        return key;
+    }
+
+    @Nullable
+    String getValue() {
+        return value;
+    }
+
+    @Nullable
+    ValueMatchingStrategy getValueMatchingStrategy() {
+        return valueMatchingStrategy;
     }
 
     @Override
@@ -219,6 +234,38 @@ public class KafkaMessageByHeaderSelector implements KafkaMessageSelector {
         ENDS_WITH
     }
 
-    // Lombok will complete this class; declaration required to build the javadocs
-    public static class KafkaMessageByHeaderSelectorBuilder {}
+    @Override
+    public String toString() {
+        return "KafkaMessageByHeaderSelector{" +
+                "key='" + key + '\'' +
+                ", value='" + value + '\'' +
+                ", valueMatchingStrategy=" + valueMatchingStrategy +
+                '}';
+    }
+
+    public static class KafkaMessageByHeaderSelectorBuilder {
+
+        private String key;
+        private String value;
+        private KafkaMessageByHeaderSelector.ValueMatchingStrategy valueMatchingStrategy;
+
+        public KafkaMessageByHeaderSelectorBuilder key(String key) {
+            this.key = key;
+            return this;
+        }
+
+        public KafkaMessageByHeaderSelectorBuilder value(String value) {
+            this.value = value;
+            return this;
+        }
+
+        public KafkaMessageByHeaderSelectorBuilder valueMatchingStrategy(KafkaMessageByHeaderSelector.ValueMatchingStrategy valueMatchingStrategy) {
+            this.valueMatchingStrategy = valueMatchingStrategy;
+            return this;
+        }
+
+        public KafkaMessageByHeaderSelector build() {
+            return new KafkaMessageByHeaderSelector(key, value, valueMatchingStrategy);
+        }
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1146,13 +1146,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.projectlombok</groupId>
-      <artifactId>lombok</artifactId>
-      <version>1.18.34</version>
-      <scope>provided</scope>
-    </dependency>
-
     <!-- Test scoped dependencies -->
     <dependency>
       <groupId>org.assertj</groupId>


### PR DESCRIPTION
as a cleanup for https://github.com/citrusframework/citrus/pull/1217.

cc: @tschlat we had a little discussion going on about lombok and decided not to use it for the moment. mainly because some companies have stricter rules than we do regarding lombok and prohibit the use of it or any libraries that include it. we will ask the community for their input at a given time.