### PR TITLE
feat(#1218): add events on TestListener

### DIFF
--- a/core/citrus-api/src/main/java/org/citrusframework/context/TestContext.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/context/TestContext.java
@@ -446,7 +446,7 @@ public class TestContext implements ReferenceResolverAware, TestActionListenerAw
         try {
             testListeners.onTestStart(dummyTest);
             testListeners.onTestFailure(dummyTest, exception);
-            testListeners.onTestFinish(dummyTest);
+            testListeners.onTestExecutionEnd(dummyTest);
         } catch (Exception e) {
             logger.warn("Executing error handler listener failed!", e);
         }

--- a/core/citrus-api/src/main/java/org/citrusframework/report/TestListener.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/report/TestListener.java
@@ -20,36 +20,105 @@ import org.citrusframework.TestCase;
 
 /**
  * Test listener interface. Listeners invoked on test start, finish, failure, skip, success.
- *
  */
 public interface TestListener {
     /**
-     * Invoked when test gets started
-     * @param test
+     * Invoked when test when a test starts execution
      */
     void onTestStart(TestCase test);
 
     /**
-     * Invoked when test gets finished
-     * @param test
+     * @deprecated use on {@link #onTestExecutionEnd(TestCase)}
      */
-    void onTestFinish(TestCase test);
+    @Deprecated(forRemoval = true)
+    default void onTestFinish(TestCase test) {
+        // Do nothing
+    }
 
     /**
-     * Invoked when test finished with success
-     * @param test
+     * Invoked when test execution has ended (after final actions execution and
+     * before {@link org.citrusframework.container.AfterTest} execution)
+     *
+     * @see #onTestEnd(TestCase)
+     */
+    default void onTestExecutionStart(TestCase test) {
+        onTestFinish(test);
+    }
+
+
+    /**
+     * Invoked when test execution has ended (after final actions execution and
+     * before {@link org.citrusframework.container.AfterTest} execution)
+     *
+     * @see #onTestEnd(TestCase)
+     */
+    default void onTestExecutionEnd(TestCase test) {
+        onTestFinish(test);
+    }
+
+    /**
+     * Invoked at the very end of test execution
+     *
+     * @see #onTestFinish(TestCase)
+     */
+    default void onTestEnd(TestCase test) {
+        // Default implementation does nothing
+    }
+
+    /**
+     * Invoked when a test finishes successfully
      */
     void onTestSuccess(TestCase test);
 
     /**
-     * Invoked when test finished with failure
-     * @param test
+     * Invoked when a test finishes with failure
      */
     void onTestFailure(TestCase test, Throwable cause);
 
     /**
-     * Invoked when test is skipped
-     * @param test
+     * Invoked when a test is skipped
      */
     void onTestSkipped(TestCase test);
+
+    /**
+     * Invoked when final actions start, only if any exist
+     */
+    default void onFinalActionsStart(TestCase test) {
+        // Default implementation does nothing
+    }
+
+    /**
+     * Invoked after final actions have completely finished, only if any exist
+     */
+    default void onFinalActionsEnd(TestCase test) {
+        // Default implementation does nothing
+    }
+
+    /**
+     * Invoked when {@link org.citrusframework.container.BeforeTest} execution starts, only if any exist
+     */
+    default void onBeforeTestStart(TestCase test) {
+        // Default implementation does nothing
+    }
+
+    /**
+     * Invoked when {@link org.citrusframework.container.BeforeTest} execution ends, only if any exist
+     */
+    default void onBeforeTestEnd(TestCase test) {
+        // Default implementation does nothing
+    }
+
+    /**
+     * Invoked when {@link org.citrusframework.container.AfterTest} execution starts, only if any exist
+     */
+    default void onAfterTestStart(TestCase test) {
+        // Default implementation does nothing
+    }
+
+    /**
+     * Invoked when {@link org.citrusframework.container.AfterTest} execution ends, only if any exist
+     */
+    default void onAfterTestEnd(TestCase test) {
+        // Default implementation does nothing
+    }
 }

--- a/core/citrus-api/src/main/java/org/citrusframework/report/TestListeners.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/report/TestListeners.java
@@ -37,9 +37,26 @@ public class TestListeners implements TestListenerAware {
         }
     }
 
+    /**
+     * @deprecated use on {@link #onTestExecutionEnd(TestCase)}
+     */
+    @Deprecated(forRemoval = true)
     public void onTestFinish(TestCase test) {
         for (TestListener listener : testListeners) {
             listener.onTestFinish(test);
+        }
+    }
+
+    public void onTestExecutionStart(TestCase test) {
+        for (TestListener listener : testListeners) {
+            listener.onTestExecutionStart(test);
+        }
+
+    }
+
+    public void onTestExecutionEnd(TestCase test) {
+        for (TestListener listener : testListeners) {
+            listener.onTestExecutionEnd(test);
         }
     }
 
@@ -52,6 +69,48 @@ public class TestListeners implements TestListenerAware {
     public void onTestStart(TestCase test) {
         for (TestListener listener : testListeners) {
             listener.onTestStart(test);
+        }
+    }
+
+    public void onTestFinalization(TestCase test) {
+        for (TestListener listener : testListeners) {
+            listener.onTestEnd(test);
+        }
+    }
+
+    public void onFinalActionsStart(TestCase test) {
+        for (TestListener listener : testListeners) {
+            listener.onFinalActionsStart(test);
+        }
+    }
+
+    public void onFinalActionsEnd(TestCase test) {
+        for (TestListener listener : testListeners) {
+            listener.onFinalActionsEnd(test);
+        }
+    }
+
+    public void onBeforeTestEnd(TestCase test) {
+        for (TestListener listener : testListeners) {
+            listener.onBeforeTestEnd(test);
+        }
+    }
+
+    public void onAfterTestEnd(TestCase test) {
+        for (TestListener listener : testListeners) {
+            listener.onAfterTestEnd(test);
+        }
+    }
+
+    public void onBeforeTestStart(TestCase test) {
+        for (TestListener listener : testListeners) {
+            listener.onBeforeTestStart(test);
+        }
+    }
+
+    public void onAfterTestStart(TestCase test) {
+        for (TestListener listener : testListeners) {
+            listener.onAfterTestStart(test);
         }
     }
 
@@ -70,7 +129,6 @@ public class TestListeners implements TestListenerAware {
 
     /**
      * Obtains the testListeners.
-     * @return
      */
     public List<TestListener> getTestListeners() {
         return testListeners;

--- a/core/citrus-api/src/main/java/org/citrusframework/report/TestReporters.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/report/TestReporters.java
@@ -80,7 +80,7 @@ public class TestReporters implements TestListener, TestSuiteListener, TestRepor
     }
 
     @Override
-    public void onTestFinish(TestCase test) {
+    public void onTestExecutionEnd(TestCase test) {
         if (nonNull(test.getTestResult())) {
             testResults.addResult(test.getTestResult());
         }
@@ -108,8 +108,6 @@ public class TestReporters implements TestListener, TestSuiteListener, TestRepor
 
     /**
      * Obtains the testReporters.
-     *
-     * @return
      */
     public List<TestReporter> getTestReporters() {
         return unmodifiableList(testReporters);
@@ -117,8 +115,6 @@ public class TestReporters implements TestListener, TestSuiteListener, TestRepor
 
     /**
      * Obtains the autoClear.
-     *
-     * @return
      */
     public boolean isAutoClear() {
         return autoClear;
@@ -126,8 +122,6 @@ public class TestReporters implements TestListener, TestSuiteListener, TestRepor
 
     /**
      * Specifies the autoClear.
-     *
-     * @param autoClear
      */
     public void setAutoClear(boolean autoClear) {
         this.autoClear = autoClear;
@@ -135,8 +129,6 @@ public class TestReporters implements TestListener, TestSuiteListener, TestRepor
 
     /**
      * Gets the testResults.
-     *
-     * @return
      */
     public TestResults getTestResults() {
         return testResults;

--- a/core/citrus-api/src/test/java/org/citrusframework/context/TestContextUnitTest.java
+++ b/core/citrus-api/src/test/java/org/citrusframework/context/TestContextUnitTest.java
@@ -54,13 +54,13 @@ public class TestContextUnitTest {
         var testListenerMock = attachTestListenerMockToFixture();
 
         var cause = new CitrusRuntimeException("thrown with a purpose!");
-        doThrow(cause).when(testListenerMock).onTestFinish(any(TestContext.EmptyTestCase.class));
+        doThrow(cause).when(testListenerMock).onTestExecutionEnd(any(TestContext.EmptyTestCase.class));
 
         invokeHandleErrorOnFixture(cause);
 
         verify(testListenerMock).onTestStart(any(TestContext.EmptyTestCase.class));
         verify(testListenerMock).onTestFailure(any(TestContext.EmptyTestCase.class), any(CitrusRuntimeException.class));
-        verify(testListenerMock).onTestFinish(any(TestContext.EmptyTestCase.class));
+        verify(testListenerMock).onTestExecutionEnd(any(TestContext.EmptyTestCase.class));
     }
 
     private TestListener attachTestListenerMockToFixture() {

--- a/core/citrus-api/src/test/java/org/citrusframework/report/TestReportersTest.java
+++ b/core/citrus-api/src/test/java/org/citrusframework/report/TestReportersTest.java
@@ -77,11 +77,11 @@ public class TestReportersTest {
     }
 
     @Test
-    public void onTestFinishAddsTestResultToList() {
+    public void onTestExecutionEndAddsTestResultToList() {
         var testResultMock = mock(TestResult.class);
         doReturn(testResultMock).when(testCaseMock).getTestResult();
 
-        fixture.onTestFinish(testCaseMock);
+        fixture.onTestExecutionEnd(testCaseMock);
 
         var testResults = fixture.getTestResults().asList();
         assertEquals(1, testResults.size());
@@ -89,10 +89,10 @@ public class TestReportersTest {
     }
 
     @Test
-    public void onTestFinishIgnoresNullTestResult() {
+    public void onTestExecutionEndIgnoresNullTestResult() {
         doReturn(null).when(testCaseMock).getTestResult();
 
-        fixture.onTestFinish(testCaseMock);
+        fixture.onTestExecutionEnd(testCaseMock);
 
         var testResults = fixture.getTestResults().asList();
         assertEquals(0, testResults.size());

--- a/core/citrus-base/src/main/java/org/citrusframework/report/AbstractTestListener.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/report/AbstractTestListener.java
@@ -29,7 +29,7 @@ public abstract class AbstractTestListener implements TestListener {
     public void onTestFailure(TestCase test, Throwable cause) {}
 
     @Override
-    public void onTestFinish(TestCase test) {}
+    public void onTestExecutionEnd(TestCase test) {}
 
     @Override
     public void onTestSkipped(TestCase test) {}

--- a/core/citrus-base/src/main/java/org/citrusframework/report/HtmlReporter.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/report/HtmlReporter.java
@@ -47,7 +47,7 @@ public class HtmlReporter extends AbstractOutputFileReporter implements TestList
     private static final Logger logger = LoggerFactory.getLogger(HtmlReporter.class);
 
     /** Map holding additional information of test cases */
-    private Map<String, ResultDetail> details = new HashMap<>();
+    private final Map<String, ResultDetail> details = new HashMap<>();
 
     /** Static resource for the HTML test report template */
     private String reportTemplate = HtmlReporterSettings.getReportTemplate();
@@ -119,8 +119,6 @@ public class HtmlReporter extends AbstractOutputFileReporter implements TestList
 
     /**
      * Reads citrus logo png image and converts to base64 encoded string for inline HTML image display.
-     * @return
-     * @throws IOException
      */
     private String getLogoImageData() {
         ByteArrayOutputStream os = new ByteArrayOutputStream();
@@ -158,7 +156,6 @@ public class HtmlReporter extends AbstractOutputFileReporter implements TestList
      * Gets the code section from test case XML which is responsible for the
      * error.
      * @param cause the error cause.
-     * @return
      */
     private String getCodeSnippetHtml(Throwable cause) {
         StringBuilder codeSnippet = new StringBuilder();
@@ -229,7 +226,6 @@ public class HtmlReporter extends AbstractOutputFileReporter implements TestList
     /**
      * Construct HTML code snippet for stack trace information.
      * @param cause the causing error.
-     * @return
      */
     private String getStackTraceHtml(Throwable cause) {
         StringBuilder stackTraceBuilder = new StringBuilder();
@@ -243,7 +239,7 @@ public class HtmlReporter extends AbstractOutputFileReporter implements TestList
         }
 
         return "<tr><td colspan=\"2\">" +
-        		"<div class=\"error-detail\"><pre>" + stackTraceBuilder.toString() +
+        		"<div class=\"error-detail\"><pre>" + stackTraceBuilder +
         		"</pre>" + getCodeSnippetHtml(cause) + "</div></td></tr>";
     }
 
@@ -253,7 +249,7 @@ public class HtmlReporter extends AbstractOutputFileReporter implements TestList
     }
 
     @Override
-    public void onTestFinish(TestCase test) {
+    public void onTestExecutionEnd(TestCase test) {
         // do nothing
     }
 
@@ -292,7 +288,6 @@ public class HtmlReporter extends AbstractOutputFileReporter implements TestList
     /**
      * Sets the reportFileName property.
      *
-     * @param reportFileName
      */
     public void setReportFileName(String reportFileName) {
         this.reportFileName = reportFileName;
@@ -301,7 +296,6 @@ public class HtmlReporter extends AbstractOutputFileReporter implements TestList
     /**
      * Gets the reportFileName.
      *
-     * @return
      */
     @Override
     public String getReportFileName() {
@@ -311,7 +305,6 @@ public class HtmlReporter extends AbstractOutputFileReporter implements TestList
     /**
      * Sets the dateFormat property.
      *
-     * @param dateFormat
      */
     public void setDateFormat(DateFormat dateFormat) {
         this.dateFormat = dateFormat;
@@ -320,7 +313,6 @@ public class HtmlReporter extends AbstractOutputFileReporter implements TestList
     /**
      * Sets the reportTemplate property.
      *
-     * @param reportTemplate
      */
     public void setReportTemplate(String reportTemplate) {
         this.reportTemplate = reportTemplate;
@@ -329,7 +321,6 @@ public class HtmlReporter extends AbstractOutputFileReporter implements TestList
     /**
      * Sets the testDetailTemplate property.
      *
-     * @param testDetailTemplate
      */
     public void setTestDetailTemplate(String testDetailTemplate) {
         this.testDetailTemplate = testDetailTemplate;
@@ -337,7 +328,6 @@ public class HtmlReporter extends AbstractOutputFileReporter implements TestList
 
     /**
      * Sets the enabled property.
-     * @param enabled
      */
     public void setEnabled(boolean enabled) {
         this.enabled = enabled;

--- a/core/citrus-base/src/main/java/org/citrusframework/report/LoggingReporter.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/report/LoggingReporter.java
@@ -169,7 +169,7 @@ public class LoggingReporter extends AbstractTestReporter implements MessageList
     }
 
     @Override
-    public void onTestFinish(TestCase test) {
+    public void onTestExecutionEnd(TestCase test) {
         // do nothing
     }
 

--- a/core/citrus-base/src/main/java/org/citrusframework/report/MessageTracingTestListener.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/report/MessageTracingTestListener.java
@@ -34,10 +34,12 @@ import org.citrusframework.message.RawMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static java.lang.System.lineSeparator;
+
 /**
  * Test listener collects all messages sent and received by Citrus during test execution. Listener
  * writes a trace file with all message content per test case to a output directory.
- *
+ * <p>
  * Note: This class is not thread safe! Parallel test execution leads to behaviour that messages get mixed.
  * Proper correlation to test case is not possible here.
  *
@@ -77,7 +79,7 @@ public class MessageTracingTestListener extends AbstractTestListener implements 
      * {@inheritDoc}
      */
     @Override
-    public void onTestFinish(TestCase test) {
+    public void onTestExecutionEnd(TestCase test) {
         if (messages.isEmpty()) {
             return; // do not write empty message trace file
         }
@@ -118,7 +120,6 @@ public class MessageTracingTestListener extends AbstractTestListener implements 
 
     /**
      * Creates message separator line.
-     * @return
      */
     private String separator() {
         return "======================================================================";
@@ -126,10 +127,9 @@ public class MessageTracingTestListener extends AbstractTestListener implements 
 
     /**
      * Get new line character.
-     * @return
      */
     private String newLine() {
-        return System.getProperty("line.separator");
+        return lineSeparator();
     }
 
     /**

--- a/core/citrus-base/src/test/java/org/citrusframework/report/LoggingReporterTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/report/LoggingReporterTest.java
@@ -93,7 +93,7 @@ public class LoggingReporterTest {
         fixture.onTestStart(test);
         fixture.onTestActionStart(test, echo);
         fixture.onTestActionFinish(test, echo);
-        fixture.onTestFinish(test);
+        fixture.onTestExecutionEnd(test);
         fixture.onTestSuccess(test);
         fixture.onFinish();
         fixture.onFinishSuccess();
@@ -123,7 +123,7 @@ public class LoggingReporterTest {
         fixture.onStartSuccess();
         fixture.onTestStart(test);
         fixture.onTestActionStart(test, echo);
-        fixture.onTestFinish(test);
+        fixture.onTestExecutionEnd(test);
         fixture.onTestFailure(test, cause);
         fixture.onFinish();
         fixture.onFinishSuccess();
@@ -171,7 +171,7 @@ public class LoggingReporterTest {
         fixture.onStart();
         fixture.onStartSuccess();
         fixture.onTestStart(test);
-        fixture.onTestFinish(test);
+        fixture.onTestExecutionEnd(test);
         fixture.onTestSuccess(test);
         fixture.onTestSkipped(new DefaultTestCase());
         fixture.onFinish();
@@ -207,7 +207,7 @@ public class LoggingReporterTest {
         fixture.onTestStart(test);
         fixture.onTestActionStart(test, echo);
         fixture.onTestActionFinish(test, echo);
-        fixture.onTestFinish(test);
+        fixture.onTestExecutionEnd(test);
         fixture.onTestSuccess(test);
         fixture.onFinish();
         fixture.onFinishFailure(new CitrusRuntimeException("Failed!"));

--- a/core/citrus-base/src/test/java/org/citrusframework/report/MessageTracingTestListenerTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/report/MessageTracingTestListenerTest.java
@@ -43,13 +43,13 @@ public class MessageTracingTestListenerTest extends UnitTestSupport {
     }
 
     @Test
-    public void shouldReturnTheSameTraceFile() throws Exception {
+    public void shouldReturnTheSameTraceFile() {
         String testname = "SomeDummyTest";
         Assert.assertEquals(testling.getTraceFile(testname).getAbsolutePath(), testling.getTraceFile(testname).getAbsolutePath());
     }
 
     @Test
-    public void shouldContainMessages() throws Exception {
+    public void shouldContainMessages() {
         String testname = "SomeDummyTest";
         String inboundPayload = "Inbound Message";
         String outboundPayload = "Outbound Message";
@@ -61,7 +61,7 @@ public class MessageTracingTestListenerTest extends UnitTestSupport {
         testling.onTestStart(testCaseMock);
         testling.onInboundMessage(inboundMessageMock, context);
         testling.onOutboundMessage(outboundMessageMock, context);
-        testling.onTestFinish(testCaseMock);
+        testling.onTestExecutionEnd(testCaseMock);
 
         assertFileExistsWithContent(testname, inboundPayload);
         assertFileExistsWithContent(testname, outboundPayload);

--- a/tools/restdocs/src/main/java/org/citrusframework/restdocs/http/CitrusRestDocConfigurer.java
+++ b/tools/restdocs/src/main/java/org/citrusframework/restdocs/http/CitrusRestDocConfigurer.java
@@ -77,7 +77,7 @@ public class CitrusRestDocConfigurer extends RestDocumentationConfigurer<CitrusS
     }
 
     @Override
-    public void onTestFinish(TestCase test) {
+    public void onTestExecutionEnd(TestCase test) {
     }
 
     @Override

--- a/tools/restdocs/src/main/java/org/citrusframework/restdocs/soap/CitrusRestDocSoapConfigurer.java
+++ b/tools/restdocs/src/main/java/org/citrusframework/restdocs/soap/CitrusRestDocSoapConfigurer.java
@@ -96,7 +96,7 @@ public class CitrusRestDocSoapConfigurer extends RestDocumentationConfigurer<Cit
     }
 
     @Override
-    public void onTestFinish(TestCase test) {
+    public void onTestExecutionEnd(TestCase test) {
         if (contextProvider instanceof ManualRestDocumentation) {
             ((ManualRestDocumentation) contextProvider).afterTest();
         }


### PR DESCRIPTION
[Related issue.](https://github.com/citrusframework/citrus/issues/1218)

The following methods have been added to the TestListener interface:

```java
default void onTestEnd(TestCase test)
default void onFinalActionsEnd(TestCase test)
default void onAfterSequenceBeforeTest(TestCase test)
default void onAfterSequenceAfterTest(TestCase test)
default void onBeforeSequenceBeforeTest(TestCase test)
default void onBeforeSequenceAfterTest(TestCase test)
```

Tests have been written in DefaultCaseTest