### PR TITLE
Auto create AWS clients for LocalStack Testcontainers

### DIFF
--- a/connectors/citrus-testcontainers/pom.xml
+++ b/connectors/citrus-testcontainers/pom.xml
@@ -56,6 +56,28 @@
       <artifactId>commons-dbcp2</artifactId>
     </dependency>
 
+    <!-- Optional AWS clients -->
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>s3</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sqs</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sns</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>dynamodb</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- Optional Quarkus Test integration -->
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/ClientFactory.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/ClientFactory.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.testcontainers.aws2;
+
+import java.util.Optional;
+
+import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.testcontainers.aws2.client.DefaultClientFactoryFinder;
+
+@FunctionalInterface
+public interface ClientFactory<T> {
+
+    /**
+     * Create client for given LocalStackContainer.
+     * @param container
+     * @return
+     */
+    T createClient(LocalStackContainer container);
+
+    /**
+     * Checks if created client is suitable for given service.
+     * @param service
+     * @return
+     */
+    default boolean supports(LocalStackContainer.Service service) {
+        return service != null;
+    }
+
+    static Optional<ClientFactory<?>> lookup(ReferenceResolver referenceResolver, LocalStackContainer.Service service) {
+        Optional<ClientFactory<?>> clientFactoryBean = referenceResolver.resolveAll(ClientFactory.class).values()
+                .stream()
+                .filter(factory -> factory.supports(service))
+                .findFirst()
+                .map(factory -> (ClientFactory<?>) factory);
+
+        if (clientFactoryBean.isPresent()) {
+            return clientFactoryBean;
+        }
+
+        return lookup(service);
+    }
+
+    static Optional<ClientFactory<?>> lookup(LocalStackContainer.Service service) {
+        return new DefaultClientFactoryFinder().find(service);
+    }
+}

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/LocalStackContainer.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/LocalStackContainer.java
@@ -21,7 +21,10 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -45,6 +48,8 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
     private static final String DOCKER_IMAGE_TAG = LocalStackSettings.getVersion();
 
     private final Set<Service> services = new HashSet<>();
+    private final Map<Service, Object> clients = new HashMap<>();
+
     private String secretKey = "secretkey";
     private String accessKey = "accesskey";
     private String region = Region.US_EAST_1.id();
@@ -181,6 +186,34 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
 
     public Service[] getServices() {
         return services.toArray(Service[]::new);
+    }
+
+    public void addClient(Service service, Object client) {
+        this.clients.put(service, client);
+    }
+
+    public <T> T getClient(Service service) {
+        if (!services.contains(service)) {
+            throw new CitrusRuntimeException("Unable to create client for disabled service: %s".formatted(service));
+        }
+
+        Object client = clients.get(service);
+        if (client != null) {
+            return (T) client;
+        }
+
+        // lazy load client for this container
+        Optional<ClientFactory<?>> clientFactory = ClientFactory.lookup(service);
+        if (clientFactory.isPresent()) {
+            client = clientFactory.get().createClient(this);
+            clients.put(service, client);
+        }
+
+        if (client != null) {
+            return (T) client;
+        }
+
+        throw new CitrusRuntimeException("Missing client for service %s".formatted(service));
     }
 
     public enum Service {

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/LocalStackSettings.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/LocalStackSettings.java
@@ -49,6 +49,10 @@ public class LocalStackSettings {
     private static final String CONTAINER_NAME_ENV = LOCALSTACK_ENV_PREFIX + "CONTAINER_NAME";
     public static final String CONTAINER_NAME_DEFAULT = "aws2Container";
 
+    private static final String AUTO_CREATE_CLIENTS_PROPERTY = LOCALSTACK_PROPERTY_PREFIX + "auto.create.clients";
+    private static final String AUTO_CREATE_CLIENTS_ENV = LOCALSTACK_ENV_PREFIX + "AUTO_CREATE_CLIENTS";
+    public static final String AUTO_CREATE_CLIENTS_DEFAULT = "true";
+
     private static final String STARTUP_TIMEOUT_PROPERTY = LOCALSTACK_PROPERTY_PREFIX + "startup.timeout";
     private static final String STARTUP_TIMEOUT_ENV = LOCALSTACK_ENV_PREFIX + "STARTUP_TIMEOUT";
 
@@ -98,6 +102,15 @@ public class LocalStackSettings {
     public static String getContainerName() {
         return System.getProperty(CONTAINER_NAME_PROPERTY,
                 System.getenv(CONTAINER_NAME_ENV) != null ? System.getenv(CONTAINER_NAME_ENV) : CONTAINER_NAME_DEFAULT);
+    }
+
+    /**
+     * Auto create clients for enabled services and add them as beans to the Citrus registry.
+     * @return the enabled/disabled flag.
+     */
+    public static boolean isAutoCreateClients() {
+        return Boolean.parseBoolean(System.getProperty(AUTO_CREATE_CLIENTS_PROPERTY,
+                System.getenv(AUTO_CREATE_CLIENTS_ENV) != null ? System.getenv(AUTO_CREATE_CLIENTS_ENV) : AUTO_CREATE_CLIENTS_DEFAULT));
     }
 
     /**

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/client/DefaultClientFactoryFinder.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/client/DefaultClientFactoryFinder.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.testcontainers.aws2.client;
+
+import java.util.Optional;
+
+import org.citrusframework.testcontainers.aws2.ClientFactory;
+import org.citrusframework.testcontainers.aws2.LocalStackContainer;
+
+public class DefaultClientFactoryFinder {
+
+    public Optional<ClientFactory<?>> find(LocalStackContainer.Service service) {
+        return switch (service) {
+            case S3 -> Optional.of(new S3ClientFactory());
+            case SQS -> Optional.of(new SqsClientFactory());
+            case SNS -> Optional.of(new SnsClientFactory());
+            case DYNAMODB -> Optional.of(new DynamoDbClientFactory());
+            default -> Optional.empty();
+        };
+    }
+
+}

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/client/DynamoDbClientFactory.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/client/DynamoDbClientFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.testcontainers.aws2.client;
+
+import org.citrusframework.testcontainers.aws2.ClientFactory;
+import org.citrusframework.testcontainers.aws2.LocalStackContainer;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+
+public class DynamoDbClientFactory implements ClientFactory<DynamoDbClient> {
+
+    @Override
+    public DynamoDbClient createClient(LocalStackContainer container) {
+        return DynamoDbClient.builder()
+                .endpointOverride(container.getServiceEndpoint())
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(container.getAccessKey(), container.getSecretKey())
+                        )
+                )
+                .region(Region.of(container.getRegion()))
+                .build();
+    }
+
+    @Override
+    public boolean supports(LocalStackContainer.Service service) {
+        return LocalStackContainer.Service.DYNAMODB == service;
+    }
+}

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/client/S3ClientFactory.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/client/S3ClientFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.testcontainers.aws2.client;
+
+import org.citrusframework.testcontainers.aws2.ClientFactory;
+import org.citrusframework.testcontainers.aws2.LocalStackContainer;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+public class S3ClientFactory implements ClientFactory<S3Client> {
+
+    @Override
+    public S3Client createClient(LocalStackContainer container) {
+        return S3Client.builder()
+                .endpointOverride(container.getServiceEndpoint())
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(container.getAccessKey(), container.getSecretKey())
+                        )
+                )
+                .forcePathStyle(true)
+                .region(Region.of(container.getRegion()))
+                .build();
+    }
+
+    @Override
+    public boolean supports(LocalStackContainer.Service service) {
+        return LocalStackContainer.Service.S3 == service;
+    }
+}

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/client/SnsClientFactory.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/client/SnsClientFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.testcontainers.aws2.client;
+
+import org.citrusframework.testcontainers.aws2.ClientFactory;
+import org.citrusframework.testcontainers.aws2.LocalStackContainer;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sns.SnsClient;
+
+public class SnsClientFactory implements ClientFactory<SnsClient> {
+
+    @Override
+    public SnsClient createClient(LocalStackContainer container) {
+        return SnsClient.builder()
+                .endpointOverride(container.getServiceEndpoint())
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(container.getAccessKey(), container.getSecretKey())
+                        )
+                )
+                .region(Region.of(container.getRegion()))
+                .build();
+    }
+
+    @Override
+    public boolean supports(LocalStackContainer.Service service) {
+        return LocalStackContainer.Service.SNS == service;
+    }
+}

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/client/SqsClientFactory.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/client/SqsClientFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.testcontainers.aws2.client;
+
+import org.citrusframework.testcontainers.aws2.ClientFactory;
+import org.citrusframework.testcontainers.aws2.LocalStackContainer;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sqs.SqsClient;
+
+public class SqsClientFactory implements ClientFactory<SqsClient> {
+
+    @Override
+    public SqsClient createClient(LocalStackContainer container) {
+        return SqsClient.builder()
+                .endpointOverride(container.getServiceEndpoint())
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(container.getAccessKey(), container.getSecretKey())
+                        )
+                )
+                .region(Region.of(container.getRegion()))
+                .build();
+    }
+
+    @Override
+    public boolean supports(LocalStackContainer.Service service) {
+        return LocalStackContainer.Service.SQS == service;
+    }
+}

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/xml/Start.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/xml/Start.java
@@ -35,6 +35,7 @@ import org.citrusframework.testcontainers.TestContainersSettings;
 import org.citrusframework.testcontainers.actions.AbstractTestcontainersAction;
 import org.citrusframework.testcontainers.actions.StartTestcontainersAction;
 import org.citrusframework.testcontainers.aws2.LocalStackContainer;
+import org.citrusframework.testcontainers.aws2.LocalStackSettings;
 import org.citrusframework.testcontainers.aws2.StartLocalStackAction;
 import org.citrusframework.testcontainers.kafka.StartKafkaAction;
 import org.citrusframework.testcontainers.mongodb.StartMongoDBAction;
@@ -60,6 +61,8 @@ public class Start extends AbstractTestcontainersAction.Builder<StartTestcontain
         if (container.getVersion() != null) {
             builder.version(container.getVersion());
         }
+
+        builder.autoCreateClients(container.isAutoCreateClients());
 
         configureStartActionBuilder(builder, container);
 
@@ -438,6 +441,9 @@ public class Start extends AbstractTestcontainersAction.Builder<StartTestcontain
         @XmlAttribute
         protected String version;
 
+        @XmlAttribute(name = "auto-create-clients")
+        protected boolean autoCreateClients = LocalStackSettings.isAutoCreateClients();
+
         @XmlAttribute(name = "services")
         protected String serviceList;
 
@@ -467,6 +473,14 @@ public class Start extends AbstractTestcontainersAction.Builder<StartTestcontain
 
         public void setServices(Services services) {
             this.services = services;
+        }
+
+        public boolean isAutoCreateClients() {
+            return autoCreateClients;
+        }
+
+        public void setAutoCreateClients(boolean autoCreateClients) {
+            this.autoCreateClients = autoCreateClients;
         }
 
         @XmlAccessorType(XmlAccessType.FIELD)

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/yaml/Start.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/yaml/Start.java
@@ -27,6 +27,7 @@ import org.citrusframework.testcontainers.TestContainersSettings;
 import org.citrusframework.testcontainers.actions.AbstractTestcontainersAction;
 import org.citrusframework.testcontainers.actions.StartTestcontainersAction;
 import org.citrusframework.testcontainers.aws2.LocalStackContainer;
+import org.citrusframework.testcontainers.aws2.LocalStackSettings;
 import org.citrusframework.testcontainers.aws2.StartLocalStackAction;
 import org.citrusframework.testcontainers.kafka.StartKafkaAction;
 import org.citrusframework.testcontainers.mongodb.StartMongoDBAction;
@@ -49,6 +50,8 @@ public class Start extends AbstractTestcontainersAction.Builder<StartTestcontain
         if (container.getVersion() != null) {
             builder.version(container.getVersion());
         }
+
+        builder.autoCreateClients(container.isAutoCreateClients());
 
         configureStartActionBuilder(builder, container);
 
@@ -309,9 +312,19 @@ public class Start extends AbstractTestcontainersAction.Builder<StartTestcontain
 
     public static class LocalStack extends Container {
 
+        protected boolean autoCreateClients = LocalStackSettings.isAutoCreateClients();
+
         protected String version;
 
         protected List<String> services;
+
+        public boolean isAutoCreateClients() {
+            return autoCreateClients;
+        }
+
+        public void setAutoCreateClients(boolean autoCreateClients) {
+            this.autoCreateClients = autoCreateClients;
+        }
 
         public String getVersion() {
             return version;

--- a/pom.xml
+++ b/pom.xml
@@ -622,7 +622,25 @@
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>s3</artifactId>
         <version>${aws-java-sdk2.version}</version>
-        <scope>test</scope>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>sqs</artifactId>
+        <version>${aws-java-sdk2.version}</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>sns</artifactId>
+        <version>${aws-java-sdk2.version}</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>dynamodb</artifactId>
+        <version>${aws-java-sdk2.version}</version>
+        <scope>provided</scope>
       </dependency>
 
       <!-- Quarkus -->

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-4.5.0-SNAPSHOT.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-4.5.0-SNAPSHOT.xsd
@@ -1981,6 +1981,7 @@
                 <xs:attribute name="service-name" type="xs:string"/>
                 <xs:attribute name="version" type="xs:string"/>
                 <xs:attribute name="auto-remove" type="xs:boolean"/>
+                <xs:attribute name="auto-create-clients" type="xs:boolean"/>
                 <xs:attribute name="services" type="xs:string"/>
                 <xs:attribute name="image" type="xs:string"/>
                 <xs:attribute name="command" type="xs:string"/>

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
@@ -1981,6 +1981,7 @@
                 <xs:attribute name="service-name" type="xs:string"/>
                 <xs:attribute name="version" type="xs:string"/>
                 <xs:attribute name="auto-remove" type="xs:boolean"/>
+                <xs:attribute name="auto-create-clients" type="xs:boolean"/>
                 <xs:attribute name="services" type="xs:string"/>
                 <xs:attribute name="image" type="xs:string"/>
                 <xs:attribute name="command" type="xs:string"/>


### PR DESCRIPTION
- Support a set of clients that get created automatically to access the services on the LocalStack Testcontainers instance