### PR TITLE
fix: Maven build for citrus-kafka failing

### DIFF
--- a/core/citrus-api/src/test/java/org/citrusframework/spi/AbstractReferenceResolverAwareTestActionBuilderTest.java
+++ b/core/citrus-api/src/test/java/org/citrusframework/spi/AbstractReferenceResolverAwareTestActionBuilderTest.java
@@ -1,7 +1,10 @@
 package org.citrusframework.spi;
 
+import java.lang.reflect.Field;
+
 import org.citrusframework.TestAction;
 import org.citrusframework.TestActionBuilder;
+import org.citrusframework.util.ReflectionHelper;
 import org.mockito.Mock;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -14,8 +17,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.MockitoAnnotations.openMocks;
-import static org.springframework.test.util.ReflectionTestUtils.getField;
-import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 public class AbstractReferenceResolverAwareTestActionBuilderTest {
 
@@ -26,6 +27,12 @@ public class AbstractReferenceResolverAwareTestActionBuilderTest {
     private TestReferenceResolver referenceResolverAware;
 
     private AbstractReferenceResolverAwareTestActionBuilder fixture;
+
+    private static final Field delegate = ReflectionHelper.findField(
+            AbstractReferenceResolverAwareTestActionBuilder.class, "delegate");
+
+    private static final Field referenceResolverField = ReflectionHelper.findField(
+            AbstractReferenceResolverAwareTestActionBuilder.class, "referenceResolver");
 
     private AutoCloseable openedMocks;
 
@@ -41,7 +48,7 @@ public class AbstractReferenceResolverAwareTestActionBuilderTest {
             }
         };
 
-        setField(fixture, "delegate", referenceResolverAware);
+        ReflectionHelper.setField(delegate, fixture, referenceResolverAware);
     }
 
     @Test
@@ -53,18 +60,18 @@ public class AbstractReferenceResolverAwareTestActionBuilderTest {
     public void setReferenceResolver() {
         fixture.setReferenceResolver(referenceResolver);
 
-        assertNotNull(getField(fixture, "referenceResolver"), "ReferenceResolver should be set");
+        assertNotNull(ReflectionHelper.getField(referenceResolverField, fixture), "ReferenceResolver should be set");
         verify(referenceResolverAware).setReferenceResolver(referenceResolver);
     }
 
     @Test
     public void setReferenceResolver_doesNotPropagateToNonReferenceResolverAware() {
         var testActionBuilder = mock(TestActionBuilder.class);
-        setField(fixture, "delegate", testActionBuilder);
+        ReflectionHelper.setField(delegate, fixture, testActionBuilder);
 
         fixture.setReferenceResolver(referenceResolver);
 
-        assertNotNull(getField(fixture, "referenceResolver"), "ReferenceResolver should be set");
+        assertNotNull(ReflectionHelper.getField(referenceResolverField, fixture), "ReferenceResolver should be set");
         verifyNoInteractions(referenceResolverAware);
         verifyNoInteractions(testActionBuilder);
     }
@@ -73,7 +80,7 @@ public class AbstractReferenceResolverAwareTestActionBuilderTest {
     public void setReferenceResolver_ignoresNullReferenceResolver() {
         fixture.setReferenceResolver(null);
 
-        assertNull(getField(fixture, "referenceResolver"), "ReferenceResolver should NOT be set");
+        assertNull(ReflectionHelper.getField(referenceResolverField, fixture), "ReferenceResolver should NOT be set");
         verifyNoInteractions(referenceResolverAware);
     }
 

--- a/core/citrus-base/src/main/java/org/citrusframework/TestCaseRunnerFactory.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/TestCaseRunnerFactory.java
@@ -53,7 +53,7 @@ public class TestCaseRunnerFactory {
     /** Default Citrus test runner from classpath resource properties. */
     private final ResourcePathTypeResolver typeResolver = new ResourcePathTypeResolver(RESOURCE_PATH);
 
-    private static final TestCaseRunnerFactory INSTANCE = new TestCaseRunnerFactory();
+    static final TestCaseRunnerFactory INSTANCE = new TestCaseRunnerFactory();
 
     private TestCaseRunnerFactory() {
         // Singleton

--- a/core/citrus-base/src/test/java/org/citrusframework/TestCaseRunnerFactoryTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/TestCaseRunnerFactoryTest.java
@@ -18,9 +18,8 @@ package org.citrusframework;
 
 import org.citrusframework.context.TestContext;
 import org.citrusframework.spi.ResourcePathTypeResolver;
+import org.citrusframework.util.ReflectionHelper;
 import org.mockito.Mockito;
-import org.springframework.test.util.ReflectionTestUtils;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -57,24 +56,21 @@ public class TestCaseRunnerFactoryTest {
         ResourcePathTypeResolver resolverMock = Mockito.mock(ResourcePathTypeResolver.class);
 
         Mockito.doReturn(new CustomTestCaseRunnerProvider()).when(resolverMock).resolve("custom");
-        TestCaseRunnerFactory instance = (TestCaseRunnerFactory) ReflectionTestUtils.getField(
-            TestCaseRunnerFactory.class,"INSTANCE");
-        Assert.assertNotNull(instance);
-
         TestContext testContext = new TestContext();
 
-        Object currentResolver = ReflectionTestUtils.getField(instance, "typeResolver");
+        Object currentResolver = ReflectionHelper.getField(ReflectionHelper.findField(TestCaseRunnerFactory.class, "typeResolver"), TestCaseRunnerFactory.INSTANCE);
         try {
-            ReflectionTestUtils.setField(instance, "typeResolver", resolverMock);
+            ReflectionHelper.setField(ReflectionHelper.findField(TestCaseRunnerFactory.class, "typeResolver"),
+                    TestCaseRunnerFactory.INSTANCE, resolverMock);
             TestCaseRunner runner = TestCaseRunnerFactory.createRunner(testContext);
 
             assertEquals(runner.getClass(), CustomTestCaseRunner.class);
 
             CustomTestCaseRunner defaultTestCaseRunner = (CustomTestCaseRunner) runner;
             assertEquals(defaultTestCaseRunner.getContext(), testContext);
-
         } finally {
-            ReflectionTestUtils.setField(instance, "typeResolver", currentResolver);
+            ReflectionHelper.setField(ReflectionHelper.findField(TestCaseRunnerFactory.class, "typeResolver"),
+                    TestCaseRunnerFactory.INSTANCE, currentResolver);
         }
 
     }
@@ -84,16 +80,14 @@ public class TestCaseRunnerFactoryTest {
         ResourcePathTypeResolver resolverMock = Mockito.mock(ResourcePathTypeResolver.class);
 
         Mockito.doReturn(new CustomTestCaseRunnerProvider()).when(resolverMock).resolve("custom");
-        TestCaseRunnerFactory instance = (TestCaseRunnerFactory) ReflectionTestUtils.getField(
-            TestCaseRunnerFactory.class,"INSTANCE");
-        Assert.assertNotNull(instance);
 
         TestContext testContext = new TestContext();
         TestCase testCase = new DefaultTestCase();
 
-        Object currentResolver = ReflectionTestUtils.getField(instance, "typeResolver");
+        Object currentResolver = ReflectionHelper.getField(ReflectionHelper.findField(TestCaseRunnerFactory.class, "typeResolver"), TestCaseRunnerFactory.INSTANCE);
         try {
-            ReflectionTestUtils.setField(instance, "typeResolver", resolverMock);
+            ReflectionHelper.setField(ReflectionHelper.findField(TestCaseRunnerFactory.class, "typeResolver"),
+                    TestCaseRunnerFactory.INSTANCE, resolverMock);
             TestCaseRunner runner = TestCaseRunnerFactory.createRunner(testCase, testContext);
 
             assertEquals(runner.getClass(), CustomTestCaseRunner.class);
@@ -101,9 +95,9 @@ public class TestCaseRunnerFactoryTest {
             CustomTestCaseRunner defaultTestCaseRunner = (CustomTestCaseRunner) runner;
             assertEquals(defaultTestCaseRunner.getContext(), testContext);
             assertEquals(defaultTestCaseRunner.getTestCase(), testCase);
-
         } finally {
-            ReflectionTestUtils.setField(instance, "typeResolver", currentResolver);
+            ReflectionHelper.setField(ReflectionHelper.findField(TestCaseRunnerFactory.class, "typeResolver"),
+                    TestCaseRunnerFactory.INSTANCE, currentResolver);
         }
 
     }

--- a/core/citrus-base/src/test/java/org/citrusframework/actions/ReceiveMessageBuilderTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/actions/ReceiveMessageBuilderTest.java
@@ -33,6 +33,7 @@ import org.citrusframework.message.Message;
 import org.citrusframework.message.MessageType;
 import org.citrusframework.spi.ReferenceResolver;
 import org.citrusframework.spi.Resource;
+import org.citrusframework.util.ReflectionHelper;
 import org.citrusframework.validation.HeaderValidator;
 import org.citrusframework.validation.MessageValidator;
 import org.citrusframework.validation.ValidationProcessor;
@@ -50,7 +51,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.citrusframework.validation.json.JsonMessageValidationContext.Builder.json;
 import static org.citrusframework.validation.json.JsonPathMessageValidationContext.Builder.jsonPath;
@@ -137,7 +137,7 @@ class ReceiveMessageBuilderTest {
         builder.message().name("foo");
 
         //THEN
-		assertTrue(builder.build().getMessageBuilder() instanceof DefaultMessageBuilder);
+        assertInstanceOf(DefaultMessageBuilder.class, builder.build().getMessageBuilder());
 		assertEquals("foo", builder.build().getMessageBuilder().build(context, MessageType.PLAINTEXT.name()).getName());
 	}
 
@@ -780,7 +780,8 @@ class ReceiveMessageBuilderTest {
 		doReturn(validator1).when(referenceResolver).resolve(name1);
 		doReturn(validator2).when(referenceResolver).resolve(name2);
 		doReturn(validator3).when(referenceResolver).resolve(name3);
-		ReflectionTestUtils.setField(builder, "referenceResolver", referenceResolver);
+		ReflectionHelper.setField(ReflectionHelper.findField(ReceiveMessageAction.Builder.class, "referenceResolver"),
+				builder, referenceResolver);
 
 		//WHEN
 		builder.validators(name1, name2, name3);
@@ -823,7 +824,8 @@ class ReceiveMessageBuilderTest {
 		doReturn(validator1).when(referenceResolver).resolve(name1);
 		doReturn(validator2).when(referenceResolver).resolve(name2);
 		doReturn(validator3).when(referenceResolver).resolve(name3);
-		ReflectionTestUtils.setField(builder, "referenceResolver", referenceResolver);
+		ReflectionHelper.setField(ReflectionHelper.findField(ReceiveMessageAction.Builder.class, "referenceResolver"),
+				builder, referenceResolver);
 
 		//WHEN
 		builder.validators(name1, name2, name3);
@@ -859,7 +861,8 @@ class ReceiveMessageBuilderTest {
 		final DataDictionary<?> dataDictionary = mock(DataDictionary.class);
 		final ReferenceResolver referenceResolver = mock(ReferenceResolver.class);
 		when(referenceResolver.resolve(name, DataDictionary.class)).thenReturn(dataDictionary);
-		ReflectionTestUtils.setField(builder, "referenceResolver", referenceResolver);
+		ReflectionHelper.setField(ReflectionHelper.findField(ReceiveMessageAction.Builder.class, "referenceResolver"),
+				builder, referenceResolver);
 
 		//WHEN
 		builder.message().dictionary(name);
@@ -888,13 +891,15 @@ class ReceiveMessageBuilderTest {
 		//GIVEN
 		final ReceiveMessageAction.Builder builder = new ReceiveMessageAction.Builder();
 		final ReferenceResolver referenceResolver = mock(ReferenceResolver.class);
-		ReflectionTestUtils.setField(builder, "referenceResolver", referenceResolver);
+		ReflectionHelper.setField(ReflectionHelper.findField(ReceiveMessageAction.Builder.class, "referenceResolver"),
+				builder, referenceResolver);
 
 		//WHEN
 		builder.withReferenceResolver(referenceResolver);
 
 		//THEN
-		assertEquals(referenceResolver, ReflectionTestUtils.getField(builder, "referenceResolver"));
+		assertEquals(referenceResolver, ReflectionHelper.getField(
+				ReflectionHelper.findField(ReceiveMessageAction.Builder.class, "referenceResolver"), builder));
 	}
 
     @Test
@@ -927,7 +932,7 @@ class ReceiveMessageBuilderTest {
 
 	private <T> T getFieldFromBuilder(ReceiveMessageAction.Builder builder, final Class<T> targetClass, final String fieldName) {
 		final T validationContext = targetClass.cast(
-				ReflectionTestUtils.getField(builder, fieldName));
+				ReflectionHelper.getField(ReflectionHelper.findField(ReceiveMessageAction.Builder.class, fieldName), builder));
 		assertNotNull(validationContext);
 		return validationContext;
 	}

--- a/core/citrus-base/src/test/java/org/citrusframework/functions/core/ChangeDateFunctionTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/functions/core/ChangeDateFunctionTest.java
@@ -16,20 +16,20 @@
 
 package org.citrusframework.functions.core;
 
+import java.util.Calendar;
+import java.util.Collections;
+
 import org.citrusframework.UnitTestSupport;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.exceptions.InvalidFunctionUsageException;
 import org.citrusframework.functions.FunctionParameterHelper;
+import org.citrusframework.util.ReflectionHelper;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-import java.util.Calendar;
-import java.util.Collections;
 
 import static org.mockito.Mockito.doReturn;
 
@@ -50,7 +50,7 @@ public class ChangeDateFunctionTest extends UnitTestSupport {
         mockitoContext = MockitoAnnotations.openMocks(this);
 
         fixture = new ChangeDateFunction();
-        ReflectionTestUtils.setField(fixture, "calendarProvider", calendarProviderMock, ChangeDateFunction.CalendarProvider.class);
+        ReflectionHelper.setField(ReflectionHelper.findField(ChangeDateFunction.class, "calendarProvider"), fixture, calendarProviderMock);
     }
 
     @Test

--- a/core/citrus-base/src/test/java/org/citrusframework/report/LoggingReporterTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/report/LoggingReporterTest.java
@@ -16,6 +16,19 @@
 
 package org.citrusframework.report;
 
+import java.time.Duration;
+import java.util.Locale;
+
+import org.citrusframework.DefaultTestCase;
+import org.citrusframework.actions.EchoAction;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.util.ReflectionHelper;
+import org.mockito.Mock;
+import org.slf4j.Logger;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import static java.lang.String.format;
 import static org.citrusframework.TestResult.failed;
 import static org.citrusframework.TestResult.skipped;
@@ -27,18 +40,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.openMocks;
-import static org.springframework.test.util.ReflectionTestUtils.setField;
-
-import java.time.Duration;
-import java.util.Locale;
-import org.citrusframework.DefaultTestCase;
-import org.citrusframework.actions.EchoAction;
-import org.citrusframework.exceptions.CitrusRuntimeException;
-import org.mockito.Mock;
-import org.slf4j.Logger;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
 
 public class LoggingReporterTest {
 
@@ -68,7 +69,7 @@ public class LoggingReporterTest {
         fixture = new LoggingReporter();
 
         // Comment this line if you want to see the logs in stdout
-        setField(fixture, "logger", logger, Logger.class);
+        ReflectionHelper.setField(ReflectionHelper.findField(LoggingReporter.class, "logger"), null, logger);
     }
 
     @Test

--- a/core/citrus-base/src/test/java/org/citrusframework/sharding/ShardingConfigurationTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/sharding/ShardingConfigurationTest.java
@@ -16,28 +16,23 @@
 
 package org.citrusframework.sharding;
 
+import java.util.Optional;
+
 import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.util.ReflectionHelper;
 import org.citrusframework.util.SystemProvider;
 import org.mockito.Mock;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.util.Optional;
-
-import static org.citrusframework.sharding.ShardingConfiguration.SHARD_NUMBER_ENV_VAR_NAME;
-import static org.citrusframework.sharding.ShardingConfiguration.SHARD_NUMBER_PROPERTY_NAME;
-import static org.citrusframework.sharding.ShardingConfiguration.SHARD_SEED_ENV_VAR_NAME;
-import static org.citrusframework.sharding.ShardingConfiguration.SHARD_SEED_PROPERTY_NAME;
-import static org.citrusframework.sharding.ShardingConfiguration.TOTAL_SHARD_NUMBER_ENV_VAR_NAME;
-import static org.citrusframework.sharding.ShardingConfiguration.TOTAL_SHARD_NUMBER_PROPERTY_NAME;
+import static org.citrusframework.sharding.ShardingConfiguration.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.openMocks;
-import static org.springframework.test.util.ReflectionTestUtils.getField;
 import static org.testng.Assert.expectThrows;
 
 public class ShardingConfigurationTest {
@@ -58,9 +53,12 @@ public class ShardingConfigurationTest {
     }
 
     private static void assertProperties(ShardingConfiguration fixture, int totalNumberOfShards, int shardNumber, String seed) {
-        assertEquals(totalNumberOfShards, getField(fixture, "totalNumberOfShards"));
-        assertEquals(shardNumber, getField(fixture, "shardNumber"));
-        assertEquals(seed, getField(fixture, "seed"));
+        assertEquals(totalNumberOfShards, ReflectionHelper.getField(
+                ReflectionHelper.findField(ShardingConfiguration.class, "totalNumberOfShards"), fixture));
+        assertEquals(shardNumber, ReflectionHelper.getField(
+                ReflectionHelper.findField(ShardingConfiguration.class, "shardNumber"), fixture));
+        assertEquals(seed, ReflectionHelper.getField(
+                ReflectionHelper.findField(ShardingConfiguration.class, "seed"), fixture));
     }
 
     @Test

--- a/endpoints/citrus-kafka/src/main/resources/org/citrusframework/schema/citrus-kafka-config-4.4.0-SNAPSHOT.xsd
+++ b/endpoints/citrus-kafka/src/main/resources/org/citrusframework/schema/citrus-kafka-config-4.4.0-SNAPSHOT.xsd
@@ -45,6 +45,7 @@
       <xs:attribute name="id" type="xs:ID"/>
       <xs:attribute name="client-id" type="xs:string"/>
       <xs:attribute name="consumer-group" type="xs:string"/>
+      <xs:attribute name="random-consumer-group" type="xs:boolean" default="false"/>
       <xs:attribute name="auto-commit" type="xs:string"/>
       <xs:attribute name="auto-commit-interval" type="xs:int"/>
       <xs:attribute name="server" type="xs:string"/>

--- a/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/integration/KafkaEndpointJavaIT.java
+++ b/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/integration/KafkaEndpointJavaIT.java
@@ -16,6 +16,8 @@
 
 package org.citrusframework.kafka.integration;
 
+import java.time.Duration;
+
 import org.assertj.core.api.ThrowableAssert;
 import org.citrusframework.annotations.CitrusTest;
 import org.citrusframework.exceptions.CitrusRuntimeException;
@@ -23,15 +25,9 @@ import org.citrusframework.exceptions.TestCaseFailedException;
 import org.citrusframework.kafka.endpoint.KafkaEndpoint;
 import org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector;
 import org.citrusframework.kafka.message.KafkaMessage;
+import org.citrusframework.spi.BindToRegistry;
 import org.citrusframework.testng.spring.TestNGCitrusSpringSupport;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ContextConfiguration;
 import org.testng.annotations.Test;
-
-import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.citrusframework.actions.ReceiveMessageAction.Builder.receive;
@@ -44,12 +40,13 @@ import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSe
 import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.kafkaHeaderEquals;
 
 @Test
-@DirtiesContext
-@ContextConfiguration(classes = {KafkaEndpointJavaIT.KafkaEndpointConfiguration.class})
 public class KafkaEndpointJavaIT extends TestNGCitrusSpringSupport {
 
-    @Autowired
-    private KafkaEndpoint kafkaWithRandomConsumerGroupEndpoint;
+    @BindToRegistry
+    private final KafkaEndpoint kafkaWithRandomConsumerGroupEndpoint = KafkaEndpoint.builder()
+            .randomConsumerGroup(true)
+            .topic("hello")
+            .build();
 
     @Test
     @CitrusTest
@@ -285,15 +282,4 @@ public class KafkaEndpointJavaIT extends TestNGCitrusSpringSupport {
         );
     }
 
-    @TestConfiguration
-    static class KafkaEndpointConfiguration {
-
-        @Bean
-        public KafkaEndpoint kafkaWithRandomConsumerGroupEndpoint() {
-            return KafkaEndpoint.builder()
-                    .randomConsumerGroup(true)
-                    .topic("hello")
-                    .build();
-        }
-    }
 }

--- a/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/integration/KafkaEndpointXmlIT.java
+++ b/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/integration/KafkaEndpointXmlIT.java
@@ -19,11 +19,9 @@ package org.citrusframework.kafka.integration;
 import org.citrusframework.annotations.CitrusTestSource;
 import org.citrusframework.common.TestLoader;
 import org.citrusframework.testng.spring.TestNGCitrusSpringSupport;
-import org.springframework.test.annotation.DirtiesContext;
 import org.testng.annotations.Test;
 
 @Test
-@DirtiesContext
 public class KafkaEndpointXmlIT extends TestNGCitrusSpringSupport {
 
     @CitrusTestSource(type = TestLoader.SPRING, name = "KafkaEndpointIT_singleMessage")

--- a/pom.xml
+++ b/pom.xml
@@ -1154,9 +1154,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-test</artifactId>
-      <version>3.3.3</version>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
- Fix Maven build due to embedded Kafka broker starting before old broker has been fully stopped
- Avoids "Address already in use" errors on fast machines
- Remove DirtiesContext for Kafka integration tests to avoid embedded Kafka broker being restarted for each test
- Remove obsolete org.springframework.boot:spring-boot-starter-test dependency in favor of using Citrus ReflectionHelper utils
- Fix citrus-kafka-config-4.4.0-SNAPSHOT.xsd missing changes