### PR TITLE
chore: Catch all errors to avoid loosing failures

### DIFF
--- a/core/citrus-base/src/main/java/org/citrusframework/DefaultTestCase.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/DefaultTestCase.java
@@ -120,7 +120,7 @@ public class DefaultTestCase extends AbstractActionContainer implements TestCase
             } catch (final TestCaseFailedException e) {
                 gracefullyStopTimer();
                 throw e;
-            } catch (final Exception | AssertionError e) {
+            } catch (final Exception | Error e) {
                 testResult = getTestResultInstanceProvider(context).createFailed(this, e);
                 throw new TestCaseFailedException(e);
             }
@@ -143,7 +143,7 @@ public class DefaultTestCase extends AbstractActionContainer implements TestCase
             debugVariables("Test", context);
 
             beforeTest(context);
-        } catch (final Exception | AssertionError e) {
+        } catch (final Exception | Error e) {
             testResult = getTestResultInstanceProvider(context).createFailed(this, e);
             throw new TestCaseFailedException(e);
         }
@@ -171,7 +171,7 @@ public class DefaultTestCase extends AbstractActionContainer implements TestCase
                 if (sequenceAfterTest.shouldExecute(getName(), packageName, groups)) {
                     sequenceAfterTest.execute(context);
                 }
-            } catch (final Exception | AssertionError e) {
+            } catch (final Exception | Error e) {
                 logger.warn("After test failed with errors", e);
             }
         }
@@ -194,7 +194,7 @@ public class DefaultTestCase extends AbstractActionContainer implements TestCase
             } else {
                 context.getTestActionListeners().onTestActionSkipped(this, action);
             }
-        } catch (final Exception | AssertionError e) {
+        } catch (final Exception | Error e) {
             testResult = getTestResultInstanceProvider(context).createFailed(this, e);
             throw new TestCaseFailedException(e);
         } finally {
@@ -238,8 +238,11 @@ public class DefaultTestCase extends AbstractActionContainer implements TestCase
                 throw new TestCaseFailedException(contextException);
             }
         } catch (final TestCaseFailedException e) {
+            if (isNull(testResult) || testResult.isSuccess()) {
+                testResult = getTestResultInstanceProvider(context).createFailed(this, e.getCause());
+            }
             throw e;
-        } catch (final Exception | AssertionError e) {
+        } catch (final Exception | Error e) {
             testResult = getTestResultInstanceProvider(context).createFailed(this, e);
             throw new TestCaseFailedException(e);
         } finally {

--- a/core/citrus-base/src/main/java/org/citrusframework/common/DefaultTestLoader.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/common/DefaultTestLoader.java
@@ -16,6 +16,10 @@
 
 package org.citrusframework.common;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
 import org.citrusframework.Citrus;
 import org.citrusframework.CitrusContext;
 import org.citrusframework.DefaultTestCase;
@@ -27,10 +31,6 @@ import org.citrusframework.annotations.CitrusResource;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.exceptions.TestCaseFailedException;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Consumer;
 
 import static org.citrusframework.TestResult.failed;
 
@@ -91,9 +91,17 @@ public class DefaultTestLoader implements TestLoader {
         try {
             doLoad();
         } catch (TestCaseFailedException e) {
+            if (testCase == null) {
+                testCase = runner.getTestCase();
+            }
+
+            if (testCase.getTestResult() == null || testCase.getTestResult().isSuccess()) {
+                testCase.setTestResult(failed(testCase.getName(), testCase.getTestClass().getName(), e));
+            }
+
             // This kind of exception indicates that the error has already been handled. Just throw and end test run.
             throw e;
-        } catch (Exception | AssertionError e) {
+        } catch (Exception | Error e) {
             if (testCase == null) {
                 testCase = runner.getTestCase();
             }

--- a/core/citrus-base/src/main/java/org/citrusframework/container/Parallel.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/container/Parallel.java
@@ -107,7 +107,7 @@ public class Parallel extends AbstractActionContainer {
             } catch (CitrusRuntimeException e) {
                 logger.error("Parallel test action raised error", e);
                 exceptionHandler.accept(e);
-            } catch (Exception | AssertionError e) {
+            } catch (Exception | Error e) {
                 logger.error("Parallel test action raised error", e);
                 exceptionHandler.accept(new CitrusRuntimeException(e));
             }

--- a/core/citrus-spring/src/main/java/org/citrusframework/common/SpringXmlTestLoader.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/common/SpringXmlTestLoader.java
@@ -57,8 +57,7 @@ public class SpringXmlTestLoader extends DefaultTestLoader implements TestSource
             citrus.run(testCase, context);
             handler.forEach(handler -> handler.accept(testCase));
         } catch (NoSuchBeanDefinitionException e) {
-            throw citrusContext.getTestContextFactory().getObject()
-                    .handleError(testName, packageName, "Failed to load Spring XML test with name '" + testName + "'", e);
+            throw context.handleError(testName, packageName, "Failed to load Spring XML test with name '" + testName + "'", e);
         }
     }
 

--- a/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/GroovyTestLoader.java
+++ b/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/GroovyTestLoader.java
@@ -55,8 +55,7 @@ public class GroovyTestLoader extends DefaultTestLoader implements TestSourceAwa
 
             handler.forEach(it -> it.accept(testCase));
         } catch (IOException e) {
-            throw citrusContext.getTestContextFactory().getObject()
-                    .handleError(testName, packageName, "Failed to load Groovy test source '" + testName + "'", e);
+            throw context.handleError(testName, packageName, "Failed to load Groovy test source '" + testName + "'", e);
         }
     }
 

--- a/runtime/citrus-xml/src/main/java/org/citrusframework/xml/XmlTestLoader.java
+++ b/runtime/citrus-xml/src/main/java/org/citrusframework/xml/XmlTestLoader.java
@@ -90,8 +90,7 @@ public class XmlTestLoader extends DefaultTestLoader implements TestSourceAware 
             citrus.run(testCase, context);
             handler.forEach(handler -> handler.accept(testCase));
         } catch (JAXBException | IOException e) {
-            throw citrusContext.getTestContextFactory().getObject()
-                    .handleError(testName, packageName, "Failed to load XML test with name '" + testName + "'", e);
+            throw context.handleError(testName, packageName, "Failed to load XML test with name '" + testName + "'", e);
         }
     }
 

--- a/runtime/citrus-yaml/src/main/java/org/citrusframework/yaml/YamlTestLoader.java
+++ b/runtime/citrus-yaml/src/main/java/org/citrusframework/yaml/YamlTestLoader.java
@@ -123,8 +123,7 @@ public class YamlTestLoader extends DefaultTestLoader implements TestSourceAware
             citrus.run(testCase, context);
             handler.forEach(handler -> handler.accept(testCase));
         } catch (IOException e) {
-            throw citrusContext.getTestContextFactory().getObject()
-                    .handleError(testName, packageName, "Failed to load YAML test with name '" + testName + "'", e);
+            throw context.handleError(testName, packageName, "Failed to load YAML test with name '" + testName + "'", e);
         }
     }
 


### PR DESCRIPTION
- Avoid test false positives when errors such as ClassNotFoundError are the cause of the test failure