### PR TITLE
Add Quarkus Testcontainers test resource

### DIFF
--- a/connectors/citrus-testcontainers/pom.xml
+++ b/connectors/citrus-testcontainers/pom.xml
@@ -56,6 +56,13 @@
       <artifactId>commons-dbcp2</artifactId>
     </dependency>
 
+    <!-- Optional Quarkus Test integration -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-test-common</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- AWS Localstack -->
     <dependency>
       <groupId>software.amazon.awssdk</groupId>

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/LocalStackContainer.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/LocalStackContainer.java
@@ -42,7 +42,7 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
     private static final String HOSTNAME_EXTERNAL_ENV = "HOSTNAME_EXTERNAL";
 
     private static final String DOCKER_IMAGE_NAME = LocalStackSettings.getImageName();
-    private static final String DOCKER_IMAGE_TAG = LocalStackSettings.VERSION_DEFAULT;
+    private static final String DOCKER_IMAGE_TAG = LocalStackSettings.getVersion();
 
     private final Set<Service> services = new HashSet<>();
     private String secretKey = "secretkey";
@@ -210,6 +210,13 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
 
         public static String serviceName(Service service) {
             return service.serviceName;
+        }
+
+        public static Service fromServiceName(String serviceName) {
+            return Arrays.stream(Service.values())
+                    .filter(service -> service.serviceName.equals(serviceName))
+                    .findFirst()
+                    .orElseThrow(() -> new CitrusRuntimeException("Unknown AWS LocalStack service name: %s".formatted(serviceName)));
         }
     }
 }

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/StartLocalStackAction.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/StartLocalStackAction.java
@@ -27,12 +27,8 @@ import org.testcontainers.containers.wait.strategy.Wait;
 
 public class StartLocalStackAction extends StartTestcontainersAction<LocalStackContainer> {
 
-    private final Set<LocalStackContainer.Service> services;
-
     public StartLocalStackAction(Builder builder) {
         super(builder);
-
-        this.services = builder.services;
     }
 
     @Override

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/quarkus/LocalStackContainerResource.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/quarkus/LocalStackContainerResource.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.testcontainers.aws2.quarkus;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.Map;
+
+import io.quarkus.test.common.QuarkusTestResourceConfigurableLifecycleManager;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.testcontainers.aws2.LocalStackContainer;
+import org.citrusframework.testcontainers.aws2.StartLocalStackAction;
+import org.citrusframework.testcontainers.quarkus.ContainerLifecycleListener;
+import org.citrusframework.testcontainers.quarkus.TestcontainersResource;
+
+public class LocalStackContainerResource extends TestcontainersResource<LocalStackContainer>
+        implements QuarkusTestResourceConfigurableLifecycleManager<LocalStackContainerSupport> {
+
+    public static final String SERVICES_INIT_ARG = "aws.localstack.services";
+
+    public LocalStackContainerResource() {
+        super(LocalStackContainer.class);
+    }
+
+    @Override
+    public void init(LocalStackContainerSupport config) {
+        for (Class<? extends ContainerLifecycleListener<LocalStackContainer>> lifecycleListenerType :
+                config.containerLifecycleListener()) {
+            try {
+                registerContainerLifecycleListener(lifecycleListenerType.getDeclaredConstructor().newInstance());
+            } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+                throw new CitrusRuntimeException("Failed to instantiate container lifecycle listener from type: %s"
+                        .formatted(lifecycleListenerType), e);
+            }
+        }
+
+        container = new StartLocalStackAction.Builder()
+                .withServices(config.services())
+                .build().getContainer();
+    }
+
+    @Override
+    protected void doInit(Map<String, String> initArgs) {
+        String[] serviceNames = initArgs.getOrDefault(SERVICES_INIT_ARG, "").split(",");
+        container = new StartLocalStackAction.Builder()
+                .withServices(Arrays.stream(serviceNames)
+                        .map(String::trim)
+                        .map(LocalStackContainer.Service::fromServiceName)
+                        .toArray(LocalStackContainer.Service[]::new))
+                .build().getContainer();
+    }
+}

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/quarkus/LocalStackContainerSupport.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/quarkus/LocalStackContainerSupport.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.citrusframework.quarkus;
+package org.citrusframework.testcontainers.aws2.quarkus;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -22,17 +22,22 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import io.quarkus.test.common.QuarkusTestResource;
+import org.citrusframework.testcontainers.aws2.LocalStackContainer;
+import org.citrusframework.testcontainers.quarkus.ContainerLifecycleListener;
 
-/**
- * Special Citrus annotation that enables Citrus support on QuarkusTest framework.
- */
-@QuarkusTestResource(value = CitrusTestResource.class, restrictToAnnotatedClass = true)
+@QuarkusTestResource(LocalStackContainerResource.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-public @interface CitrusSupport {
+public @interface LocalStackContainerSupport {
 
     /**
-     * Supplier capable of setting application properties for the Quarkus application under test.
+     * Enabled services.
+     * @return
      */
-    Class<? extends ApplicationPropertiesSupplier>[] applicationPropertiesSupplier() default {};
+    LocalStackContainer.Service[] services() default {};
+
+    /**
+     * Container lifecycle listeners
+     */
+    Class<? extends ContainerLifecycleListener<LocalStackContainer>>[] containerLifecycleListener() default {};
 }

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/quarkus/KafkaContainerResource.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/quarkus/KafkaContainerResource.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.testcontainers.kafka.quarkus;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Collections;
+import java.util.Map;
+
+import io.quarkus.test.common.QuarkusTestResourceConfigurableLifecycleManager;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.testcontainers.kafka.StartKafkaAction;
+import org.citrusframework.testcontainers.quarkus.ContainerLifecycleListener;
+import org.citrusframework.testcontainers.quarkus.TestcontainersResource;
+import org.testcontainers.containers.KafkaContainer;
+
+public class KafkaContainerResource extends TestcontainersResource<KafkaContainer>
+        implements QuarkusTestResourceConfigurableLifecycleManager<KafkaContainerSupport> {
+
+    public KafkaContainerResource() {
+        super(KafkaContainer.class);
+    }
+
+    @Override
+    public void init(KafkaContainerSupport config) {
+        for (Class<? extends ContainerLifecycleListener<KafkaContainer>> lifecycleListenerType :
+                config.containerLifecycleListener()) {
+            try {
+                registerContainerLifecycleListener(lifecycleListenerType.getDeclaredConstructor().newInstance());
+            } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+                throw new CitrusRuntimeException("Failed to instantiate container lifecycle listener from type: %s"
+                        .formatted(lifecycleListenerType), e);
+            }
+        }
+
+        doInit(Collections.emptyMap());
+    }
+
+    @Override
+    protected void doInit(Map<String, String> initArgs) {
+        container = new StartKafkaAction.Builder().build().getContainer();
+    }
+}

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/quarkus/KafkaContainerSupport.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/quarkus/KafkaContainerSupport.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.citrusframework.quarkus;
+package org.citrusframework.testcontainers.kafka.quarkus;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -22,17 +22,16 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import io.quarkus.test.common.QuarkusTestResource;
+import org.citrusframework.testcontainers.quarkus.ContainerLifecycleListener;
+import org.testcontainers.containers.KafkaContainer;
 
-/**
- * Special Citrus annotation that enables Citrus support on QuarkusTest framework.
- */
-@QuarkusTestResource(value = CitrusTestResource.class, restrictToAnnotatedClass = true)
+@QuarkusTestResource(KafkaContainerResource.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-public @interface CitrusSupport {
+public @interface KafkaContainerSupport {
 
     /**
-     * Supplier capable of setting application properties for the Quarkus application under test.
+     * Container lifecycle listeners
      */
-    Class<? extends ApplicationPropertiesSupplier>[] applicationPropertiesSupplier() default {};
+    Class<? extends ContainerLifecycleListener<KafkaContainer>>[] containerLifecycleListener() default {};
 }

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/quarkus/ContainerLifecycleListener.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/quarkus/ContainerLifecycleListener.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.testcontainers.quarkus;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Listener gets invoked when Testcontainers instance is started or stopped.
+ * Allows implementations to perform actions with given container instance,
+ * in particular configuring the application under test with the container exposed connection settings.
+ * @param <T> the container type
+ */
+public interface ContainerLifecycleListener<T> {
+
+    String INIT_ARG = "citrus.testcontainers.lifecycle.listener";
+
+    /**
+     * Invoked when Testcontainers instance has been started. Returned key-value
+     * map is used to set application properties on the system under test which is the Quarkus application
+     * started via QuarkusTest annotation.
+     * @param container
+     * @return
+     */
+    default Map<String, String> started(T container) {
+        return Collections.emptyMap();
+    }
+
+    /**
+     * Invoked after the Testcontainers instance has been stopped.
+     * @param container
+     */
+    default void stopped(T container) {
+    }
+}

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/quarkus/GenericContainerProvider.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/quarkus/GenericContainerProvider.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.testcontainers.quarkus;
+
+import org.testcontainers.containers.GenericContainer;
+
+@FunctionalInterface
+public interface GenericContainerProvider {
+
+    GenericContainer<?> create();
+}

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/quarkus/GenericContainerResource.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/quarkus/GenericContainerResource.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.testcontainers.quarkus;
+
+import java.lang.reflect.InvocationTargetException;
+
+import io.quarkus.test.common.QuarkusTestResourceConfigurableLifecycleManager;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.testcontainers.containers.GenericContainer;
+
+public class GenericContainerResource extends TestcontainersResource<GenericContainer<?>>
+        implements QuarkusTestResourceConfigurableLifecycleManager<TestcontainersSupport> {
+
+    public GenericContainerResource() {
+        super((Class) GenericContainer.class);
+    }
+
+    @Override
+    public void init(TestcontainersSupport config) {
+        for (Class<? extends ContainerLifecycleListener<? extends GenericContainer<?>>> lifecycleListenerType :
+                config.containerLifecycleListener()) {
+            try {
+                registerContainerLifecycleListener((ContainerLifecycleListener<GenericContainer<?>>) lifecycleListenerType.getDeclaredConstructor().newInstance());
+            } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+                throw new CitrusRuntimeException("Failed to instantiate container lifecycle listener from type: %s"
+                        .formatted(lifecycleListenerType), e);
+            }
+        }
+
+        try {
+            container = config.containerProvider().getDeclaredConstructor().newInstance().create();
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+            throw new CitrusRuntimeException("Failed to instantiate container provider from type: %s"
+                    .formatted(config.containerProvider()), e);
+        }
+    }
+}

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/quarkus/TestcontainersResource.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/quarkus/TestcontainersResource.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.testcontainers.quarkus;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import org.citrusframework.annotations.CitrusResource;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.testcontainers.containers.GenericContainer;
+
+public class TestcontainersResource<T extends GenericContainer<?>> implements QuarkusTestResourceLifecycleManager {
+
+    private final Set<ContainerLifecycleListener<T>> containerLifecycleListeners = new HashSet<>();
+
+    protected T container;
+
+    private final Class<T> containerType;
+
+    public TestcontainersResource(Class<T> containerType) {
+        this.containerType = containerType;
+    }
+
+    @Override
+    public final void init(Map<String, String> initArgs) {
+        String[] qualifiedClassNames = initArgs.getOrDefault(ContainerLifecycleListener.INIT_ARG, "").split(",");
+        for (String qualifiedClassName : qualifiedClassNames) {
+            try {
+                Class<?> cls = Class.forName(qualifiedClassName, true, Thread.currentThread().getContextClassLoader());
+                Object instance = cls.getDeclaredConstructor().newInstance();
+                if (instance instanceof ContainerLifecycleListener<?> containerLifecycleListener) {
+                    registerContainerLifecycleListener((ContainerLifecycleListener<T>) containerLifecycleListener);
+                }
+            } catch (ClassNotFoundException | InvocationTargetException | InstantiationException |
+                     IllegalAccessException | NoSuchMethodException e) {
+                throw new CitrusRuntimeException("Failed to instantiate container lifecycle listener from type: %s".formatted(qualifiedClassName), e);
+            }
+        }
+
+        doInit(initArgs);
+    }
+
+    protected void doInit(Map<String, String> initArgs) {
+    }
+
+    @Override
+    public final Map<String, String> start() {
+        Map<String, String> conf = doStart();
+        for (ContainerLifecycleListener<T> listener : containerLifecycleListeners) {
+            conf.putAll(listener.started(container));
+        }
+        return conf;
+    }
+
+    protected Map<String, String> doStart() {
+        container.start();
+        return new HashMap<>();
+    }
+
+    @Override
+    public final void stop() {
+        doStop();
+        containerLifecycleListeners.forEach(listener -> listener.stopped(container));
+    }
+
+    protected void doStop() {
+        container.stop();
+    }
+
+    @Override
+    public void inject(TestInjector testInjector) {
+        testInjector.injectIntoFields(container, new TestInjector.AnnotatedAndMatchesType(CitrusResource.class, containerType));
+    }
+
+    protected void registerContainerLifecycleListener(ContainerLifecycleListener<T> containerLifecycleListener) {
+        this.containerLifecycleListeners.add(containerLifecycleListener);
+    }
+
+}

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/quarkus/TestcontainersSupport.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/quarkus/TestcontainersSupport.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.citrusframework.quarkus;
+package org.citrusframework.testcontainers.quarkus;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -22,17 +22,21 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import io.quarkus.test.common.QuarkusTestResource;
+import org.testcontainers.containers.GenericContainer;
 
-/**
- * Special Citrus annotation that enables Citrus support on QuarkusTest framework.
- */
-@QuarkusTestResource(value = CitrusTestResource.class, restrictToAnnotatedClass = true)
+@QuarkusTestResource(GenericContainerResource.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-public @interface CitrusSupport {
+public @interface TestcontainersSupport {
 
     /**
-     * Supplier capable of setting application properties for the Quarkus application under test.
+     * Container provider capable of creating the container instance.
+     * @return
      */
-    Class<? extends ApplicationPropertiesSupplier>[] applicationPropertiesSupplier() default {};
+    Class<? extends GenericContainerProvider> containerProvider();
+
+    /**
+     * Container lifecycle listeners
+     */
+    Class<? extends ContainerLifecycleListener<? extends GenericContainer<?>>>[] containerLifecycleListener() default {};
 }

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/redpanda/quarkus/RedpandaContainerResource.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/redpanda/quarkus/RedpandaContainerResource.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.testcontainers.redpanda.quarkus;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Collections;
+import java.util.Map;
+
+import io.quarkus.test.common.QuarkusTestResourceConfigurableLifecycleManager;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.testcontainers.quarkus.ContainerLifecycleListener;
+import org.citrusframework.testcontainers.quarkus.TestcontainersResource;
+import org.citrusframework.testcontainers.redpanda.StartRedpandaAction;
+import org.testcontainers.redpanda.RedpandaContainer;
+
+public class RedpandaContainerResource extends TestcontainersResource<RedpandaContainer>
+        implements QuarkusTestResourceConfigurableLifecycleManager<RedpandaContainerSupport> {
+
+    public RedpandaContainerResource() {
+        super(RedpandaContainer.class);
+    }
+
+    @Override
+    public void init(RedpandaContainerSupport config) {
+        for (Class<? extends ContainerLifecycleListener<RedpandaContainer>> lifecycleListenerType :
+                config.containerLifecycleListener()) {
+            try {
+                registerContainerLifecycleListener(lifecycleListenerType.getDeclaredConstructor().newInstance());
+            } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+                throw new CitrusRuntimeException("Failed to instantiate container lifecycle listener from type: %s"
+                        .formatted(lifecycleListenerType), e);
+            }
+        }
+
+        doInit(Collections.emptyMap());
+    }
+
+    @Override
+    protected void doInit(Map<String, String> initArgs) {
+        container = new StartRedpandaAction.Builder().build().getContainer();
+    }
+}

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/redpanda/quarkus/RedpandaContainerSupport.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/redpanda/quarkus/RedpandaContainerSupport.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.citrusframework.quarkus;
+package org.citrusframework.testcontainers.redpanda.quarkus;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -22,17 +22,16 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import io.quarkus.test.common.QuarkusTestResource;
+import org.citrusframework.testcontainers.quarkus.ContainerLifecycleListener;
+import org.testcontainers.redpanda.RedpandaContainer;
 
-/**
- * Special Citrus annotation that enables Citrus support on QuarkusTest framework.
- */
-@QuarkusTestResource(value = CitrusTestResource.class, restrictToAnnotatedClass = true)
+@QuarkusTestResource(RedpandaContainerResource.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-public @interface CitrusSupport {
+public @interface RedpandaContainerSupport {
 
     /**
-     * Supplier capable of setting application properties for the Quarkus application under test.
+     * Container lifecycle listeners
      */
-    Class<? extends ApplicationPropertiesSupplier>[] applicationPropertiesSupplier() default {};
+    Class<? extends ContainerLifecycleListener<RedpandaContainer>>[] containerLifecycleListener() default {};
 }

--- a/connectors/citrus-testcontainers/src/test/java/org/citrusframework/testcontainers/integration/StartGenericTestcontainersIT.java
+++ b/connectors/citrus-testcontainers/src/test/java/org/citrusframework/testcontainers/integration/StartGenericTestcontainersIT.java
@@ -41,7 +41,7 @@ public class StartGenericTestcontainersIT extends AbstractTestcontainersIT {
     @Test
     @CitrusTest
     public void shouldStartContainer() {
-        GenericContainer<?> busyBox = new GenericContainer("busybox:latest")
+        GenericContainer<?> busyBox = new GenericContainer<>("busybox:latest")
                 .withCommand("echo", "Hello World");
 
         given(doFinally().actions(testcontainers().stop()

--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,7 @@
     <ascii-table-version>1.8.0</ascii-table-version>
     <assertj.version>3.26.3</assertj.version>
     <awaitility.version>4.2.2</awaitility.version>
-    <aws-java-sdk2.version>2.29.21</aws-java-sdk2.version>
+    <aws-java-sdk2.version>2.27.19</aws-java-sdk2.version>
     <bouncycastle.version>1.79</bouncycastle.version>
     <byte.buddy.version>1.15.10</byte.buddy.version>
     <commons.dbcp2.version>2.12.0</commons.dbcp2.version>
@@ -244,13 +244,14 @@
     <k8s.model.version>6.13.4</k8s.model.version>
     <kafka.version>3.9.0</kafka.version>
     <knative-client.version>6.13.4</knative-client.version>
-    <log4j2.version>2.22.1</log4j2.version>
+    <log4j2.version>2.23.1</log4j2.version>
     <mockito.version>5.14.2</mockito.version>
     <mockftpserver.version>3.2.0</mockftpserver.version>
     <netty.version>4.1.105.Final</netty.version>
     <okhttp.version>4.12.0</okhttp.version>
     <picoli-version>4.7.6</picoli-version>
     <postgresql.version>42.7.4</postgresql.version>
+    <quarkus.platform.version>3.16.4</quarkus.platform.version>
     <saaj.version>3.0.4</saaj.version>
     <selenium.version>4.27.0</selenium.version>
     <slf4j.version>2.0.11</slf4j.version>
@@ -622,6 +623,33 @@
         <artifactId>s3</artifactId>
         <version>${aws-java-sdk2.version}</version>
         <scope>test</scope>
+      </dependency>
+
+      <!-- Quarkus -->
+      <dependency>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-arc</artifactId>
+        <version>${quarkus.platform.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-arc-deployment</artifactId>
+        <version>${quarkus.platform.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-junit5</artifactId>
+        <version>${quarkus.platform.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-test-common</artifactId>
+        <version>${quarkus.platform.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-jacoco</artifactId>
+        <version>${quarkus.platform.version}</version>
       </dependency>
 
       <!-- Citrus http dependencies -->

--- a/runtime/citrus-quarkus/citrus-quarkus-it/src/main/java/org/citrusframework/quarkus/app/DemoApplication.java
+++ b/runtime/citrus-quarkus/citrus-quarkus-it/src/main/java/org/citrusframework/quarkus/app/DemoApplication.java
@@ -19,14 +19,20 @@ package org.citrusframework.quarkus.app;
 import io.quarkus.runtime.StartupEvent;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
-import org.jboss.logging.Logger;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @ApplicationScoped
 public class DemoApplication {
 
-    private static final Logger logger = Logger.getLogger(DemoApplication.class);
+    private static final Logger logger = LoggerFactory.getLogger(DemoApplication.class);
+
+    @ConfigProperty(name = "greeting.message")
+    String message;
 
     void onStart(@Observes StartupEvent ev) {
         logger.info("Demo application started!");
+        logger.info(message);
     }
 }

--- a/runtime/citrus-quarkus/citrus-quarkus-it/src/main/resources/application.properties
+++ b/runtime/citrus-quarkus/citrus-quarkus-it/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-quarkus.log.level=DEBUG
+quarkus.log.level=INFO

--- a/runtime/citrus-quarkus/citrus-quarkus-it/src/test/java/org/citrusframework/quarkus/app/DemoApplicationTest.java
+++ b/runtime/citrus-quarkus/citrus-quarkus-it/src/test/java/org/citrusframework/quarkus/app/DemoApplicationTest.java
@@ -16,6 +16,9 @@
 
 package org.citrusframework.quarkus.app;
 
+import java.util.Collections;
+import java.util.Map;
+
 import io.quarkus.test.junit.QuarkusTest;
 import org.citrusframework.Citrus;
 import org.citrusframework.TestCaseRunner;
@@ -28,6 +31,7 @@ import org.citrusframework.endpoint.direct.DirectEndpointBuilder;
 import org.citrusframework.endpoint.direct.annotation.DirectEndpointConfig;
 import org.citrusframework.message.DefaultMessageQueue;
 import org.citrusframework.message.MessageQueue;
+import org.citrusframework.quarkus.ApplicationPropertiesSupplier;
 import org.citrusframework.quarkus.CitrusSupport;
 import org.citrusframework.spi.BindToRegistry;
 import org.citrusframework.validation.DefaultTextEqualsMessageValidator;
@@ -41,8 +45,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @QuarkusTest
-@CitrusSupport
-class DemoApplicationTest {
+@CitrusSupport(applicationPropertiesSupplier = DemoApplicationTest.class)
+public class DemoApplicationTest implements ApplicationPropertiesSupplier {
 
     @CitrusFramework
     private Citrus citrus;
@@ -110,5 +114,10 @@ class DemoApplicationTest {
                         .message()
                         .body("${greeting}")
         );
+    }
+
+    @Override
+    public Map<String, String> get() {
+        return Collections.singletonMap("greeting.message", "Hello, Citrus rocks!");
     }
 }

--- a/runtime/citrus-quarkus/citrus-quarkus-it/src/test/resources/application.properties
+++ b/runtime/citrus-quarkus/citrus-quarkus-it/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.arc.ignored-split-packages=org.citrusframework.*

--- a/runtime/citrus-quarkus/citrus-quarkus-runtime/src/main/java/org/citrusframework/quarkus/ApplicationPropertiesSupplier.java
+++ b/runtime/citrus-quarkus/citrus-quarkus-runtime/src/main/java/org/citrusframework/quarkus/ApplicationPropertiesSupplier.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.quarkus;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * Supplier able to set application properties on the Quarkus application under test.
+ * Supplier gets called as part of the Quarkus test lifecycle manager before the Quarkus application is started.
+ * Returned application properties are set as system properties for the Quarkus application.
+ */
+@FunctionalInterface
+public interface ApplicationPropertiesSupplier extends Supplier<Map<String, String>> {
+    String INIT_ARG = "citrus.quarkus.application.properties.supplier";
+
+}

--- a/runtime/citrus-quarkus/pom.xml
+++ b/runtime/citrus-quarkus/pom.xml
@@ -14,41 +14,6 @@
   <description>Citrus Quarkus Extension</description>
   <packaging>pom</packaging>
 
-  <properties>
-    <quarkus.platform.version>3.16.0</quarkus.platform.version>
-  </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-arc</artifactId>
-        <version>${quarkus.platform.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-arc-deployment</artifactId>
-        <version>${quarkus.platform.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-junit5</artifactId>
-        <version>${quarkus.platform.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-test-common</artifactId>
-        <version>${quarkus.platform.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-jacoco</artifactId>
-        <version>${quarkus.platform.version}</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <build>
     <pluginManagement>
       <plugins>

--- a/src/manual/runtimes-quarkus.adoc
+++ b/src/manual/runtimes-quarkus.adoc
@@ -1,7 +1,10 @@
 [[runtime-quarkus]]
 == QuarkusTest runtime
 
-Quarkus has emerged into a popular enterprise Java framework. For unit and integration testing the Quarkus framework provides a special integrations with JUnit Jupiter. Citrus adds a Quarkus test resource that developers can use to include Citrus capabilities into arbitrary Quarkus tests.
+Quarkus has emerged into a popular enterprise Java framework.
+For unit and integration testing the Quarkus framework provides integrations with JUnit Jupiter.
+Citrus adds a Quarkus test resource implementation that allows developers to combine Citrus with Quarkus during testing.
+You can use the Citrus test resource annotations on your Quarkus tests and include Citrus capabilities into arbitrary Quarkus tests.
 
 NOTE: The Citrus QuarkusTest extension is shipped in a separate Maven module. You need to include the module as a dependency in your project accordingly.
 
@@ -15,9 +18,11 @@ NOTE: The Citrus QuarkusTest extension is shipped in a separate Maven module. Yo
 </dependency>
 ----
 
-Usually a Quarkus test is annotated with the `@QuarkusTest` or `QuarkusIntegrationTest` annotation. Users may add an annotation named `@CitrusSupport` in order to also enable Citrus capabilities on the test.
+Usually a Quarkus test is annotated with the `@QuarkusTest` or `QuarkusIntegrationTest` annotation.
+Users just add an annotation named `@CitrusSupport` to also enable Citrus capabilities on the test.
 
-The Citrus support will automatically hook into the QuarkusTest lifecycle management making sure to call the Citrus before/after suite and before/after test handlers.
+The Citrus support will automatically hook into the QuarkusTest lifecycle management to inject Citrus resources with `@CitrusResource` annotation.
+Also, the Citrus extension makes sure to start a proper Citrus instance and call before/after suite and before/after test handlers.
 
 This way you are able to combine Citrus with `@QuarkusTest` annotated classes very easily.
 
@@ -56,11 +61,15 @@ public class DemoApplicationTest {
 }
 ----
 
-The `@CitrusSupport` annotation enables the Citrus features on the test. First of all users may inject Citrus related resources such as `TestCaseRunner` or `TestContext`.
+The `@CitrusSupport` annotation enables the Citrus features on the test.
+First of all users may inject Citrus related resources such as `TestCaseRunner` or the `TestContext`.
 
-The `TestCaseRunner` reference runs arbitrary Citrus actions as part of the test.
+As usual the `TestCaseRunner` is the entrance to the Citrus domain specific language for running arbitrary Citrus actions as part of the test.
 
-The test is also able to configure Message endpoints.
+[[runtime-quarkus-endpoint-config]]
+=== Endpoint configuration
+
+The test is able to configure Message endpoints to connect to different messaging transports as part of the test.
 
 .Configure message endpoints
 [source,java]
@@ -96,6 +105,298 @@ public class DemoApplicationTest {
 }
 ----
 
-Creating new message endpoints is very easy. Just use the proper endpoint builder and optionally bind the new endpoint to the Citrus bean registry via `BindToRegistry` annotation.
-
+Creating new message endpoints is very easy.
+Just use the proper endpoint builder and optionally bind the new endpoint to the Citrus bean registry via `@BindToRegistry` annotation.
 You may then use the message endpoint in all `send` and `receive` test actions in order to exchange messages.
+
+You may move the endpoint configuration into a separate class and load the endpoints with the configuration class as follows:
+
+.EndpointConfig.class
+[source,java]
+----
+public class EndpointConfig {
+
+    @BindToRegistry
+    public KafkaEndpoint bookings() {
+        return new KafkaEndpointBuilder()
+            .topic("bookings")
+            .build();
+    }
+}
+----
+
+The endpoint configuration class uses `@BindToRegistry` members or methods to add beans to the Citrus registry.
+The configuration class may be referenced by many tests then using the `@CitrusConfiguration` annotation.
+
+.Load endpoint config classes
+[source,java]
+----
+@QuarkusTest
+@CitrusSupport
+@CitrusConfiguration(classes = EndpointConfig.class)
+public class DemoApplicationTest {
+
+    @CitrusResource
+    private KafkaEndpoint bookings;
+
+    @CitrusResource
+    private TestCaseRunner t;
+
+    @Test
+    void shouldVerifyDemoApp() {
+        t.when(
+            send()
+                .endpoint(bookings)
+                .message()
+                .body("How about Citrus!?")
+        );
+
+        t.when(
+            receive()
+                .endpoint(bookings)
+                .message()
+                .body("Citrus rocks!")
+        );
+    }
+}
+----
+
+Citrus loads the configuration class and injects the `KafkaEndpoint` instance to the test with `@CitrusResource`  annotation.
+
+[[runtime-quarkus-dynamic-tests]]
+=== Load dynamic tests
+
+Citrus supports many test languages besides writing tests in pure Java.
+Users can load tests written in XML, YAML, Groovy and many more via dynamic tests.
+
+.Load YAML tests
+[source,java]
+----
+@QuarkusTest
+@CitrusSupport
+@CitrusConfiguration(classes = EndpointConfig.class)
+public class DemoApplicationTest {
+
+    @CitrusTestFactory
+    public Stream<DynamicTest> loadYamlTests() {
+        return CitrusTestFactorySupport.factory(TestLoader.YAML).packageScan("some.package.name");
+    }
+}
+----
+
+The example above loads YAML test case definitions and runs those as dynamic tests with JUnit Jupiter.
+The package scan loads all files in the given folder and runs the tests via Citrus.
+All YAML tests are able to reference the message endpoints configured in the configuration class `EndpointConfig.class`.
+
+A sample YAML test may look like this:
+
+.my-test.yaml
+[source,yaml]
+----
+name: my-test
+actions:
+  - send:
+      endpoint: bookings
+      message:
+        body:
+          data: How about Citrus!?
+  - receive:
+      endpoint: bookings
+      timeout: 5000
+      message:
+        body:
+          data: Citrus rocks!
+----
+
+[[runtime-quarkus-application-properties]]
+=== Set application properties
+
+The `@QuarkusTest` annotation will automatically start the application under test.
+Citrus provides the ability to programmatically set application properties before the Quarkus application is started.
+This is important when you need to overwrite configuration based on test message endpoints configured in the test.
+
+The next example shows a Citrus enabled Quarkus test that supplies a set of application properties to configure the application under test.
+
+.Supply application properties
+[source,java]
+----
+@QuarkusTest
+@CitrusSupport(applicationPropertiesSupplier = DemoAppConfigurationSupplier.class)
+@CitrusConfiguration(classes = EndpointConfig.class)
+public class DemoApplicationTest {
+
+    // ...
+}
+----
+
+The `DemoAppConfiguration` class implements the `Supplier` interface and set a config property.
+This property will be set on the application under test.
+
+.DemoAppConfigurationSupplier.class
+[source,java]
+----
+public class DemoAppConfigurationSupplier implements ApplicationPropertiesSupplier {
+
+    @Override
+    public Map<String, String> get() {
+        Map<String, String> conf = new Hasmap<>();
+        conf.put("quarkus.log.level", "INFO");
+        conf.put("greeting.message", "Hello, Citrus rocks!");
+        return conf;
+    }
+}
+----
+
+The application properties supplier is able to set Quarkus properties as well as application domain properties.
+The example above sets `greeting.message` property which can be referenced in the Quarkus application:
+
+.DemoApplication
+[source,java]
+----
+@ApplicationScoped
+public class DemoApplication {
+
+    private static final Logger logger = Logger.getLogger(DemoApplication.class);
+
+    @ConfigProperty(name = "greeting.message")
+    String message;
+
+    void onStart(@Observes StartupEvent ev) {
+        logger.info(message);
+    }
+}
+----
+
+[[runtime-quarkus-testcontainers]]
+=== Testcontainers support
+
+Citrus integrates with Testcontainers to easily start/stop Testcontainers instances as part of the test.
+You can leverage the Citrus Testcontainers features within a Quarkus test very easily.
+Citrus implements Quarkus test resources for each of the supported containers (AWS LocalStack, Kafka, Redpanda, ...).
+
+The following example starts an AWS LocalStack Testcontainers instance and uses the S3 service on that container to upload a file to the S3 bucket.
+The Quarkus application under test should handle this S3 file then.
+
+.AwsS3SourceTest
+[source,java]
+----
+@QuarkusTest
+@CitrusSupport
+@LocalStackContainerSupport(services = LocalStackContainer.Service.S3, containerLifecycleListener = AwsS3SourceTest.class)
+public class AwsS3SourceTest implements ContainerLifecycleListener<LocalStackContainer> {
+
+    @CitrusResource
+    private TestCaseRunner tc;
+
+    @CitrusResource
+    private LocalStackContainer localStackContainer;
+
+    @Test
+    public void shouldHandleUploadedS3File() {
+        tc.given(this::uploadS3File);
+
+        // verify that the Quarkus application has handled the S3 file
+    }
+
+    private void uploadS3File(TestContext context) {
+        S3Client s3Client = createS3Client(localStackContainer);
+
+        CreateMultipartUploadResponse initResponse = s3Client.createMultipartUpload(b -> b.bucket(s3BucketName).key(s3Key));
+        String etag = s3Client.uploadPart(b -> b.bucket(s3BucketName)
+                        .key(s3Key)
+                        .uploadId(initResponse.uploadId())
+                        .partNumber(1),
+                RequestBody.fromString(s3Data)).eTag();
+        s3Client.completeMultipartUpload(b -> b.bucket(s3BucketName)
+                .multipartUpload(CompletedMultipartUpload.builder()
+                        .parts(Collections.singletonList(CompletedPart.builder()
+                                .partNumber(1)
+                                .eTag(etag).build())).build())
+                .key(s3Key)
+                .uploadId(initResponse.uploadId()));
+    }
+
+    @Override
+    public Map<String, String> started(LocalStackContainer container) {
+        S3Client s3Client = createS3Client(container);
+
+        s3Client.createBucket(b -> b.bucket(s3BucketName));
+
+        Map<String, String> conf = new HashMap<>();
+        conf.put("my.app.aws-s3-source.accessKey", container.getAccessKey());
+        conf.put("my.app.aws-s3-source.secretKey", container.getSecretKey());
+        conf.put("my.app.aws-s3-source.region", container.getRegion());
+        conf.put("my.app.aws-s3-source.bucketNameOrArn", s3BucketName);
+        conf.put("my.app.aws-s3-source.uriEndpointOverride", container.getServiceEndpoint().toString());
+        conf.put("my.app.aws-s3-source.overrideEndpoint", "true");
+        conf.put("my.app.aws-s3-source.forcePathStyle", "true");
+
+        return conf;
+    }
+
+    private static S3Client createS3Client(LocalStackContainer container) {
+        return S3Client.builder()
+                .endpointOverride(container.getServiceEndpoint())
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(container.getAccessKey(), container.getSecretKey())
+                        )
+                )
+                .forcePathStyle(true)
+                .region(Region.of(container.getRegion()))
+                .build();
+    }
+}
+----
+
+A few things happened in this example and let's explain those features one after another.
+First thing to notice is the `@LocalStackContainerSupport` annotation that makes Citrus run the AWS LocalStack Testcontainers instance.
+Also, the annotation provides the enabled services on that container (`services = LocalStackContainer.Service.S3`).
+This starts the Testcontainers instance as part of the Quarkus test.
+
+The test also implements the `ContainerLifecycleListener` interface.
+This enables the test to handle the container instance after it has been started.
+This is a good place to create an S3 client and the bucket for the test.
+
+.Create S3 client
+[source,java]
+----
+@Override
+public Map<String, String> started(LocalStackContainer container) {
+    S3Client s3Client = createS3Client(container);
+
+    s3Client.createBucket(b -> b.bucket(s3BucketName));
+
+    Map<String, String> conf = new HashMap<>();
+    conf.put("my.app.aws-s3-source.accessKey", container.getAccessKey());
+    conf.put("my.app.aws-s3-source.secretKey", container.getSecretKey());
+    conf.put("my.app.aws-s3-source.region", container.getRegion());
+    conf.put("my.app.aws-s3-source.bucketNameOrArn", s3BucketName);
+    conf.put("my.app.aws-s3-source.uriEndpointOverride", container.getServiceEndpoint().toString());
+    conf.put("my.app.aws-s3-source.overrideEndpoint", "true");
+    conf.put("my.app.aws-s3-source.forcePathStyle", "true");
+
+    return conf;
+}
+----
+
+Also, the started listener may return some application properties that get set for the Quarkus application under test.
+This is the opportunity to set the Testcontainers connection settings for the Quarkus application.
+
+Obviously the Quarkus application uses some property based configuration with the `my.app.*` properties.
+The test is able to reference the Testcontainers exposed settings as values for these properties (e.g. `my.app.aws-s3-source.accessKey=container.getAccessKey()`).
+
+With this configuration in place the test is able to upload and S3 file to the test bucket on the Testcontainers instance with the `uploadS3File()` method.
+This should trigger the Quarkus application under test to handle the new file accordingly.
+We can add some verification and assertion steps to verify that the Quarkus application has handled the S3 file.
+
+This is how Citrus is able to start Testcontainers instances as part of a Quarkus test.
+The application properties supplier as well as the container lifecycle listener interfaces allow us to connect the Quarkus application with the Testcontainers instance.
+The test is able to use the services on the Testcontainers instance to trigger some test data that is consumed by the application under test.
+
+Please also have a look into the other provided Testcontainers annotations in Citrus:
+
+* @LocalStackContainerSupport
+* @KakfaContainerSupport
+* @RedpandaContainerSupport
+* @TestcontainersSupport


### PR DESCRIPTION
- Easily add Testcontainers instance to your Quarkus test using annotation based config
- Enable users to access Testcontainers instance after container has been started/stopped via listeners
- Enable users to supply application properties to the Quarkus application under test (e.g. set connection settings from Testcontainers instance)