### PR TITLE
add timeout to iterating action containers

### DIFF
--- a/core/citrus-base/src/main/java/org/citrusframework/AbstractIteratingContainerBuilder.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/AbstractIteratingContainerBuilder.java
@@ -19,18 +19,19 @@ package org.citrusframework;
 import org.citrusframework.container.AbstractIteratingActionContainer;
 import org.citrusframework.container.IteratingConditionExpression;
 
+import java.time.Duration;
+
 public abstract class AbstractIteratingContainerBuilder<T extends AbstractIteratingActionContainer, S extends AbstractIteratingContainerBuilder<T, S>> extends AbstractTestContainerBuilder<T, S> {
 
     protected String condition;
     protected IteratingConditionExpression conditionExpression;
     protected String indexName = "i";
+    protected Duration timeout;
     protected int index;
     protected int start = 1;
 
     /**
      * Adds a condition to this iterate container.
-     * @param condition
-     * @return
      */
     public S condition(String condition) {
         this.condition = condition;
@@ -39,8 +40,6 @@ public abstract class AbstractIteratingContainerBuilder<T extends AbstractIterat
 
     /**
      * Adds a condition expression to this iterate container.
-     * @param condition
-     * @return
      */
     public S condition(IteratingConditionExpression condition) {
         this.conditionExpression = condition;
@@ -49,22 +48,65 @@ public abstract class AbstractIteratingContainerBuilder<T extends AbstractIterat
 
     /**
      * Sets the index variable name.
-     * @param name
-     * @return
      */
     public S index(String name) {
         this.indexName = name;
         return self;
     }
 
+    public S timeout(Duration timeout) {
+        this.timeout = timeout;
+        return self;
+    }
+
     /**
      * Sets the index start value.
-     * @param index
-     * @return
      */
     public S startsWith(int index) {
         this.start = index;
         return self;
+    }
+
+    /**
+     * @return the condition
+     */
+    public String getCondition() {
+        return condition;
+    }
+
+    /**
+     * @return the condition expression
+     */
+    public IteratingConditionExpression getConditionExpression() {
+        return conditionExpression;
+    }
+
+    /**
+     * @return the index name
+     */
+    public String getIndexName() {
+        return indexName;
+    }
+
+    /**
+     * @return the timeout duration
+     */
+    public Duration getTimeout() {
+        return timeout;
+    }
+
+    /**
+     * @return the index
+     */
+    public int getIndex() {
+        return index;
+    }
+
+    /**
+     * @return the start index
+     */
+    public int getStart() {
+        return start;
     }
 
     @Override
@@ -74,45 +116,5 @@ public abstract class AbstractIteratingContainerBuilder<T extends AbstractIterat
         }
 
         return super.build();
-    }
-
-    /**
-     * Gets the condition.
-     * @return the condition
-     */
-    public String getCondition() {
-        return condition;
-    }
-
-    /**
-     * Gets the condition.
-     * @return the conditionExpression
-     */
-    public IteratingConditionExpression getConditionExpression() {
-        return conditionExpression;
-    }
-
-    /**
-     * Gets the indexName.
-     * @return the indexName
-     */
-    public String getIndexName() {
-        return indexName;
-    }
-
-    /**
-     * Gets the index.
-     * @return the index
-     */
-    public int getIndex() {
-        return index;
-    }
-
-    /**
-     * Gets the start index.
-     * @return
-     */
-    public int getStart() {
-        return start;
     }
 }

--- a/core/citrus-base/src/test/java/org/citrusframework/container/AbstractIteratingActionContainerTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/container/AbstractIteratingActionContainerTest.java
@@ -1,0 +1,134 @@
+package org.citrusframework.container;
+
+import static java.lang.Thread.currentThread;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.citrusframework.container.AbstractIteratingActionContainerTest.Fixture.FixtureBuilder.fixture;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+import java.time.Duration;
+import org.apache.commons.lang3.time.StopWatch;
+import org.citrusframework.AbstractIteratingContainerBuilder;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.mockito.Mock;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class AbstractIteratingActionContainerTest {
+
+    public static final Duration ONE_SECOND = Duration.ofSeconds(1);
+
+    @Mock
+    private TestContext testContext;
+
+    private AutoCloseable mockitoContext;
+
+    private static StopWatch getStartedStopWatch() {
+        var stopWatch = new StopWatch();
+        stopWatch.start();
+        return stopWatch;
+    }
+
+    @DataProvider
+    public static Fixture[] synchronousIterations() {
+        return new Fixture[]{
+            fixture(ONE_SECOND, null).doBuild(),
+            fixture(ONE_SECOND, Duration.ofMillis(0)).doBuild(),
+            fixture(ONE_SECOND, Duration.ofMillis(-1)).doBuild()
+        };
+    }
+
+    @BeforeMethod
+    public void beforeMethodSetup() {
+        mockitoContext = openMocks(this);
+    }
+
+    @AfterMethod
+    public void afterMethodTeardown() throws Exception {
+        mockitoContext.close();
+    }
+
+    @Test(dataProvider = "synchronousIterations")
+    public void synchronousIteration(Fixture iteratingActionContainer) {
+        var stopWatch = getStartedStopWatch();
+
+        iteratingActionContainer.doExecute(testContext);
+
+        assertThat(stopWatch.getDuration())
+            .isGreaterThan(ONE_SECOND);
+    }
+
+    @Test
+    public void asynchronousIteration_doesExecuteWithTimeout() {
+        var timeout = Duration.ofSeconds(2);
+        var iteratingActionContainer = fixture(ONE_SECOND, timeout).doBuild();
+
+        var stopWatch = getStartedStopWatch();
+
+        iteratingActionContainer.doExecute(testContext);
+
+        assertThat(stopWatch.getDuration())
+            .isGreaterThan(ONE_SECOND)
+            .isLessThan(timeout);
+    }
+
+    @Test
+    public void asynchronousIteration_throwsTimeoutException_whenSleepTimeGreaterThanTimeout() {
+        var sleepTime = Duration.ofSeconds(2);
+        var iteratingActionContainer = fixture(sleepTime, ONE_SECOND).doBuild();
+
+        var stopWatch = getStartedStopWatch();
+
+        assertThatThrownBy(() -> iteratingActionContainer.doExecute(testContext))
+            .isInstanceOf(CitrusRuntimeException.class)
+            .hasMessage("Iteration reached timeout!");
+
+        assertThat(stopWatch.getDuration())
+            .isGreaterThan(ONE_SECOND)
+            .isLessThan(sleepTime);
+    }
+
+    public static class Fixture extends AbstractIteratingActionContainer {
+
+        private final Duration sleepTime;
+
+        private Fixture(Duration sleepTime, FixtureBuilder builder) {
+            super("AbstractIteratingActionContainerTest", builder);
+            this.sleepTime = sleepTime;
+        }
+
+        @Override
+        protected void executeIteration(TestContext context) {
+            try {
+                Thread.sleep(sleepTime.toMillis());
+            } catch (InterruptedException e) {
+                currentThread().interrupt();
+                throw new IllegalArgumentException(e);
+            }
+        }
+
+        static class FixtureBuilder extends
+            AbstractIteratingContainerBuilder<Fixture, FixtureBuilder> {
+
+            private final Duration sleepTime;
+
+            public FixtureBuilder(Duration sleepTime) {
+                super();
+                this.sleepTime = sleepTime;
+            }
+
+            static FixtureBuilder fixture(Duration sleepTime, Duration timeout) {
+                return new FixtureBuilder(sleepTime)
+                    .timeout(timeout);
+            }
+
+            @Override
+            protected Fixture doBuild() {
+                return new Fixture(sleepTime, this);
+            }
+        }
+    }
+}

--- a/core/citrus-base/src/test/java/org/citrusframework/container/RepeatOnErrorUntilTrueTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/container/RepeatOnErrorUntilTrueTest.java
@@ -20,64 +20,113 @@ import org.citrusframework.TestAction;
 import org.citrusframework.UnitTestSupport;
 import org.citrusframework.actions.FailAction;
 import org.citrusframework.exceptions.CitrusRuntimeException;
-import org.mockito.Mockito;
+import org.mockito.Mock;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import static org.mockito.Mockito.reset;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 public class RepeatOnErrorUntilTrueTest extends UnitTestSupport {
 
-    private TestAction action = Mockito.mock(TestAction.class);
+    @Mock
+    private TestAction action;
+
+    private AutoCloseable openedMocks;
+
+    @BeforeMethod
+    public void beforeMethodSetup() {
+        openedMocks = openMocks(this);
+    }
+
+    @AfterMethod
+    public void afterMethodTearDown() throws Exception {
+        openedMocks.close();
+    }
+
+    @Test
+    public void buildWithLongApi() {
+        var autoSleepMillis = 5L;
+
+        RepeatOnErrorUntilTrue repeat = new RepeatOnErrorUntilTrue.Builder()
+                .autoSleep(autoSleepMillis)
+                .build();
+
+        assertThat(repeat)
+                .satisfies(
+                        r -> assertThat(r.getAutoSleep()).isEqualTo(autoSleepMillis),
+                        r -> assertThat(r.getAutoSleepDuration()).isEqualTo(Duration.ofMillis(autoSleepMillis))
+                );
+    }
+
+    @Test
+    public void buildWithDurationApi() {
+        var autoSleepMillis = 120_000L;
+        var autoSleepDuration = Duration.ofMinutes(2);
+
+        RepeatOnErrorUntilTrue repeat = new RepeatOnErrorUntilTrue.Builder()
+                .autoSleep(autoSleepDuration)
+                .build();
+
+        assertThat(repeat)
+                .satisfies(
+                        r -> assertThat(r.getAutoSleep()).isEqualTo(autoSleepMillis),
+                        r -> assertThat(r.getAutoSleepDuration()).isEqualTo(autoSleepDuration)
+                );
+    }
+
+    @DataProvider
+    public Object[][] expressionProvider() {
+        return new Object[][]{
+                new Object[]{"i = 5"},
+                new Object[]{"@greaterThan(4)@"}
+        };
+    }
 
     @Test(dataProvider = "expressionProvider")
     public void testSuccessOnFirstIteration(String expression) {
-        reset(action);
-
         RepeatOnErrorUntilTrue repeat = new RepeatOnErrorUntilTrue.Builder()
                 .condition(expression)
                 .index("i")
                 .actions(() -> action)
                 .build();
+
         repeat.execute(context);
+
         verify(action).execute(context);
     }
 
-    @DataProvider
-    public Object[][] expressionProvider() {
-        return new Object[][] {
-                new Object[] {"i = 5"},
-                new Object[] {"@greaterThan(4)@"}
-        };
-    }
-
-    @Test(expectedExceptions=CitrusRuntimeException.class)
+    @Test(expectedExceptions = CitrusRuntimeException.class)
     public void testRepeatOnErrorNoSuccess() {
-        reset(action);
-
         RepeatOnErrorUntilTrue repeat = new RepeatOnErrorUntilTrue.Builder()
                 .condition("i = 5")
                 .index("i")
-                .autoSleep(0L)
+                .autoSleep(Duration.ofMillis(0))
                 .actions(() -> action, new FailAction.Builder())
                 .build();
+
         repeat.execute(context);
+
         verify(action, times(4)).execute(context);
     }
 
-    @Test(expectedExceptions=CitrusRuntimeException.class)
+    @Test(expectedExceptions = CitrusRuntimeException.class)
     public void testRepeatOnErrorNoSuccessConditionExpression() {
-        reset(action);
-
         RepeatOnErrorUntilTrue repeat = new RepeatOnErrorUntilTrue.Builder()
                 .condition((index, context) -> index == 5)
                 .index("i")
-                .autoSleep(0L)
+                .autoSleep(Duration.ofMillis(0))
                 .actions(() -> action, new FailAction.Builder())
                 .build();
+
         repeat.execute(context);
+
         verify(action, times(4)).execute(context);
     }
 }

--- a/core/citrus-spring/src/main/java/org/citrusframework/config/xml/AbstractIteratingTestContainerFactoryBean.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/config/xml/AbstractIteratingTestContainerFactoryBean.java
@@ -20,6 +20,8 @@ import org.citrusframework.AbstractIteratingContainerBuilder;
 import org.citrusframework.container.AbstractIteratingActionContainer;
 import org.citrusframework.container.IteratingConditionExpression;
 
+import java.time.Duration;
+
 public abstract class AbstractIteratingTestContainerFactoryBean<T extends AbstractIteratingActionContainer, B extends AbstractIteratingContainerBuilder<?, ?>> extends AbstractTestContainerFactoryBean<T, B> {
 
     /**
@@ -52,5 +54,13 @@ public abstract class AbstractIteratingTestContainerFactoryBean<T extends Abstra
      */
     public void setStart(int start) {
         getBuilder().startsWith(start);
+    }
+
+    /**
+     * Setter fot timeout duration.
+     * @param timeout the maximum duration this action will take before ending in a timeout
+     */
+    public void setTimeout(Duration timeout) {
+        getBuilder().timeout(timeout);
     }
 }

--- a/core/citrus-spring/src/main/java/org/citrusframework/config/xml/AbstractIterationTestActionParser.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/config/xml/AbstractIterationTestActionParser.java
@@ -22,23 +22,29 @@ import org.springframework.beans.factory.xml.BeanDefinitionParser;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.w3c.dom.Element;
 
-import org.citrusframework.config.util.BeanDefinitionParserUtils;
+import java.time.Duration;
+
+import static org.citrusframework.config.util.BeanDefinitionParserUtils.setPropertyValue;
+import static org.citrusframework.util.StringUtils.hasText;
 
 /**
- * Abstract parser implementation for all iterative container actions. Parser takes care of
- * index name, aborting condition, index start value and description
- *
+ * Abstract parser implementation for all iterative container actions. Parser takes care of index name, aborting
+ * condition, index start value and description
  */
-public abstract class AbstractIterationTestActionParser  implements BeanDefinitionParser {
+public abstract class AbstractIterationTestActionParser implements BeanDefinitionParser {
 
     @Override
     public BeanDefinition parse(Element element, ParserContext parserContext) {
         BeanDefinitionBuilder builder = parseComponent(element, parserContext);
 
-        DescriptionElementParser.doParse(element, builder);
+        MessageSelectorParser.doParse(element, builder);
 
-        BeanDefinitionParserUtils.setPropertyValue(builder, element.getAttribute("index"), "indexName");
-        BeanDefinitionParserUtils.setPropertyValue(builder, element.getAttribute("condition"), "condition");
+        setPropertyValue(builder, element.getAttribute("condition"), "condition");
+        setPropertyValue(builder, element.getAttribute("index"), "indexName");
+
+        if (hasText(element.getAttribute("timeout"))) {
+            builder.addPropertyValue("timeout", Duration.parse(element.getAttribute("timeout")));
+        }
 
         builder.addPropertyValue("name", element.getLocalName());
 

--- a/core/citrus-spring/src/main/java/org/citrusframework/config/xml/RepeatOnErrorUntilTrueParser.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/config/xml/RepeatOnErrorUntilTrueParser.java
@@ -46,7 +46,7 @@ public class RepeatOnErrorUntilTrueParser extends AbstractIterationTestActionPar
 
         /**
          * Setter for auto sleep time (in milliseconds).
-         * @param autoSleep
+         * @param autoSleep the auto sleep time in between repeats in milliseconds
          */
         public void setAutoSleep(Long autoSleep) {
             this.builder.autoSleep(autoSleep);

--- a/core/citrus-spring/src/main/resources/org/citrusframework/schema/citrus-testcase.xsd
+++ b/core/citrus-spring/src/main/resources/org/citrusframework/schema/citrus-testcase.xsd
@@ -649,6 +649,7 @@
         <xs:attribute name="condition" type="xs:string" use="required"/>
         <xs:attribute name="start" type="xs:string"/>
         <xs:attribute name="step" type="xs:string"/>
+        <xs:attribute name="timeout" type="xs:string"/>
     </xs:complexType>
 
     <xs:complexType name="RepeatUntilTrueActionType">
@@ -658,6 +659,7 @@
         </xs:sequence>
         <xs:attribute name="index" type="xs:string"/>
         <xs:attribute name="condition" type="xs:string" use="required"/>
+        <xs:attribute name="timeout" type="xs:string"/>
     </xs:complexType>
 
     <xs:complexType name="RepeatOnErrorUntilTrueActionType">
@@ -665,9 +667,10 @@
             <xs:element ref="description" minOccurs="0"/>
             <xs:group ref="actionGroup" maxOccurs="unbounded"/>
         </xs:sequence>
-        <xs:attribute name="index" type="xs:string"/>
-        <xs:attribute name="condition" type="xs:string" use="required"/>
         <xs:attribute name="auto-sleep" type="xs:string"/>
+        <xs:attribute name="condition" type="xs:string" use="required"/>
+        <xs:attribute name="index" type="xs:string"/>
+        <xs:attribute name="timeout" type="xs:string"/>
     </xs:complexType>
 
     <xs:complexType name="ConditionalActionType">

--- a/core/citrus-spring/src/test/java/org/citrusframework/config/xml/IterateParserTest.java
+++ b/core/citrus-spring/src/test/java/org/citrusframework/config/xml/IterateParserTest.java
@@ -16,11 +16,14 @@
 
 package org.citrusframework.config.xml;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
 import org.citrusframework.container.Iterate;
 import org.citrusframework.testng.AbstractActionParserTest;
+import org.testng.annotations.Test;
+
+import java.time.Duration;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 public class IterateParserTest extends AbstractActionParserTest<Iterate> {
 
@@ -30,24 +33,27 @@ public class IterateParserTest extends AbstractActionParserTest<Iterate> {
         assertActionClassAndName(Iterate.class, "iterate");
 
         Iterate action = getNextTestActionFromTest();
-        Assert.assertEquals(action.getCondition(), "i lt 3");
-        Assert.assertEquals(action.getIndexName(), "i");
-        Assert.assertEquals(action.getStart(), 1);
-        Assert.assertEquals(action.getStep(), 1);
-        Assert.assertEquals(action.getActionCount(), 1);
+        assertEquals(action.getCondition(), "i lt 3");
+        assertEquals(action.getIndexName(), "i");
+        assertEquals(action.getStart(), 1);
+        assertEquals(action.getStep(), 1);
+        assertEquals(action.getActionCount(), 1);
+        assertNull(action.getTimeout());
 
         action = getNextTestActionFromTest();
-        Assert.assertEquals(action.getCondition(), "index lt= 2");
-        Assert.assertEquals(action.getIndexName(), "index");
-        Assert.assertEquals(action.getStart(), 1);
-        Assert.assertEquals(action.getStep(), 1);
-        Assert.assertEquals(action.getActionCount(), 1);
+        assertEquals(action.getCondition(), "index lt= 2");
+        assertEquals(action.getIndexName(), "index");
+        assertEquals(action.getStart(), 1);
+        assertEquals(action.getStep(), 1);
+        assertEquals(action.getActionCount(), 1);
+        assertNull(action.getTimeout());
 
         action = getNextTestActionFromTest();
-        Assert.assertEquals(action.getCondition(), "i lt= 10");
-        Assert.assertEquals(action.getIndexName(), "i");
-        Assert.assertEquals(action.getStart(), 0);
-        Assert.assertEquals(action.getStep(), 5);
-        Assert.assertEquals(action.getActionCount(), 2);
+        assertEquals(action.getCondition(), "i lt= 10");
+        assertEquals(action.getIndexName(), "i");
+        assertEquals(action.getStart(), 0);
+        assertEquals(action.getStep(), 5);
+        assertEquals(action.getActionCount(), 2);
+        assertEquals(action.getTimeout(), Duration.ofSeconds(3));
     }
 }

--- a/core/citrus-spring/src/test/java/org/citrusframework/config/xml/RepeatOnErrorUntilTrueParserTest.java
+++ b/core/citrus-spring/src/test/java/org/citrusframework/config/xml/RepeatOnErrorUntilTrueParserTest.java
@@ -16,11 +16,14 @@
 
 package org.citrusframework.config.xml;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
 import org.citrusframework.container.RepeatOnErrorUntilTrue;
 import org.citrusframework.testng.AbstractActionParserTest;
+import org.testng.annotations.Test;
+
+import java.time.Duration;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 public class RepeatOnErrorUntilTrueParserTest extends AbstractActionParserTest<RepeatOnErrorUntilTrue> {
 
@@ -30,31 +33,35 @@ public class RepeatOnErrorUntilTrueParserTest extends AbstractActionParserTest<R
         assertActionClassAndName(RepeatOnErrorUntilTrue.class, "repeat-onerror-until-true");
 
         RepeatOnErrorUntilTrue action = getNextTestActionFromTest();
-        Assert.assertEquals(action.getCondition(), "i gt 3");
-        Assert.assertEquals(action.getIndexName(), "i");
-        Assert.assertEquals(action.getStart(), 1);
-        Assert.assertEquals(action.getAutoSleep(), Long.valueOf(1000L));
-        Assert.assertEquals(action.getActionCount(), 1);
+        assertEquals(action.getCondition(), "i gt 3");
+        assertEquals(action.getIndexName(), "i");
+        assertEquals(action.getStart(), 1);
+        assertEquals(action.getAutoSleep(), Long.valueOf(1000L));
+        assertEquals(action.getActionCount(), 1);
+        assertNull(action.getTimeout());
 
         action = getNextTestActionFromTest();
-        Assert.assertEquals(action.getCondition(), "index gt= 2");
-        Assert.assertEquals(action.getIndexName(), "index");
-        Assert.assertEquals(action.getStart(), 1);
-        Assert.assertEquals(action.getAutoSleep(), Long.valueOf(1000L));
-        Assert.assertEquals(action.getActionCount(), 1);
+        assertEquals(action.getCondition(), "index gt= 2");
+        assertEquals(action.getIndexName(), "index");
+        assertEquals(action.getStart(), 1);
+        assertEquals(action.getAutoSleep(), Long.valueOf(1000L));
+        assertEquals(action.getActionCount(), 1);
+        assertNull(action.getTimeout());
 
         action = getNextTestActionFromTest();
-        Assert.assertEquals(action.getCondition(), "i gt= 10");
-        Assert.assertEquals(action.getIndexName(), "i");
-        Assert.assertEquals(action.getStart(), 1);
-        Assert.assertEquals(action.getAutoSleep(), Long.valueOf(500L));
-        Assert.assertEquals(action.getActionCount(), 2);
+        assertEquals(action.getCondition(), "i gt= 10");
+        assertEquals(action.getIndexName(), "i");
+        assertEquals(action.getStart(), 1);
+        assertEquals(action.getAutoSleep(), Long.valueOf(500L));
+        assertEquals(action.getActionCount(), 2);
+        assertNull(action.getTimeout());
 
         action = getNextTestActionFromTest();
-        Assert.assertEquals(action.getCondition(), "i gt= 5");
-        Assert.assertEquals(action.getIndexName(), "i");
-        Assert.assertEquals(action.getStart(), 1);
-        Assert.assertEquals(action.getAutoSleep(), Long.valueOf(250L));
-        Assert.assertEquals(action.getActionCount(), 1);
+        assertEquals(action.getCondition(), "i gt= 5");
+        assertEquals(action.getIndexName(), "i");
+        assertEquals(action.getStart(), 1);
+        assertEquals(action.getAutoSleep(), Long.valueOf(250L));
+        assertEquals(action.getActionCount(), 1);
+        assertEquals(action.getTimeout(), Duration.ofSeconds(1));
     }
 }

--- a/core/citrus-spring/src/test/java/org/citrusframework/config/xml/RepeatUntilTrueParserTest.java
+++ b/core/citrus-spring/src/test/java/org/citrusframework/config/xml/RepeatUntilTrueParserTest.java
@@ -16,11 +16,14 @@
 
 package org.citrusframework.config.xml;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
 import org.citrusframework.container.RepeatUntilTrue;
 import org.citrusframework.testng.AbstractActionParserTest;
+import org.testng.annotations.Test;
+
+import java.time.Duration;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 public class RepeatUntilTrueParserTest extends AbstractActionParserTest<RepeatUntilTrue> {
 
@@ -30,21 +33,24 @@ public class RepeatUntilTrueParserTest extends AbstractActionParserTest<RepeatUn
         assertActionClassAndName(RepeatUntilTrue.class, "repeat-until-true");
 
         RepeatUntilTrue action = getNextTestActionFromTest();
-        Assert.assertEquals(action.getCondition(), "i lt 3");
-        Assert.assertEquals(action.getIndexName(), "i");
-        Assert.assertEquals(action.getStart(), 1);
-        Assert.assertEquals(action.getActionCount(), 1);
+        assertEquals(action.getCondition(), "i lt 3");
+        assertEquals(action.getIndexName(), "i");
+        assertEquals(action.getStart(), 1);
+        assertEquals(action.getActionCount(), 1);
+        assertNull(action.getTimeout());
 
         action = getNextTestActionFromTest();
-        Assert.assertEquals(action.getCondition(), "index lt= 2");
-        Assert.assertEquals(action.getIndexName(), "index");
-        Assert.assertEquals(action.getStart(), 1);
-        Assert.assertEquals(action.getActionCount(), 1);
+        assertEquals(action.getCondition(), "index lt= 2");
+        assertEquals(action.getIndexName(), "index");
+        assertEquals(action.getStart(), 1);
+        assertEquals(action.getActionCount(), 1);
+        assertNull(action.getTimeout());
 
         action = getNextTestActionFromTest();
-        Assert.assertEquals(action.getCondition(), "i lt= 10");
-        Assert.assertEquals(action.getIndexName(), "i");
-        Assert.assertEquals(action.getStart(), 1);
-        Assert.assertEquals(action.getActionCount(), 2);
+        assertEquals(action.getCondition(), "i lt= 10");
+        assertEquals(action.getIndexName(), "i");
+        assertEquals(action.getStart(), 1);
+        assertEquals(action.getActionCount(), 2);
+        assertEquals(action.getTimeout(), Duration.ofSeconds(2));
     }
 }

--- a/core/citrus-spring/src/test/resources/org/citrusframework/config/xml/IterateParserTest-context.xml
+++ b/core/citrus-spring/src/test/resources/org/citrusframework/config/xml/IterateParserTest-context.xml
@@ -1,24 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<spring:beans xmlns="http://www.citrusframework.org/schema/testcase" 
-              xmlns:spring="http://www.springframework.org/schema/beans" 
-              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+<spring:beans xmlns="http://www.citrusframework.org/schema/testcase"
+              xmlns:spring="http://www.springframework.org/schema/beans"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd 
                                   http://www.citrusframework.org/schema/testcase http://www.citrusframework.org/schema/testcase/citrus-testcase.xsd">
     <testcase name="IterateParserTest">
         <actions>
             <iterate condition="i lt 3">
-                <echo><message>Hello Citrus!</message></echo>
+                <echo>
+                    <message>Hello Citrus!</message>
+                </echo>
             </iterate>
-            
+
             <iterate condition="index lt= 2" index="index">
-                <echo><message>Hello Citrus!</message></echo>
+                <echo>
+                    <message>Hello Citrus!</message>
+                </echo>
             </iterate>
-            
-            <iterate condition="i lt= 10" index="i" start="0" step="5">
-                <echo><message>Hello Citrus!</message></echo>
-                <echo><message>Hello You!</message></echo>
+
+            <iterate condition="i lt= 10" index="i" start="0" step="5" timeout="PT3S">
+                <echo>
+                    <message>Hello Citrus!</message>
+                </echo>
+                <echo>
+                    <message>Hello You!</message>
+                </echo>
             </iterate>
         </actions>
     </testcase>
-    
 </spring:beans>

--- a/core/citrus-spring/src/test/resources/org/citrusframework/config/xml/RepeatOnErrorUntilTrueParserTest-context.xml
+++ b/core/citrus-spring/src/test/resources/org/citrusframework/config/xml/RepeatOnErrorUntilTrueParserTest-context.xml
@@ -1,28 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<spring:beans xmlns="http://www.citrusframework.org/schema/testcase" 
-              xmlns:spring="http://www.springframework.org/schema/beans" 
-              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+<spring:beans xmlns="http://www.citrusframework.org/schema/testcase"
+              xmlns:spring="http://www.springframework.org/schema/beans"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd 
                                   http://www.citrusframework.org/schema/testcase http://www.citrusframework.org/schema/testcase/citrus-testcase.xsd">
     <testcase name="RepeatOnErrorUntilTrueParserTest">
         <actions>
             <repeat-onerror-until-true condition="i gt 3">
-                <echo><message>Hello Citrus!</message></echo>
-            </repeat-onerror-until-true>
-            
-            <repeat-onerror-until-true condition="index gt= 2" index="index">
-                <echo><message>Hello Citrus!</message></echo>
-            </repeat-onerror-until-true>
-            
-            <repeat-onerror-until-true condition="i gt= 10" index="i" auto-sleep="500">
-                <echo><message>Hello Citrus!</message></echo>
-                <echo><message>Hello You!</message></echo>
+                <echo>
+                    <message>Hello Citrus!</message>
+                </echo>
             </repeat-onerror-until-true>
 
-            <repeat-onerror-until-true condition="i gt= 5" auto-sleep="250">
-                <echo><message>Hello Citrus!</message></echo>
+            <repeat-onerror-until-true condition="index gt= 2" index="index">
+                <echo>
+                    <message>Hello Citrus!</message>
+                </echo>
+            </repeat-onerror-until-true>
+
+            <repeat-onerror-until-true condition="i gt= 10" index="i" auto-sleep="500">
+                <echo>
+                    <message>Hello Citrus!</message>
+                </echo>
+                <echo>
+                    <message>Hello You!</message>
+                </echo>
+            </repeat-onerror-until-true>
+
+            <repeat-onerror-until-true condition="i gt= 5" auto-sleep="250" timeout="PT1S">
+                <echo>
+                    <message>Hello Citrus!</message>
+                </echo>
             </repeat-onerror-until-true>
         </actions>
     </testcase>
-    
 </spring:beans>

--- a/core/citrus-spring/src/test/resources/org/citrusframework/config/xml/RepeatUntilTrueParserTest-context.xml
+++ b/core/citrus-spring/src/test/resources/org/citrusframework/config/xml/RepeatUntilTrueParserTest-context.xml
@@ -1,24 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<spring:beans xmlns="http://www.citrusframework.org/schema/testcase" 
-              xmlns:spring="http://www.springframework.org/schema/beans" 
-              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+<spring:beans xmlns="http://www.citrusframework.org/schema/testcase"
+              xmlns:spring="http://www.springframework.org/schema/beans"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd 
                                   http://www.citrusframework.org/schema/testcase http://www.citrusframework.org/schema/testcase/citrus-testcase.xsd">
     <testcase name="RepeatUntilTrueParserTest">
         <actions>
             <repeat-until-true condition="i lt 3">
-                <echo><message>Hello Citrus!</message></echo>
+                <echo>
+                    <message>Hello Citrus!</message>
+                </echo>
             </repeat-until-true>
-            
+
             <repeat-until-true condition="index lt= 2" index="index">
-                <echo><message>Hello Citrus!</message></echo>
+                <echo>
+                    <message>Hello Citrus!</message>
+                </echo>
             </repeat-until-true>
-            
-            <repeat-until-true condition="i lt= 10" index="i">
-                <echo><message>Hello Citrus!</message></echo>
-                <echo><message>Hello You!</message></echo>
+
+            <repeat-until-true condition="i lt= 10" index="i" timeout="PT2S">
+                <echo>
+                    <message>Hello Citrus!</message>
+                </echo>
+                <echo>
+                    <message>Hello You!</message>
+                </echo>
             </repeat-until-true>
         </actions>
     </testcase>
-    
 </spring:beans>

--- a/endpoints/citrus-kafka/src/test/resources/org/citrusframework/kafka/integration/KafkaEndpointIT_selectiveMessage.xml
+++ b/endpoints/citrus-kafka/src/test/resources/org/citrusframework/kafka/integration/KafkaEndpointIT_selectiveMessage.xml
@@ -59,7 +59,7 @@
         <variable name="extractedTraceparent"/>
       </create-variables>
 
-      <repeat-onerror-until-true condition="@assertThat('${extractedTraceparent}', 'equalTo(01-${traceId}-${spanId}-00)')@">
+      <repeat-onerror-until-true condition="@assertThat('${extractedTraceparent}', 'equalTo(01-${traceId}-${spanId}-00)')@" timeout="PT5S">
         <receive endpoint="helloKafkaEndpoint">
           <description>Receive Kafka request: Kafka broker -> Citrus</description>
           <selector>

--- a/endpoints/citrus-kafka/src/test/resources/org/citrusframework/kafka/integration/KafkaEndpointIT_singleMessage.xml
+++ b/endpoints/citrus-kafka/src/test/resources/org/citrusframework/kafka/integration/KafkaEndpointIT_singleMessage.xml
@@ -57,7 +57,7 @@
         <variable name="extractedCorrelationId"/>
       </create-variables>
 
-      <repeat-onerror-until-true condition="@assertThat('${extractedCorrelationId}', 'equalTo(${correlationId})')@">
+      <repeat-onerror-until-true condition="@assertThat('${extractedCorrelationId}', 'equalTo(${correlationId})')@" timeout="PT5S">
         <receive endpoint="helloKafkaEndpoint">
           <description>Receive Kafka request: Kafka broker -> Citrus</description>
           <message>


### PR DESCRIPTION
as promised, a timeout implementation on all iterating actions. this is currently:
* repeat until condition
* repeat on error
* iterate

this will partially help with https://github.com/citrusframework/citrus/issues/1258, because the kafka IT's won't run forever.