### PR TITLE
fix(#1302): Fix total test duration report

### DIFF
--- a/core/citrus-api/src/main/java/org/citrusframework/report/TestResults.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/report/TestResults.java
@@ -16,19 +16,18 @@
 
 package org.citrusframework.report;
 
-import org.citrusframework.TestResult;
-
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicLong;
+
+import org.citrusframework.TestResult;
 
 import static java.util.Collections.synchronizedSet;
-import static java.util.Objects.nonNull;
 
 /**
  * Multiple {@link org.citrusframework.TestResult} instances combined to a {@link TestResults}.
@@ -47,8 +46,6 @@ public class TestResults {
      */
     private final Set<TestResult> results = synchronizedSet(new LinkedHashSet<>());
 
-    private final AtomicLong totalDurationMillis = new AtomicLong(0);
-
     /**
      * Provides access to results as list generated from synchronized result list.
      */
@@ -62,10 +59,6 @@ public class TestResults {
      * Adds a test result to the result list.
      */
     public boolean addResult(TestResult result) {
-        if (nonNull(result.getDuration())) {
-            totalDurationMillis.accumulateAndGet(result.getDuration().toMillis(), Long::sum);
-        }
-
         return results.add(result);
     }
 
@@ -195,7 +188,10 @@ public class TestResults {
      * Gets the total duration of all tests.
      */
     public Duration getTotalDuration() {
-        return Duration.ofMillis(totalDurationMillis.get());
+        return Duration.ofMillis(results.stream()
+                .filter(r -> Objects.nonNull(r.getDuration()))
+                .mapToLong(r -> r.getDuration().toMillis())
+                .sum());
     }
 
     private DecimalFormat getNewDecimalFormat() {

--- a/core/citrus-base/src/main/java/org/citrusframework/report/LoggingReporter.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/report/LoggingReporter.java
@@ -16,12 +16,8 @@
 
 package org.citrusframework.report;
 
-import static java.lang.String.format;
-import static java.time.Duration.ZERO;
-import static java.util.Objects.nonNull;
-import static org.citrusframework.util.StringUtils.hasText;
-
 import java.util.Optional;
+
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.citrusframework.CitrusVersion;
 import org.citrusframework.TestAction;
@@ -34,6 +30,11 @@ import org.citrusframework.message.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.helpers.NOPLoggerFactory;
+
+import static java.lang.String.format;
+import static java.time.Duration.ZERO;
+import static java.util.Objects.nonNull;
+import static org.citrusframework.util.StringUtils.hasText;
 
 /**
  * Simple logging reporter printing test start and ending to the console/logger.
@@ -115,10 +116,14 @@ public class LoggingReporter extends AbstractTestReporter implements MessageList
         newLine();
 
         info(format("TOTAL:\t\t%s", testResults.getFailed() + testResults.getSuccess()));
-        info(format("SUCCESS:\t%s (%s%%)", testResults.getSuccess(), testResults.getSuccessPercentageFormatted()));
+        info(format("PASSED:\t\t%s (%s%%)", testResults.getSuccess(), testResults.getSuccessPercentageFormatted()));
         info(format("FAILED:\t\t%s (%s%%)", testResults.getFailed(), testResults.getFailedPercentageFormatted()));
-        debug(format("SKIPPED:\t%s (%s%%)", testResults.getSkipped(), testResults.getSkippedPercentageFormatted()));
-        info(format("PERFORMANCE:\t%s ms", testResults.getTotalDuration().toMillis()));
+
+        if (testResults.getSkipped() > 0) {
+            info(format("SKIP:\t\t%s (%s%%)", testResults.getSkipped(), testResults.getSkippedPercentageFormatted()));
+        }
+
+        info(format("TIME:\t\t%s ms", testResults.getTotalDuration().toMillis()));
 
         newLine();
 

--- a/core/citrus-base/src/test/java/org/citrusframework/report/LoggingReporterTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/report/LoggingReporterTest.java
@@ -223,9 +223,9 @@ public class LoggingReporterTest {
 
     private void verifyResultSummaryLog(int total, int success, int failed, long performance) {
         verify(logger).info("TOTAL:\t\t" + total);
-        verify(logger).info("SUCCESS:\t" + success + " (" + calculatePercentage(total, success) + "%)");
+        verify(logger).info("PASSED:\t\t" + success + " (" + calculatePercentage(total, success) + "%)");
         verify(logger).info("FAILED:\t\t" + failed + " (" + calculatePercentage(total, failed) + "%)");
-        verify(logger).info("PERFORMANCE:\t" + performance + " ms");
+        verify(logger).info("TIME:\t\t" + performance + " ms");
     }
 
     private String calculatePercentage(int total, int success) {


### PR DESCRIPTION
- Make sure to print total test duration in milliseconds
- Improve test report summary logs