### PR TITLE
fix(#1294): Allow to set general Docker registry mirror

### DIFF
--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/TestContainersSettings.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/TestContainersSettings.java
@@ -29,6 +29,19 @@ public final class TestContainersSettings {
     private static final String ENABLED_ENV = TESTCONTAINERS_ENV_PREFIX + "ENABLED";
     private static final String ENABLED_DEFAULT = "true";
 
+    public static final String DOCKER_REGISTRY = "docker.io";
+    private static final String REGISTRY_PROPERTY = TESTCONTAINERS_PROPERTY_PREFIX + "registry";
+    private static final String REGISTRY_ENV = TESTCONTAINERS_ENV_PREFIX + "REGISTRY";
+    private static final String REGISTRY_DEFAULT = DOCKER_REGISTRY;
+
+    private static final String REGISTRY_MIRROR_ENABLED_PROPERTY = TESTCONTAINERS_PROPERTY_PREFIX + "registry.mirror.enabled";
+    private static final String REGISTRY_MIRROR_ENABLED_ENV = TESTCONTAINERS_ENV_PREFIX + "REGISTRY_MIRROR_ENABLED";
+    private static final String REGISTRY_MIRROR_ENABLED_DEFAULT = "false";
+
+    private static final String REGISTRY_MIRROR_PROPERTY = TESTCONTAINERS_PROPERTY_PREFIX + "registry.mirror";
+    private static final String REGISTRY_MIRROR_ENV = TESTCONTAINERS_ENV_PREFIX + "REGISTRY_MIRROR";
+    private static final String REGISTRY_MIRROR_DEFAULT = "mirror.gcr.io";
+
     private static final String AUTO_REMOVE_RESOURCES_PROPERTY = TESTCONTAINERS_PROPERTY_PREFIX + "auto.remove.resources";
     private static final String AUTO_REMOVE_RESOURCES_ENV = TESTCONTAINERS_ENV_PREFIX + "AUTO_REMOVE_RESOURCES";
     private static final String AUTO_REMOVE_RESOURCES_DEFAULT = "true";
@@ -77,6 +90,31 @@ public final class TestContainersSettings {
     }
 
     /**
+     * Docker registry.
+     * @return
+     */
+    public static String getRegistry() {
+        return System.getProperty(REGISTRY_PROPERTY, Optional.ofNullable(System.getenv(REGISTRY_ENV)).orElse(REGISTRY_DEFAULT));
+    }
+
+    /**
+     * True when using Docker registry mirror.
+     * @return
+     */
+    public static boolean isRegistryMirrorEnabled() {
+        return Boolean.parseBoolean(System.getProperty(REGISTRY_MIRROR_ENABLED_PROPERTY,
+                Optional.ofNullable(System.getenv(REGISTRY_MIRROR_ENABLED_ENV)).orElse(REGISTRY_MIRROR_ENABLED_DEFAULT)));
+    }
+
+    /**
+     * Docker registry mirror.
+     * @return
+     */
+    public static String getRegistryMirror() {
+        return System.getProperty(REGISTRY_MIRROR_PROPERTY, Optional.ofNullable(System.getenv(REGISTRY_MIRROR_ENV)).orElse(REGISTRY_MIRROR_DEFAULT));
+    }
+
+    /**
      * True when using KubeDock services.
      * @return
      */
@@ -117,5 +155,22 @@ public final class TestContainersSettings {
     public static long getConnectTimeout() {
         return Long.parseLong(System.getProperty(CONNECT_TIMEOUT_PROPERTY,
                 System.getenv(CONNECT_TIMEOUT_ENV) != null ? System.getenv(CONNECT_TIMEOUT_ENV) : CONNECT_TIMEOUT_DEFAULT));
+    }
+
+    /**
+     * Gets the Docker registry to use for pulling Testcontainers images.
+     * Uses registry mirror if enabled.
+     * The default Docker registry is left empty.
+     * @return
+     */
+    public static String getDockerRegistry() {
+        String registry = "";
+        if (TestContainersSettings.isRegistryMirrorEnabled()) {
+            registry = TestContainersSettings.getRegistryMirror() + "/";
+        } else if (!TestContainersSettings.DOCKER_REGISTRY.equals(TestContainersSettings.getRegistry())) {
+            registry = TestContainersSettings.getRegistry() + "/";
+        }
+
+        return registry;
     }
 }

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/actions/StartTestcontainersAction.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/actions/StartTestcontainersAction.java
@@ -30,6 +30,7 @@ import org.citrusframework.spi.Resource;
 import org.citrusframework.spi.Resources;
 import org.citrusframework.testcontainers.TestContainersSettings;
 import org.citrusframework.testcontainers.WaitStrategyHelper;
+import org.citrusframework.util.StringUtils;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -298,7 +299,14 @@ public class StartTestcontainersAction<C extends GenericContainer<?>> extends Ab
         }
 
         protected C buildContainer() {
-            C container = (C) new GenericContainer<>(image);
+            String imageName;
+            if (StringUtils.hasText(TestContainersSettings.getRegistry()) && !image.startsWith(TestContainersSettings.getDockerRegistry())) {
+                imageName = TestContainersSettings.getDockerRegistry() + image;
+            } else {
+                imageName = image;
+            }
+
+            C container = (C) new GenericContainer<>(imageName);
 
             if (network != null) {
                 container.withNetwork(network);

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/LocalStackSettings.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/LocalStackSettings.java
@@ -73,7 +73,7 @@ public class LocalStackSettings {
      * @return
      */
     public static String getImageName() {
-        return System.getProperty(IMAGE_NAME_PROPERTY,
+        return TestContainersSettings.getDockerRegistry() + System.getProperty(IMAGE_NAME_PROPERTY,
                 System.getenv(IMAGE_NAME_ENV) != null ? System.getenv(IMAGE_NAME_ENV) : IMAGE_NAME_DEFAULT);
     }
 

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/KafkaSettings.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/KafkaSettings.java
@@ -59,7 +59,7 @@ public class KafkaSettings {
      * @return
      */
     public static String getImageName() {
-        return System.getProperty(IMAGE_NAME_PROPERTY,
+        return TestContainersSettings.getDockerRegistry() + System.getProperty(IMAGE_NAME_PROPERTY,
                 System.getenv(IMAGE_NAME_ENV) != null ? System.getenv(IMAGE_NAME_ENV) : IMAGE_NAME_DEFAULT);
     }
 

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/mongodb/MongoDBSettings.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/mongodb/MongoDBSettings.java
@@ -28,6 +28,10 @@ public class MongoDBSettings {
     private static final String MONGODB_PROPERTY_PREFIX = TestContainersSettings.TESTCONTAINERS_PROPERTY_PREFIX + "mongodb.";
     private static final String MONGODB_ENV_PREFIX = TestContainersSettings.TESTCONTAINERS_ENV_PREFIX + "MONGODB_";
 
+    private static final String IMAGE_NAME_PROPERTY = MONGODB_PROPERTY_PREFIX + "image.name";
+    private static final String IMAGE_NAME_ENV = MONGODB_ENV_PREFIX + "IMAGE_NAME";
+    private static final String IMAGE_NAME_DEFAULT = "mongo";
+
     private static final String VERSION_PROPERTY = MONGODB_PROPERTY_PREFIX + "version";
     private static final String VERSION_ENV = MONGODB_ENV_PREFIX + "VERSION";
     private static final String VERSION_DEFAULT = "4.0.10";
@@ -46,6 +50,15 @@ public class MongoDBSettings {
 
     private MongoDBSettings() {
         // prevent instantiation of utility class
+    }
+
+    /**
+     * MongoDB image name setting.
+     * @return
+     */
+    public static String getImageName() {
+        return TestContainersSettings.getDockerRegistry() + System.getProperty(IMAGE_NAME_PROPERTY,
+                System.getenv(IMAGE_NAME_ENV) != null ? System.getenv(IMAGE_NAME_ENV) : IMAGE_NAME_DEFAULT);
     }
 
     /**

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/mongodb/StartMongoDBAction.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/mongodb/StartMongoDBAction.java
@@ -17,7 +17,6 @@
 package org.citrusframework.testcontainers.mongodb;
 
 import org.citrusframework.context.TestContext;
-import org.citrusframework.kubernetes.KubernetesSupport;
 import org.citrusframework.testcontainers.TestContainersSettings;
 import org.citrusframework.testcontainers.actions.StartTestcontainersAction;
 import org.citrusframework.testcontainers.postgresql.PostgreSQLSettings;
@@ -63,7 +62,7 @@ public class StartMongoDBAction extends StartTestcontainersAction<MongoDBContain
             }
 
             if (image == null) {
-                image("mongo");
+                image(MongoDBSettings.getImageName());
             }
 
             withLabel("app", "citrus");

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/postgresql/PostgreSQLSettings.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/postgresql/PostgreSQLSettings.java
@@ -28,6 +28,10 @@ public class PostgreSQLSettings {
     private static final String POSTGRESQL_PROPERTY_PREFIX = TestContainersSettings.TESTCONTAINERS_PROPERTY_PREFIX + "postgresql.";
     private static final String POSTGRESQL_ENV_PREFIX = TestContainersSettings.TESTCONTAINERS_ENV_PREFIX + "POSTGRESQL_";
 
+    private static final String IMAGE_NAME_PROPERTY = POSTGRESQL_PROPERTY_PREFIX + "image.name";
+    private static final String IMAGE_NAME_ENV = POSTGRESQL_ENV_PREFIX + "IMAGE_NAME";
+    private static final String IMAGE_NAME_DEFAULT = "postgres";
+
     private static final String POSTGRESQL_VERSION_PROPERTY = POSTGRESQL_PROPERTY_PREFIX + "version";
     private static final String POSTGRESQL_VERSION_ENV = POSTGRESQL_ENV_PREFIX + "POSTGRESQL_VERSION";
     private static final String POSTGRESQL_VERSION_DEFAULT = PostgreSQLContainer.DEFAULT_TAG;
@@ -58,6 +62,15 @@ public class PostgreSQLSettings {
 
     private PostgreSQLSettings() {
         // prevent instantiation of utility class
+    }
+
+    /**
+     * PostgreSQL image name setting.
+     * @return
+     */
+    public static String getImageName() {
+        return TestContainersSettings.getDockerRegistry() + System.getProperty(IMAGE_NAME_PROPERTY,
+                System.getenv(IMAGE_NAME_ENV) != null ? System.getenv(IMAGE_NAME_ENV) : IMAGE_NAME_DEFAULT);
     }
 
     /**

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/postgresql/StartPostgreSQLAction.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/postgresql/StartPostgreSQLAction.java
@@ -22,7 +22,6 @@ import javax.script.ScriptException;
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;
-import org.citrusframework.kubernetes.KubernetesSupport;
 import org.citrusframework.spi.Resource;
 import org.citrusframework.spi.Resources;
 import org.citrusframework.testcontainers.TestContainersSettings;
@@ -155,7 +154,7 @@ public class StartPostgreSQLAction extends StartTestcontainersAction<PostgreSQLC
             }
 
             if (image == null) {
-                image("postgres");
+                image(PostgreSQLSettings.getImageName());
             }
 
             env.putIfAbsent("PGDATA", "/var/lib/postgresql/data/mydata");

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/redpanda/RedpandaSettings.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/redpanda/RedpandaSettings.java
@@ -55,11 +55,11 @@ public class RedpandaSettings {
     }
 
     /**
-     * Redpanda version setting.
+     * Redpanda image name setting.
      * @return
      */
     public static String getImageName() {
-        return System.getProperty(IMAGE_NAME_PROPERTY,
+        return TestContainersSettings.getDockerRegistry() + System.getProperty(IMAGE_NAME_PROPERTY,
                 System.getenv(IMAGE_NAME_ENV) != null ? System.getenv(IMAGE_NAME_ENV) : IMAGE_NAME_DEFAULT);
     }
 


### PR DESCRIPTION
- Users may set Docker registry mirror for Testcontainers images used in Citrus