### PR TITLE
chore: include template name in success message

### DIFF
--- a/core/citrus-base/src/main/java/org/citrusframework/container/Template.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/container/Template.java
@@ -16,15 +16,6 @@
 
 package org.citrusframework.container;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
 import org.citrusframework.AbstractTestActionBuilder;
 import org.citrusframework.TestAction;
 import org.citrusframework.TestActionBuilder;
@@ -40,6 +31,15 @@ import org.citrusframework.util.FileUtils;
 import org.citrusframework.variable.VariableUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * This class represents a previously defined block of test actions. Test cases can call
@@ -90,9 +90,7 @@ public class Template extends AbstractTestAction {
 
     @Override
     public void doExecute(TestContext context) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Executing template '" + getName() + "' with " + actions.size() + " embedded actions");
-        }
+        logger.debug("Executing template '{}' with {} embedded actions", getTemplateName(), actions.size());
 
         TestContext innerContext;
 
@@ -112,9 +110,7 @@ public class Template extends AbstractTestAction {
                 paramValue = FunctionUtils.resolveFunction(paramValue, context);
             }
 
-            if (logger.isDebugEnabled()) {
-                logger.debug("Setting parameter for template " + param + "=" + paramValue);
-            }
+            logger.debug("Setting parameter for template {}={}", param, paramValue);
 
             innerContext.setVariable(param, paramValue);
         }
@@ -123,7 +119,7 @@ public class Template extends AbstractTestAction {
             action.build().execute(innerContext);
         }
 
-        logger.info("Template was executed successfully");
+        logger.info("Template '{}' was executed successfully", getTemplateName());
     }
 
     /**
@@ -349,8 +345,8 @@ public class Template extends AbstractTestAction {
          * @return the builder itself or the delegate builder if this builder is a delegating builder.
          */
         private TestActionBuilder<?> resolveActionBuilder(TestActionBuilder<?> builder) {
-            if (builder instanceof DelegatingTestActionBuilder) {
-                return resolveActionBuilder(((DelegatingTestActionBuilder<?>) builder).getDelegate());
+            if (builder instanceof DelegatingTestActionBuilder<?> delegatingTestActionBuilder) {
+                return resolveActionBuilder(delegatingTestActionBuilder.getDelegate());
             }
             return builder;
         }


### PR DESCRIPTION
I want to know _which_ template was successfully executed.