### PR TITLE
chore: SQL data source handling

### DIFF
--- a/connectors/citrus-sql/src/main/java/org/citrusframework/actions/ExecutePLSQLAction.java
+++ b/connectors/citrus-sql/src/main/java/org/citrusframework/actions/ExecutePLSQLAction.java
@@ -226,7 +226,7 @@ public class ExecutePLSQLAction extends AbstractDatabaseConnectingTestAction {
         }
 
         @Override
-        public ExecutePLSQLAction build() {
+        public ExecutePLSQLAction doBuild() {
             return new ExecutePLSQLAction(this);
         }
     }

--- a/connectors/citrus-sql/src/main/java/org/citrusframework/actions/ExecuteSQLAction.java
+++ b/connectors/citrus-sql/src/main/java/org/citrusframework/actions/ExecuteSQLAction.java
@@ -16,12 +16,12 @@
 
 package org.citrusframework.actions;
 
+import java.util.List;
+import javax.sql.DataSource;
+
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.springframework.transaction.support.TransactionTemplate;
-
-import javax.sql.DataSource;
-import java.util.List;
 
 /**
  * Test action execute SQL statements. Use this action when executing
@@ -149,7 +149,7 @@ public class ExecuteSQLAction extends AbstractDatabaseConnectingTestAction {
         }
 
         @Override
-        public ExecuteSQLAction build() {
+        public ExecuteSQLAction doBuild() {
             return new ExecuteSQLAction(this);
         }
     }

--- a/connectors/citrus-sql/src/main/java/org/citrusframework/actions/ExecuteSQLQueryAction.java
+++ b/connectors/citrus-sql/src/main/java/org/citrusframework/actions/ExecuteSQLQueryAction.java
@@ -536,7 +536,7 @@ public class ExecuteSQLQueryAction extends AbstractDatabaseConnectingTestAction 
         }
 
         @Override
-        public ExecuteSQLQueryAction build() {
+        public ExecuteSQLQueryAction doBuild() {
             return new ExecuteSQLQueryAction(this);
         }
     }

--- a/connectors/citrus-sql/src/main/java/org/citrusframework/sql/xml/Plsql.java
+++ b/connectors/citrus-sql/src/main/java/org/citrusframework/sql/xml/Plsql.java
@@ -16,16 +16,15 @@
 
 package org.citrusframework.sql.xml;
 
-import javax.sql.DataSource;
+import java.util.ArrayList;
+import java.util.List;
+
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlType;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.citrusframework.TestActionBuilder;
 import org.citrusframework.actions.ExecutePLSQLAction;
 import org.citrusframework.spi.ReferenceResolver;
@@ -37,7 +36,6 @@ public class Plsql implements TestActionBuilder<ExecutePLSQLAction>, ReferenceRe
 
     private final ExecutePLSQLAction.Builder builder = new ExecutePLSQLAction.Builder();
 
-    private String dataSource;
     private String transactionManager;
 
     private ReferenceResolver referenceResolver;
@@ -50,7 +48,7 @@ public class Plsql implements TestActionBuilder<ExecutePLSQLAction>, ReferenceRe
 
     @XmlAttribute(name = "datasource", required = true)
     public Plsql setDataSource(String dataSource) {
-        this.dataSource = dataSource;
+        builder.dataSource(dataSource);
         builder.name(String.format("plsql:%s", dataSource));
         return this;
     }
@@ -96,7 +94,7 @@ public class Plsql implements TestActionBuilder<ExecutePLSQLAction>, ReferenceRe
     @Override
     public ExecutePLSQLAction build() {
         if (referenceResolver != null) {
-            builder.dataSource(referenceResolver.resolve(dataSource, DataSource.class));
+            builder.withReferenceResolver(referenceResolver);
 
             if (transactionManager != null) {
                 builder.transactionManager(referenceResolver.resolve(transactionManager, PlatformTransactionManager.class));

--- a/connectors/citrus-sql/src/main/java/org/citrusframework/sql/xml/Sql.java
+++ b/connectors/citrus-sql/src/main/java/org/citrusframework/sql/xml/Sql.java
@@ -20,7 +20,6 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import javax.sql.DataSource;
 
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
@@ -43,7 +42,6 @@ public class Sql implements TestActionBuilder<AbstractDatabaseConnectingTestActi
 
     private AbstractDatabaseConnectingTestAction.Builder<?, ?> builder = new ExecuteSQLAction.Builder();
 
-    private String dataSource;
     private String transactionManager;
 
     private ReferenceResolver referenceResolver;
@@ -60,9 +58,9 @@ public class Sql implements TestActionBuilder<AbstractDatabaseConnectingTestActi
         return this;
     }
 
-    @XmlAttribute(name = "datasource", required = true)
+    @XmlAttribute(name = "datasource")
     public Sql setDataSource(String dataSource) {
-        this.dataSource = dataSource;
+        builder.dataSource(dataSource);
         builder.name(String.format("sql:%s", dataSource));
         return this;
     }
@@ -120,7 +118,7 @@ public class Sql implements TestActionBuilder<AbstractDatabaseConnectingTestActi
     @Override
     public AbstractDatabaseConnectingTestAction build() {
         if (referenceResolver != null) {
-            builder.dataSource(referenceResolver.resolve(dataSource, DataSource.class));
+            builder.withReferenceResolver(referenceResolver);
 
             if (transactionManager != null) {
                 builder.transactionManager(referenceResolver.resolve(transactionManager, PlatformTransactionManager.class));

--- a/connectors/citrus-sql/src/main/java/org/citrusframework/sql/yaml/Plsql.java
+++ b/connectors/citrus-sql/src/main/java/org/citrusframework/sql/yaml/Plsql.java
@@ -17,7 +17,6 @@
 package org.citrusframework.sql.yaml;
 
 import java.util.List;
-import javax.sql.DataSource;
 
 import org.citrusframework.TestActionBuilder;
 import org.citrusframework.actions.ExecutePLSQLAction;
@@ -29,7 +28,6 @@ public class Plsql implements TestActionBuilder<ExecutePLSQLAction>, ReferenceRe
 
     private final ExecutePLSQLAction.Builder builder = new ExecutePLSQLAction.Builder();
 
-    private String dataSource;
     private String transactionManager;
 
     private ReferenceResolver referenceResolver;
@@ -39,7 +37,7 @@ public class Plsql implements TestActionBuilder<ExecutePLSQLAction>, ReferenceRe
     }
 
     public void setDataSource(String dataSource) {
-        this.dataSource = dataSource;
+        builder.dataSource(dataSource);
         builder.name(String.format("plsql:%s", dataSource));
     }
 
@@ -80,7 +78,7 @@ public class Plsql implements TestActionBuilder<ExecutePLSQLAction>, ReferenceRe
     @Override
     public ExecutePLSQLAction build() {
         if (referenceResolver != null) {
-            builder.dataSource(referenceResolver.resolve(dataSource, DataSource.class));
+            builder.withReferenceResolver(referenceResolver);
 
             if (transactionManager != null) {
                 builder.transactionManager(referenceResolver.resolve(transactionManager, PlatformTransactionManager.class));

--- a/connectors/citrus-sql/src/main/java/org/citrusframework/sql/yaml/Sql.java
+++ b/connectors/citrus-sql/src/main/java/org/citrusframework/sql/yaml/Sql.java
@@ -20,7 +20,6 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import javax.sql.DataSource;
 
 import org.citrusframework.TestActionBuilder;
 import org.citrusframework.actions.AbstractDatabaseConnectingTestAction;
@@ -35,7 +34,6 @@ public class Sql implements TestActionBuilder<AbstractDatabaseConnectingTestActi
 
     private AbstractDatabaseConnectingTestAction.Builder<?, ?> builder = new ExecuteSQLAction.Builder();
 
-    private String dataSource;
     private String transactionManager;
 
     private ReferenceResolver referenceResolver;
@@ -49,7 +47,7 @@ public class Sql implements TestActionBuilder<AbstractDatabaseConnectingTestActi
     }
 
     public void setDataSource(String dataSource) {
-        this.dataSource = dataSource;
+        builder.dataSource(dataSource);
         builder.name(String.format("sql:%s", dataSource));
     }
 
@@ -110,7 +108,7 @@ public class Sql implements TestActionBuilder<AbstractDatabaseConnectingTestActi
     @Override
     public AbstractDatabaseConnectingTestAction build() {
         if (referenceResolver != null) {
-            builder.dataSource(referenceResolver.resolve(dataSource, DataSource.class));
+            builder.withReferenceResolver(referenceResolver);
 
             if (transactionManager != null) {
                 builder.transactionManager(referenceResolver.resolve(transactionManager, PlatformTransactionManager.class));

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/postgresql/PostgreSQLSettings.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/postgresql/PostgreSQLSettings.java
@@ -144,15 +144,19 @@ public class PostgreSQLSettings {
             context.setVariable(getEnvVarName(containerType, "CONTAINER_ID"), dockerContainerId);
             context.setVariable(getEnvVarName(containerType, "CONTAINER_NAME"), dockerContainerName);
 
+            context.setVariable(getEnvVarName(containerType, "SERVICE_PORT"), container.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT));
+            context.setVariable(getEnvVarName(containerType, "PORT"), container.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT));
             context.setVariable(getEnvVarName(containerType, "LOCAL_URL"), container.getJdbcUrl());
             context.setVariable(getEnvVarName(containerType, "SERVICE_LOCAL_URL"), container.getJdbcUrl());
 
             if (!KubernetesSupport.isConnected(context) || !TestContainersSettings.isKubedockEnabled()) {
                 context.setVariable(getEnvVarName(containerType, "SERVICE_NAME"), serviceName);
                 context.setVariable(getEnvVarName(containerType, "SERVICE_URL"), container.getJdbcUrl());
+                context.setVariable(getEnvVarName(containerType, "URL"), container.getJdbcUrl());
             } else {
                 context.setVariable(getEnvVarName(containerType, "SERVICE_NAME"), serviceName);
                 context.setVariable(getEnvVarName(containerType, "SERVICE_URL"), container.getJdbcUrl().replace("localhost", serviceName));
+                context.setVariable(getEnvVarName(containerType, "URL"), container.getJdbcUrl().replace("localhost", serviceName));
             }
 
             context.setVariable(getEnvVarName(containerType, "DRIVER"), container.getDriverClassName());

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-4.4.0-SNAPSHOT.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-4.4.0-SNAPSHOT.xsd
@@ -810,7 +810,7 @@
         </xs:complexType>
       </xs:element>
     </xs:sequence>
-    <xs:attribute name="datasource" type="xs:string" use="required"/>
+    <xs:attribute name="datasource" type="xs:string"/>
     <xs:attribute name="ignore-errors" type="xs:boolean"/>
   </xs:complexType>
 

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
@@ -810,7 +810,7 @@
         </xs:complexType>
       </xs:element>
     </xs:sequence>
-    <xs:attribute name="datasource" type="xs:string" use="required"/>
+    <xs:attribute name="datasource" type="xs:string"/>
     <xs:attribute name="ignore-errors" type="xs:boolean"/>
   </xs:complexType>
 


### PR DESCRIPTION
- Auto resolve data source from Citrus bean registry
- Allow to set data source by its name in the bean registry