### PR TITLE
fix: Set validate expressions on Http YAML DSL

### DIFF
--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/yaml/Http.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/yaml/Http.java
@@ -273,7 +273,7 @@ public class Http implements TestActionBuilder<TestAction>, ReferenceResolverAwa
             receive.setTimeout(request.timeout);
         }
 
-        request.getValidates().forEach(receive.getValidate()::add);
+        request.getValidate().forEach(receive.getValidate()::add);
 
         if (request.extract != null) {
             receive.setExtract(request.extract);
@@ -503,7 +503,7 @@ public class Http implements TestActionBuilder<TestAction>, ReferenceResolverAwa
 
         protected Receive.Selector selector;
 
-        protected List<Receive.Validate> validates;
+        protected List<Receive.Validate> validate;
 
         protected Message.Extract extract;
 
@@ -627,12 +627,16 @@ public class Http implements TestActionBuilder<TestAction>, ReferenceResolverAwa
             this.selector = selector;
         }
 
-        public List<Receive.Validate> getValidates() {
-            if (validates == null) {
-                validates = new ArrayList<>();
+        public List<Receive.Validate> getValidate() {
+            if (validate == null) {
+                validate = new ArrayList<>();
             }
 
-            return validates;
+            return validate;
+        }
+
+        public void setValidate(List<Receive.Validate> validate) {
+            this.validate = validate;
         }
 
         public Message.Extract getExtract() {
@@ -752,6 +756,10 @@ public class Http implements TestActionBuilder<TestAction>, ReferenceResolverAwa
             }
 
             return validate;
+        }
+
+        public void setValidate(List<Receive.Validate> validate) {
+            this.validate = validate;
         }
 
         public Message.Extract getExtract() {

--- a/endpoints/citrus-http/src/test/resources/org/citrusframework/http/yaml/http-client-test.yaml
+++ b/endpoints/citrus-http/src/test/resources/org/citrusframework/http/yaml/http-client-test.yaml
@@ -41,6 +41,10 @@ actions:
           body:
             data: |
               <order><id>${id}</id><item>foo</item></order>
+        validate:
+          - xpath:
+              - expression: //order/item
+                value: foo
         extract:
           body:
             - variable: "orderId"

--- a/endpoints/citrus-http/src/test/resources/org/citrusframework/http/yaml/http-server-test.yaml
+++ b/endpoints/citrus-http/src/test/resources/org/citrusframework/http/yaml/http-server-test.yaml
@@ -50,6 +50,10 @@ actions:
           body:
             data: |
               <user><id>1001</id><name>new_user</name></user>
+        validate:
+          - xpath:
+              - expression: //user/name
+                value: new_user
         extract:
           body:
             - variable: "userId"


### PR DESCRIPTION
- Making it possible to set validate expressions when verifying Http request/response in YAML DSL