### PR TITLE
fix: Fix duplicate invocation of deprecated onTestFinish callback

### DIFF
--- a/core/citrus-api/src/main/java/org/citrusframework/report/TestListener.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/report/TestListener.java
@@ -36,13 +36,11 @@ public interface TestListener {
     }
 
     /**
-     * Invoked when test execution has ended (after final actions execution and
-     * before {@link org.citrusframework.container.AfterTest} execution)
-     *
-     * @see #onTestEnd(TestCase)
+     * Invoked when test execution starts
+     * (after {@link org.citrusframework.container.BeforeTest} execution} execution)
      */
     default void onTestExecutionStart(TestCase test) {
-        onTestFinish(test);
+        // Default implementation does nothing
     }
 
 


### PR DESCRIPTION
Does it make sense to invoke the deprecated `onTestFinish()` in new `onTestExecutionStart()`? I guess onTestFinish method would be called twice as the new `onTestExecutionEnd()` does also call the deprecated method, too.