### PR TITLE
chore(citrus-camel): Support send receive action builder for Camel en…

### DIFF
--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelActionBuilder.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelActionBuilder.java
@@ -20,6 +20,8 @@ import jakarta.annotation.Nullable;
 import org.apache.camel.CamelContext;
 import org.citrusframework.TestAction;
 import org.citrusframework.TestActionBuilder;
+import org.citrusframework.actions.ReceiveMessageAction;
+import org.citrusframework.actions.SendMessageAction;
 import org.citrusframework.spi.ReferenceResolver;
 import org.citrusframework.spi.ReferenceResolverAware;
 import org.citrusframework.util.ObjectHelper;
@@ -29,14 +31,6 @@ public class CamelActionBuilder implements TestActionBuilder.DelegatingTestActio
     private CamelContext camelContext;
 
     private TestActionBuilder<?> delegate;
-
-    /**
-     * Static entrance method for the Camel action builder.
-     * @return
-     */
-    public static CamelActionBuilder camel() {
-        return new CamelActionBuilder();
-    }
 
     /**
      * Static entrance for all Camel related Java DSL functionalities.
@@ -53,6 +47,26 @@ public class CamelActionBuilder implements TestActionBuilder.DelegatingTestActio
      */
     public CamelContextActionBuilder camelContext() {
         CamelContextActionBuilder builder = new CamelContextActionBuilder();
+        this.delegate = builder;
+        return builder;
+    }
+
+    /**
+     * Sends message using Camel endpointUri and components.
+     * @return
+     */
+    public CamelExchangeActionBuilder<SendMessageAction.Builder> send() {
+        CamelExchangeActionBuilder<SendMessageAction.Builder> builder = CamelExchangeActionBuilder.send();
+        this.delegate = builder;
+        return builder;
+    }
+
+    /**
+     * Receive messages using Camel endpointUri and components.
+     * @return
+     */
+    public CamelExchangeActionBuilder<ReceiveMessageAction.Builder> receive() {
+        CamelExchangeActionBuilder<ReceiveMessageAction.Builder> builder = CamelExchangeActionBuilder.receive();
         this.delegate = builder;
         return builder;
     }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelExchangeActionBuilder.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelExchangeActionBuilder.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.actions;
+
+import org.citrusframework.TestAction;
+import org.citrusframework.TestActionBuilder;
+import org.citrusframework.actions.ReceiveMessageAction;
+import org.citrusframework.actions.SendMessageAction;
+import org.citrusframework.camel.endpoint.CamelEndpoint;
+import org.citrusframework.endpoint.EndpointUriBuilder;
+import org.citrusframework.message.builder.MessageBuilderSupport;
+import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.spi.ReferenceResolverAware;
+import org.citrusframework.util.ObjectHelper;
+
+/**
+ * Action builder.
+ */
+public class CamelExchangeActionBuilder<T extends MessageBuilderSupport.MessageActionBuilder<?, ?, ?>> implements TestActionBuilder.DelegatingTestActionBuilder<TestAction>, ReferenceResolverAware {
+
+    private T delegate;
+
+    private ReferenceResolver referenceResolver;
+
+    static CamelExchangeActionBuilder<SendMessageAction.Builder> send() {
+        CamelExchangeActionBuilder<SendMessageAction.Builder> instance = new CamelExchangeActionBuilder<>();
+        instance.delegate = SendMessageAction.Builder.send();
+        return instance;
+    }
+
+    static CamelExchangeActionBuilder<ReceiveMessageAction.Builder> receive() {
+        CamelExchangeActionBuilder<ReceiveMessageAction.Builder> instance = new CamelExchangeActionBuilder<>();
+        instance.delegate = ReceiveMessageAction.Builder.receive();
+        return instance;
+    }
+
+    public T endpoint(CamelEndpoint endpoint) {
+        delegate.endpoint(endpoint);
+        return delegate;
+    }
+
+    public T endpoint(EndpointUriBuilder builder) {
+        return endpoint(builder.getUri());
+    }
+
+    public T endpoint(String endpointUri) {
+        return endpoint(endpointUri, false);
+    }
+
+    public T endpoint(String endpointUri, boolean inOut) {
+        String prefix;
+        if (inOut) {
+            prefix = "camel:sync:";
+        } else {
+            prefix = "camel:";
+        }
+
+        if (endpointUri.startsWith("camel:")) {
+            delegate.endpoint(endpointUri);
+        } else {
+            delegate.endpoint(prefix + endpointUri);
+        }
+        return delegate;
+    }
+
+    /**
+     * Sets the bean reference resolver.
+     * @param referenceResolver
+     */
+    public CamelExchangeActionBuilder<T> withReferenceResolver(ReferenceResolver referenceResolver) {
+        setReferenceResolver(referenceResolver);
+        return this;
+    }
+
+    @Override
+    public void setReferenceResolver(ReferenceResolver referenceResolver) {
+        this.referenceResolver = referenceResolver;
+        if (delegate != null) {
+            delegate.setReferenceResolver(referenceResolver);
+        }
+    }
+
+    @Override
+    public T getDelegate() {
+        return delegate;
+    }
+
+    @Override
+    public TestAction build() {
+        ObjectHelper.assertNotNull(delegate, "Missing delegate action to build");
+        delegate.setReferenceResolver(referenceResolver);
+        return delegate.build();
+    }
+}

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/dsl/CamelSupport.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/dsl/CamelSupport.java
@@ -24,10 +24,13 @@ import org.apache.camel.builder.DataFormatClause;
 import org.apache.camel.builder.ExpressionClauseSupport;
 import org.apache.camel.model.OutputDefinition;
 import org.apache.camel.model.ProcessorDefinition;
+import org.citrusframework.actions.ReceiveMessageAction;
+import org.citrusframework.actions.SendMessageAction;
 import org.citrusframework.camel.CamelSettings;
 import org.citrusframework.camel.actions.CamelActionBuilder;
 import org.citrusframework.camel.actions.CamelContextActionBuilder;
 import org.citrusframework.camel.actions.CamelControlBusAction;
+import org.citrusframework.camel.actions.CamelExchangeActionBuilder;
 import org.citrusframework.camel.actions.CamelJBangActionBuilder;
 import org.citrusframework.camel.actions.CamelRouteActionBuilder;
 import org.citrusframework.camel.actions.CreateCamelComponentAction;
@@ -67,7 +70,7 @@ public class CamelSupport {
     }
 
     /**
-     * Static entrance for all Camel related Java DSL functionalities.
+     * Sets Camel context.
      * @return
      */
     public CamelSupport camelContext(CamelContext camelContext) {
@@ -76,11 +79,27 @@ public class CamelSupport {
     }
 
     /**
-     * Static entrance for all Camel related Java DSL functionalities.
+     * Entrance for Camel context related Java DSL functionalities.
      * @return
      */
     public CamelContextActionBuilder camelContext() {
         return new CamelContextActionBuilder();
+    }
+
+    /**
+     * Sends message using Camel endpointUris.
+     * @return
+     */
+    public CamelExchangeActionBuilder<SendMessageAction.Builder> send() {
+        return new CamelActionBuilder().send();
+    }
+
+    /**
+     * Receives message using Camel endpointUris.
+     * @return
+     */
+    public CamelExchangeActionBuilder<ReceiveMessageAction.Builder> receive() {
+        return new CamelActionBuilder().receive();
     }
 
     /**

--- a/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/groovy/camel-control-bus.test.groovy
+++ b/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/groovy/camel-control-bus.test.groovy
@@ -16,7 +16,7 @@
 
 package org.citrusframework.camel.groovy
 
-import static org.citrusframework.camel.actions.CamelActionBuilder.camel
+import static org.citrusframework.camel.dsl.CamelSupport.camel
 
 name "CamelControlBusTest"
 author "Christoph"

--- a/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/groovy/camel-create-routes.test.groovy
+++ b/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/groovy/camel-create-routes.test.groovy
@@ -16,7 +16,7 @@
 
 package org.citrusframework.camel.groovy
 
-import static org.citrusframework.camel.actions.CamelActionBuilder.camel
+import static org.citrusframework.camel.dsl.CamelSupport.camel
 
 name "CamelCreateRouteTest"
 author "Christoph"

--- a/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/groovy/camel-remove-routes.test.groovy
+++ b/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/groovy/camel-remove-routes.test.groovy
@@ -16,7 +16,7 @@
 
 package org.citrusframework.camel.groovy
 
-import static org.citrusframework.camel.actions.CamelActionBuilder.camel
+import static org.citrusframework.camel.dsl.CamelSupport.camel
 
 name "CamelRemoveRouteTest"
 author "Christoph"

--- a/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/groovy/camel-start-routes.test.groovy
+++ b/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/groovy/camel-start-routes.test.groovy
@@ -16,7 +16,7 @@
 
 package org.citrusframework.camel.groovy
 
-import static org.citrusframework.camel.actions.CamelActionBuilder.camel
+import static org.citrusframework.camel.dsl.CamelSupport.camel
 
 name "CamelStartRouteTest"
 author "Christoph"

--- a/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/groovy/camel-stop-routes.test.groovy
+++ b/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/groovy/camel-stop-routes.test.groovy
@@ -16,7 +16,7 @@
 
 package org.citrusframework.camel.groovy
 
-import static org.citrusframework.camel.actions.CamelActionBuilder.camel
+import static org.citrusframework.camel.dsl.CamelSupport.camel
 
 name "CamelStopRouteTest"
 author "Christoph"


### PR DESCRIPTION
…dpoints

- Build send/receive actions with Camel endpointUris
- Use single Java DSL static entrace with CamelSupport