### PR TITLE
fix: Make sure to use current pid to verify Camel app status

### DIFF
--- a/connectors/citrus-jbang-connector/src/main/java/org/citrusframework/jbang/ProcessAndOutput.java
+++ b/connectors/citrus-jbang-connector/src/main/java/org/citrusframework/jbang/ProcessAndOutput.java
@@ -44,6 +44,8 @@ public class ProcessAndOutput {
 
     private BufferedReader reader;
 
+    private String app;
+
     ProcessAndOutput(Process process) {
         this(process, "");
     }
@@ -140,9 +142,19 @@ public class ProcessAndOutput {
      * Typically, we need the JBang command process id.
      * @return
      */
+    public Long getProcessId() {
+        return getProcessId(app);
+    }
+
+    /**
+     * Get the process id of first descendant or the parent process itself in case there is no descendant process.
+     * On Linux the shell command represents the parent process and the JBang command as descendant process.
+     * Typically, we need the JBang command process id.
+     * @return
+     */
     public Long getProcessId(String app) {
         try {
-            if (isUnix()) {
+            if (app != null && isUnix()) {
                 // wait for descendant process to be available
                 await().atMost(5000L, TimeUnit.MILLISECONDS)
                         .until(() -> process.descendants().findAny().isPresent());
@@ -164,5 +176,13 @@ public class ProcessAndOutput {
     private static boolean isUnix() {
         String os = System.getProperty("os.name").toLowerCase();
         return os.contains("nix") || os.contains("nux") || os.contains("aix");
+    }
+
+    /**
+     * Sets the application name that identifies this process.
+     * @param app
+     */
+    public void setApp(String app) {
+        this.app = app;
     }
 }

--- a/connectors/citrus-jbang-connector/src/main/java/org/citrusframework/jbang/actions/JBangAction.java
+++ b/connectors/citrus-jbang-connector/src/main/java/org/citrusframework/jbang/actions/JBangAction.java
@@ -83,13 +83,15 @@ public class JBangAction extends AbstractTestAction {
                 .withSystemProperties(systemProperties)
                 .run(context.replaceDynamicContentInString(scriptOrFile), context.resolveDynamicValuesInList(args));
 
+        result.setApp(Objects.requireNonNullElse(app, scriptName));
+
         if (printOutput) {
             logger.info("JBang script '%s' output:".formatted(scriptName));
             logger.info(result.getOutput());
         }
 
         if (pidVar != null) {
-            context.setVariable(pidVar, result.getProcessId(Objects.requireNonNullElse(app, scriptName)));
+            context.setVariable(pidVar, result.getProcessId());
         }
 
         int exitValue = result.getProcess().exitValue();
@@ -105,7 +107,7 @@ public class JBangAction extends AbstractTestAction {
 
         if (validationProcessor != null) {
             validationProcessor.validate(new DefaultMessage(result.getOutput().trim())
-                    .setHeader("pid", result.getProcessId(Objects.requireNonNullElse(app, scriptName)))
+                    .setHeader("pid", result.getProcessId())
                     .setHeader("exitCode", result.getProcess().exitValue()), context);
         }
 

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelRunIntegrationAction.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelRunIntegrationAction.java
@@ -16,11 +16,9 @@
 
 package org.citrusframework.camel.actions;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -29,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import org.citrusframework.camel.CamelSettings;
 import org.citrusframework.camel.jbang.CamelJBangSettings;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;
@@ -124,30 +121,10 @@ public class CamelRunIntegrationAction extends AbstractCamelJBangAction {
 
             ProcessAndOutput pao = camelJBang().run(name, integrationToRun, resourceFiles, args.toArray(String[]::new));
 
-            if (!pao.getProcess().isAlive()) {
-                logger.info("Failed to start Camel integration '%s'".formatted(name));
-                logger.info(pao.getOutput());
+            verifyProcessIsAlive(pao, name);
 
-                throw new CitrusRuntimeException(String.format("Failed to start Camel integration - exit code %s", pao.getProcess().exitValue()));
-            }
-
-            // Wait for first log to unsure the run process is correctly launched before setting the pid in context
-            int maxAttempts = CamelSettings.getMaxAttempts();
-            long delayBetweenAttempts = CamelSettings.getDelayBetweenAttempts();
-            for (int i = 0; i < maxAttempts; i++) {
-                String log = pao.getOutput();
-                if (log.length() > 0) {
-                    break;
-                }
-
-                try {
-                    Thread.sleep(delayBetweenAttempts);
-                } catch (InterruptedException e) {
-                    logger.warn("Interrupted while waiting for Camel integration '%s' first log".formatted(name), e);
-                }
-            }
-
-            Long pid = pao.getProcessId(integrationToRun.getFileName().toString());
+            pao.setApp(integrationToRun.getFileName().toString());
+            Long pid = pao.getProcessId();
 
             context.setVariable(name + ":pid", pid);
             context.setVariable(name + ":process:" + pid, pao);
@@ -171,6 +148,15 @@ public class CamelRunIntegrationAction extends AbstractCamelJBangAction {
             }
         } catch (IOException e) {
             throw new CitrusRuntimeException("Failed to create temporary file from Camel integration");
+        }
+    }
+
+    private static void verifyProcessIsAlive(ProcessAndOutput pao, String name) {
+        if (!pao.getProcess().isAlive()) {
+            logger.info("Failed to start Camel integration '%s'".formatted(name));
+            logger.info(pao.getOutput());
+
+            throw new CitrusRuntimeException(String.format("Failed to start Camel integration - exit code %s", pao.getProcess().exitValue()));
         }
     }
 


### PR DESCRIPTION
- Auto adjust the pid that identifies the running Camel JBang application
- Camel JBang pid may change on Unix OS due to descendant process being launched
- Racing conditions may lead to parent pid being stored in test context
- Make sure to also search for descendant process ids when verifying the Camel integration app status