### PR TITLE
chore: Add test action to connect to a Kubernetes service

### DIFF
--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/KubernetesSettings.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/KubernetesSettings.java
@@ -24,6 +24,10 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import io.fabric8.kubernetes.api.model.NamedContext;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import org.citrusframework.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -146,6 +150,14 @@ public class KubernetesSettings {
                 return Files.readString(namespace.toPath());
             } catch (IOException e) {
                 logger.warn("Failed to read Kubernetes namespace from filesystem {}", namespace, e);
+            }
+        }
+
+        try (final KubernetesClient k8s = new KubernetesClientBuilder().build()) {
+            NamedContext currentContext = k8s.getConfiguration().getCurrentContext();
+            if (currentContext != null && currentContext.getContext() != null && StringUtils.hasText(currentContext.getContext().getNamespace())) {
+                logger.debug("Reading current namespace from context: {}", currentContext.getName());
+                return currentContext.getContext().getNamespace();
             }
         }
 

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/actions/AbstractKubernetesAction.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/actions/AbstractKubernetesAction.java
@@ -17,6 +17,7 @@
 package org.citrusframework.kubernetes.actions;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import org.citrusframework.AbstractTestActionBuilder;
 import org.citrusframework.actions.AbstractTestAction;
 import org.citrusframework.kubernetes.KubernetesActor;
@@ -105,6 +106,11 @@ public abstract class AbstractKubernetesAction extends AbstractTestAction implem
             if (kubernetesClient == null) {
                 if (referenceResolver != null && referenceResolver.isResolvable(KubernetesClient.class)) {
                     kubernetesClient = referenceResolver.resolve(KubernetesClient.class);
+                } else {
+                    kubernetesClient = new KubernetesClientBuilder().build();
+                    if (referenceResolver != null) {
+                        referenceResolver.bind("kubernetesClient", kubernetesClient);
+                    }
                 }
             }
 

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/actions/KubernetesActionBuilder.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/actions/KubernetesActionBuilder.java
@@ -466,6 +466,30 @@ public class KubernetesActionBuilder implements TestActionBuilder.DelegatingTest
     public class ServiceActionBuilder {
 
         /**
+         * Connect to given Kubernetes service via local port forward.
+         * @param serviceName the name of the Kubernetes service.
+         */
+        public ServiceConnectAction.Builder connect(String serviceName) {
+            ServiceConnectAction.Builder builder = new ServiceConnectAction.Builder()
+                    .client(kubernetesClient)
+                    .service(serviceName);
+            delegate = builder;
+            return builder;
+        }
+
+        /**
+         * Connect to given Kubernetes service via local port forward.
+         * @param serviceName the name of the Kubernetes service.
+         */
+        public ServiceDisconnectAction.Builder disconnect(String serviceName) {
+            ServiceDisconnectAction.Builder builder = new ServiceDisconnectAction.Builder()
+                    .client(kubernetesClient)
+                    .service(serviceName);
+            delegate = builder;
+            return builder;
+        }
+
+        /**
          * Create service instance.
          * @param serviceName the name of the Kubernetes service.
          */

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/actions/ServiceConnectAction.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/actions/ServiceConnectAction.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.kubernetes.actions;
+
+import io.fabric8.kubernetes.client.LocalPortForward;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.http.client.HttpClient;
+import org.citrusframework.http.client.HttpClientBuilder;
+import org.citrusframework.http.server.HttpServer;
+import org.citrusframework.kubernetes.KubernetesSettings;
+import org.citrusframework.util.StringUtils;
+
+import static org.citrusframework.kubernetes.actions.KubernetesActionBuilder.kubernetes;
+
+/**
+ * Action connects the test to a Kubernetes service so clients may invoke the service.
+ * This is for services that are only accessible from within the cluster (e.g. service type is ClusterIP).
+ * The test action connects to the service via port forwarding and exposes a Http client to the Citrus context
+ * so other test actions can access the service running in Kubernetes.
+ */
+public class ServiceConnectAction extends AbstractKubernetesAction {
+
+    private final String clientName;
+    private final String serviceName;
+    private final String port;
+    private final String localPort;
+
+    public ServiceConnectAction(Builder builder) {
+        super("service-connect", builder);
+
+        this.serviceName = builder.serviceName;
+        this.port = builder.port;
+        this.clientName = builder.clientName;
+        this.localPort = builder.localPort;
+    }
+
+    @Override
+    public void doExecute(TestContext context) {
+        if (KubernetesSettings.isLocal()) {
+            if (context.getReferenceResolver().isResolvable(serviceName)) {
+                HttpServer server = context.getReferenceResolver().resolve(serviceName, HttpServer.class);
+                HttpClient serviceClient = new HttpClientBuilder()
+                        .requestUrl("http://localhost:%d".formatted(server.getPort()))
+                        .build();
+                context.getReferenceResolver().bind(clientName, serviceClient);
+            }
+
+            return;
+        }
+
+        LocalPortForward portForward;
+        if (StringUtils.hasText(localPort)) {
+            portForward = getKubernetesClient().services()
+                    .inNamespace(namespace(context))
+                    .withName(serviceName)
+                    .portForward(Integer.parseInt(context.replaceDynamicContentInString(port)), Integer.parseInt(context.replaceDynamicContentInString(localPort)));
+        } else {
+            portForward = getKubernetesClient().services()
+                    .inNamespace(namespace(context))
+                    .withName(serviceName)
+                    .portForward(Integer.parseInt(context.replaceDynamicContentInString(port)));
+        }
+
+        if (context.getReferenceResolver().isResolvable(clientName)) {
+            throw new CitrusRuntimeException("Failed to bind Kubernetes service client '%s' - client already exists".formatted(clientName));
+        }
+
+        HttpClient serviceClient = new HttpClientBuilder()
+                .requestUrl("http://localhost:%d".formatted(portForward.getLocalPort()))
+                .build();
+        context.getReferenceResolver().bind(clientName, serviceClient);
+
+        if (context.getReferenceResolver().isResolvable(serviceName + ":port-forward")) {
+            throw new CitrusRuntimeException("Failed to bind Kubernetes service port forward '%s' - already exists".formatted(serviceName + ":port-forward"));
+        }
+        context.getReferenceResolver().bind(serviceName + ":port-forward", portForward);
+
+        if (isAutoRemoveResources()) {
+            context.doFinally(kubernetes().client(getKubernetesClient())
+                    .services()
+                    .disconnect(serviceName)
+                    .inNamespace(getNamespace()));
+        }
+    }
+
+    /**
+     * Action builder.
+     */
+    public static class Builder extends AbstractKubernetesAction.Builder<ServiceConnectAction, Builder> {
+
+        private String clientName;
+        private String localPort;
+        private String serviceName = KubernetesSettings.getServiceName();
+        private String port;
+
+        public Builder service(String serviceName) {
+            this.serviceName = serviceName;
+            return this;
+        }
+
+        public Builder client(String clientName) {
+            this.clientName = clientName;
+            return this;
+        }
+
+        public Builder port(String port) {
+            this.port = port;
+            return this;
+        }
+
+        public Builder port(int port) {
+            this.port = String.valueOf(port);
+            return this;
+        }
+
+        public Builder portMapping(String port, String localPort) {
+            if (port != null) {
+                port(port);
+            }
+
+            if (localPort != null) {
+                localPort(localPort);
+            }
+            return this;
+        }
+
+        public Builder portMapping(int port, int localPort) {
+            port(port);
+            localPort(localPort);
+            return this;
+        }
+
+        public Builder localPort(String localPort) {
+            this.localPort = localPort;
+            return this;
+        }
+
+        public Builder localPort(int localPort) {
+            this.localPort = String.valueOf(localPort);
+            return this;
+        }
+
+        @Override
+        public ServiceConnectAction doBuild() {
+            if (clientName == null) {
+                client(serviceName + ".client");
+            }
+
+            return new ServiceConnectAction(this);
+        }
+    }
+}

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/actions/ServiceDisconnectAction.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/actions/ServiceDisconnectAction.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.kubernetes.actions;
+
+import java.io.IOException;
+
+import io.fabric8.kubernetes.client.LocalPortForward;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.kubernetes.KubernetesSettings;
+
+/**
+ * Action closes port forward for a Kubernetes service.
+ * Resolves port forward from Citrus context and closes it when still alive.
+ */
+public class ServiceDisconnectAction extends AbstractKubernetesAction {
+
+    private final String serviceName;
+
+    public ServiceDisconnectAction(Builder builder) {
+        super("service-disconnect", builder);
+
+        this.serviceName = builder.serviceName;
+    }
+
+    @Override
+    public void doExecute(TestContext context) {
+        logger.info("Disconnect from Kubernetes service '{}'", serviceName);
+
+        if (KubernetesSettings.isLocal()) {
+            return;
+        }
+
+        if (context.getReferenceResolver().isResolvable(serviceName + ":port-forward", LocalPortForward.class)) {
+            LocalPortForward portForward = context.getReferenceResolver().resolve(serviceName + ":port-forward", LocalPortForward.class);
+            try {
+                if (portForward.isAlive()) {
+                    portForward.close();
+                    logger.info("Successfully disconnected from Kubernetes service '{}'", serviceName);
+                }
+            } catch (IOException e) {
+                logger.warn("Failed to close local port forward for Kubernetes service '{}'", serviceName);
+            }
+        } else {
+            logger.warn("Failed to disconnect from Kubernetes service '{}' - no port forward available", serviceName);
+        }
+    }
+
+    /**
+     * Action builder.
+     */
+    public static class Builder extends AbstractKubernetesAction.Builder<ServiceDisconnectAction, Builder> {
+
+        private String serviceName = KubernetesSettings.getServiceName();
+
+        public Builder service(String serviceName) {
+            this.serviceName = serviceName;
+            return this;
+        }
+
+        @Override
+        public ServiceDisconnectAction doBuild() {
+            return new ServiceDisconnectAction(this);
+        }
+    }
+}

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/functions/ResolveExternalServiceUrlFunction.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/functions/ResolveExternalServiceUrlFunction.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.kubernetes.functions;
+
+import java.util.List;
+
+import io.fabric8.kubernetes.api.model.LoadBalancerStatus;
+import io.fabric8.kubernetes.api.model.NodeAddress;
+import io.fabric8.kubernetes.api.model.NodeList;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServicePort;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.exceptions.InvalidFunctionUsageException;
+import org.citrusframework.functions.Function;
+import org.citrusframework.kubernetes.KubernetesSettings;
+import org.citrusframework.kubernetes.KubernetesSupport;
+
+/**
+ * Function resolves the URL to a Kubernetes service by inspecting the exposed host ip and port.
+ */
+public class ResolveExternalServiceUrlFunction implements Function {
+
+    @Override
+    public String execute(List<String> parameterList, TestContext context) {
+        if (KubernetesSettings.isLocal()) {
+            // delegate to arbitrary resolve service function
+            return new ResolveServiceUrlFunction().execute(parameterList, context);
+        }
+
+        if (parameterList.isEmpty()) {
+            throw new InvalidFunctionUsageException("Function parameters must not be empty - please provide a proper service name");
+        }
+
+        String serviceName = parameterList.get(0);
+
+        String namespace;
+        if (parameterList.size() > 1) {
+            namespace = parameterList.get(1);
+        } else {
+            namespace = KubernetesSupport.getNamespace(context);
+        }
+
+        KubernetesClient k8sClient = KubernetesSupport.getKubernetesClient(context);
+
+        Service service = k8sClient.services()
+                .inNamespace(namespace)
+                .withName(serviceName)
+                .get();
+
+        if (service == null) {
+            throw new CitrusRuntimeException(String.format("Unable to resolve service instance %s/%s", namespace, serviceName));
+        }
+
+        String hostIp = null;
+        Integer nodePort = null;
+        if ("NodePort".equals(service.getSpec().getType())) {
+            List<ServicePort> servicePorts = service.getSpec().getPorts();
+            if (servicePorts != null && !servicePorts.isEmpty()) {
+                nodePort = servicePorts.get(0).getNodePort();
+            }
+
+            if (nodePort == null) {
+                throw new CitrusRuntimeException(String.format("Unable to resolve service endpoint URL for service '%s' - " +
+                        "failed to determine node port", service.getMetadata().getName()));
+            }
+
+            NodeList nodeList = k8sClient.nodes().list();
+            if (nodeList != null && !nodeList.getItems().isEmpty() && nodeList.getItems().get(0).getStatus() != null) {
+                List<NodeAddress> nodeAddresses = nodeList.getItems().get(0).getStatus().getAddresses();
+                if (nodeAddresses != null) {
+                    hostIp = nodeAddresses.stream()
+                            .filter(nodeAddress -> "ExternalIP".equals(nodeAddress.getType()))
+                            .map(NodeAddress::getAddress)
+                            .findFirst()
+                            .orElse(null);
+                }
+            }
+        } else if ("LoadBalancer".equals(service.getSpec().getType()) && service.getStatus() != null) {
+            LoadBalancerStatus loadBalancerStatus = service.getStatus().getLoadBalancer();
+            if (loadBalancerStatus != null && loadBalancerStatus.getIngress() != null &&
+                    !loadBalancerStatus.getIngress().isEmpty()) {
+                hostIp = loadBalancerStatus.getIngress().get(0).getIp();
+            }
+        } else {
+            List<String> externalIps = service.getSpec().getExternalIPs();
+            if (externalIps != null && !externalIps.isEmpty()) {
+                hostIp = externalIps.get(0);
+            }
+
+            List<ServicePort> servicePorts = service.getSpec().getPorts();
+            if (servicePorts != null && !servicePorts.isEmpty()) {
+                nodePort = servicePorts.get(0).getNodePort();
+            }
+        }
+
+        if (hostIp == null) {
+            throw new CitrusRuntimeException(String.format("Unable to resolve service endpoint URL for service '%s' - " +
+                    "failed to determine load balancer ingress ip", service.getMetadata().getName()));
+        }
+
+        if (nodePort != null) {
+            return "http://%s:%s".formatted(hostIp, nodePort);
+        } else {
+            return "http://%s".formatted(hostIp);
+        }
+    }
+}

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/functions/ResolveServiceUrlFunction.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/functions/ResolveServiceUrlFunction.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.kubernetes.functions;
+
+import java.util.List;
+import java.util.Locale;
+
+import org.citrusframework.context.TestContext;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.functions.Function;
+import org.citrusframework.http.server.HttpServer;
+import org.citrusframework.kubernetes.KubernetesSettings;
+
+import static org.citrusframework.kubernetes.KubernetesSupport.getNamespace;
+
+/**
+ * Function resolves URL to a Kubernetes service. Supports different modes such as local and in-cluster.
+ * In local mode constructs a localhost service URL with a given local service port.
+ * The in-cluster mode uses the service name and the current namespace to construct a Kubernetes service URL.
+ */
+public class ResolveServiceUrlFunction implements Function {
+
+    @Override
+    public String execute(List<String> parameterList, TestContext context) {
+        if (parameterList.isEmpty()) {
+            throw new CitrusRuntimeException("Missing service name for resolve function");
+        }
+
+        String serviceName = parameterList.get(0);
+
+        boolean secure = false;
+        int servicePort = 0;
+        if (parameterList.size() > 1) {
+            try {
+                servicePort = Integer.parseInt(parameterList.get(1));
+            } catch (IllegalArgumentException e) {
+                secure = Boolean.parseBoolean(parameterList.get(1).toLowerCase(Locale.US));
+            }
+        }
+
+        if (parameterList.size() > 2) {
+            secure = Boolean.parseBoolean(parameterList.get(2).toLowerCase(Locale.US));
+        }
+
+        String scheme = "http://";
+        if (secure) {
+            scheme = "https://";
+        }
+
+        if (KubernetesSettings.isLocal()) {
+            if (context.getReferenceResolver().isResolvable(serviceName)) {
+                HttpServer server = context.getReferenceResolver().resolve(serviceName, HttpServer.class);
+                servicePort = server.getPort();
+            }
+
+            return String.format("%slocalhost%s", scheme, servicePort > 0 ? ":" + servicePort : "");
+        } else {
+            return String.format("%s%s.%s", scheme, serviceName, getNamespace(context));
+        }
+    }
+}

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/xml/Connect.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/xml/Connect.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.kubernetes.xml;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
+import org.citrusframework.TestActor;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.kubernetes.actions.AbstractKubernetesAction;
+import org.citrusframework.kubernetes.actions.ServiceConnectAction;
+import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.spi.ReferenceResolverAware;
+
+@XmlRootElement(name = "connect")
+public class Connect extends AbstractKubernetesAction.Builder<AbstractKubernetesAction, Connect> implements ReferenceResolverAware {
+
+    private AbstractKubernetesAction.Builder<? extends AbstractKubernetesAction, ?> delegate;
+
+    @XmlElement
+    public void setService(Service service) {
+        ServiceConnectAction.Builder builder = new ServiceConnectAction.Builder();
+
+        builder.service(service.getName());
+        builder.client(service.getClient());
+        builder.port(service.getPort());
+        builder.localPort(service.getLocalPort());
+
+        this.delegate = builder;
+    }
+
+    @Override
+    public Connect description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public Connect actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public Connect client(KubernetesClient client) {
+        delegate.client(client);
+        return this;
+    }
+
+    @Override
+    public Connect inNamespace(String namespace) {
+        this.delegate.inNamespace(namespace);
+        return this;
+    }
+
+    @Override
+    public Connect autoRemoveResources(boolean enabled) {
+        this.delegate.autoRemoveResources(enabled);
+        return this;
+    }
+
+    @Override
+    public void setReferenceResolver(ReferenceResolver referenceResolver) {
+        this.delegate.setReferenceResolver(referenceResolver);
+    }
+
+    @Override
+    public AbstractKubernetesAction doBuild() {
+        if (delegate == null) {
+            throw new CitrusRuntimeException("Missing Kubernetes connect action - please provide proper action details");
+        }
+
+        return delegate.build();
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(name = "", propOrder = {})
+    public static class Service {
+
+        @XmlAttribute(required = true)
+        protected String name;
+        @XmlAttribute
+        protected String client;
+        @XmlAttribute(required = true)
+        protected String port;
+        @XmlAttribute(name = "local-port")
+        protected String localPort;
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setClient(String client) {
+            this.client = client;
+        }
+
+        public String getClient() {
+            return client;
+        }
+
+        public void setPort(String port) {
+            this.port = port;
+        }
+
+        public String getPort() {
+            return port;
+        }
+
+        public void setLocalPort(String localPort) {
+            this.localPort = localPort;
+        }
+
+        public String getLocalPort() {
+            return localPort;
+        }
+    }
+}

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/xml/Disconnect.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/xml/Disconnect.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.kubernetes.xml;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
+import org.citrusframework.TestActor;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.kubernetes.actions.AbstractKubernetesAction;
+import org.citrusframework.kubernetes.actions.ServiceDisconnectAction;
+import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.spi.ReferenceResolverAware;
+
+@XmlRootElement(name = "disconnect")
+public class Disconnect extends AbstractKubernetesAction.Builder<AbstractKubernetesAction, Disconnect> implements ReferenceResolverAware {
+
+    private AbstractKubernetesAction.Builder<? extends AbstractKubernetesAction, ?> delegate;
+
+    @XmlElement
+    public void setService(Service service) {
+        ServiceDisconnectAction.Builder builder = new ServiceDisconnectAction.Builder();
+        builder.service(service.getName());
+        this.delegate = builder;
+    }
+
+    @Override
+    public Disconnect description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public Disconnect actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public Disconnect client(KubernetesClient client) {
+        delegate.client(client);
+        return this;
+    }
+
+    @Override
+    public Disconnect inNamespace(String namespace) {
+        this.delegate.inNamespace(namespace);
+        return this;
+    }
+
+    @Override
+    public Disconnect autoRemoveResources(boolean enabled) {
+        this.delegate.autoRemoveResources(enabled);
+        return this;
+    }
+
+    @Override
+    public void setReferenceResolver(ReferenceResolver referenceResolver) {
+        this.delegate.setReferenceResolver(referenceResolver);
+    }
+
+    @Override
+    public AbstractKubernetesAction doBuild() {
+        if (delegate == null) {
+            throw new CitrusRuntimeException("Missing Kubernetes disconnect action - please provide proper action details");
+        }
+
+        return delegate.build();
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(name = "", propOrder = {})
+    public static class Service {
+
+        @XmlAttribute(required = true)
+        protected String name;
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+}

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/xml/Kubernetes.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/xml/Kubernetes.java
@@ -74,6 +74,16 @@ public class Kubernetes implements TestActionBuilder<KubernetesAction>, Referenc
         return this;
     }
 
+    @XmlElement
+    public void setConnect(Connect builder) {
+        this.builder = builder;
+    }
+
+    @XmlElement
+    public void setDisconnect(Disconnect builder) {
+        this.builder = builder;
+    }
+
     @XmlElement(name = "create-service")
     public void setCreateService(CreateService builder) {
         this.builder = builder;

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/yaml/Connect.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/yaml/Connect.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.kubernetes.yaml;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.citrusframework.TestActor;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.kubernetes.actions.AbstractKubernetesAction;
+import org.citrusframework.kubernetes.actions.ServiceConnectAction;
+import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.spi.ReferenceResolverAware;
+
+public class Connect extends AbstractKubernetesAction.Builder<AbstractKubernetesAction, Connect> implements ReferenceResolverAware {
+
+    private AbstractKubernetesAction.Builder<? extends AbstractKubernetesAction, ?> delegate;
+
+    public void setService(Service service) {
+        ServiceConnectAction.Builder builder = new ServiceConnectAction.Builder();
+
+        builder.service(service.getName());
+        builder.client(service.getClient());
+        builder.port(service.getPort());
+        builder.localPort(service.getLocalPort());
+
+        this.delegate = builder;
+    }
+
+    @Override
+    public void setReferenceResolver(ReferenceResolver referenceResolver) {
+        this.delegate.setReferenceResolver(referenceResolver);
+    }
+
+    @Override
+    public Connect description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public Connect actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public Connect client(KubernetesClient client) {
+        delegate.client(client);
+        return this;
+    }
+
+    @Override
+    public Connect inNamespace(String namespace) {
+        this.delegate.inNamespace(namespace);
+        return this;
+    }
+
+    @Override
+    public Connect autoRemoveResources(boolean enabled) {
+        this.delegate.autoRemoveResources(enabled);
+        return this;
+    }
+
+    @Override
+    public AbstractKubernetesAction doBuild() {
+        if (delegate == null) {
+            throw new CitrusRuntimeException("Missing Kubernetes connect action - please provide proper action details");
+        }
+
+        return delegate.build();
+    }
+
+    public static class Service {
+
+        protected String name;
+        protected String client;
+        protected String port;
+        protected String localPort;
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setClient(String client) {
+            this.client = client;
+        }
+
+        public String getClient() {
+            return client;
+        }
+
+        public void setPort(String port) {
+            this.port = port;
+        }
+
+        public String getPort() {
+            return port;
+        }
+
+        public void setLocalPort(String localPort) {
+            this.localPort = localPort;
+        }
+
+        public String getLocalPort() {
+            return localPort;
+        }
+    }
+}

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/yaml/Disconnect.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/yaml/Disconnect.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.kubernetes.yaml;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.citrusframework.TestActor;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.kubernetes.actions.AbstractKubernetesAction;
+import org.citrusframework.kubernetes.actions.ServiceDisconnectAction;
+import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.spi.ReferenceResolverAware;
+
+public class Disconnect extends AbstractKubernetesAction.Builder<AbstractKubernetesAction, Disconnect> implements ReferenceResolverAware {
+
+    private AbstractKubernetesAction.Builder<? extends AbstractKubernetesAction, ?> delegate;
+
+    public void setService(Service service) {
+        ServiceDisconnectAction.Builder builder = new ServiceDisconnectAction.Builder();
+        builder.service(service.getName());
+        this.delegate = builder;
+    }
+
+    @Override
+    public void setReferenceResolver(ReferenceResolver referenceResolver) {
+        this.delegate.setReferenceResolver(referenceResolver);
+    }
+
+    @Override
+    public Disconnect description(String description) {
+        delegate.description(description);
+        return this;
+    }
+
+    @Override
+    public Disconnect actor(TestActor actor) {
+        delegate.actor(actor);
+        return this;
+    }
+
+    @Override
+    public Disconnect client(KubernetesClient client) {
+        delegate.client(client);
+        return this;
+    }
+
+    @Override
+    public Disconnect inNamespace(String namespace) {
+        this.delegate.inNamespace(namespace);
+        return this;
+    }
+
+    @Override
+    public Disconnect autoRemoveResources(boolean enabled) {
+        this.delegate.autoRemoveResources(enabled);
+        return this;
+    }
+
+    @Override
+    public AbstractKubernetesAction doBuild() {
+        if (delegate == null) {
+            throw new CitrusRuntimeException("Missing Kubernetes disconnect action - please provide proper action details");
+        }
+
+        return delegate.build();
+    }
+
+    public static class Service {
+
+        protected String name;
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+
+}

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/yaml/Kubernetes.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/yaml/Kubernetes.java
@@ -61,6 +61,14 @@ public class Kubernetes implements TestActionBuilder<KubernetesAction>, Referenc
         this.kubernetesClient = client;
     }
 
+    public void setConnect(Connect builder) {
+        this.builder = builder;
+    }
+
+    public void setDisconnect(Disconnect builder) {
+        this.builder = builder;
+    }
+
     public void setCreateService(CreateService builder) {
         this.builder = builder;
     }

--- a/connectors/citrus-kubernetes/src/main/resources/META-INF/citrus/function/resolveExternalServiceUrl
+++ b/connectors/citrus-kubernetes/src/main/resources/META-INF/citrus/function/resolveExternalServiceUrl
@@ -1,0 +1,1 @@
+type=org.citrusframework.kubernetes.functions.ResolveExternalServiceUrlFunction

--- a/connectors/citrus-kubernetes/src/main/resources/META-INF/citrus/function/resolveServiceUrl
+++ b/connectors/citrus-kubernetes/src/main/resources/META-INF/citrus/function/resolveServiceUrl
@@ -1,0 +1,1 @@
+type=org.citrusframework.kubernetes.functions.ResolveServiceUrlFunction

--- a/connectors/citrus-kubernetes/src/test/java/org/citrusframework/kubernetes/functions/ResolveExternalServiceUrlFunctionTest.java
+++ b/connectors/citrus-kubernetes/src/test/java/org/citrusframework/kubernetes/functions/ResolveExternalServiceUrlFunctionTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.kubernetes.functions;
+
+import java.util.List;
+
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceList;
+import io.fabric8.kubernetes.api.model.ServicePortBuilder;
+import io.fabric8.kubernetes.api.model.ServiceSpec;
+import io.fabric8.kubernetes.api.model.ServiceStatus;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.ServiceResource;
+import org.citrusframework.functions.DefaultFunctionLibrary;
+import org.citrusframework.kubernetes.KubernetesSupport;
+import org.citrusframework.kubernetes.UnitTestSupport;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+public class ResolveExternalServiceUrlFunctionTest extends UnitTestSupport {
+
+    @Mock
+    private KubernetesClient k8sClient;
+    @Mock
+    private ServiceResource<Service> serviceResource;
+    @Mock
+    private MixedOperation<Service, ServiceList, ServiceResource<Service>> clientOperation;
+
+    @BeforeClass
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    private final ResolveExternalServiceUrlFunction function = new ResolveExternalServiceUrlFunction();
+
+    @Test
+    public void shouldResolveExternalServiceUrl() {
+        Service service = new Service();
+        service.setMetadata(new ObjectMeta());
+        service.getMetadata().setNamespace(KubernetesSupport.getNamespace(context));
+        service.getMetadata().setName("myService");
+        service.setSpec(new ServiceSpec());
+        service.getSpec().setClusterIP("127.0.0.1");
+        service.getSpec().setExternalIPs(List.of("10.0.0.41"));
+        service.getSpec().getPorts().add(new ServicePortBuilder().withPort(80).withNodePort(4567).build());
+
+        service.setStatus(new ServiceStatus());
+        context.getReferenceResolver().bind("k8sClient", k8sClient);
+
+        reset(k8sClient, clientOperation, serviceResource);
+        when(k8sClient.services()).thenReturn(clientOperation);
+        when(clientOperation.inNamespace(anyString())).thenReturn(clientOperation);
+        when(clientOperation.withName("myService")).thenReturn(serviceResource);
+        when(serviceResource.get()).thenReturn(service);
+
+        Assert.assertEquals(function.execute(List.of("myService"), context), "http://10.0.0.41:4567");
+    }
+
+    @Test
+    public void shouldResolve() {
+        Assert.assertNotNull(new DefaultFunctionLibrary().getFunction("resolveExternalServiceUrl"));
+    }
+}

--- a/connectors/citrus-kubernetes/src/test/java/org/citrusframework/kubernetes/functions/ResolveServiceUrlFunctionTest.java
+++ b/connectors/citrus-kubernetes/src/test/java/org/citrusframework/kubernetes/functions/ResolveServiceUrlFunctionTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.kubernetes.functions;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.citrusframework.context.TestContext;
+import org.citrusframework.context.TestContextFactory;
+import org.citrusframework.functions.DefaultFunctionLibrary;
+import org.citrusframework.http.server.HttpServerBuilder;
+import org.citrusframework.kubernetes.ClusterType;
+import org.citrusframework.kubernetes.KubernetesVariableNames;
+import org.citrusframework.kubernetes.UnitTestSupport;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class ResolveServiceUrlFunctionTest extends UnitTestSupport {
+
+    private final ResolveServiceUrlFunction function = new ResolveServiceUrlFunction();
+
+    @Test
+    public void shouldResolveService() {
+        TestContext context = TestContextFactory.newInstance().getObject();
+
+        context.setVariable(KubernetesVariableNames.NAMESPACE.value(), "default");
+
+        Assert.assertEquals(function.execute(Collections.singletonList("test-service"), context), "http://test-service.default");
+        Assert.assertEquals(function.execute(Arrays.asList("test-service", "8080"), context), "http://test-service.default");
+    }
+
+    @Test
+    public void shouldResolveSecureService() {
+        TestContext context = TestContextFactory.newInstance().getObject();
+
+        context.setVariable(KubernetesVariableNames.NAMESPACE.value(), "default");
+
+        Assert.assertEquals(function.execute(Arrays.asList("test-service", "TRUE"), context), "https://test-service.default");
+        Assert.assertEquals(function.execute(Arrays.asList("test-service", "8080", "TRUE"), context), "https://test-service.default");
+    }
+
+    @Test
+    public void shouldResolveLocalService() {
+        try {
+            System.setProperty("citrus.kubernetes.cluster.type", ClusterType.LOCAL.name());
+            TestContext context = TestContextFactory.newInstance().getObject();
+
+            context.getReferenceResolver().bind("test-service", new HttpServerBuilder()
+                    .autoStart(false)
+                    .port(8888)
+                    .build());
+
+            Assert.assertEquals(function.execute(Collections.singletonList("test-service"), context),"http://localhost:8888");
+            Assert.assertEquals(function.execute(Collections.singletonList("foo-service"), context), "http://localhost");
+            Assert.assertEquals(function.execute(Arrays.asList("foo-service", "8080"), context), "http://localhost:8080");
+        } finally {
+            System.setProperty("citrus.kubernetes.cluster.type", ClusterType.KUBERNETES.name());
+        }
+    }
+
+    @Test
+    public void shouldResolve() {
+        Assert.assertNotNull(new DefaultFunctionLibrary().getFunction("resolveServiceUrl"));
+    }
+}

--- a/connectors/citrus-kubernetes/src/test/java/org/citrusframework/kubernetes/xml/ServiceConnectTest.java
+++ b/connectors/citrus-kubernetes/src/test/java/org/citrusframework/kubernetes/xml/ServiceConnectTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.kubernetes.xml;
+
+import java.util.Collections;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.http.client.HttpClient;
+import org.citrusframework.kubernetes.actions.ServiceConnectAction;
+import org.citrusframework.xml.XmlTestLoader;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class ServiceConnectTest extends AbstractXmlActionTest {
+
+    @Test
+    public void shouldLoadKubernetesActions() {
+        String namespace = "test";
+        Pod pod = new PodBuilder()
+                .withNewMetadata()
+                    .withName("my-pod")
+                    .withLabels(Collections.singletonMap("app", "camel"))
+                .endMetadata()
+                .build();
+
+        k8sClient.pods()
+                .inNamespace(namespace)
+                .resource(pod)
+                .create();
+
+        Service service = new ServiceBuilder()
+                .withNewMetadata()
+                .withName("my-service")
+                .withNamespace(namespace)
+                .endMetadata()
+                .withNewSpec()
+                    .withSelector(Collections.singletonMap("app", "camel"))
+                .endSpec()
+                .build();
+
+        k8sClient.services()
+                .inNamespace(namespace)
+                .resource(service)
+                .create();
+
+        XmlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/kubernetes/xml/service-connect-test.xml");
+
+        testLoader.load();
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "ServiceConnectTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 1L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), ServiceConnectAction.class);
+        Assert.assertTrue(result.getTestResult().isSuccess());
+
+        HttpClient serviceClient = context.getReferenceResolver().resolve("my-service.client", HttpClient.class);
+        Assert.assertNotNull(serviceClient);
+        Assert.assertEquals(serviceClient.getEndpointConfiguration().getRequestUrl(), "http://localhost:31234");
+    }
+}

--- a/connectors/citrus-kubernetes/src/test/java/org/citrusframework/kubernetes/xml/ServiceDisconnectTest.java
+++ b/connectors/citrus-kubernetes/src/test/java/org/citrusframework/kubernetes/xml/ServiceDisconnectTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.kubernetes.xml;
+
+import java.io.IOException;
+
+import io.fabric8.kubernetes.client.LocalPortForward;
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.http.client.HttpClient;
+import org.citrusframework.kubernetes.actions.ServiceDisconnectAction;
+import org.citrusframework.xml.XmlTestLoader;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ServiceDisconnectTest extends AbstractXmlActionTest {
+
+    @Mock
+    private LocalPortForward portForward;
+
+    @Mock
+    private HttpClient serviceClient;
+
+    @BeforeClass
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void shouldLoadKubernetesActions() throws IOException {
+        context.getReferenceResolver().bind("my-service:port-forward", portForward);
+        context.getReferenceResolver().bind("my-service.client", serviceClient);
+
+        when(portForward.isAlive()).thenReturn(true);
+
+        XmlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/kubernetes/xml/service-disconnect-test.xml");
+
+        testLoader.load();
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "ServiceDisconnectTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 1L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), ServiceDisconnectAction.class);
+        Assert.assertTrue(result.getTestResult().isSuccess());
+
+        verify(portForward).isAlive();
+        verify(portForward).close();
+    }
+}

--- a/connectors/citrus-kubernetes/src/test/java/org/citrusframework/kubernetes/yaml/ServiceConnectTest.java
+++ b/connectors/citrus-kubernetes/src/test/java/org/citrusframework/kubernetes/yaml/ServiceConnectTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.kubernetes.yaml;
+
+import java.util.Collections;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.http.client.HttpClient;
+import org.citrusframework.kubernetes.actions.ServiceConnectAction;
+import org.citrusframework.yaml.YamlTestLoader;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class ServiceConnectTest extends AbstractYamlActionTest {
+
+    @Test
+    public void shouldLoadKubernetesActions() {
+        String namespace = "test";
+        Pod pod = new PodBuilder()
+                .withNewMetadata()
+                .withName("my-pod")
+                .withLabels(Collections.singletonMap("app", "camel"))
+                .endMetadata()
+                .build();
+
+        k8sClient.pods()
+                .inNamespace(namespace)
+                .resource(pod)
+                .create();
+
+        Service service = new ServiceBuilder()
+                .withNewMetadata()
+                .withName("my-service")
+                .withNamespace(namespace)
+                .endMetadata()
+                .withNewSpec()
+                .withSelector(Collections.singletonMap("app", "camel"))
+                .endSpec()
+                .build();
+
+        k8sClient.services()
+                .inNamespace(namespace)
+                .resource(service)
+                .create();
+
+        YamlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/kubernetes/yaml/service-connect-test.yaml");
+
+        testLoader.load();
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "ServiceConnectTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 1L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), ServiceConnectAction.class);
+        Assert.assertTrue(result.getTestResult().isSuccess());
+
+        HttpClient serviceClient = context.getReferenceResolver().resolve("my-service.client", HttpClient.class);
+        Assert.assertNotNull(serviceClient);
+        Assert.assertEquals(serviceClient.getEndpointConfiguration().getRequestUrl(), "http://localhost:31234");
+    }
+}

--- a/connectors/citrus-kubernetes/src/test/java/org/citrusframework/kubernetes/yaml/ServiceDisconnectTest.java
+++ b/connectors/citrus-kubernetes/src/test/java/org/citrusframework/kubernetes/yaml/ServiceDisconnectTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.kubernetes.yaml;
+
+import java.io.IOException;
+
+import io.fabric8.kubernetes.client.LocalPortForward;
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.http.client.HttpClient;
+import org.citrusframework.kubernetes.actions.ServiceDisconnectAction;
+import org.citrusframework.yaml.YamlTestLoader;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ServiceDisconnectTest extends AbstractYamlActionTest {
+
+    @Mock
+    private LocalPortForward portForward;
+
+    @Mock
+    private HttpClient serviceClient;
+
+    @BeforeClass
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void shouldLoadKubernetesActions() throws IOException {
+        context.getReferenceResolver().bind("my-service:port-forward", portForward);
+        context.getReferenceResolver().bind("my-service.client", serviceClient);
+
+        when(portForward.isAlive()).thenReturn(true);
+
+        YamlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/kubernetes/yaml/service-disconnect-test.yaml");
+
+        testLoader.load();
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "ServiceDisconnectTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 1L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), ServiceDisconnectAction.class);
+        Assert.assertTrue(result.getTestResult().isSuccess());
+
+        verify(portForward).isAlive();
+        verify(portForward).close();
+    }
+}

--- a/connectors/citrus-kubernetes/src/test/resources/org/citrusframework/kubernetes/xml/service-connect-test.xml
+++ b/connectors/citrus-kubernetes/src/test/resources/org/citrusframework/kubernetes/xml/service-connect-test.xml
@@ -1,0 +1,28 @@
+<!--
+  ~ Copyright the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<test name="ServiceConnectTest" author="Christoph" status="FINAL" xmlns="http://citrusframework.org/schema/xml/testcase"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://citrusframework.org/schema/xml/testcase http://citrusframework.org/schema/xml/testcase/citrus-testcase.xsd">
+  <description>Sample test in XML</description>
+  <actions>
+    <kubernetes client="k8sClient" namespace="test">
+      <connect>
+        <service name="my-service" port="8080" local-port="31234"/>
+      </connect>
+    </kubernetes>
+  </actions>
+</test>

--- a/connectors/citrus-kubernetes/src/test/resources/org/citrusframework/kubernetes/xml/service-disconnect-test.xml
+++ b/connectors/citrus-kubernetes/src/test/resources/org/citrusframework/kubernetes/xml/service-disconnect-test.xml
@@ -1,0 +1,28 @@
+<!--
+  ~ Copyright the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<test name="ServiceDisconnectTest" author="Christoph" status="FINAL" xmlns="http://citrusframework.org/schema/xml/testcase"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://citrusframework.org/schema/xml/testcase http://citrusframework.org/schema/xml/testcase/citrus-testcase.xsd">
+  <description>Sample test in XML</description>
+  <actions>
+    <kubernetes client="k8sClient" namespace="test">
+      <disconnect>
+        <service name="my-service"/>
+      </disconnect>
+    </kubernetes>
+  </actions>
+</test>

--- a/connectors/citrus-kubernetes/src/test/resources/org/citrusframework/kubernetes/yaml/service-connect-test.yaml
+++ b/connectors/citrus-kubernetes/src/test/resources/org/citrusframework/kubernetes/yaml/service-connect-test.yaml
@@ -1,0 +1,13 @@
+name: "ServiceConnectTest"
+author: "Christoph"
+status: "FINAL"
+description: Sample test in XML
+actions:
+  - kubernetes:
+      client: "k8sClient"
+      namespace: "test"
+      connect:
+        service:
+          name: "my-service"
+          port: 8080
+          localPort: 31234

--- a/connectors/citrus-kubernetes/src/test/resources/org/citrusframework/kubernetes/yaml/service-disconnect-test.yaml
+++ b/connectors/citrus-kubernetes/src/test/resources/org/citrusframework/kubernetes/yaml/service-disconnect-test.yaml
@@ -1,0 +1,11 @@
+name: "ServiceDisconnectTest"
+author: "Christoph"
+status: "FINAL"
+description: Sample test in XML
+actions:
+  - kubernetes:
+      client: "k8sClient"
+      namespace: "test"
+      disconnect:
+        service:
+          name: "my-service"

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-4.6.0-SNAPSHOT.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-4.6.0-SNAPSHOT.xsd
@@ -1652,6 +1652,30 @@
     <xs:sequence>
       <xs:element name="description" type="xs:string" minOccurs="0"/>
       <xs:choice>
+        <xs:element name="connect">
+          <xs:complexType>
+            <xs:choice>
+              <xs:element name="service">
+                <xs:complexType>
+                  <xs:attribute name="name" use="required" type="xs:string"/>
+                  <xs:attribute name="port" use="required" type="xs:string"/>
+                  <xs:attribute name="local-port" type="xs:string"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:choice>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="disconnect">
+          <xs:complexType>
+            <xs:choice>
+              <xs:element name="service">
+                <xs:complexType>
+                  <xs:attribute name="name" use="required" type="xs:string"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:choice>
+          </xs:complexType>
+        </xs:element>
         <xs:element name="create-service">
           <xs:complexType>
             <xs:sequence>

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
@@ -1652,6 +1652,30 @@
     <xs:sequence>
       <xs:element name="description" type="xs:string" minOccurs="0"/>
       <xs:choice>
+        <xs:element name="connect">
+          <xs:complexType>
+            <xs:choice>
+              <xs:element name="service">
+                <xs:complexType>
+                  <xs:attribute name="name" use="required" type="xs:string"/>
+                  <xs:attribute name="port" use="required" type="xs:string"/>
+                  <xs:attribute name="local-port" type="xs:string"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:choice>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="disconnect">
+          <xs:complexType>
+            <xs:choice>
+              <xs:element name="service">
+                <xs:complexType>
+                  <xs:attribute name="name" use="required" type="xs:string"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:choice>
+          </xs:complexType>
+        </xs:element>
         <xs:element name="create-service">
           <xs:complexType>
             <xs:sequence>


### PR DESCRIPTION
- Uses port forward to connect a local port with an exposed port on a service and pod running on Kubernetes
- Enables users to invoke the Kubernetes service from the local host