### PR TITLE
fix(desp): multiple dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,16 +187,16 @@
     <asciidoctor.maven.plugin.version>2.2.4</asciidoctor.maven.plugin.version>
     <jaxb.maven.plugin.version>3.1.0</jaxb.maven.plugin.version>
 
-    <activemq.artemis.version>2.37.0</activemq.artemis.version>
+    <activemq.artemis.version>2.38.0</activemq.artemis.version>
     <angus-mail.version>2.0.2</angus-mail.version>
     <apache.ant.version>1.10.15</apache.ant.version>
-    <apache.camel.version>4.8.0</apache.camel.version>
+    <apache.camel.version>4.8.1</apache.camel.version>
     <apicurio.data-models.version>1.1.27</apicurio.data-models.version>
     <ascii-table-version>1.8.0</ascii-table-version>
     <assertj.version>3.26.3</assertj.version>
     <awaitility.version>4.2.2</awaitility.version>
     <bouncycastle.version>1.78.1</bouncycastle.version>
-    <byte.buddy.version>1.15.4</byte.buddy.version>
+    <byte.buddy.version>1.15.7</byte.buddy.version>
     <commons.dbcp2.version>2.12.0</commons.dbcp2.version>
     <commons.cli.version>1.9.0</commons.cli.version>
     <commons.codec.version>1.17.1</commons.codec.version>
@@ -212,9 +212,9 @@
     <greenmail.version>2.1.0</greenmail.version>
     <hamcrest.version>3.0</hamcrest.version>
     <htmlunit.version>4.13.0</htmlunit.version>
-    <httpclient.version>5.4</httpclient.version>
+    <httpclient.version>5.4.1</httpclient.version>
     <hsqldb.version>2.7.3</hsqldb.version>
-    <jackson.version>2.18.0</jackson.version>
+    <jackson.version>2.18.1</jackson.version>
     <jakarta.activation.api.version>2.1.3</jakarta.activation.api.version>
     <jakarta.activation.version>2.0.1</jakarta.activation.version>
     <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>
@@ -235,8 +235,8 @@
     <json-schema-validator.version>1.5.2</json-schema-validator.version>
     <json-smart.version>2.5.1</json-smart.version>
     <jtidy.version>r938</jtidy.version>
-    <junit.jupiter.version>5.11.2</junit.jupiter.version>
-    <junit.platform.version>1.11.2</junit.platform.version>
+    <junit.jupiter.version>5.11.3</junit.jupiter.version>
+    <junit.platform.version>1.11.3</junit.platform.version>
     <junit.version>4.13.2</junit.version>
     <junixsocket.version>2.10.1</junixsocket.version>
     <k8s.client.version>6.13.4</k8s.client.version>
@@ -244,7 +244,7 @@
     <kafka.version>3.8.0</kafka.version>
     <knative-client.version>6.13.4</knative-client.version>
     <log4j2.version>2.22.1</log4j2.version>
-    <mockito.version>5.14.1</mockito.version>
+    <mockito.version>5.14.2</mockito.version>
     <mockftpserver.version>3.2.0</mockftpserver.version>
     <netty.version>4.1.105.Final</netty.version>
     <okhttp.version>4.12.0</okhttp.version>
@@ -256,20 +256,20 @@
     <snakeyaml.version>2.3</snakeyaml.version>
     <spring.version>6.1.14</spring.version>
     <spring.ws.version>4.0.11</spring.ws.version>
-    <spring.integration.version>6.3.4</spring.integration.version>
-    <spring.restdocs.version>3.0.1</spring.restdocs.version>
+    <spring.integration.version>6.3.5</spring.integration.version>
+    <spring.restdocs.version>3.0.2</spring.restdocs.version>
     <sshd.version>2.14.0</sshd.version>
     <swagger.version>1.6.9</swagger.version>
     <swagger.parser.version>2.1.22</swagger.parser.version>
     <testng.version>7.10.2</testng.version>
     <vertx.version>4.5.10</vertx.version>
     <wsdl4j.version>1.6.3</wsdl4j.version>
-    <xbean-spring.version>4.25</xbean-spring.version>
+    <xbean-spring.version>4.26</xbean-spring.version>
     <xmlbeans.version>5.2.1</xmlbeans.version>
     <xmlbeans-xpath.version>2.6.0</xmlbeans-xpath.version>
     <xerces.version>2.12.2</xerces.version>
     <xstream.version>1.4.20</xstream.version>
-    <zookeeper.version>3.9.2</zookeeper.version>
+    <zookeeper.version>3.9.3</zookeeper.version>
 
     <skip.integration.tests>false</skip.integration.tests>
     <skip.unit.tests>false</skip.unit.tests>

--- a/runtime/citrus-quarkus/pom.xml
+++ b/runtime/citrus-quarkus/pom.xml
@@ -15,7 +15,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <quarkus.platform.version>3.15.1</quarkus.platform.version>
+    <quarkus.platform.version>3.16.0</quarkus.platform.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
* activemq to 2.38.0
* apache camel to 4.8.1
* byte-buddy to 1.15.7
* httpclient to 5.4.1
* jackson to 2.18.1
* junit to 5.11.3 and platform to 1.11.3
* mockito to 5.14.2
* spring to 3.0.2 and integration to 6.3.5
* xbean-spring to 4.26
* zookeeper to 3.9.3