### PR TITLE
chore: Add Java test loader implementation

### DIFF
--- a/core/citrus-api/src/main/java/org/citrusframework/CitrusSettings.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/CitrusSettings.java
@@ -16,17 +16,17 @@
 
 package org.citrusframework;
 
-import org.citrusframework.common.TestLoader;
-import org.citrusframework.message.MessageType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.File;
 import java.io.InputStream;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Stream;
+
+import org.citrusframework.common.TestLoader;
+import org.citrusframework.message.MessageType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static java.lang.Boolean.parseBoolean;
 import static java.lang.System.getProperty;
@@ -37,6 +37,7 @@ import static java.util.Collections.emptySet;
 import static java.util.logging.LogManager.getLogManager;
 import static java.util.stream.Collectors.toSet;
 import static org.citrusframework.common.TestLoader.GROOVY;
+import static org.citrusframework.common.TestLoader.JAVA;
 import static org.citrusframework.common.TestLoader.SPRING;
 import static org.citrusframework.common.TestLoader.YAML;
 
@@ -415,6 +416,7 @@ public final class CitrusSettings {
             case TestLoader.XML, SPRING -> getXmlTestFileNamePattern();
             case GROOVY -> getGroovyTestFileNamePattern();
             case YAML -> getYamlTestFileNamePattern();
+            case JAVA -> getJavaTestFileNamePattern();
             default -> emptySet();
         };
     }

--- a/core/citrus-api/src/main/java/org/citrusframework/TestClass.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/TestClass.java
@@ -71,4 +71,20 @@ public class TestClass extends TestSource {
             throw new CitrusRuntimeException("Failed to create test class", e);
         }
     }
+
+    public static boolean isKnownToClasspath(String testClass) {
+        try {
+            String className;
+            if (testClass.contains("#")) {
+                className = testClass.substring(0, testClass.indexOf("#"));
+            } else {
+                className = testClass;
+            }
+
+            Class.forName(className);
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
 }

--- a/core/citrus-api/src/main/java/org/citrusframework/common/TestLoader.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/common/TestLoader.java
@@ -41,6 +41,7 @@ public interface TestLoader {
     /** Default Citrus test loader from classpath resource properties */
     ResourcePathTypeResolver TYPE_RESOLVER = new ResourcePathTypeResolver(RESOURCE_PATH);
 
+    String JAVA = "java";
     String XML = "xml";
     String YAML = "yaml";
     String SPRING = "spring";

--- a/core/citrus-base/src/main/java/org/citrusframework/common/JavaTestLoader.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/common/JavaTestLoader.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.common;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Paths;
+import javax.tools.JavaCompiler;
+import javax.tools.ToolProvider;
+
+import org.citrusframework.annotations.CitrusAnnotations;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.spi.Resource;
+import org.citrusframework.util.FileUtils;
+import org.citrusframework.util.ReflectionHelper;
+import org.citrusframework.util.StringUtils;
+
+/**
+ * Test loader implementation able to compile a Java source file and run the test method
+ */
+public class JavaTestLoader extends DefaultTestLoader implements TestSourceAware {
+
+    private String source;
+
+    @Override
+    public void doLoad() {
+        Resource javaSource = FileUtils.getFileResource(getSource());
+
+        try {
+            // Compile source file.
+            JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+            int success = compiler.run(null, null, null, javaSource.getFile().getAbsolutePath());
+            if (success != 0) {
+                throw new CitrusRuntimeException("Failed to compile Java source file: %s".formatted(javaSource.getFile().getAbsolutePath()));
+            }
+
+            // Load and instantiate compiled class.
+            URLClassLoader classLoader = URLClassLoader.newInstance(new URL[] { Paths.get(javaSource.getURI()).getParent().toUri().toURL() });
+            Class<?> cls = Class.forName(getClassName(), true, classLoader);
+            Object instance = cls.getDeclaredConstructor().newInstance();
+
+            CitrusAnnotations.injectAll(instance, citrus, context);
+            CitrusAnnotations.injectTestRunner(instance, runner);
+
+            doWithTestCase(tc -> {
+                try {
+                    ReflectionHelper.invokeMethod(instance.getClass().getDeclaredMethod("run"), instance);
+                } catch (NoSuchMethodException e) {
+                    throw new CitrusRuntimeException("Failed to run Java test method 'run()' on class: %s".formatted(instance.getClass()), e);
+                }
+            });
+
+            super.doLoad();
+        } catch (IOException | ClassNotFoundException | NoSuchMethodException | InstantiationException |
+                 IllegalAccessException | InvocationTargetException e) {
+            throw context.handleError(testName, packageName, "Failed to load Java test with name '" + testName + "'", e);
+        }
+    }
+
+    /**
+     * Gets custom Spring application context file for the Java test case. If not set creates default
+     * context file path from testName and packageName.
+     * @return
+     */
+    public String getSource() {
+        if (StringUtils.hasText(source)) {
+            return source;
+        } else {
+            String path = StringUtils.hasText(packageName) ? packageName.replace('.', '/') : "";
+            String fileName = testName.endsWith(FileUtils.FILE_EXTENSION_JAVA) ? testName : testName + FileUtils.FILE_EXTENSION_JAVA;
+            return StringUtils.hasText(path) ? path + "/" + fileName : fileName;
+        }
+    }
+
+    public String getClassName() {
+        if (StringUtils.hasText(source)) {
+            if (source.contains(":")) {
+                return FileUtils.getBaseName(FileUtils.getFileName(source.substring(source.indexOf(":"))));
+            }
+
+            return FileUtils.getBaseName(FileUtils.getFileName(source));
+        }
+
+        return FileUtils.getBaseName(testName.endsWith(FileUtils.FILE_EXTENSION_JAVA) ? testName : testName + FileUtils.FILE_EXTENSION_JAVA);
+    }
+
+    /**
+     * Sets custom Spring application context file for Java test case.
+     * @param source
+     */
+    @Override
+    public void setSource(String source) {
+        this.source = source;
+    }
+}

--- a/core/citrus-base/src/main/resources/META-INF/citrus/test/loader/java
+++ b/core/citrus-base/src/main/resources/META-INF/citrus/test/loader/java
@@ -1,0 +1,1 @@
+type=org.citrusframework.common.JavaTestLoader

--- a/runtime/citrus-junit5/src/main/java/org/citrusframework/junit/jupiter/CitrusTestFactorySupport.java
+++ b/runtime/citrus-junit5/src/main/java/org/citrusframework/junit/jupiter/CitrusTestFactorySupport.java
@@ -48,6 +48,10 @@ public final class CitrusTestFactorySupport {
         return new CitrusTestFactorySupport(type, TestLoader::load);
     }
 
+    public static CitrusTestFactorySupport java() {
+        return factory(TestLoader.JAVA);
+    }
+
     public static CitrusTestFactorySupport xml() {
         return factory(TestLoader.XML);
     }

--- a/runtime/citrus-junit5/src/test/java/org/citrusframework/junit/jupiter/integration/java/JavaTestLoader_IT.java
+++ b/runtime/citrus-junit5/src/test/java/org/citrusframework/junit/jupiter/integration/java/JavaTestLoader_IT.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.junit.jupiter.integration.java;
+
+import java.util.stream.Stream;
+
+import org.citrusframework.annotations.CitrusTestSource;
+import org.citrusframework.common.TestLoader;
+import org.citrusframework.junit.jupiter.CitrusSupport;
+import org.citrusframework.junit.jupiter.CitrusTestFactory;
+import org.citrusframework.junit.jupiter.CitrusTestFactorySupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
+
+@CitrusSupport
+public class JavaTestLoader_IT {
+
+    @Test
+    @DisplayName("JavaTestLoader_IT")
+    @CitrusTestSource(type = TestLoader.JAVA)
+    public void JavaTest() {
+    }
+
+    @Test
+    @CitrusTestSource(type = TestLoader.JAVA, name = "JavaTest")
+    public void JavaTestLoader_1_IT() {
+    }
+
+    @CitrusTestFactory
+    public Stream<DynamicTest> JavaTestLoader_2_IT() {
+        return Stream.of(
+                CitrusTestFactorySupport.java().dynamicTest("org.citrusframework.junit.jupiter.simple", "EchoTest.java"),
+                CitrusTestFactorySupport.java().dynamicTest("org.citrusframework.junit.jupiter.simple", "DelayTest.java")
+        );
+    }
+
+    @CitrusTestFactory
+    public Stream<DynamicTest> JavaTestLoader_3_IT() {
+        return CitrusTestFactorySupport.java().packageScan("org.citrusframework.junit.jupiter.simple");
+    }
+
+    @Test
+    @CitrusTestSource(type = TestLoader.JAVA, sources = "classpath:org/citrusframework/junit/jupiter/integration/java/JavaTest.java")
+    public void JavaTestLoader_4_IT() {
+    }
+}

--- a/runtime/citrus-junit5/src/test/resources/org/citrusframework/junit/jupiter/integration/java/JavaTest.java
+++ b/runtime/citrus-junit5/src/test/resources/org/citrusframework/junit/jupiter/integration/java/JavaTest.java
@@ -1,0 +1,18 @@
+import org.citrusframework.TestActionRunner;
+import org.citrusframework.annotations.CitrusResource;
+
+import static org.citrusframework.actions.EchoAction.Builder.echo;
+
+public class JavaTest implements Runnable {
+
+    @CitrusResource
+    TestActionRunner t;
+
+    @Override
+    public void run() {
+        t.run(
+            echo().message("Hello Citrus!")
+        );
+    }
+
+}

--- a/runtime/citrus-junit5/src/test/resources/org/citrusframework/junit/jupiter/simple/DelayTest.java
+++ b/runtime/citrus-junit5/src/test/resources/org/citrusframework/junit/jupiter/simple/DelayTest.java
@@ -1,0 +1,18 @@
+import org.citrusframework.TestActionRunner;
+import org.citrusframework.annotations.CitrusResource;
+
+import static org.citrusframework.actions.SleepAction.Builder.delay;
+
+public class DelayTest implements Runnable {
+
+    @CitrusResource
+    TestActionRunner t;
+
+    @Override
+    public void run() {
+        t.run(
+            delay().milliseconds(200L)
+        );
+    }
+
+}

--- a/runtime/citrus-junit5/src/test/resources/org/citrusframework/junit/jupiter/simple/EchoTest.java
+++ b/runtime/citrus-junit5/src/test/resources/org/citrusframework/junit/jupiter/simple/EchoTest.java
@@ -1,0 +1,18 @@
+import org.citrusframework.TestActionRunner;
+import org.citrusframework.annotations.CitrusResource;
+
+import static org.citrusframework.actions.EchoAction.Builder.echo;
+
+public class EchoTest implements Runnable {
+
+    @CitrusResource
+    TestActionRunner t;
+
+    @Override
+    public void run() {
+        t.run(
+            echo().message("Hello Citrus!")
+        );
+    }
+
+}

--- a/runtime/citrus-testng/src/main/java/org/citrusframework/testng/TestNGCitrusSupport.java
+++ b/runtime/citrus-testng/src/main/java/org/citrusframework/testng/TestNGCitrusSupport.java
@@ -128,7 +128,7 @@ public class TestNGCitrusSupport implements IHookable, GherkinTestActionRunner {
                     }
                 }
             } else {
-                testLoader = new DefaultTestLoader();
+                testLoader = createTestLoader();
             }
 
             CitrusAnnotations.injectAll(testLoader, citrus, ctx);
@@ -236,6 +236,15 @@ public class TestNGCitrusSupport implements IHookable, GherkinTestActionRunner {
         testLoader.setPackageName(packageName);
 
         return testLoader;
+    }
+
+    /**
+     * Create default test loader.
+     * Subclasses may overwrite in order to provide custom loaders.
+     * @return
+     */
+    protected TestLoader createTestLoader() {
+        return new DefaultTestLoader();
     }
 
     @Override

--- a/runtime/citrus-testng/src/main/java/org/citrusframework/testng/TestNGEngine.java
+++ b/runtime/citrus-testng/src/main/java/org/citrusframework/testng/TestNGEngine.java
@@ -84,7 +84,7 @@ public class TestNGEngine extends AbstractTestEngine {
 
     private void addTestSources(XmlSuite suite, TestRunConfiguration configuration) {
         List<TestSource> testSources = configuration.getTestSources().stream()
-                .filter(source -> !"java".equals(source.getType()))
+                .filter(source -> !"java".equals(source.getType()) || !TestClass.isKnownToClasspath(source.getName()))
                 .toList();
 
         for (TestSource source : testSources) {
@@ -156,6 +156,7 @@ public class TestNGEngine extends AbstractTestEngine {
         List<TestClass> testClasses = configuration.getTestSources().stream()
                 .filter(source -> "java".equals(source.getType()))
                 .map(TestSource::getName)
+                .filter(TestClass::isKnownToClasspath)
                 .map(TestClass::fromString)
                 .toList();
 

--- a/runtime/citrus-testng/src/main/java/org/citrusframework/testng/main/TestNGCitrusTest.java
+++ b/runtime/citrus-testng/src/main/java/org/citrusframework/testng/main/TestNGCitrusTest.java
@@ -16,22 +16,14 @@
 
 package org.citrusframework.testng.main;
 
-import org.citrusframework.Citrus;
-import org.citrusframework.TestCaseRunner;
-import org.citrusframework.annotations.CitrusAnnotations;
-import org.citrusframework.annotations.CitrusFramework;
-import org.citrusframework.annotations.CitrusResource;
 import org.citrusframework.annotations.CitrusTest;
 import org.citrusframework.common.TestLoader;
 import org.citrusframework.common.TestSourceAware;
-import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;
-import org.citrusframework.report.TestListeners;
 import org.citrusframework.testng.TestNGCitrusSupport;
 import org.citrusframework.util.FileUtils;
 import org.citrusframework.util.StringUtils;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Optional;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
@@ -49,12 +41,6 @@ public class TestNGCitrusTest extends TestNGCitrusSupport {
     public static final String TEST_NAME_PARAM = "name";
     public static final String TEST_SOURCE_PARAM = "source";
 
-    @CitrusFramework
-    Citrus citrus;
-
-    @CitrusResource
-    private TestContext context;
-
     private String name;
     private String source;
 
@@ -67,8 +53,11 @@ public class TestNGCitrusTest extends TestNGCitrusSupport {
 
     @Test
     @CitrusTest
-    @Parameters( "runner" )
-    public void execute(@Optional @CitrusResource TestCaseRunner runner) {
+    public void execute() {
+    }
+
+    @Override
+    protected TestLoader createTestLoader() {
         String type;
         if (StringUtils.hasText(source)) {
             type = FileUtils.getFileExtension(source);
@@ -88,16 +77,6 @@ public class TestNGCitrusTest extends TestNGCitrusSupport {
             sourceAwareTestLoader.setSource(source);
         }
 
-        TestListeners original = context.getTestListeners();
-        try {
-            // Remove all test listeners as test would be reported twice
-            context.setTestListeners(new TestListeners());
-            CitrusAnnotations.injectAll(testLoader, citrus, context);
-            CitrusAnnotations.injectTestRunner(testLoader, runner);
-            testLoader.load();
-        } finally {
-            // bring back original test listeners so test outcome is reported properly
-            context.setTestListeners(original);
-        }
+        return testLoader;
     }
 }


### PR DESCRIPTION
- Allows Citrus JBang to run Java code as a test
- Java code just needs to implement Runnable interface