### PR TITLE
fix: Make sure to use current pid to verify Camel app status

### DIFF
--- a/connectors/citrus-jbang-connector/src/main/java/org/citrusframework/jbang/ProcessAndOutput.java
+++ b/connectors/citrus-jbang-connector/src/main/java/org/citrusframework/jbang/ProcessAndOutput.java
@@ -36,7 +36,9 @@ import static org.awaitility.Awaitility.await;
  */
 public class ProcessAndOutput {
 
-    /** Logger */
+    /**
+     * Logger
+     */
     private static final Logger LOG = LoggerFactory.getLogger(ProcessAndOutput.class);
 
     private final Process process;
@@ -140,6 +142,7 @@ public class ProcessAndOutput {
      * Get the process id of first descendant or the parent process itself in case there is no descendant process.
      * On Linux the shell command represents the parent process and the JBang command as descendant process.
      * Typically, we need the JBang command process id.
+     *
      * @return
      */
     public Long getProcessId() {
@@ -150,9 +153,11 @@ public class ProcessAndOutput {
      * Get the process id of first descendant or the parent process itself in case there is no descendant process.
      * On Linux the shell command represents the parent process and the JBang command as descendant process.
      * Typically, we need the JBang command process id.
+     *
      * @return
      */
     public Long getProcessId(String app) {
+
         try {
             if (app != null && isUnix()) {
                 // wait for descendant process to be available
@@ -173,6 +178,17 @@ public class ProcessAndOutput {
         }
     }
 
+    /**
+     * Get the process id of the parent process.
+     * Typically, we need the JBang command process id.
+     *
+     * @return
+     */
+    public Long getParentProcessId() {
+        return process.pid();
+    }
+
+
     private static boolean isUnix() {
         String os = System.getProperty("os.name").toLowerCase();
         return os.contains("nix") || os.contains("nux") || os.contains("aix");
@@ -180,6 +196,7 @@ public class ProcessAndOutput {
 
     /**
      * Sets the application name that identifies this process.
+     *
      * @param app
      */
     public void setApp(String app) {

--- a/connectors/citrus-jbang-connector/src/main/java/org/citrusframework/jbang/ProcessAndOutput.java
+++ b/connectors/citrus-jbang-connector/src/main/java/org/citrusframework/jbang/ProcessAndOutput.java
@@ -44,6 +44,8 @@ public class ProcessAndOutput {
 
     private BufferedReader reader;
 
+    private String app;
+
     ProcessAndOutput(Process process) {
         this(process, "");
     }
@@ -140,9 +142,19 @@ public class ProcessAndOutput {
      * Typically, we need the JBang command process id.
      * @return
      */
+    public Long getProcessId() {
+        return getProcessId(app);
+    }
+
+    /**
+     * Get the process id of first descendant or the parent process itself in case there is no descendant process.
+     * On Linux the shell command represents the parent process and the JBang command as descendant process.
+     * Typically, we need the JBang command process id.
+     * @return
+     */
     public Long getProcessId(String app) {
         try {
-            if (isUnix()) {
+            if (app != null && isUnix()) {
                 // wait for descendant process to be available
                 await().atMost(5000L, TimeUnit.MILLISECONDS)
                         .until(() -> process.descendants().findAny().isPresent());
@@ -164,5 +176,13 @@ public class ProcessAndOutput {
     private static boolean isUnix() {
         String os = System.getProperty("os.name").toLowerCase();
         return os.contains("nix") || os.contains("nux") || os.contains("aix");
+    }
+
+    /**
+     * Sets the application name that identifies this process.
+     * @param app
+     */
+    public void setApp(String app) {
+        this.app = app;
     }
 }

--- a/connectors/citrus-jbang-connector/src/main/java/org/citrusframework/jbang/actions/JBangAction.java
+++ b/connectors/citrus-jbang-connector/src/main/java/org/citrusframework/jbang/actions/JBangAction.java
@@ -83,13 +83,15 @@ public class JBangAction extends AbstractTestAction {
                 .withSystemProperties(systemProperties)
                 .run(context.replaceDynamicContentInString(scriptOrFile), context.resolveDynamicValuesInList(args));
 
+        result.setApp(Objects.requireNonNullElse(app, scriptName));
+
         if (printOutput) {
             logger.info("JBang script '%s' output:".formatted(scriptName));
             logger.info(result.getOutput());
         }
 
         if (pidVar != null) {
-            context.setVariable(pidVar, result.getProcessId(Objects.requireNonNullElse(app, scriptName)));
+            context.setVariable(pidVar, result.getProcessId());
         }
 
         int exitValue = result.getProcess().exitValue();
@@ -105,7 +107,7 @@ public class JBangAction extends AbstractTestAction {
 
         if (validationProcessor != null) {
             validationProcessor.validate(new DefaultMessage(result.getOutput().trim())
-                    .setHeader("pid", result.getProcessId(Objects.requireNonNullElse(app, scriptName)))
+                    .setHeader("pid", result.getProcessId())
                     .setHeader("exitCode", result.getProcess().exitValue()), context);
         }
 

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelRunIntegrationAction.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelRunIntegrationAction.java
@@ -121,14 +121,11 @@ public class CamelRunIntegrationAction extends AbstractCamelJBangAction {
 
             ProcessAndOutput pao = camelJBang().run(name, integrationToRun, resourceFiles, args.toArray(String[]::new));
 
-            if (!pao.getProcess().isAlive()) {
-                logger.info("Failed to start Camel integration '%s'".formatted(name));
-                logger.info(pao.getOutput());
+            verifyProcessIsAlive(pao, name);
 
-                throw new CitrusRuntimeException(String.format("Failed to start Camel integration - exit code %s", pao.getProcess().exitValue()));
-            }
+            pao.setApp(integrationToRun.getFileName().toString());
+            Long pid = pao.getProcessId();
 
-            Long pid = pao.getProcessId(integrationToRun.getFileName().toString());
             context.setVariable(name + ":pid", pid);
             context.setVariable(name + ":process:" + pid, pao);
 
@@ -151,6 +148,15 @@ public class CamelRunIntegrationAction extends AbstractCamelJBangAction {
             }
         } catch (IOException e) {
             throw new CitrusRuntimeException("Failed to create temporary file from Camel integration");
+        }
+    }
+
+    private static void verifyProcessIsAlive(ProcessAndOutput pao, String name) {
+        if (!pao.getProcess().isAlive()) {
+            logger.info("Failed to start Camel integration '%s'".formatted(name));
+            logger.info(pao.getOutput());
+
+            throw new CitrusRuntimeException(String.format("Failed to start Camel integration - exit code %s", pao.getProcess().exitValue()));
         }
     }
 

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelRunIntegrationAction.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelRunIntegrationAction.java
@@ -124,7 +124,7 @@ public class CamelRunIntegrationAction extends AbstractCamelJBangAction {
             verifyProcessIsAlive(pao, name);
 
             pao.setApp(integrationToRun.getFileName().toString());
-            Long pid = pao.getProcessId();
+            Long pid = pao.getParentProcessId();
 
             context.setVariable(name + ":pid", pid);
             context.setVariable(name + ":process:" + pid, pao);


### PR DESCRIPTION
## Bug

The integration tests `org.citrusframework.camel.yaml.JBangTest.shouldLoadCamelActions` and `org.citrusframework.camel.xml.JBangTest.shouldLoadCamelActions` fails on my local environement.
The Camel Jbang CamelRunIntegrationAction sets the wrong process pid from a temporary descendant process in the context. This descendant process is not the Camel Jbang run process. When the CamelVerifyIntegrationAction use the pid from the context object and keeps waiting for the integration process to be Running. 
The descendant process is not active very long.

```
Processing 19951 command: Optional[/usr/bin/bash -c jbang -Dgreeting="Hello Camel" camel@apache/camel run --name hello-yaml --verbose /home/user1/work/sources/gansheer/citrus/endpoints/citrus-camel/target/test-classes/org/citrusframework/camel/integration/route.yaml]
Processing descendant 19963 command: Optional[/usr/lib/jvm/java-21-openjdk-21.0.5.0.11-1.fc41.x86_64/bin/java -classpath /home/user1/.jbang/bin/jbang.jar dev.jbang.Main -Dgreeting=Hello Camel camel@apache/camel run --name hello-yaml --verbose /home/user1/work/sources/gansheer/citrus/endpoints/citrus-camel/target/test-classes/org/citrusframework/camel/integration/route.yaml]
2024-12-17 09:41:01.372|INFO |main|CamelRunIntegrationAction - Started Camel integration 'hello-yaml' (19963)
2024-12-17 09:41:01.382|INFO |main|CamelRunIntegrationAction - Waiting for the Camel integration 'hello-yaml' (19963) to be running ...
2024-12-17 09:41:02.344|INFO |main|CamelVerifyIntegrationAction - Camel JBang version: 4.9.0

2024-12-17 09:41:02.344|INFO |main|CamelVerifyIntegrationAction - Verify Camel integration 'hello-yaml' ...
2024-12-17 09:41:02.344|INFO |main|INTEGRATION_STATUS - Waiting for Camel integration 'hello-yaml' to be in state 'Running'
2024-12-17 09:41:04.263|INFO |main|CamelVerifyIntegrationAction - 
  PID   NAME        READY  STATUS   AGE  TOTAL  REMOTE  FAIL  INFLIGHT   
 19951  hello-yaml   1/1   Running   3s      0       0   0/0       0/0   


2024-12-17 09:41:06.560|INFO |main|CamelVerifyIntegrationAction - Waiting for Camel integration 'hello-yaml' to be in state 'Running'- retry in 2000 ms
2024-12-17 09:41:08.353|INFO |main|CamelVerifyIntegrationAction - 
  PID   NAME       READY  STATUS   AGE  TOTAL  REMOTE  FAIL  INFLIGHT   
 19951  hello-yaml   1/1   Running   7s      4       0   0/0       0/0 
```

## Fix

* Use the parent process pid to identify the running Camel JBang application
* Camel JBang pid may change on Unix OS due to descendant process being launched
* Racing conditions may lead to parent pid being stored in test context
* Make sure to also search for descendant process ids when verifying the Camel integration app status
