### PR TITLE
chore(citrus-camel): Add Camel JBang support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ logs/
 .externalToolBuilders/
 maven-eclipse.xml
 .mvn/wrapper/maven-wrapper.jar
+
+.citrus-jbang/
+.camel-jbang/

--- a/endpoints/citrus-camel/pom.xml
+++ b/endpoints/citrus-camel/pom.xml
@@ -29,6 +29,12 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.citrusframework</groupId>
+      <artifactId>citrus-jbang-connector</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework</groupId>

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/CamelSettings.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/CamelSettings.java
@@ -32,6 +32,18 @@ public final class CamelSettings {
     private static final String TIMEOUT_ENV = CAMEL_ENV_PREFIX + "TIMEOUT";
     private static final long TIMEOUT_DEFAULT = TimeUnit.SECONDS.toMillis(5);
 
+    private static final String MAX_ATTEMPTS_PROPERTY = CAMEL_PROPERTY_PREFIX + "max.attempts";
+    private static final String MAX_ATTEMPTS_ENV = CAMEL_ENV_PREFIX + "MAX_ATTEMPTS";
+    private static final String MAX_ATTEMPTS_DEFAULT = "60";
+
+    private static final String DELAY_BETWEEN_ATTEMPTS_PROPERTY = CAMEL_PROPERTY_PREFIX + "delay.between.attempts";
+    private static final String DELAY_BETWEEN_ATTEMPTS_ENV = CAMEL_ENV_PREFIX + "DELAY_BETWEEN_ATTEMPTS";
+    private static final String DELAY_BETWEEN_ATTEMPTS_DEFAULT = "2000";
+
+    private static final String PRINT_LOGS_PROPERTY = CAMEL_PROPERTY_PREFIX + "print.logs";
+    private static final String PRINT_LOGS_ENV = CAMEL_ENV_PREFIX + "PRINT_LOGS";
+    private static final String PRINT_LOGS_DEFAULT = "true";
+
     private CamelSettings() {
         // prevent instantiation of utility class
     }
@@ -53,5 +65,32 @@ public final class CamelSettings {
     public static String getContextName() {
         return System.getProperty(CONTEXT_NAME_PROPERTY,
                 System.getenv(CONTEXT_NAME_ENV) != null ? System.getenv(CONTEXT_NAME_ENV) : CONTEXT_NAME_DEFAULT);
+    }
+
+    /**
+     * Maximum number of attempts when polling for running state and log messages.
+     * @return
+     */
+    public static int getMaxAttempts() {
+        return Integer.parseInt(System.getProperty(MAX_ATTEMPTS_PROPERTY,
+                System.getenv(MAX_ATTEMPTS_ENV) != null ? System.getenv(MAX_ATTEMPTS_ENV) : MAX_ATTEMPTS_DEFAULT));
+    }
+
+    /**
+     * Delay in milliseconds to wait after polling attempt.
+     * @return
+     */
+    public static long getDelayBetweenAttempts() {
+        return Long.parseLong(System.getProperty(DELAY_BETWEEN_ATTEMPTS_PROPERTY,
+                System.getenv(DELAY_BETWEEN_ATTEMPTS_ENV) != null ? System.getenv(DELAY_BETWEEN_ATTEMPTS_ENV) : DELAY_BETWEEN_ATTEMPTS_DEFAULT));
+    }
+
+    /**
+     * When set to true test will print Camel JBang route logs e.g. while waiting for a log message.
+     * @return
+     */
+    public static boolean isPrintLogs() {
+        return Boolean.parseBoolean(System.getProperty(PRINT_LOGS_PROPERTY,
+                System.getenv(PRINT_LOGS_ENV) != null ? System.getenv(PRINT_LOGS_ENV) : PRINT_LOGS_DEFAULT));
     }
 }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/AbstractCamelJBangAction.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/AbstractCamelJBangAction.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.actions;
+
+import org.citrusframework.AbstractTestActionBuilder;
+import org.citrusframework.actions.AbstractTestAction;
+import org.citrusframework.camel.jbang.CamelJBang;
+
+/**
+ * Abstract action to access Camel JBang tooling. Action provides common Camel JBang settings such as explicit Camel version.
+ */
+public abstract class AbstractCamelJBangAction extends AbstractTestAction {
+
+    private final String camelVersion;
+    private final String kameletsVersion;
+
+    private final CamelJBang camelJBang = CamelJBang.camel();
+
+    protected AbstractCamelJBangAction(String name, Builder<?, ?> builder) {
+        super(name, builder);
+
+        this.camelVersion = builder.camelVersion;
+        this.kameletsVersion = builder.kameletsVersion;
+
+        if (camelVersion != null) {
+            camelJBang.camelApp().withSystemProperty("camel.jbang.version", camelVersion);
+        }
+
+        if (kameletsVersion != null) {
+            camelJBang.camelApp().withSystemProperty("camel-kamelets.version", camelVersion);
+        }
+    }
+
+    /**
+     * Provides access to the configured Camel JBang instance.
+     * @return
+     */
+    protected CamelJBang camelJBang() {
+        return camelJBang;
+    }
+
+    public String getCamelVersion() {
+        return camelVersion;
+    }
+
+    public String getKameletsVersion() {
+        return kameletsVersion;
+    }
+
+    /**
+     * Action builder.
+     */
+    public static abstract class Builder<T extends AbstractCamelJBangAction, B extends Builder<T, B>> extends AbstractTestActionBuilder<T, B> {
+
+        protected String camelVersion;
+        protected String kameletsVersion;
+
+        /**
+         * Sets explicit Camel version.
+         * @param camelVersion
+         * @return
+         */
+        public B camelVersion(String camelVersion) {
+            this.camelVersion = camelVersion;
+            return self;
+        }
+
+        /**
+         * Sets explicit Kamelets version.
+         * @param kameletsVersion
+         * @return
+         */
+        public B kameletsVersion(String kameletsVersion) {
+            this.kameletsVersion = kameletsVersion;
+            return self;
+        }
+
+    }
+}

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelActionBuilder.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelActionBuilder.java
@@ -106,6 +106,16 @@ public class CamelActionBuilder implements TestActionBuilder.DelegatingTestActio
     }
 
     /**
+     * Perform actions with Camel JBang.
+     * @return
+     */
+    public CamelJBangActionBuilder jbang() {
+        CamelJBangActionBuilder builder = new CamelJBangActionBuilder();
+        this.delegate = builder;
+        return builder;
+    }
+
+    /**
      * Sets the bean reference resolver.
      * @param referenceResolver
      */

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelJBangActionBuilder.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelJBangActionBuilder.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.actions;
+
+import org.citrusframework.spi.AbstractReferenceResolverAwareTestActionBuilder;
+import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.spi.ReferenceResolverAware;
+import org.citrusframework.util.ObjectHelper;
+
+/**
+ * Action builder.
+ */
+public class CamelJBangActionBuilder extends AbstractReferenceResolverAwareTestActionBuilder<AbstractCamelJBangAction> {
+
+    private String camelVersion;
+    private String kameletsVersion;
+
+    public CamelJBangActionBuilder camelVersion(String camelVersion) {
+        this.camelVersion = camelVersion;
+        return this;
+    }
+
+    public CamelJBangActionBuilder kameletsVersion(String kameletsVersion) {
+        this.kameletsVersion = kameletsVersion;
+        return this;
+    }
+
+    /**
+     * Runs Camel integration.
+     * @return
+     */
+    public CamelRunIntegrationAction.Builder run() {
+        CamelRunIntegrationAction.Builder builder = new CamelRunIntegrationAction.Builder();
+        this.delegate = builder;
+        return builder;
+    }
+
+    /**
+     * Verify that given Camel integration is running.
+     * @param name
+     */
+    public CamelVerifyIntegrationAction.Builder verify(String name) {
+        CamelVerifyIntegrationAction.Builder builder = new CamelVerifyIntegrationAction.Builder()
+                .integration(name);
+        this.delegate = builder;
+        return builder;
+    }
+
+    /**
+     * Runs Camel integration from given source code.
+     * @param name
+     * @param sourceCode
+     * @return
+     */
+    public CamelRunIntegrationAction.Builder run(String name, String sourceCode) {
+        CamelRunIntegrationAction.Builder builder = new CamelRunIntegrationAction.Builder()
+                .integrationName(name)
+                .integration(sourceCode);
+
+        this.delegate = builder;
+        return builder;
+    }
+
+    /**
+     * Stop the Camel integration JBang process identified by th given integration name.
+     */
+    public CamelStopIntegrationAction.Builder stop(String name) {
+        CamelStopIntegrationAction.Builder builder = new CamelStopIntegrationAction.Builder()
+                .integration(name);
+
+        this.delegate = builder;
+        return builder;
+    }
+
+    /**
+     * Sets the bean reference resolver.
+     * @param referenceResolver
+     */
+    public CamelJBangActionBuilder withReferenceResolver(ReferenceResolver referenceResolver) {
+        this.referenceResolver = referenceResolver;
+        return this;
+    }
+
+    @Override
+    public AbstractCamelJBangAction build() {
+        ObjectHelper.assertNotNull(delegate, "Missing delegate action to build");
+
+        if (delegate instanceof ReferenceResolverAware referenceResolverAware) {
+            referenceResolverAware.setReferenceResolver(referenceResolver);
+        }
+
+        if (delegate instanceof AbstractCamelJBangAction.Builder<?,?> camelJBangActionBuilder) {
+            if (camelVersion != null) {
+                camelJBangActionBuilder.camelVersion(camelVersion);
+            }
+
+            if (kameletsVersion != null) {
+                camelJBangActionBuilder.kameletsVersion(kameletsVersion);
+            }
+        }
+
+        return delegate.build();
+    }
+}

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelRunIntegrationAction.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelRunIntegrationAction.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.actions;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+import org.citrusframework.camel.jbang.CamelJBangSettings;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.jbang.ProcessAndOutput;
+import org.citrusframework.spi.Resource;
+import org.citrusframework.util.FileUtils;
+import org.citrusframework.util.IsJsonPredicate;
+import org.citrusframework.util.IsXmlPredicate;
+import org.citrusframework.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Runs given Camel integration with Camel JBang tooling.
+ */
+public class CamelRunIntegrationAction extends AbstractCamelJBangAction {
+
+    /** Logger */
+    private static final Logger logger = LoggerFactory.getLogger(CamelRunIntegrationAction.class);
+
+    /** Name of Camel integration */
+    private final String integrationName;
+
+    /** Camel integration resource */
+    private final Resource integrationResource;
+
+    /** Source code to run as a Camel integration */
+    private final String sourceCode;
+
+    /**
+     * Default constructor.
+     */
+    public CamelRunIntegrationAction(Builder builder) {
+        super("run-integration", builder);
+
+        this.integrationName = builder.integrationName;
+        this.integrationResource = builder.integrationResource;
+        this.sourceCode = builder.sourceCode;
+    }
+
+    @Override
+    public void doExecute(TestContext context) {
+        String name = context.replaceDynamicContentInString(integrationName);
+
+        try {
+            logger.info("Starting Camel integration '%s' ...".formatted(name));
+
+            Path integrationToRun;
+            if (StringUtils.hasText(sourceCode)) {
+                Path workDir = CamelJBangSettings.getWorkDir();
+                Files.createDirectories(workDir);
+                integrationToRun = workDir.resolve(String.format("i-%s.%s", name, getFileExt(sourceCode)));
+                Files.writeString(integrationToRun, sourceCode,
+                        StandardOpenOption.WRITE,
+                        StandardOpenOption.CREATE,
+                        StandardOpenOption.TRUNCATE_EXISTING);
+            } else if (integrationResource != null) {
+                integrationToRun = integrationResource.getFile().toPath();
+            } else {
+                throw new CitrusRuntimeException("Missing Camel integration source code or file");
+            }
+
+            ProcessAndOutput pao = camelJBang().run(name, integrationToRun);
+
+            if (!pao.getProcess().isAlive()) {
+                logger.info("Failed to start Camel integration '%s'".formatted(name));
+                logger.info(pao.getOutput());
+
+                throw new CitrusRuntimeException(String.format("Failed to start Camel integration - exit code %s", pao.getProcess().exitValue()));
+            }
+
+            Long pid = pao.getProcessId(integrationToRun.getFileName().toString());
+            context.setVariable(name + ":pid", pid);
+            context.setVariable(name + ":process:" + pid, pao);
+
+            logger.info("Started Camel integration '%s'".formatted(name));
+        } catch (IOException e) {
+            throw new CitrusRuntimeException("Failed to create temporary file from Camel integration");
+        }
+    }
+
+    private String getFileExt(String sourceCode) {
+        if (IsXmlPredicate.getInstance().test(sourceCode)) {
+            return "xml";
+        } else if (IsJsonPredicate.getInstance().test(sourceCode)) {
+            return "json";
+        } else if (sourceCode.contains("static void main(")) {
+            return "java";
+        } else if (sourceCode.contains("- from:") || sourceCode.contains("- route:") ||
+                sourceCode.contains("- routeConfiguration:") || sourceCode.contains("- rest:") || sourceCode.contains("- beans:")) {
+            return "yaml";
+        } else if (sourceCode.contains("kind: Kamelet") || sourceCode.contains("kind: KameletBinding") ||
+                sourceCode.contains("kind: Pipe") || sourceCode.contains("kind: Integration")) {
+            return "yaml";
+        } else {
+            return "groovy";
+        }
+    }
+
+    public String getIntegrationName() {
+        return integrationName;
+    }
+
+    /**
+     * Action builder.
+     */
+    public static final class Builder extends AbstractCamelJBangAction.Builder<CamelRunIntegrationAction, Builder> {
+
+        private String sourceCode;
+        private String integrationName = "route";
+        private Resource integrationResource;
+
+        /**
+         * Runs Camel integration from given source code.
+         * @param sourceCode
+         * @return
+         */
+        public Builder integration(String sourceCode) {
+            this.sourceCode = sourceCode;
+            return this;
+        }
+
+        /**
+         * Runs given Camel integration resource.
+         * @param resource
+         * @return
+         */
+        public Builder integration(Resource resource) {
+            this.integrationResource = resource;
+            if (integrationName == null) {
+                this.integrationName = FileUtils.getBaseName(FileUtils.getFileName(resource.getLocation()));
+            }
+            return this;
+        }
+
+        /**
+         * Adds route using one of the supported languages XML or Groovy.
+         * @param name
+         * @param sourceCode
+         * @return
+         */
+        public Builder integration(String name, String sourceCode) {
+            this.integrationName = name;
+            this.sourceCode = sourceCode;
+            return this;
+        }
+
+        /**
+         * Sets the integration name.
+         * @param name
+         * @return
+         */
+        public Builder integrationName(String name) {
+            this.integrationName = name;
+            return this;
+        }
+
+        @Override
+        public CamelRunIntegrationAction build() {
+            return new CamelRunIntegrationAction(this);
+        }
+    }
+}

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelStopIntegrationAction.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelStopIntegrationAction.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.actions;
+
+import org.citrusframework.context.TestContext;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Stops given Camel integration with Camel JBang tooling.
+ */
+public class CamelStopIntegrationAction extends AbstractCamelJBangAction {
+
+    /** Logger */
+    private static final Logger logger = LoggerFactory.getLogger(CamelStopIntegrationAction.class);
+
+    /** Route id */
+    private final String integrationName;
+
+    /**
+     * Default constructor.
+     */
+    public CamelStopIntegrationAction(Builder builder) {
+        super("stop-integration", builder);
+
+        this.integrationName = builder.integrationName;
+    }
+
+    @Override
+    public void doExecute(TestContext context) {
+        String name = context.replaceDynamicContentInString(integrationName);
+
+        logger.info("Stopping Camel integration '%s' ...".formatted(name));
+
+        Long pid;
+        if (context.getVariables().containsKey(name + ":pid")) {
+            pid = context.getVariable(name + ":pid", Long.class);
+        } else {
+            pid = camelJBang().getAll().stream()
+                    .filter(props -> name.equals(props.get("NAME")) && !props.getOrDefault("PID", "").isBlank())
+                    .map(props -> Long.valueOf(props.get("PID"))).findFirst()
+                    .orElseThrow(() -> new CitrusRuntimeException(String.format("Missing process id for Camel integration %s:pid", name)));
+        }
+
+        camelJBang().stop(pid);
+
+        logger.info("Stopped Camel integration '%s'".formatted(name));
+    }
+
+    public String getIntegrationName() {
+        return integrationName;
+    }
+
+    /**
+     * Action builder.
+     */
+    public static final class Builder extends AbstractCamelJBangAction.Builder<CamelStopIntegrationAction, Builder> {
+
+        private String integrationName = "route";
+
+        /**
+         * Stop Camel JBang process for this integration.
+         * @param name
+         * @return
+         */
+        public Builder integration(String name) {
+            this.integrationName = name;
+            return this;
+        }
+
+        /**
+         * Sets the integration name.
+         * @param name
+         * @return
+         */
+        public Builder integrationName(String name) {
+            this.integrationName = name;
+            return this;
+        }
+
+        @Override
+        public CamelStopIntegrationAction build() {
+            return new CamelStopIntegrationAction(this);
+        }
+    }
+}

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelVerifyIntegrationAction.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelVerifyIntegrationAction.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.actions;
+
+import java.util.Map;
+
+import org.citrusframework.camel.CamelSettings;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.exceptions.ActionTimeoutException;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.jbang.ProcessAndOutput;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Verifies Camel integration via Camel JBang. Checks route for running/stopped state and optionally waits for a log message to be present.
+ * Raises errors when either the Camel integration is not in expected state or the log message is not available.
+ * Both operations are automatically retried for a given amount of attempts.
+ */
+public class CamelVerifyIntegrationAction extends AbstractCamelJBangAction {
+
+    private static final Logger INTEGRATION_STATUS_LOG = LoggerFactory.getLogger("INTEGRATION_STATUS");
+    private static final Logger INTEGRATION_LOG = LoggerFactory.getLogger("INTEGRATION_LOGS");
+
+    /** Logger */
+    private static final Logger logger = LoggerFactory.getLogger(CamelVerifyIntegrationAction.class);
+
+    private final String integrationName;
+
+    private final String logMessage;
+    private final int maxAttempts;
+    private final long delayBetweenAttempts;
+
+    private final String phase;
+    private final boolean printLogs;
+
+    private final boolean stopOnErrorStatus;
+
+    /**
+     * Default constructor.
+     */
+    public CamelVerifyIntegrationAction(Builder builder) {
+        super("verify-integration", builder);
+
+        this.integrationName = builder.integrationName;
+        this.phase = builder.phase;
+        this.logMessage = builder.logMessage;
+        this.maxAttempts = builder.maxAttempts;
+        this.delayBetweenAttempts = builder.delayBetweenAttempts;
+        this.printLogs = builder.printLogs;
+        this.stopOnErrorStatus = builder.stopOnErrorStatus;
+    }
+
+    @Override
+    public void doExecute(TestContext context) {
+        String name = context.replaceDynamicContentInString(integrationName);
+
+        logger.info("Verify Camel integration '%s' ...".formatted(name));
+
+        Long pid = verifyRouteStatus(name, context.replaceDynamicContentInString(phase), context);
+
+        if (logMessage != null) {
+            verifyRouteLogs(pid, name, context.replaceDynamicContentInString(logMessage), context);
+        }
+
+        logger.info("Successfully verified Camel integration '%s'".formatted(name));
+    }
+
+    private void verifyRouteLogs(Long pid, String name, String message, TestContext context) {
+        if (printLogs) {
+            INTEGRATION_LOG.info(String.format("Waiting for integration '%s' to log message", name));
+        }
+
+        String log;
+        int offset = 0;
+
+        ProcessAndOutput pao = context.getVariable(name + ":process:" + pid, ProcessAndOutput.class);
+        for (int i = 0; i < maxAttempts; i++) {
+            log = pao.getOutput();
+
+            if (printLogs && (offset < log.length())) {
+                INTEGRATION_LOG.info(log.substring(offset));
+                offset = log.length();
+            }
+
+            if (log.contains(message)) {
+                logger.info("Verified integration logs - All values OK!");
+                return;
+            }
+
+            if (!printLogs) {
+                logger.warn(String.format("Waiting for integration '%s' to log message - retry in %s ms", name, delayBetweenAttempts));
+            }
+
+            try {
+                Thread.sleep(delayBetweenAttempts);
+            } catch (InterruptedException e) {
+                logger.warn("Interrupted while waiting for integration logs", e);
+            }
+        }
+
+        throw new ActionTimeoutException((maxAttempts * delayBetweenAttempts),
+                new CitrusRuntimeException(String.format("Failed to verify integration '%s' - " +
+                        "has not printed message '%s' after %d attempts", name, message, maxAttempts)));
+    }
+
+    private Long verifyRouteStatus(String name, String phase, TestContext context) {
+        INTEGRATION_STATUS_LOG.info(String.format("Waiting for integration '%s' to be in state '%s'", name, phase));
+
+        for (int i = 0; i < maxAttempts; i++) {
+            if (context.getVariables().containsKey(name + ":pid")) {
+                Long pid = context.getVariable(name + ":pid", Long.class);
+                Map<String, String> properties = camelJBang().get(pid);
+                if ((phase.equals("Stopped") && properties.isEmpty()) || (!properties.isEmpty() && properties.get("STATUS").equals(phase))) {
+                    logger.info(String.format("Verified integration '%s' state '%s' - All values OK!", name, phase));
+                    return pid;
+                } else if (phase.equals("Error")) {
+                    logger.info(String.format("Integration '%s' is in state 'Error'", name));
+                    if (stopOnErrorStatus) {
+                        throw new CitrusRuntimeException(String.format("Failed to verify integration '%s' - is in state 'Error'", name));
+                    }
+                }
+            }
+
+            logger.info(System.lineSeparator() + camelJBang().ps());
+            logger.info(String.format("Waiting for integration '%s' to be in state '%s'- retry in %s ms", name, phase, delayBetweenAttempts));
+            try {
+                Thread.sleep(delayBetweenAttempts);
+            } catch (InterruptedException e) {
+                logger.warn("Interrupted while waiting for integration state", e);
+            }
+        }
+
+        throw new ActionTimeoutException((maxAttempts * delayBetweenAttempts),
+                new CitrusRuntimeException(String.format("Failed to verify integration '%s' - " +
+                        "is not in state '%s' after %d attempts", name, phase, maxAttempts)));
+
+    }
+
+    public String getIntegrationName() {
+        return integrationName;
+    }
+
+    /**
+     * Action builder.
+     */
+    public static final class Builder extends AbstractCamelJBangAction.Builder<CamelVerifyIntegrationAction, Builder> {
+
+        private String integrationName = "route";
+
+        private String logMessage;
+
+        private int maxAttempts = CamelSettings.getMaxAttempts();
+        private long delayBetweenAttempts = CamelSettings.getDelayBetweenAttempts();
+
+        private String phase = "Running";
+        private boolean printLogs = CamelSettings.isPrintLogs();
+
+        private boolean stopOnErrorStatus = true;
+
+        /**
+         * Identify Camel JBang process for this route.
+         * @param name
+         * @return
+         */
+        public Builder integration(String name) {
+            this.integrationName = name;
+            return this;
+        }
+
+        /**
+         * Sets the integration name.
+         * @param name
+         * @return
+         */
+        public Builder integrationName(String name) {
+            this.integrationName = name;
+            return this;
+        }
+
+        public Builder isRunning() {
+            this.phase = "Running";
+            return this;
+        }
+
+        public Builder isStopped() {
+            this.phase = "Stopped";
+            return this;
+        }
+
+        public Builder isInPhase(String phase) {
+            this.phase = phase;
+            return this;
+        }
+
+        public Builder printLogs(boolean printLogs) {
+            this.printLogs = printLogs;
+            return this;
+        }
+
+        public Builder waitForLogMessage(String logMessage) {
+            this.logMessage = logMessage;
+            return this;
+        }
+
+        public Builder maxAttempts(int maxAttempts) {
+            this.maxAttempts = maxAttempts;
+            return this;
+        }
+
+        public Builder delayBetweenAttempts(long delayBetweenAttempts) {
+            this.delayBetweenAttempts = delayBetweenAttempts;
+            return this;
+        }
+
+        public Builder stopOnErrorStatus(boolean stopOnErrorStatus) {
+            this.stopOnErrorStatus = stopOnErrorStatus;
+            return this;
+        }
+
+        @Override
+        public CamelVerifyIntegrationAction build() {
+            return new CamelVerifyIntegrationAction(this);
+        }
+    }
+}

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/dsl/CamelSupport.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/dsl/CamelSupport.java
@@ -28,6 +28,7 @@ import org.citrusframework.camel.CamelSettings;
 import org.citrusframework.camel.actions.CamelActionBuilder;
 import org.citrusframework.camel.actions.CamelContextActionBuilder;
 import org.citrusframework.camel.actions.CamelControlBusAction;
+import org.citrusframework.camel.actions.CamelJBangActionBuilder;
 import org.citrusframework.camel.actions.CamelRouteActionBuilder;
 import org.citrusframework.camel.actions.CreateCamelComponentAction;
 import org.citrusframework.camel.endpoint.CamelEndpoint;
@@ -188,6 +189,16 @@ public class CamelSupport {
         return new CamelActionBuilder()
                 .camelContext(camelContext)
                 .route();
+    }
+
+    /**
+     * Perform actions with Camel JBang.
+     * @return
+     */
+    public CamelJBangActionBuilder jbang() {
+        return new CamelActionBuilder()
+                .camelContext(camelContext)
+                .jbang();
     }
 
     /**

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/jbang/CamelJBang.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/jbang/CamelJBang.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.jbang;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.jbang.JBangSupport;
+import org.citrusframework.jbang.ProcessAndOutput;
+
+/**
+ * Camel JBang app.
+ */
+public class CamelJBang {
+
+    private final JBangSupport camelApp = JBangSupport.jbang().app(CamelJBangSettings.getCamelApp());
+
+    /**
+     * Prevent direct instantiation.
+     */
+    private CamelJBang() {
+        if (!"latest".equals(CamelJBangSettings.getCamelVersion())) {
+            camelApp.withSystemProperty("camel.jbang.version", CamelJBangSettings.getCamelVersion());
+        }
+
+        if (!CamelJBangSettings.getKameletsVersion().isBlank()) {
+            camelApp.withSystemProperty("camel-kamelets.version", CamelJBangSettings.getKameletsVersion());
+        }
+
+        for (String url : CamelJBangSettings.getTrustUrl()) {
+            camelApp.trust(url);
+        }
+    }
+
+    /**
+     * Static entrance method to retrieve instance of Camel JBang.
+     * @return
+     */
+    public static CamelJBang camel() {
+        return new CamelJBang();
+    }
+
+    /**
+     * Provides access to the underlying JBang support. For instance to set system properties on the JBang binary.
+     * @return
+     */
+    public JBangSupport camelApp() {
+        return camelApp;
+    }
+
+    /**
+     * Run given integration with JBang Camel app.
+     * @param name
+     * @param path
+     * @param args
+     * @return
+     */
+    public ProcessAndOutput run(String name, Path path, String... args) {
+        return run(name, path.toAbsolutePath().toString(), args);
+    }
+
+    /**
+     * Run given integration with JBang Camel app.
+     * @param name
+     * @param file
+     * @param args
+     * @return
+     */
+    public ProcessAndOutput run(String name, String file, String... args) {
+        List<String> runArgs = new ArrayList<>();
+        runArgs.add("--name");
+        runArgs.add(name);
+
+        if (CamelJBangSettings.getKameletsLocalDir() != null) {
+            runArgs.add("--local-kamelet-dir");
+            runArgs.add(CamelJBangSettings.getKameletsLocalDir().toString());
+        }
+
+        runArgs.addAll(Arrays.asList(args));
+
+        runArgs.add(file);
+
+        if (CamelJBangSettings.isCamelDumpIntegrationOutput()) {
+            Path workDir = CamelJBangSettings.getWorkDir();
+            File outputFile = workDir.resolve(String.format("i-%s-output.txt", name)).toFile();
+
+            if (Stream.of(args).noneMatch(it -> it.contains("--logging-color"))) {
+                // disable logging colors when writing logs to file
+                runArgs.add("--logging-color=false");
+            }
+
+            return camelApp.runAsync("run", outputFile, runArgs);
+        } else {
+            return camelApp.runAsync("run", runArgs);
+        }
+    }
+
+    /**
+     * Get details for integration previously run via JBang Camel app. Integration is identified by its process id.
+     * @param pid
+     */
+    public void stop(Long pid) {
+        ProcessAndOutput p = camelApp.run("stop", String.valueOf(pid)) ;
+        if (p.getProcess().exitValue() != JBangSupport.OK_EXIT_CODE) {
+            throw new CitrusRuntimeException(String.format("Failed to stop Camel K integration - exit code %d", p.getProcess().exitValue()));
+        }
+    }
+
+    /**
+     * Get information on running integrations.
+     */
+    public String ps() {
+        ProcessAndOutput p = camelApp.run("ps");
+        return p.getOutput();
+    }
+
+    /**
+     * Get Camel JBang version.
+     */
+    public String version() {
+        ProcessAndOutput p = camelApp.run("--version");
+        return p.getOutput();
+    }
+
+    /**
+     * Get details for integration previously run via JBang Camel app. Integration is identified by its process id.
+     * @param pid
+     */
+    public Map<String, String> get(Long pid) {
+        Map<String, String> properties = new HashMap<>();
+
+        String output = ps();
+        if (output.isBlank()) {
+            return properties;
+        }
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(output.getBytes(StandardCharsets.UTF_8))))) {
+            String line = reader.readLine();
+
+            List<String> names = new ArrayList<>(Arrays.asList(line.trim().split("\\s+")));
+
+            while ((line = reader.readLine()) != null) {
+                List<String> values = new ArrayList<>(Arrays.asList(line.trim().split("\\s+")));
+                if (!values.isEmpty() && values.get(0).equals(String.valueOf(pid))) {
+                    for (int i=0; i < names.size(); i++) {
+                        if (i < values.size()) {
+                            properties.put(names.get(i), values.get(i));
+                        } else {
+                            properties.put(names.get(i), "");
+                        }
+                    }
+                    break;
+                }
+            }
+
+            return properties;
+        } catch (IOException e) {
+            throw new CitrusRuntimeException("Failed to get integration details from JBang", e);
+        }
+    }
+
+    /**
+     * Get list of integrations previously run via JBang Camel app.
+     */
+    public List<Map<String, String>> getAll() {
+        List<Map<String, String>> integrations = new ArrayList<>();
+
+        String output = ps();
+        if (output.isBlank()) {
+            return integrations;
+        }
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(output.getBytes(StandardCharsets.UTF_8))))) {
+            String line = reader.readLine();
+
+            List<String> names = new ArrayList<>(Arrays.asList(line.trim().split("\\s+")));
+
+            while ((line = reader.readLine()) != null) {
+                Map<String, String> properties = new HashMap<>();
+                List<String> values = new ArrayList<>(Arrays.asList(line.trim().split("\\s+")));
+                for (int i=0; i < names.size(); i++) {
+                    if (i < values.size()) {
+                        properties.put(names.get(i), values.get(i));
+                    } else {
+                        properties.put(names.get(i), "");
+                    }
+                }
+
+                integrations.add(properties);
+            }
+
+            return integrations;
+        } catch (IOException e) {
+            throw new CitrusRuntimeException("Failed to list integrations from JBang", e);
+        }
+    }
+
+}

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/jbang/CamelJBangSettings.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/jbang/CamelJBangSettings.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.jbang;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+
+import org.citrusframework.jbang.JBangSettings;
+import org.citrusframework.util.StringUtils;
+
+public final class CamelJBangSettings {
+
+    private static final String JBANG_PROPERTY_PREFIX = "citrus.jbang.camel.";
+    private static final String JBANG_ENV_PREFIX = "CITRUS_JBANG_CAMEL_";
+
+    private static final String WORK_DIR_PROPERTY = JBANG_PROPERTY_PREFIX + "work.dir";
+    private static final String WORK_DIR_ENV = JBANG_ENV_PREFIX + "WORK_DIR";
+
+    private static final String CAMEL_APP_PROPERTY = JBANG_PROPERTY_PREFIX + "app";
+    private static final String CAMEL_APP_ENV = JBANG_ENV_PREFIX + "APP";
+    private static final String CAMEL_APP_DEFAULT = "camel@apache/camel";
+
+    private static final String CAMEL_VERSION_PROPERTY = JBANG_PROPERTY_PREFIX + "version";
+    private static final String CAMEL_VERSION_ENV = JBANG_ENV_PREFIX + "VERSION";
+    private static final String CAMEL_VERSION_DEFAULT = "latest";
+
+    private static final String KAMELETS_VERSION_PROPERTY = JBANG_PROPERTY_PREFIX + "kamelets.version";
+    private static final String KAMELETS_VERSION_ENV = JBANG_ENV_PREFIX + "KAMELETS_VERSION";
+    private static final String KAMELETS_VERSION_DEFAULT = "";
+
+    private static final String KAMELETS_LOCAL_DIR_PROPERTY = JBANG_PROPERTY_PREFIX + "kamelets.local.dir";
+    private static final String KAMELETS_LOCAL_DIR_ENV = JBANG_ENV_PREFIX + "KAMELETS_LOCAL_DIR";
+
+    private static final String TRUST_URL_PROPERTY = JBANG_PROPERTY_PREFIX + "trust.url";
+    private static final String TRUST_URL_ENV = JBANG_ENV_PREFIX + "TRUST_URL";
+    private static final String TRUST_URL_DEFAULT = "https://github.com/apache/camel/";
+
+    private static final String CAMEL_DUMP_INTEGRATION_OUTPUT_PROPERTY = JBANG_PROPERTY_PREFIX + "dump.integration.output";
+    private static final String CAMEL_DUMP_INTEGRATION_OUTPUT_ENV = JBANG_ENV_PREFIX + "DUMP_INTEGRATION_OUTPUT";
+    private static final String CAMEL_DUMP_INTEGRATION_OUTPUT_DEFAULT = "false";
+
+    private CamelJBangSettings() {
+        // prevent instantiation of utility class
+    }
+
+    /**
+     * JBang local work dir.
+     * @return
+     */
+    public static Path getWorkDir() {
+        String workDir = Optional.ofNullable(System.getProperty(WORK_DIR_PROPERTY, System.getenv(WORK_DIR_ENV)))
+                .orElse("");
+
+        if (!StringUtils.hasText(workDir)) {
+            return JBangSettings.getWorkDir();
+        }
+
+        Path path = Paths.get(workDir);
+        if (path.isAbsolute()) {
+            return path.toAbsolutePath();
+        } else {
+            return Paths.get("").toAbsolutePath().resolve(workDir).toAbsolutePath();
+        }
+    }
+
+    /**
+     * JBang local Kamelets dir.
+     * @return
+     */
+    public static Path getKameletsLocalDir() {
+        return Optional.ofNullable(System.getProperty(KAMELETS_LOCAL_DIR_PROPERTY, System.getenv(KAMELETS_LOCAL_DIR_ENV))).map(dir -> {
+            Path path = Paths.get(dir);
+            if (path.isAbsolute()) {
+                return path.toAbsolutePath();
+            } else {
+                return getWorkDir().resolve(dir).toAbsolutePath();
+            }
+        }).orElse(null);
+    }
+
+    /**
+     * JBang trust URLs.
+     * @return
+     */
+    public static String[] getTrustUrl() {
+        return System.getProperty(TRUST_URL_PROPERTY,
+                System.getenv(TRUST_URL_ENV) != null ? System.getenv(TRUST_URL_ENV) : TRUST_URL_DEFAULT).split(",");
+    }
+
+    /**
+     * When set to true JBang process output for Camel integrations will be redirected to a file in the current working directory.
+     * @return
+     */
+    public static boolean isCamelDumpIntegrationOutput() {
+        return Boolean.parseBoolean(System.getProperty(CAMEL_DUMP_INTEGRATION_OUTPUT_PROPERTY,
+                System.getenv(CAMEL_DUMP_INTEGRATION_OUTPUT_ENV) != null ? System.getenv(CAMEL_DUMP_INTEGRATION_OUTPUT_ENV) : CAMEL_DUMP_INTEGRATION_OUTPUT_DEFAULT));
+    }
+
+    /**
+     * Camel JBang app name.
+     * @return
+     */
+    public static String getCamelApp() {
+        return System.getProperty(CAMEL_APP_PROPERTY,
+                System.getenv(CAMEL_APP_ENV) != null ? System.getenv(CAMEL_APP_ENV) : CAMEL_APP_DEFAULT);
+    }
+
+    /**
+     * Camel JBang version.
+     * @return
+     */
+    public static String getCamelVersion() {
+        return System.getProperty(CAMEL_VERSION_PROPERTY,
+                System.getenv(CAMEL_VERSION_ENV) != null ? System.getenv(CAMEL_VERSION_ENV) : CAMEL_VERSION_DEFAULT);
+    }
+
+    /**
+     * Kamelets version used by the JBang runtime.
+     * @return
+     */
+    public static String getKameletsVersion() {
+        return System.getProperty(KAMELETS_VERSION_PROPERTY,
+                System.getenv(KAMELETS_VERSION_ENV) != null ? System.getenv(KAMELETS_VERSION_ENV) : KAMELETS_VERSION_DEFAULT);
+    }
+
+}

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/JBang.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/JBang.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.xml;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlValue;
+import org.citrusframework.camel.CamelSettings;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+        "run",
+        "stop",
+        "verify",
+})
+public class JBang {
+
+    @XmlAttribute
+    private String camelVersion;
+
+    @XmlAttribute
+    private String kameletsVersion;
+
+    @XmlElement
+    protected RunIntegration run;
+
+    @XmlElement
+    protected StopIntegration stop;
+
+    @XmlElement
+    protected VerifyIntegration verify;
+
+    public void setCamelVersion(String camelVersion) {
+        this.camelVersion = camelVersion;
+    }
+
+    public String getCamelVersion() {
+        return camelVersion;
+    }
+
+    public void setKameletsVersion(String kameletsVersion) {
+        this.kameletsVersion = kameletsVersion;
+    }
+
+    public String getKameletsVersion() {
+        return kameletsVersion;
+    }
+
+    public void setRun(RunIntegration run) {
+        this.run = run;
+    }
+
+    public RunIntegration getRun() {
+        return run;
+    }
+
+    public void setStop(StopIntegration stop) {
+        this.stop = stop;
+    }
+
+    public StopIntegration getStop() {
+        return stop;
+    }
+
+    public void setVerify(VerifyIntegration verify) {
+        this.verify = verify;
+    }
+
+    public VerifyIntegration getVerify() {
+        return verify;
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(name = "", propOrder = {
+            "integration"
+    })
+    public static class RunIntegration {
+
+        @XmlElement(required = true)
+        private Integration integration;
+
+        public Integration getIntegration() {
+            return integration;
+        }
+
+        public void setIntegration(Integration integration) {
+            this.integration = integration;
+        }
+
+        @XmlAccessorType(XmlAccessType.FIELD)
+        @XmlType(name = "")
+        public static class Integration {
+            @XmlAttribute
+            protected String name;
+
+            @XmlAttribute
+            protected String file;
+
+            @XmlValue
+            protected String sourceCode;
+
+            public void setName(String name) {
+                this.name = name;
+            }
+
+            public String getName() {
+                return name;
+            }
+
+            public void setFile(String file) {
+                this.file = file;
+            }
+
+            public String getFile() {
+                return file;
+            }
+
+            public void setSourceCode(String sourceCode) {
+                this.sourceCode = sourceCode;
+            }
+
+            public String getSourceCode() {
+                return sourceCode;
+            }
+        }
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(name = "")
+    public static class StopIntegration {
+        @XmlAttribute
+        protected String integration;
+
+        public void setIntegration(String integration) {
+            this.integration = integration;
+        }
+
+        public String getIntegration() {
+            return integration;
+        }
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(name = "")
+    public static class VerifyIntegration {
+        @XmlAttribute
+        protected String integration;
+
+        @XmlAttribute(name = "log-message")
+        private String logMessage;
+
+        @XmlAttribute(name = "max-attempts")
+        private int maxAttempts = CamelSettings.getMaxAttempts();
+        @XmlAttribute(name = "delay-between-attempts")
+        private long delayBetweenAttempts = CamelSettings.getDelayBetweenAttempts();
+
+        @XmlAttribute
+        private String phase = "Running";
+        @XmlAttribute(name = "print-logs")
+        private boolean printLogs = CamelSettings.isPrintLogs();
+
+        @XmlAttribute(name = "stop-on-error-status")
+        private boolean stopOnErrorStatus = true;
+
+        public void setIntegration(String integration) {
+            this.integration = integration;
+        }
+
+        public String getIntegration() {
+            return integration;
+        }
+
+        public void setLogMessage(String logMessage) {
+            this.logMessage = logMessage;
+        }
+
+        public String getLogMessage() {
+            return logMessage;
+        }
+
+        public void setPhase(String phase) {
+            this.phase = phase;
+        }
+
+        public String getPhase() {
+            return phase;
+        }
+
+        public void setPrintLogs(boolean printLogs) {
+            this.printLogs = printLogs;
+        }
+
+        public boolean isPrintLogs() {
+            return printLogs;
+        }
+
+        public void setDelayBetweenAttempts(long delayBetweenAttempts) {
+            this.delayBetweenAttempts = delayBetweenAttempts;
+        }
+
+        public long getDelayBetweenAttempts() {
+            return delayBetweenAttempts;
+        }
+
+        public void setMaxAttempts(int maxAttempts) {
+            this.maxAttempts = maxAttempts;
+        }
+
+        public int getMaxAttempts() {
+            return maxAttempts;
+        }
+
+        public void setStopOnErrorStatus(boolean stopOnErrorStatus) {
+            this.stopOnErrorStatus = stopOnErrorStatus;
+        }
+
+        public boolean isStopOnErrorStatus() {
+            return stopOnErrorStatus;
+        }
+    }
+}

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/Camel.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/Camel.java
@@ -17,6 +17,7 @@
 package org.citrusframework.camel.yaml;
 
 import org.apache.camel.CamelContext;
+import org.citrusframework.AbstractTestActionBuilder;
 import org.citrusframework.TestAction;
 import org.citrusframework.TestActionBuilder;
 import org.citrusframework.TestActor;
@@ -83,15 +84,22 @@ public class Camel implements TestActionBuilder<TestAction>, ReferenceResolverAw
         this.delegate = builder;
     }
 
+    public void setJbang(JBang builder) {
+        this.delegate = builder;
+    }
+
     @Override
     public TestAction build() {
         if (delegate == null) {
             throw new CitrusRuntimeException("Missing Camel action - please provide proper action details");
         }
 
-        AbstractCamelAction.Builder<?, ?> builder = delegate.getBuilder();
+        AbstractTestActionBuilder<?, ?> builder = delegate.getBuilder();
 
-        builder.setReferenceResolver(referenceResolver);
+        if (builder instanceof ReferenceResolverAware referenceResolverAware) {
+            referenceResolverAware.setReferenceResolver(referenceResolver);
+        }
+
         builder.description(description);
 
         if (referenceResolver != null) {
@@ -99,8 +107,8 @@ public class Camel implements TestActionBuilder<TestAction>, ReferenceResolverAw
                 builder.actor(referenceResolver.resolve(actor, TestActor.class));
             }
 
-            if (camelContext != null) {
-                builder.context(referenceResolver.resolve(camelContext, CamelContext.class));
+            if (camelContext != null && builder instanceof AbstractCamelAction.Builder<?, ?> camelActionBuilder) {
+                camelActionBuilder.context(referenceResolver.resolve(camelContext, CamelContext.class));
             }
         }
 

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/CamelActionBuilderWrapper.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/CamelActionBuilderWrapper.java
@@ -16,13 +16,13 @@
 
 package org.citrusframework.camel.yaml;
 
-import org.citrusframework.camel.actions.AbstractCamelAction;
+import org.citrusframework.AbstractTestActionBuilder;
 
 /**
  * Special wrapper holding a Camel action builder for future reference.
  * @param <B>
  */
-public interface CamelActionBuilderWrapper<B extends AbstractCamelAction.Builder<?, ?>> {
+public interface CamelActionBuilderWrapper<B extends AbstractTestActionBuilder<?, ?>> {
 
     /**
      * Gets the wrapped Camel action builder.

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/JBang.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/JBang.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.yaml;
+
+import org.citrusframework.camel.actions.AbstractCamelJBangAction;
+import org.citrusframework.camel.actions.CamelRunIntegrationAction;
+import org.citrusframework.camel.actions.CamelStopIntegrationAction;
+import org.citrusframework.camel.actions.CamelVerifyIntegrationAction;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.spi.Resources;
+
+public class JBang implements CamelActionBuilderWrapper<AbstractCamelJBangAction.Builder<?, ?>> {
+
+    private String camelVersion;
+    private String kameletsVersion;
+
+    protected RunIntegration run;
+    protected StopIntegration stop;
+    protected VerifyIntegration verify;
+
+    public void setCamelVersion(String camelVersion) {
+        this.camelVersion = camelVersion;
+    }
+
+    public String getCamelVersion() {
+        return camelVersion;
+    }
+
+    public void setKameletsVersion(String kameletsVersion) {
+        this.kameletsVersion = kameletsVersion;
+    }
+
+    public String getKameletsVersion() {
+        return kameletsVersion;
+    }
+
+    public void setRun(RunIntegration run) {
+        this.run = run;
+    }
+
+    public RunIntegration getRun() {
+        return run;
+    }
+
+    public void setStop(StopIntegration stop) {
+        this.stop = stop;
+    }
+
+    public StopIntegration getStop() {
+        return stop;
+    }
+
+    public void setVerify(VerifyIntegration verify) {
+        this.verify = verify;
+    }
+
+    public VerifyIntegration getVerify() {
+        return verify;
+    }
+
+    @Override
+    public AbstractCamelJBangAction.Builder<?, ?> getBuilder() {
+        AbstractCamelJBangAction.Builder<?, ?> builder;
+        if (run != null) {
+            builder = run.getBuilder();
+        } else if (stop != null) {
+            builder = stop.getBuilder();
+        } else if (verify != null) {
+            builder = verify.getBuilder();
+        } else {
+            throw new CitrusRuntimeException("Missing Camel JBang action specification");
+        }
+
+        builder.camelVersion(camelVersion);
+        builder.kameletsVersion(kameletsVersion);
+
+        return builder;
+    }
+
+    public static class RunIntegration implements CamelActionBuilderWrapper<CamelRunIntegrationAction.Builder> {
+
+        private final CamelRunIntegrationAction.Builder builder = new CamelRunIntegrationAction.Builder();
+
+        public void setIntegration(Integration integration) {
+            builder.integrationName(integration.name);
+
+            if (integration.file != null) {
+                builder.integration(Resources.create(integration.file));
+            }
+
+            if (integration.sourceCode != null) {
+                builder.integration(integration.sourceCode);
+            }
+        }
+
+        public static class Integration {
+            private String name;
+            private String file;
+            private String sourceCode;
+
+            public void setName(String integrationName) {
+                this.name = integrationName;
+            }
+
+            public void setFile(String file) {
+                this.file = file;
+            }
+
+            public void setSources(String sourceCode) {
+                this.sourceCode = sourceCode;
+            }
+        }
+
+        @Override
+        public CamelRunIntegrationAction.Builder getBuilder() {
+            return builder;
+        }
+    }
+
+    public static class StopIntegration implements CamelActionBuilderWrapper<CamelStopIntegrationAction.Builder> {
+
+        private final CamelStopIntegrationAction.Builder builder = new CamelStopIntegrationAction.Builder();
+
+        public void setIntegration(String integrationName) {
+            builder.integrationName(integrationName);
+        }
+
+        @Override
+        public CamelStopIntegrationAction.Builder getBuilder() {
+            return builder;
+        }
+    }
+
+    public static class VerifyIntegration implements CamelActionBuilderWrapper<CamelVerifyIntegrationAction.Builder> {
+
+        private final CamelVerifyIntegrationAction.Builder builder = new CamelVerifyIntegrationAction.Builder();
+
+        public void setIntegration(String integrationName) {
+            builder.integrationName(integrationName);
+        }
+
+        public void setLogMessage(String logMessage) {
+            builder.waitForLogMessage(logMessage);
+        }
+
+        public void setPhase(String phase) {
+            builder.isInPhase(phase);
+        }
+
+        public void setPrintLogs(boolean printLogs) {
+            builder.printLogs(printLogs);
+        }
+
+        public void setDelayBetweenAttempts(long delayBetweenAttempts) {
+            builder.delayBetweenAttempts(delayBetweenAttempts);
+        }
+
+        public void setMaxAttempts(int maxAttempts) {
+            builder.maxAttempts(maxAttempts);
+        }
+
+        public void setStopOnErrorStatus(boolean stopOnErrorStatus) {
+            builder.stopOnErrorStatus(stopOnErrorStatus);
+        }
+
+        @Override
+        public CamelVerifyIntegrationAction.Builder getBuilder() {
+            return builder;
+        }
+    }
+}

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/integration/CamelJBangIT.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/integration/CamelJBangIT.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.integration;
+
+import org.citrusframework.annotations.CitrusTest;
+import org.citrusframework.spi.Resources;
+import org.citrusframework.testng.TestNGCitrusSupport;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.camel.dsl.CamelSupport.camel;
+import static org.citrusframework.container.Catch.Builder.catchException;
+import static org.citrusframework.container.FinallySequence.Builder.doFinally;
+
+public class CamelJBangIT extends TestNGCitrusSupport {
+
+    @Test
+    @CitrusTest(name = "RunIntegration_SourceCode_IT")
+    public void runIntegrationWithSourceCodeIT() {
+        given(doFinally().actions(
+                catchException().actions(camel().jbang().stop("hello"))
+        ));
+
+        when(camel().jbang()
+                .run("hello", """
+                - from:
+                    uri: "timer:tick"
+                    parameters:
+                      period: "1000"
+                      includeMetadata: true
+                    steps:
+                      - setBody:
+                          simple: "Hello Camel #${header.CamelTimerCounter}"
+                      - transform:
+                          simple: "${body.toUpperCase()}"
+                      - to: "log:info"
+                """));
+
+        then(camel().jbang()
+                .verify("hello")
+                .waitForLogMessage("HELLO CAMEL #10"));
+    }
+    @Test
+    @CitrusTest(name = "RunIntegration_Resource_IT")
+    public void runIntegrationWithResourceIT() {
+        given(doFinally().actions(
+            catchException().actions(camel().jbang().stop("route"))
+        ));
+
+        when(camel().jbang()
+                .run()
+                .integration(Resources.fromClasspath("route.yaml", CamelJBangIT.class)));
+
+        then(camel().jbang()
+                .verify("route")
+                .waitForLogMessage("HELLO CAMEL #10"));
+    }
+}

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/xml/JBangTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/xml/JBangTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.xml;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.citrusframework.DefaultTestCase;
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.camel.CamelSettings;
+import org.citrusframework.camel.actions.CamelRunIntegrationAction;
+import org.citrusframework.camel.actions.CamelStopIntegrationAction;
+import org.citrusframework.camel.actions.CamelVerifyIntegrationAction;
+import org.citrusframework.xml.XmlTestLoader;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class JBangTest extends AbstractXmlActionTest {
+
+    @Test
+    public void shouldLoadCamelActions() throws Exception {
+        XmlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/camel/xml/camel-jbang-test.xml");
+
+        CamelContext citrusCamelContext = new DefaultCamelContext();
+        citrusCamelContext.start();
+
+        context.getReferenceResolver().bind(CamelSettings.getContextName(), citrusCamelContext);
+        context.getReferenceResolver().bind("camelContext", citrusCamelContext);
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "CamelJBangTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 2L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), CamelRunIntegrationAction.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "run-integration");
+
+        int actionIndex = 0;
+
+        CamelRunIntegrationAction action = (CamelRunIntegrationAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getIntegrationName(), "hello-xml");
+
+        CamelVerifyIntegrationAction verifyAction = (CamelVerifyIntegrationAction) result.getTestAction(actionIndex);
+        Assert.assertEquals(verifyAction.getIntegrationName(), "hello-xml");
+
+        Assert.assertTrue(result instanceof DefaultTestCase);
+        Assert.assertEquals(((DefaultTestCase) result).getFinalActions().size(), 1);
+
+        CamelStopIntegrationAction stopAction = (CamelStopIntegrationAction) ((DefaultTestCase) result).getFinalActions().get(0);
+        Assert.assertEquals(stopAction.getIntegrationName(), "hello-xml");
+    }
+}

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/yaml/JBangTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/yaml/JBangTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.yaml;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.citrusframework.DefaultTestCase;
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.camel.CamelSettings;
+import org.citrusframework.camel.actions.CamelRunIntegrationAction;
+import org.citrusframework.camel.actions.CamelStopIntegrationAction;
+import org.citrusframework.camel.actions.CamelVerifyIntegrationAction;
+import org.citrusframework.yaml.YamlTestLoader;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class JBangTest extends AbstractYamlActionTest {
+
+    @Test
+    public void shouldLoadCamelActions() throws Exception {
+        YamlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/camel/yaml/camel-jbang-test.yaml");
+
+        CamelContext citrusCamelContext = new DefaultCamelContext();
+        citrusCamelContext.start();
+
+        context.getReferenceResolver().bind(CamelSettings.getContextName(), citrusCamelContext);
+        context.getReferenceResolver().bind("camelContext", citrusCamelContext);
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "CamelJBangTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 2L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), CamelRunIntegrationAction.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "run-integration");
+
+        int actionIndex = 0;
+
+        CamelRunIntegrationAction action = (CamelRunIntegrationAction) result.getTestAction(actionIndex++);
+        Assert.assertEquals(action.getIntegrationName(), "hello-yaml");
+
+        CamelVerifyIntegrationAction verifyAction = (CamelVerifyIntegrationAction) result.getTestAction(actionIndex);
+        Assert.assertEquals(verifyAction.getIntegrationName(), "hello-yaml");
+
+        Assert.assertTrue(result instanceof DefaultTestCase);
+        Assert.assertEquals(((DefaultTestCase) result).getFinalActions().size(), 1);
+
+        CamelStopIntegrationAction stopAction = (CamelStopIntegrationAction) ((DefaultTestCase) result).getFinalActions().get(0);
+        Assert.assertEquals(stopAction.getIntegrationName(), "hello-yaml");
+    }
+}

--- a/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/integration/route.yaml
+++ b/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/integration/route.yaml
@@ -1,0 +1,11 @@
+- from:
+    uri: "timer:tick"
+    parameters:
+      period: "1000"
+      includeMetadata: true
+    steps:
+      - setBody:
+          simple: "Hello Camel #${header.CamelTimerCounter}"
+      - transform:
+          simple: "${body.toUpperCase()}"
+      - to: "log:info"

--- a/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/xml/camel-jbang-test.xml
+++ b/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/xml/camel-jbang-test.xml
@@ -1,0 +1,45 @@
+<!--
+  ~ Copyright the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<test name="CamelJBangTest" author="Christoph" status="FINAL" xmlns="http://citrusframework.org/schema/xml/testcase"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://citrusframework.org/schema/xml/testcase http://citrusframework.org/schema/xml/testcase/citrus-testcase.xsd
+                          http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
+  <description>Sample test in XML</description>
+  <actions>
+    <camel>
+      <jbang>
+        <run>
+          <integration name="hello-xml"
+                       file="classpath:org/citrusframework/camel/integration/route.yaml"/>
+        </run>
+      </jbang>
+    </camel>
+
+    <camel>
+      <jbang>
+        <verify integration="hello-xml" log-message="HELLO CAMEL #10"/>
+      </jbang>
+    </camel>
+  </actions>
+  <finally>
+    <camel>
+      <jbang>
+        <stop integration="hello-xml"/>
+      </jbang>
+    </camel>
+  </finally>
+</test>

--- a/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/yaml/camel-jbang-test.yaml
+++ b/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/yaml/camel-jbang-test.yaml
@@ -1,0 +1,20 @@
+name: "CamelJBangTest"
+author: "Christoph"
+status: "FINAL"
+actions:
+  - camel:
+      jbang:
+        run:
+          integration:
+            name: "hello-yaml"
+            file: "classpath:org/citrusframework/camel/integration/route.yaml"
+  - camel:
+      jbang:
+        verify:
+          integration: "hello-yaml"
+          logMessage: "HELLO CAMEL #10"
+finally:
+  - camel:
+      jbang:
+        stop:
+          integration: "hello-yaml"

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-4.4.0-SNAPSHOT.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-4.4.0-SNAPSHOT.xsd
@@ -978,6 +978,60 @@
             </xs:sequence>
           </xs:complexType>
         </xs:element>
+        <xs:element name="jbang">
+          <xs:annotation>
+            <xs:documentation>Creates new Camel JBang action</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:choice>
+              <xs:element name="run">
+                <xs:annotation>
+                  <xs:documentation>Runs a Camel integration via JBang</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="integration">
+                      <xs:complexType>
+                        <xs:simpleContent>
+                          <xs:extension base="xs:string">
+                            <xs:attribute name="name" type="xs:string"/>
+                            <xs:attribute name="file" type="xs:string"/>
+                          </xs:extension>
+                        </xs:simpleContent>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="stop">
+                <xs:annotation>
+                  <xs:documentation>Stops a Camel integration identified by its name</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:sequence/>
+                  <xs:attribute name="integration" type="xs:string"/>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="verify">
+                <xs:annotation>
+                  <xs:documentation>Verifies a Camel integration, for instance its status or the presence of a log message</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:sequence/>
+                  <xs:attribute name="integration" type="xs:string"/>
+                  <xs:attribute name="log-message" type="xs:string"/>
+                  <xs:attribute name="phase" type="xs:string"/>
+                  <xs:attribute name="max-attempts" type="xs:int"/>
+                  <xs:attribute name="delay-between-attempts" type="xs:int"/>
+                  <xs:attribute name="print-logs" type="xs:boolean"/>
+                  <xs:attribute name="stop-on-error-status" type="xs:boolean"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:choice>
+            <xs:attribute name="camel-version" type="xs:string"/>
+            <xs:attribute name="kamelets-version" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
       </xs:choice>
     </xs:sequence>
     <xs:attribute name="camel-context" type="xs:string"/>
@@ -1313,6 +1367,9 @@
   </xs:complexType>
 
   <xs:complexType name="JBang">
+    <xs:annotation>
+      <xs:documentation>Connect with JBang to run scripts as spawned processes</xs:documentation>
+    </xs:annotation>
     <xs:sequence>
       <xs:element name="description" type="xs:string" minOccurs="0"/>
       <xs:element name="system-properties" minOccurs="0">

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
@@ -978,6 +978,60 @@
             </xs:sequence>
           </xs:complexType>
         </xs:element>
+        <xs:element name="jbang">
+          <xs:annotation>
+            <xs:documentation>Creates new Camel JBang action</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:choice>
+              <xs:element name="run">
+                <xs:annotation>
+                  <xs:documentation>Runs a Camel integration via JBang</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="integration">
+                      <xs:complexType>
+                        <xs:simpleContent>
+                          <xs:extension base="xs:string">
+                            <xs:attribute name="name" type="xs:string"/>
+                            <xs:attribute name="file" type="xs:string"/>
+                          </xs:extension>
+                        </xs:simpleContent>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="stop">
+                <xs:annotation>
+                  <xs:documentation>Stops a Camel integration identified by its name</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:sequence/>
+                  <xs:attribute name="integration" type="xs:string"/>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="verify">
+                <xs:annotation>
+                  <xs:documentation>Verifies a Camel integration, for instance its status or the presence of a log message</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:sequence/>
+                  <xs:attribute name="integration" type="xs:string"/>
+                  <xs:attribute name="log-message" type="xs:string"/>
+                  <xs:attribute name="phase" type="xs:string"/>
+                  <xs:attribute name="max-attempts" type="xs:int"/>
+                  <xs:attribute name="delay-between-attempts" type="xs:int"/>
+                  <xs:attribute name="print-logs" type="xs:boolean"/>
+                  <xs:attribute name="stop-on-error-status" type="xs:boolean"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:choice>
+            <xs:attribute name="camel-version" type="xs:string"/>
+            <xs:attribute name="kamelets-version" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
       </xs:choice>
     </xs:sequence>
     <xs:attribute name="camel-context" type="xs:string"/>
@@ -1313,6 +1367,9 @@
   </xs:complexType>
 
   <xs:complexType name="JBang">
+    <xs:annotation>
+      <xs:documentation>Connect with JBang to run scripts as spawned processes</xs:documentation>
+    </xs:annotation>
     <xs:sequence>
       <xs:element name="description" type="xs:string" minOccurs="0"/>
       <xs:element name="system-properties" minOccurs="0">


### PR DESCRIPTION
- Run and stop Camel integrations via JBang
- Add action to verify Camel integration status and its output