### PR TITLE
fix(citrus-base): assume most common message types before validation

### DIFF
--- a/core/citrus-api/src/main/java/org/citrusframework/message/MessagePayloadUtils.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/message/MessagePayloadUtils.java
@@ -18,6 +18,8 @@ package org.citrusframework.message;
 
 import org.citrusframework.CitrusSettings;
 
+import static java.util.Objects.nonNull;
+
 public class MessagePayloadUtils {
 
     private static final boolean prettyPrint = CitrusSettings.isPrettyPrintEnabled();
@@ -55,7 +57,7 @@ public class MessagePayloadUtils {
      * @return
      */
     public static boolean isXml(String payload) {
-        return payload.trim().startsWith("<");
+        return nonNull(payload) && payload.trim().startsWith("<");
     }
 
     /**
@@ -64,7 +66,7 @@ public class MessagePayloadUtils {
      * @return
      */
     public static boolean isJson(String payload) {
-        return payload.trim().startsWith("{") || payload.trim().startsWith("[");
+        return nonNull(payload) && (payload.trim().startsWith("{") || payload.trim().startsWith("["));
     }
 
     /**

--- a/validation/citrus-validation-json/src/test/java/org/citrusframework/actions/dsl/ReceiveMessageActionBuilderTest.java
+++ b/validation/citrus-validation-json/src/test/java/org/citrusframework/actions/dsl/ReceiveMessageActionBuilderTest.java
@@ -16,12 +16,6 @@
 
 package org.citrusframework.actions.dsl;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.networknt.schema.JsonSchema;
 import org.citrusframework.DefaultTestCaseRunner;
@@ -57,15 +51,26 @@ import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.citrusframework.actions.ReceiveMessageAction.Builder.receive;
 import static org.citrusframework.dsl.JsonPathSupport.jsonPath;
 import static org.citrusframework.dsl.JsonSupport.json;
 import static org.citrusframework.dsl.MessageSupport.MessageBodySupport.fromBody;
 import static org.citrusframework.dsl.PathExpressionSupport.path;
+import static org.citrusframework.message.MessageType.JSON;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.nullValue;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
 
 public class ReceiveMessageActionBuilderTest extends UnitTestSupport {
 
@@ -108,7 +113,7 @@ public class ReceiveMessageActionBuilderTest extends UnitTestSupport {
         ReceiveMessageAction action = ((ReceiveMessageAction)test.getActions().get(0));
         Assert.assertEquals(action.getName(), "receive");
 
-        Assert.assertEquals(action.getMessageType(), MessageType.XML.name());
+        Assert.assertEquals(action.getMessageType(), JSON.name());
         Assert.assertEquals(action.getEndpoint(), messageEndpoint);
         Assert.assertEquals(action.getValidationContexts().size(), 3);
         Assert.assertTrue(action.getValidationContexts().stream().anyMatch(HeaderValidationContext.class::isInstance));
@@ -142,7 +147,7 @@ public class ReceiveMessageActionBuilderTest extends UnitTestSupport {
         ReceiveMessageAction action = ((ReceiveMessageAction)test.getActions().get(0));
         Assert.assertEquals(action.getName(), "receive");
 
-        Assert.assertEquals(action.getMessageType(), MessageType.XML.name());
+        Assert.assertEquals(action.getMessageType(), JSON.name());
         Assert.assertEquals(action.getEndpoint(), messageEndpoint);
         Assert.assertEquals(action.getValidationContexts().size(), 3);
         Assert.assertTrue(action.getValidationContexts().stream().anyMatch(HeaderValidationContext.class::isInstance));
@@ -185,7 +190,7 @@ public class ReceiveMessageActionBuilderTest extends UnitTestSupport {
         ReceiveMessageAction action = ((ReceiveMessageAction)test.getActions().get(0));
         Assert.assertEquals(action.getName(), "receive");
 
-        Assert.assertEquals(action.getMessageType(), MessageType.XML.name());
+        Assert.assertEquals(action.getMessageType(), JSON.name());
         Assert.assertEquals(action.getEndpoint(), messageEndpoint);
         Assert.assertEquals(action.getValidationContexts().size(), 3);
         Assert.assertTrue(action.getValidationContexts().stream().anyMatch(HeaderValidationContext.class::isInstance));
@@ -468,7 +473,7 @@ public class ReceiveMessageActionBuilderTest extends UnitTestSupport {
         DefaultTestCaseRunner runner = new DefaultTestCaseRunner(context);
         runner.run(receive(messageEndpoint)
                 .message()
-                .type(MessageType.JSON)
+                .type(JSON)
                 .body("{\"text\":\"Hello World!\", \"person\":{\"name\":\"John\",\"surname\":\"Doe\"}, \"index\":5, \"id\":\"x123456789x\"}")
                 .extract(fromBody()
                         .expression("$.text", "text")
@@ -489,7 +494,7 @@ public class ReceiveMessageActionBuilderTest extends UnitTestSupport {
         ReceiveMessageAction action = ((ReceiveMessageAction)test.getActions().get(0));
         Assert.assertEquals(action.getName(), "receive");
 
-        Assert.assertEquals(action.getMessageType(), MessageType.JSON.name());
+        Assert.assertEquals(action.getMessageType(), JSON.name());
         Assert.assertEquals(action.getEndpoint(), messageEndpoint);
 
         Assert.assertEquals(action.getVariableExtractors().size(), 1);
@@ -518,7 +523,7 @@ public class ReceiveMessageActionBuilderTest extends UnitTestSupport {
         DefaultTestCaseRunner runner = new DefaultTestCaseRunner(context);
         runner.run(receive(messageEndpoint)
                 .message()
-                .type(MessageType.JSON)
+                .type(JSON)
                 .body("{\"text\":\"Hello World!\", \"person\":{\"name\":\"John\",\"surname\":\"Doe\"}, \"index\":5, \"id\":\"x123456789x\"}")
                 .extract(path()
                         .expression("$.text", "text")
@@ -539,7 +544,7 @@ public class ReceiveMessageActionBuilderTest extends UnitTestSupport {
         ReceiveMessageAction action = ((ReceiveMessageAction)test.getActions().get(0));
         Assert.assertEquals(action.getName(), "receive");
 
-        Assert.assertEquals(action.getMessageType(), MessageType.JSON.name());
+        Assert.assertEquals(action.getMessageType(), JSON.name());
         Assert.assertEquals(action.getEndpoint(), messageEndpoint);
 
         Assert.assertEquals(action.getVariableExtractors().size(), 1);
@@ -568,7 +573,7 @@ public class ReceiveMessageActionBuilderTest extends UnitTestSupport {
         DefaultTestCaseRunner runner = new DefaultTestCaseRunner(context);
         runner.run(receive(messageEndpoint)
                 .message()
-                .type(MessageType.JSON)
+                .type(JSON)
                 .body("{\"text\":\"Hello World!\", \"person\":{\"name\":\"John\",\"surname\":\"Doe\"}, \"index\":5, \"id\":\"x123456789x\"}")
                 .extract(jsonPath()
                         .expression("$.text", "text")
@@ -589,7 +594,7 @@ public class ReceiveMessageActionBuilderTest extends UnitTestSupport {
         ReceiveMessageAction action = ((ReceiveMessageAction)test.getActions().get(0));
         Assert.assertEquals(action.getName(), "receive");
 
-        Assert.assertEquals(action.getMessageType(), MessageType.JSON.name());
+        Assert.assertEquals(action.getMessageType(), JSON.name());
         Assert.assertEquals(action.getEndpoint(), messageEndpoint);
 
         Assert.assertEquals(action.getVariableExtractors().size(), 1);
@@ -613,7 +618,7 @@ public class ReceiveMessageActionBuilderTest extends UnitTestSupport {
         DefaultTestCaseRunner runner = new DefaultTestCaseRunner(context);
         runner.run(receive(messageEndpoint)
                                 .message()
-                                .type(MessageType.JSON)
+                                .type(JSON)
                                 .body("{\"text\":\"Hello World!\", \"person\":{\"name\":\"John\",\"surname\":\"Doe\",\"active\": true}, \"index\":5, \"id\":\"x123456789x\"}")
                                 .validate(jsonPath()
                                         .expression("$.person.name", "John")
@@ -629,7 +634,7 @@ public class ReceiveMessageActionBuilderTest extends UnitTestSupport {
         ReceiveMessageAction action = ((ReceiveMessageAction)test.getActions().get(0));
         Assert.assertEquals(action.getName(), "receive");
 
-        Assert.assertEquals(action.getMessageType(), MessageType.JSON.name());
+        Assert.assertEquals(action.getMessageType(), JSON.name());
         Assert.assertEquals(action.getEndpoint(), messageEndpoint);
         Assert.assertEquals(action.getValidationContexts().size(), 3);
         Assert.assertTrue(action.getValidationContexts().stream().anyMatch(HeaderValidationContext.class::isInstance));
@@ -664,7 +669,7 @@ public class ReceiveMessageActionBuilderTest extends UnitTestSupport {
         DefaultTestCaseRunner runner = new DefaultTestCaseRunner(context);
         runner.run(receive(messageEndpoint)
                                 .message()
-                                .type(MessageType.JSON)
+                                .type(JSON)
                                 .body("{\"text\":\"Citrus rocks!\", \"user\":\"christoph\"}")
                                 .validate(jsonPath()
                                         .expression("$.user", "christoph"))
@@ -678,7 +683,7 @@ public class ReceiveMessageActionBuilderTest extends UnitTestSupport {
         ReceiveMessageAction action = ((ReceiveMessageAction)test.getActions().get(0));
         Assert.assertEquals(action.getName(), "receive");
 
-        Assert.assertEquals(action.getMessageType(), MessageType.JSON.name());
+        Assert.assertEquals(action.getMessageType(), JSON.name());
         Assert.assertEquals(action.getEndpoint(), messageEndpoint);
         Assert.assertEquals(action.getValidationContexts().size(), 4);
         Assert.assertTrue(action.getValidationContexts().stream().anyMatch(HeaderValidationContext.class::isInstance));
@@ -721,7 +726,7 @@ public class ReceiveMessageActionBuilderTest extends UnitTestSupport {
         DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
         builder.$(receive().endpoint(messageEndpoint)
                 .message()
-                .type(MessageType.JSON)
+                .type(JSON)
                 .body("{\"text\":\"Hello World!\", \"person\":{\"name\":\"John\",\"surname\":\"Doe\"}, \"index\":5, \"id\":\"x123456789x\"}")
                 .extract(jsonPath().expression("$.text", "text")
                         .expression("$.toString()", "payload")
@@ -741,7 +746,7 @@ public class ReceiveMessageActionBuilderTest extends UnitTestSupport {
         ReceiveMessageAction action = ((ReceiveMessageAction)test.getActions().get(0));
         Assert.assertEquals(action.getName(), "receive");
 
-        Assert.assertEquals(action.getMessageType(), MessageType.JSON.name());
+        Assert.assertEquals(action.getMessageType(), JSON.name());
         Assert.assertEquals(action.getEndpoint(), messageEndpoint);
 
         Assert.assertEquals(action.getVariableExtractors().size(), 1);
@@ -766,7 +771,7 @@ public class ReceiveMessageActionBuilderTest extends UnitTestSupport {
         DefaultTestCaseRunner runner = new DefaultTestCaseRunner(context);
         runner.run(receive(messageEndpoint)
                                 .message()
-                                .type(MessageType.JSON)
+                                .type(JSON)
                                 .body("{\"text\":\"Hello World!\", \"person\":{\"name\":\"John\",\"surname\":\"Doe\"}, \"index\":5, \"id\":\"x123456789x\"}")
                                 .validate(jsonPath()
                                         .expression("$.person.name", "John")
@@ -787,7 +792,7 @@ public class ReceiveMessageActionBuilderTest extends UnitTestSupport {
         DefaultTestCaseRunner runner = new DefaultTestCaseRunner(context);
         runner.run(receive(messageEndpoint)
                                 .message()
-                                .type(MessageType.JSON)
+                                .type(JSON)
                                 .body("{\"text\":\"Hello Citrus!\", \"person\":{\"name\":\"John\",\"surname\":\"Doe\"}, \"index\":5, \"id\":\"x123456789x\"}")
                                 .validate(json()
                                         .expression("$.person.name", "John")
@@ -808,7 +813,7 @@ public class ReceiveMessageActionBuilderTest extends UnitTestSupport {
         DefaultTestCaseRunner runner = new DefaultTestCaseRunner(context);
         runner.run(receive(messageEndpoint)
                                 .message()
-                                .type(MessageType.JSON)
+                                .type(JSON)
                                 .body("{\"text\":\"?\", \"person\":{\"name\":\"John\",\"surname\":\"?\"}, \"index\":0, \"id\":\"x123456789x\"}")
                                 .validate(json()
                                         .ignore("$..text")
@@ -822,7 +827,7 @@ public class ReceiveMessageActionBuilderTest extends UnitTestSupport {
         ReceiveMessageAction action = ((ReceiveMessageAction)test.getActions().get(0));
         Assert.assertEquals(action.getName(), "receive");
 
-        Assert.assertEquals(action.getMessageType(), MessageType.JSON.name());
+        Assert.assertEquals(action.getMessageType(), JSON.name());
         Assert.assertEquals(action.getEndpoint(), messageEndpoint);
         Assert.assertEquals(action.getValidationContexts().size(), 2);
         Assert.assertTrue(action.getValidationContexts().stream().anyMatch(HeaderValidationContext.class::isInstance));


### PR DESCRIPTION
**edit:** moved bug documentation to: https://github.com/citrusframework/citrus/issues/1338.

closes https://github.com/citrusframework/citrus/issues/1338.