### PR TITLE
fix(#1327): Properly report statistics on skipped tests

### DIFF
--- a/core/citrus-api/src/main/java/org/citrusframework/report/TestResults.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/report/TestResults.java
@@ -101,7 +101,7 @@ public class TestResults {
     }
 
     public String getSuccessPercentageFormatted() {
-        return results.isEmpty() || getSuccess() == 0 ? ZERO_PERCENTAGE : getNewDecimalFormat().format((double) getSuccess() / (getFailed() + getSuccess()) * 100);
+        return results.isEmpty() || getSuccess() == 0 ? ZERO_PERCENTAGE : getNewDecimalFormat().format((double) getSuccess() / (results.size()) * 100);
     }
 
     /**
@@ -132,7 +132,7 @@ public class TestResults {
     }
 
     public String getFailedPercentageFormatted() {
-        return results.isEmpty() || getFailed() == 0 ? ZERO_PERCENTAGE : getNewDecimalFormat().format((double) getFailed() / (getFailed() + getSuccess()) * 100);
+        return results.isEmpty() || getFailed() == 0 ? ZERO_PERCENTAGE : getNewDecimalFormat().format((double) getFailed() / (results.size()) * 100);
     }
 
     /**

--- a/core/citrus-base/src/main/java/org/citrusframework/report/LoggingReporter.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/report/LoggingReporter.java
@@ -115,7 +115,7 @@ public class LoggingReporter extends AbstractTestReporter implements MessageList
 
         newLine();
 
-        info(format("TOTAL:\t\t%s", testResults.getFailed() + testResults.getSuccess()));
+        info(format("TOTAL:\t\t%s", testResults.getSize()));
         info(format("PASSED:\t\t%s (%s%%)", testResults.getSuccess(), testResults.getSuccessPercentageFormatted()));
         info(format("FAILED:\t\t%s (%s%%)", testResults.getFailed(), testResults.getFailedPercentageFormatted()));
 

--- a/core/citrus-base/src/test/java/org/citrusframework/report/LoggingReporterTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/report/LoggingReporterTest.java
@@ -184,7 +184,7 @@ public class LoggingReporterTest {
 
         verify(logger).info("SKIP (     0 ms) testLoggingReporterSkipped");
 
-        verifyResultSummaryLog(0, 0, 0, 0);
+        verifyResultSummaryLog(1, 0, 0, 0);
 
         verify(logger, never()).debug(anyString());
     }

--- a/core/citrus-base/src/test/java/org/citrusframework/report/TestResultsTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/report/TestResultsTest.java
@@ -115,17 +115,29 @@ public class TestResultsTest {
     }
 
     @Test
-    public void testSkippedResults() {
-        fixture.addResult(success("OkTest", TestResultsTest.class.getName()));
-        fixture.addResult(failed("FailedTest", TestResultsTest.class.getName(), new CitrusRuntimeException("This went wrong")));
-        fixture.addResult(skipped("SkippedTest", TestResultsTest.class.getName()));
+    public void testAllResults() {
+        fixture.addResult(success("OkTest1", TestResultsTest.class.getName()));
+        fixture.addResult(success("OkTest2", TestResultsTest.class.getName()));
+        fixture.addResult(failed("FailedTest1", TestResultsTest.class.getName(), new CitrusRuntimeException("This went wrong")));
+        fixture.addResult(failed("FailedTest2", TestResultsTest.class.getName(), new CitrusRuntimeException("This went wrong")));
+        fixture.addResult(skipped("SkippedTest1", TestResultsTest.class.getName()));
 
-        assertEquals(fixture.getSuccess(), 1);
-        assertEquals(fixture.getSuccessPercentageFormatted(), "50.0");
-        assertEquals(fixture.getFailed(), 1);
-        assertEquals(fixture.getFailedPercentageFormatted(), "50.0");
+        assertEquals(fixture.getSuccess(), 2);
+        assertEquals(fixture.getSuccessPercentageFormatted(), "40.0");
+        assertEquals(fixture.getFailed(), 2);
+        assertEquals(fixture.getFailedPercentageFormatted(), "40.0");
         assertEquals(fixture.getSkipped(), 1);
-        assertEquals(fixture.getSkippedPercentageFormatted(), "33.3");
+        assertEquals(fixture.getSkippedPercentageFormatted(), "20.0");
+    }
+
+    @Test
+    public void testResultsForNoResult() {
+        assertEquals(fixture.getSuccess(), 0);
+        assertEquals(fixture.getSuccessPercentageFormatted(), "0.0");
+        assertEquals(fixture.getFailed(), 0);
+        assertEquals(fixture.getFailedPercentageFormatted(), "0.0");
+        assertEquals(fixture.getSkipped(), 0);
+        assertEquals(fixture.getSkippedPercentageFormatted(), "0.0");
     }
 
     @Test


### PR DESCRIPTION
Fix the report statistics calculation for skipped tests.