### PR TITLE
Issue #929: fix set charset for request content

### DIFF
--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/interceptor/LoggingClientInterceptor.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/interceptor/LoggingClientInterceptor.java
@@ -32,12 +32,13 @@ import org.springframework.http.client.ClientHttpResponse;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
+import java.io.UnsupportedEncodingException;
 import java.util.List;
 import java.util.Map.Entry;
 
 import static java.lang.String.join;
 import static java.lang.System.lineSeparator;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Simple logging interceptor writes Http request and response messages to the console.
@@ -120,6 +121,24 @@ public class LoggingClientInterceptor implements ClientHttpRequestInterceptor {
      * @return
      */
     private String getRequestContent(HttpRequest request, String body) {
+        String contentType = request.getHeaders().getFirst(HttpHeaders.CONTENT_TYPE);
+        if (contentType != null) {
+            String[] contentTypeParts = contentType.split(";");
+            for (String contentTypePart : contentTypeParts) {
+                if(contentTypePart.startsWith("charset=") && !contentTypePart.endsWith("charset=")) {
+                    String charset = contentTypePart.split("=")[1];
+                    try {
+                        body = new String(body.getBytes(), charset);
+                    } catch (UnsupportedEncodingException e) {
+                        body = new String(body.getBytes(), UTF_8);
+                    }
+                }
+                break;
+            }
+        } else {
+            body = new String(body.getBytes(), UTF_8);
+        }
+
         StringBuilder builder = new StringBuilder();
 
         builder.append(request.getMethod());
@@ -226,7 +245,7 @@ public class LoggingClientInterceptor implements ClientHttpRequestInterceptor {
                 getBody();
             }
 
-            return new String(body, StandardCharsets.UTF_8);
+            return new String(body, UTF_8);
         }
 
         @Override

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/interceptor/LoggingClientInterceptorTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/interceptor/LoggingClientInterceptorTest.java
@@ -1,0 +1,111 @@
+package org.citrusframework.http.interceptor;
+
+import org.mockito.Mockito;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpRequest;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Method;
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+public class LoggingClientInterceptorTest {
+    private LoggingClientInterceptor loggingClientInterceptor;
+
+    @BeforeMethod
+    public void setUp() {
+        loggingClientInterceptor = new LoggingClientInterceptor();
+    }
+
+    @Test
+    public void testGetRequestContentWithCharset() throws Exception {
+        HttpRequest request = Mockito.mock(HttpRequest.class);
+        HttpHeaders headers = Mockito.mock(HttpHeaders.class);
+
+        when(request.getMethod()).thenReturn(HttpMethod.valueOf("POST"));
+        when(request.getURI()).thenReturn(new URI("http://übelexample.com"));
+        when(request.getHeaders()).thenReturn(headers);
+        when(headers.getFirst(HttpHeaders.CONTENT_TYPE)).thenReturn("application/json; charset=UTF-8");
+
+        String body = "test body";
+
+        Method method = LoggingClientInterceptor.class.getDeclaredMethod("getRequestContent", HttpRequest.class, String.class);
+        method.setAccessible(true);
+        String result = (String) method.invoke(loggingClientInterceptor, request, body);
+
+        assertThat(result).isEqualToNormalizingNewlines("""
+                POST http://übelexample.com
+                
+                test body""");
+    }
+
+    @Test
+    public void testGetRequestContentWithoutCharset() throws Exception {
+        HttpRequest request = Mockito.mock(HttpRequest.class);
+        HttpHeaders headers = Mockito.mock(HttpHeaders.class);
+
+        when(request.getMethod()).thenReturn(HttpMethod.valueOf("GET"));
+        when(request.getURI()).thenReturn(new URI("http://example.com"));
+        when(request.getHeaders()).thenReturn(headers);
+        when(headers.getFirst(HttpHeaders.CONTENT_TYPE)).thenReturn("application/json");
+
+        String body = "test body";
+
+        Method method = LoggingClientInterceptor.class.getDeclaredMethod("getRequestContent", HttpRequest.class, String.class);
+        method.setAccessible(true);
+        String result = (String) method.invoke(loggingClientInterceptor, request, body);
+
+        assertThat(result).isEqualToNormalizingNewlines("""
+                GET http://example.com
+                
+                test body""");
+    }
+
+    @Test
+    public void testGetRequestContentWithNullContentType() throws Exception {
+        HttpRequest request = Mockito.mock(HttpRequest.class);
+        HttpHeaders headers = Mockito.mock(HttpHeaders.class);
+
+        when(request.getMethod()).thenReturn(HttpMethod.valueOf("GET"));
+        when(request.getURI()).thenReturn(new URI("http://example.com"));
+        when(request.getHeaders()).thenReturn(headers);
+        when(headers.getFirst(HttpHeaders.CONTENT_TYPE)).thenReturn(null);
+
+        String body = "test body";
+
+        Method method = LoggingClientInterceptor.class.getDeclaredMethod("getRequestContent", HttpRequest.class, String.class);
+        method.setAccessible(true);
+        String result = (String) method.invoke(loggingClientInterceptor, request, body);
+
+        assertThat(result).isEqualToNormalizingNewlines("""
+                GET http://example.com
+                
+                test body""");
+    }
+
+    @Test
+    public void testGetRequestContentWithEmptyStringContentType() throws Exception {
+        HttpRequest request = Mockito.mock(HttpRequest.class);
+        HttpHeaders headers = Mockito.mock(HttpHeaders.class);
+
+        when(request.getMethod()).thenReturn(HttpMethod.valueOf("GET"));
+        when(request.getURI()).thenReturn(new URI("http://example.com"));
+        when(request.getHeaders()).thenReturn(headers);
+        when(headers.getFirst(HttpHeaders.CONTENT_TYPE)).thenReturn("");
+
+        String body = "test body";
+
+        Method method = LoggingClientInterceptor.class.getDeclaredMethod("getRequestContent", HttpRequest.class, String.class);
+        method.setAccessible(true);
+        String result = (String) method.invoke(loggingClientInterceptor, request, body);
+
+        assertThat(result).isEqualToNormalizingNewlines("""
+                GET http://example.com
+                
+                test body""");
+    }
+}


### PR DESCRIPTION
Get encoding charset from HTTP headers or fallback to UTF-8