### PR TITLE
fix(#1353): Introduce LocalStack service client options

### DIFF
--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/ClientFactory.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/ClientFactory.java
@@ -16,6 +16,7 @@
 
 package org.citrusframework.testcontainers.aws2;
 
+import java.util.Map;
 import java.util.Optional;
 
 import org.citrusframework.spi.ReferenceResolver;
@@ -27,9 +28,10 @@ public interface ClientFactory<T> {
     /**
      * Create client for given LocalStackContainer.
      * @param container
+     * @param options
      * @return
      */
-    T createClient(LocalStackContainer container);
+    T createClient(LocalStackContainer container, Map<String, String> options);
 
     /**
      * Checks if created client is suitable for given service.

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/LocalStackContainer.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/LocalStackContainer.java
@@ -21,6 +21,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -205,7 +206,7 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
         // lazy load client for this container
         Optional<ClientFactory<?>> clientFactory = ClientFactory.lookup(service);
         if (clientFactory.isPresent()) {
-            client = clientFactory.get().createClient(this);
+            client = clientFactory.get().createClient(this, Collections.emptyMap());
             clients.put(service, client);
         }
 

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/StartLocalStackAction.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/StartLocalStackAction.java
@@ -17,7 +17,9 @@
 package org.citrusframework.testcontainers.aws2;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -35,9 +37,12 @@ public class StartLocalStackAction extends StartTestcontainersAction<LocalStackC
 
     private final boolean autoCreateClients;
 
+    private final Map<String, String> options;
+
     public StartLocalStackAction(Builder builder) {
         super(builder);
         this.autoCreateClients = builder.autoCreateClients;
+        this.options = builder.options;
     }
 
     @Override
@@ -54,7 +59,7 @@ public class StartLocalStackAction extends StartTestcontainersAction<LocalStackC
 
                 Optional<ClientFactory<?>> clientFactory = ClientFactory.lookup(context.getReferenceResolver(), service);
                 if (clientFactory.isPresent()) {
-                    Object client = clientFactory.get().createClient(container);
+                    Object client = clientFactory.get().createClient(container, context.resolveDynamicValuesInMap(options));
                     container.addClient(service, client);
                     context.getReferenceResolver().bind(clientName, client);
                 } else {
@@ -74,6 +79,8 @@ public class StartLocalStackAction extends StartTestcontainersAction<LocalStackC
         private final Set<LocalStackContainer.Service> services = new HashSet<>();
 
         private boolean autoCreateClients = LocalStackSettings.isAutoCreateClients();
+
+        private Map<String, String> options = new HashMap<>();
 
         public Builder() {
             withStartupTimeout(LocalStackSettings.getStartupTimeout());
@@ -97,6 +104,16 @@ public class StartLocalStackAction extends StartTestcontainersAction<LocalStackC
         public Builder withServices(Set<LocalStackContainer.Service> services) {
             this.services.addAll(services);
            return this;
+        }
+
+        public Builder withOptions(Map<String, String> options) {
+            this.options.putAll(options);
+            return this;
+        }
+
+        public Builder withOption(String key, String value) {
+            this.options.put(key, value);
+            return this;
         }
 
         public Builder autoCreateClients(boolean enabled) {

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/client/DynamoDbClientFactory.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/client/DynamoDbClientFactory.java
@@ -16,18 +16,27 @@
 
 package org.citrusframework.testcontainers.aws2.client;
 
+import java.util.Map;
+
 import org.citrusframework.testcontainers.aws2.ClientFactory;
 import org.citrusframework.testcontainers.aws2.LocalStackContainer;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+import software.amazon.awssdk.services.dynamodb.model.StreamSpecification;
+import software.amazon.awssdk.services.dynamodb.model.StreamViewType;
 
 public class DynamoDbClientFactory implements ClientFactory<DynamoDbClient> {
 
     @Override
-    public DynamoDbClient createClient(LocalStackContainer container) {
-        return DynamoDbClient.builder()
+    public DynamoDbClient createClient(LocalStackContainer container, Map<String, String> options) {
+        DynamoDbClient ddbClient = DynamoDbClient.builder()
                 .endpointOverride(container.getServiceEndpoint())
                 .credentialsProvider(
                         StaticCredentialsProvider.create(
@@ -36,6 +45,37 @@ public class DynamoDbClientFactory implements ClientFactory<DynamoDbClient> {
                 )
                 .region(Region.of(container.getRegion()))
                 .build();
+
+        if (options.containsKey("tables")) {
+            String[] tables = options.get("tables").split(",");
+            for (String table : tables) {
+                ddbClient.createTable(b -> {
+                    b.tableName(table);
+
+                    String idAttr = options.getOrDefault("%s.id".formatted(table), "id");
+
+                    b.keySchema(KeySchemaElement.builder().attributeName(idAttr).keyType(KeyType.HASH).build());
+                    b.attributeDefinitions(AttributeDefinition.builder().attributeName(idAttr).attributeType(ScalarAttributeType.N).build());
+
+                    StreamViewType viewType = StreamViewType.valueOf(options.getOrDefault("%s.view.type".formatted(table),
+                            StreamViewType.NEW_AND_OLD_IMAGES.name()));
+
+                    b.streamSpecification(StreamSpecification.builder()
+                            .streamEnabled(true)
+                            .streamViewType(viewType).build());
+
+                    long readCapacity = Long.parseLong(options.getOrDefault("%s.read.capacity".formatted(table), "1"));
+                    long writeCapacity = Long.parseLong(options.getOrDefault("%s.write.capacity".formatted(table), "1"));
+
+                    b.provisionedThroughput(
+                            ProvisionedThroughput.builder()
+                                    .readCapacityUnits(readCapacity)
+                                    .writeCapacityUnits(writeCapacity).build());
+                });
+            }
+        }
+
+        return ddbClient;
     }
 
     @Override

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/client/EventBridgeClientFactory.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/client/EventBridgeClientFactory.java
@@ -16,6 +16,8 @@
 
 package org.citrusframework.testcontainers.aws2.client;
 
+import java.util.Map;
+
 import org.citrusframework.testcontainers.aws2.ClientFactory;
 import org.citrusframework.testcontainers.aws2.LocalStackContainer;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
@@ -26,8 +28,8 @@ import software.amazon.awssdk.services.eventbridge.EventBridgeClient;
 public class EventBridgeClientFactory implements ClientFactory<EventBridgeClient> {
 
     @Override
-    public EventBridgeClient createClient(LocalStackContainer container) {
-        return EventBridgeClient.builder()
+    public EventBridgeClient createClient(LocalStackContainer container, Map<String, String> options) {
+        EventBridgeClient eventBridgeClient = EventBridgeClient.builder()
                 .endpointOverride(container.getServiceEndpoint())
                 .credentialsProvider(
                         StaticCredentialsProvider.create(
@@ -36,6 +38,15 @@ public class EventBridgeClientFactory implements ClientFactory<EventBridgeClient
                 )
                 .region(Region.of(container.getRegion()))
                 .build();
+
+        if (options.containsKey("eventBusNames")) {
+            String[] eventBusNames = options.get("eventBusNames").split(",");
+            for (String eventBus : eventBusNames) {
+                eventBridgeClient.createEventBus(builder -> builder.name(eventBus));
+            }
+        }
+
+        return eventBridgeClient;
     }
 
     @Override

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/client/S3ClientFactory.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/client/S3ClientFactory.java
@@ -16,6 +16,8 @@
 
 package org.citrusframework.testcontainers.aws2.client;
 
+import java.util.Map;
+
 import org.citrusframework.testcontainers.aws2.ClientFactory;
 import org.citrusframework.testcontainers.aws2.LocalStackContainer;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
@@ -26,8 +28,8 @@ import software.amazon.awssdk.services.s3.S3Client;
 public class S3ClientFactory implements ClientFactory<S3Client> {
 
     @Override
-    public S3Client createClient(LocalStackContainer container) {
-        return S3Client.builder()
+    public S3Client createClient(LocalStackContainer container, Map<String, String> options) {
+        S3Client s3Client = S3Client.builder()
                 .endpointOverride(container.getServiceEndpoint())
                 .credentialsProvider(
                         StaticCredentialsProvider.create(
@@ -37,6 +39,15 @@ public class S3ClientFactory implements ClientFactory<S3Client> {
                 .forcePathStyle(true)
                 .region(Region.of(container.getRegion()))
                 .build();
+
+        if (options.containsKey("buckets")) {
+            String[] buckets = options.get("buckets").split(",");
+            for (String bucket : buckets) {
+                s3Client.createBucket(builder -> builder.bucket(bucket));
+            }
+        }
+
+        return s3Client;
     }
 
     @Override

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/client/SnsClientFactory.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/client/SnsClientFactory.java
@@ -16,6 +16,8 @@
 
 package org.citrusframework.testcontainers.aws2.client;
 
+import java.util.Map;
+
 import org.citrusframework.testcontainers.aws2.ClientFactory;
 import org.citrusframework.testcontainers.aws2.LocalStackContainer;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
@@ -26,8 +28,8 @@ import software.amazon.awssdk.services.sns.SnsClient;
 public class SnsClientFactory implements ClientFactory<SnsClient> {
 
     @Override
-    public SnsClient createClient(LocalStackContainer container) {
-        return SnsClient.builder()
+    public SnsClient createClient(LocalStackContainer container, Map<String, String> options) {
+        SnsClient snsClient = SnsClient.builder()
                 .endpointOverride(container.getServiceEndpoint())
                 .credentialsProvider(
                         StaticCredentialsProvider.create(
@@ -36,6 +38,15 @@ public class SnsClientFactory implements ClientFactory<SnsClient> {
                 )
                 .region(Region.of(container.getRegion()))
                 .build();
+
+        if (options.containsKey("topics")) {
+            String[] topics = options.get("topics").split(",");
+            for (String topic : topics) {
+                snsClient.createTopic(builder -> builder.name(topic));
+            }
+        }
+
+        return snsClient;
     }
 
     @Override

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/client/SqsClientFactory.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/client/SqsClientFactory.java
@@ -16,6 +16,8 @@
 
 package org.citrusframework.testcontainers.aws2.client;
 
+import java.util.Map;
+
 import org.citrusframework.testcontainers.aws2.ClientFactory;
 import org.citrusframework.testcontainers.aws2.LocalStackContainer;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
@@ -26,8 +28,8 @@ import software.amazon.awssdk.services.sqs.SqsClient;
 public class SqsClientFactory implements ClientFactory<SqsClient> {
 
     @Override
-    public SqsClient createClient(LocalStackContainer container) {
-        return SqsClient.builder()
+    public SqsClient createClient(LocalStackContainer container, Map<String, String> options) {
+        SqsClient sqsClient = SqsClient.builder()
                 .endpointOverride(container.getServiceEndpoint())
                 .credentialsProvider(
                         StaticCredentialsProvider.create(
@@ -36,6 +38,15 @@ public class SqsClientFactory implements ClientFactory<SqsClient> {
                 )
                 .region(Region.of(container.getRegion()))
                 .build();
+
+        if (options.containsKey("queues")) {
+            String[] queueNames = options.get("queues").split(",");
+            for (String queueName : queueNames) {
+                sqsClient.createQueue(builder -> builder.queueName(queueName));
+            }
+        }
+
+        return sqsClient;
     }
 
     @Override

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/xml/Start.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/xml/Start.java
@@ -68,6 +68,10 @@ public class Start extends AbstractTestcontainersAction.Builder<StartTestcontain
 
         builder.autoCreateClients(container.isAutoCreateClients());
 
+        if (container.getOptions() != null) {
+            container.getOptions().forEach(option -> builder.withOption(option.getName(), option.getValue()));
+        }
+
         configureStartActionBuilder(builder, container);
 
         if (container.getServices() != null) {
@@ -502,7 +506,8 @@ public class Start extends AbstractTestcontainersAction.Builder<StartTestcontain
 
     @XmlAccessorType(XmlAccessType.FIELD)
     @XmlType(name = "", propOrder = {
-            "services"
+            "services",
+            "options"
     })
     public static class LocalStack extends Container {
 
@@ -518,6 +523,8 @@ public class Start extends AbstractTestcontainersAction.Builder<StartTestcontain
         @XmlElement
         protected Services services;
 
+        @XmlElement
+        protected List<Option> options;
 
         public String getVersion() {
             return version;
@@ -542,6 +549,12 @@ public class Start extends AbstractTestcontainersAction.Builder<StartTestcontain
         public void setServices(Services services) {
             this.services = services;
         }
+
+        public List<Option> getOptions() {
+            return options;
+        }
+
+        public void setOptions(List<Option> options) {}
 
         public boolean isAutoCreateClients() {
             return autoCreateClients;
@@ -570,6 +583,32 @@ public class Start extends AbstractTestcontainersAction.Builder<StartTestcontain
             public void setServices(List<String> services) {
                 this.services = services;
             }
+        }
+
+        @XmlAccessorType(XmlAccessType.FIELD)
+        @XmlType(name = "", propOrder = {
+        })
+        public static class Option {
+
+            @XmlAttribute
+            private String name;
+
+            @XmlAttribute
+            private String value;
+
+            public String getName() {
+                return name;
+            }
+
+            public void setName(String name) {
+                this.name = name;
+            }
+
+            public String getValue() {
+                return value;
+            }
+
+            public void setValue(String value) {}
         }
     }
 

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/yaml/Start.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/yaml/Start.java
@@ -20,6 +20,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.citrusframework.TestActor;
 import org.citrusframework.exceptions.CitrusRuntimeException;
@@ -56,6 +57,10 @@ public class Start extends AbstractTestcontainersAction.Builder<StartTestcontain
         }
 
         builder.autoCreateClients(container.isAutoCreateClients());
+
+        if (container.getOptions() != null) {
+            builder.withOptions(container.getOptions());
+        }
 
         configureStartActionBuilder(builder, container);
 
@@ -346,12 +351,22 @@ public class Start extends AbstractTestcontainersAction.Builder<StartTestcontain
 
         protected List<String> services;
 
+        protected Map<String, String> options;
+
         public boolean isAutoCreateClients() {
             return autoCreateClients;
         }
 
         public void setAutoCreateClients(boolean autoCreateClients) {
             this.autoCreateClients = autoCreateClients;
+        }
+
+        public Map<String, String> getOptions() {
+            return options;
+        }
+
+        public void setOptions(Map<String, String> options) {
+            this.options = options;
         }
 
         public String getVersion() {

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-4.7.0-SNAPSHOT.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-4.7.0-SNAPSHOT.xsd
@@ -2321,6 +2321,18 @@
                         </xs:sequence>
                       </xs:complexType>
                     </xs:element>
+                    <xs:element name="options" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="option" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:attribute name="name" use="required" type="xs:string"/>
+                              <xs:attribute name="value" use="required" type="xs:string"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
                   </xs:sequence>
                   <xs:attribute name="name" type="xs:string"/>
                   <xs:attribute name="service-name" type="xs:string"/>

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
@@ -2177,332 +2177,344 @@
       <xs:documentation>Start and stop Docker containers via Testcontainers</xs:documentation>
     </xs:annotation>
     <xs:sequence>
-    <xs:element name="description" type="xs:string" minOccurs="0"/>
-    <xs:choice>
-      <xs:element name="compose">
-        <xs:complexType>
-          <xs:choice>
-            <xs:element name="up">
-              <xs:complexType>
-                <xs:sequence>
-                  <xs:element name="exposedService" minOccurs="0" maxOccurs="unbounded">
-                    <xs:complexType>
-                      <xs:sequence>
-                        <xs:element name="wait-for" minOccurs="0">
-                          <xs:complexType>
-                            <xs:attribute name="log-message" type="xs:string"/>
-                            <xs:attribute name="url" type="xs:string"/>
-                            <xs:attribute name="disabled" type="xs:boolean"/>
-                          </xs:complexType>
-                        </xs:element>
-                      </xs:sequence>
-                      <xs:attribute name="name" use="required" type="xs:string"/>
-                      <xs:attribute name="port" use="required" type="xs:string"/>
-                    </xs:complexType>
-                  </xs:element>
-                </xs:sequence>
-                <xs:attribute name="name" type="xs:string"/>
-                <xs:attribute name="file" type="xs:string"/>
-                <xs:attribute name="auto-remove" type="xs:boolean"/>
-                <xs:attribute name="startup-timeout" type="xs:int"/>
-              </xs:complexType>
-            </xs:element>
-            <xs:element name="down">
-              <xs:complexType>
-                <xs:attribute name="name" type="xs:string"/>
-              </xs:complexType>
-            </xs:element>
-          </xs:choice>
-        </xs:complexType>
-      </xs:element>
-      <xs:element name="start">
-        <xs:complexType>
-          <xs:choice>
-            <xs:element name="container">
-              <xs:complexType>
-                <xs:sequence>
-                  <xs:element name="labels" minOccurs="0">
-                    <xs:complexType>
-                      <xs:sequence>
-                        <xs:element name="label" maxOccurs="unbounded">
-                          <xs:complexType>
-                            <xs:attribute name="name" use="required" type="xs:string"/>
-                            <xs:attribute name="value" use="required" type="xs:string"/>
-                          </xs:complexType>
-                        </xs:element>
-                      </xs:sequence>
-                    </xs:complexType>
-                  </xs:element>
-                  <xs:element name="env" minOccurs="0">
-                    <xs:complexType>
-                      <xs:sequence>
-                        <xs:element name="variable" maxOccurs="unbounded">
-                          <xs:complexType>
-                            <xs:attribute name="name" use="required" type="xs:string"/>
-                            <xs:attribute name="value" use="required" type="xs:string"/>
-                          </xs:complexType>
-                        </xs:element>
-                      </xs:sequence>
-                    </xs:complexType>
-                  </xs:element>
-                  <xs:element name="exposed-ports" minOccurs="0">
-                    <xs:complexType>
-                      <xs:sequence>
-                        <xs:element name="port" maxOccurs="unbounded" type="xs:int"/>
-                      </xs:sequence>
-                    </xs:complexType>
-                  </xs:element>
-                  <xs:element name="port-bindings" minOccurs="0">
-                    <xs:complexType>
-                      <xs:sequence>
-                        <xs:element name="binding" maxOccurs="unbounded" type="xs:string"/>
-                      </xs:sequence>
-                    </xs:complexType>
-                  </xs:element>
-                  <xs:element name="wait-for" minOccurs="0">
-                    <xs:complexType>
-                      <xs:attribute name="log-message" type="xs:string"/>
-                      <xs:attribute name="url" type="xs:string"/>
-                      <xs:attribute name="disabled" type="xs:boolean"/>
-                    </xs:complexType>
-                  </xs:element>
-                  <xs:element name="volume-mounts" minOccurs="0">
-                    <xs:complexType>
-                      <xs:sequence>
-                        <xs:element name="mount" maxOccurs="unbounded">
-                          <xs:complexType>
-                            <xs:attribute name="file" use="required" type="xs:string"/>
-                            <xs:attribute name="mount-path" use="required" type="xs:string"/>
-                          </xs:complexType>
-                        </xs:element>
-                      </xs:sequence>
-                    </xs:complexType>
-                  </xs:element>
-                </xs:sequence>
-                <xs:attribute name="name" type="xs:string"/>
-                <xs:attribute name="service-name" type="xs:string"/>
-                <xs:attribute name="image" type="xs:string"/>
-                <xs:attribute name="auto-remove" type="xs:boolean"/>
-                <xs:attribute name="command" type="xs:string"/>
-                <xs:attribute name="startup-timeout" type="xs:int"/>
-              </xs:complexType>
-            </xs:element>
-            <xs:element name="localstack">
-              <xs:complexType>
-                <xs:sequence>
-                  <xs:element name="labels" minOccurs="0">
-                    <xs:complexType>
-                      <xs:sequence>
-                        <xs:element name="label" maxOccurs="unbounded">
-                          <xs:complexType>
-                            <xs:attribute name="name" use="required" type="xs:string"/>
-                            <xs:attribute name="value" use="required" type="xs:string"/>
-                          </xs:complexType>
-                        </xs:element>
-                      </xs:sequence>
-                    </xs:complexType>
-                  </xs:element>
-                  <xs:element name="env" minOccurs="0">
-                    <xs:complexType>
-                      <xs:sequence>
-                        <xs:element name="variable" maxOccurs="unbounded">
-                          <xs:complexType>
-                            <xs:attribute name="name" use="required" type="xs:string"/>
-                            <xs:attribute name="value" use="required" type="xs:string"/>
-                          </xs:complexType>
-                        </xs:element>
-                      </xs:sequence>
-                    </xs:complexType>
-                  </xs:element>
-                  <xs:element name="services" minOccurs="0">
-                    <xs:complexType>
-                      <xs:sequence>
-                        <xs:element name="service" maxOccurs="unbounded" type="xs:string"/>
-                      </xs:sequence>
-                    </xs:complexType>
-                  </xs:element>
-                </xs:sequence>
-                <xs:attribute name="name" type="xs:string"/>
-                <xs:attribute name="service-name" type="xs:string"/>
-                <xs:attribute name="version" type="xs:string"/>
-                <xs:attribute name="auto-remove" type="xs:boolean"/>
-                <xs:attribute name="auto-create-clients" type="xs:boolean"/>
-                <xs:attribute name="services" type="xs:string"/>
-                <xs:attribute name="image" type="xs:string"/>
-                <xs:attribute name="command" type="xs:string"/>
-                <xs:attribute name="startup-timeout" type="xs:int"/>
-              </xs:complexType>
-            </xs:element>
-            <xs:element name="mongodb">
-              <xs:complexType>
-                <xs:sequence>
-                  <xs:element name="labels" minOccurs="0">
-                    <xs:complexType>
-                      <xs:sequence>
-                        <xs:element name="label" maxOccurs="unbounded">
-                          <xs:complexType>
-                            <xs:attribute name="name" use="required" type="xs:string"/>
-                            <xs:attribute name="value" use="required" type="xs:string"/>
-                          </xs:complexType>
-                        </xs:element>
-                      </xs:sequence>
-                    </xs:complexType>
-                  </xs:element>
-                  <xs:element name="env" minOccurs="0">
-                    <xs:complexType>
-                      <xs:sequence>
-                        <xs:element name="variable" maxOccurs="unbounded">
-                          <xs:complexType>
-                            <xs:attribute name="name" use="required" type="xs:string"/>
-                            <xs:attribute name="value" use="required" type="xs:string"/>
-                          </xs:complexType>
-                        </xs:element>
-                      </xs:sequence>
-                    </xs:complexType>
-                  </xs:element>
-                </xs:sequence>
-                <xs:attribute name="name" type="xs:string"/>
-                <xs:attribute name="service-name" type="xs:string"/>
-                <xs:attribute name="version" type="xs:string"/>
-                <xs:attribute name="auto-remove" type="xs:boolean"/>
-                <xs:attribute name="image" type="xs:string"/>
-                <xs:attribute name="command" type="xs:string"/>
-                <xs:attribute name="startup-timeout" type="xs:int"/>
-              </xs:complexType>
-            </xs:element>
-            <xs:element name="kafka">
-              <xs:complexType>
-                <xs:sequence>
-                  <xs:element name="labels" minOccurs="0">
-                    <xs:complexType>
-                      <xs:sequence>
-                        <xs:element name="label" maxOccurs="unbounded">
-                          <xs:complexType>
-                            <xs:attribute name="name" use="required" type="xs:string"/>
-                            <xs:attribute name="value" use="required" type="xs:string"/>
-                          </xs:complexType>
-                        </xs:element>
-                      </xs:sequence>
-                    </xs:complexType>
-                  </xs:element>
-                  <xs:element name="env" minOccurs="0">
-                    <xs:complexType>
-                      <xs:sequence>
-                        <xs:element name="variable" maxOccurs="unbounded">
-                          <xs:complexType>
-                            <xs:attribute name="name" use="required" type="xs:string"/>
-                            <xs:attribute name="value" use="required" type="xs:string"/>
-                          </xs:complexType>
-                        </xs:element>
-                      </xs:sequence>
-                    </xs:complexType>
-                  </xs:element>
-                </xs:sequence>
-                <xs:attribute name="name" type="xs:string"/>
-                <xs:attribute name="service-name" type="xs:string"/>
-                <xs:attribute name="version" type="xs:string"/>
-                <xs:attribute name="auto-remove" type="xs:boolean"/>
-                <xs:attribute name="image" type="xs:string"/>
-                <xs:attribute name="command" type="xs:string"/>
-                <xs:attribute name="startup-timeout" type="xs:int"/>
-              </xs:complexType>
-            </xs:element>
-            <xs:element name="redpanda">
-              <xs:complexType>
-                <xs:sequence>
-                  <xs:element name="labels" minOccurs="0">
-                    <xs:complexType>
-                      <xs:sequence>
-                        <xs:element name="label" maxOccurs="unbounded">
-                          <xs:complexType>
-                            <xs:attribute name="name" use="required" type="xs:string"/>
-                            <xs:attribute name="value" use="required" type="xs:string"/>
-                          </xs:complexType>
-                        </xs:element>
-                      </xs:sequence>
-                    </xs:complexType>
-                  </xs:element>
-                  <xs:element name="env" minOccurs="0">
-                    <xs:complexType>
-                      <xs:sequence>
-                        <xs:element name="variable" maxOccurs="unbounded">
-                          <xs:complexType>
-                            <xs:attribute name="name" use="required" type="xs:string"/>
-                            <xs:attribute name="value" use="required" type="xs:string"/>
-                          </xs:complexType>
-                        </xs:element>
-                      </xs:sequence>
-                    </xs:complexType>
-                  </xs:element>
-                </xs:sequence>
-                <xs:attribute name="name" type="xs:string"/>
-                <xs:attribute name="service-name" type="xs:string"/>
-                <xs:attribute name="version" type="xs:string"/>
-                <xs:attribute name="auto-remove" type="xs:boolean"/>
-                <xs:attribute name="image" type="xs:string"/>
-                <xs:attribute name="command" type="xs:string"/>
-                <xs:attribute name="startup-timeout" type="xs:int"/>
-              </xs:complexType>
-            </xs:element>
-            <xs:element name="postgresql">
-              <xs:complexType>
-                <xs:sequence>
-                  <xs:element name="labels" minOccurs="0">
-                    <xs:complexType>
-                      <xs:sequence>
-                        <xs:element name="label" maxOccurs="unbounded">
-                          <xs:complexType>
-                            <xs:attribute name="name" use="required" type="xs:string"/>
-                            <xs:attribute name="value" use="required" type="xs:string"/>
-                          </xs:complexType>
-                        </xs:element>
-                      </xs:sequence>
-                    </xs:complexType>
-                  </xs:element>
-                  <xs:element name="env" minOccurs="0">
-                    <xs:complexType>
-                      <xs:sequence>
-                        <xs:element name="variable" maxOccurs="unbounded">
-                          <xs:complexType>
-                            <xs:attribute name="name" use="required" type="xs:string"/>
-                            <xs:attribute name="value" use="required" type="xs:string"/>
-                          </xs:complexType>
-                        </xs:element>
-                      </xs:sequence>
-                    </xs:complexType>
-                  </xs:element>
-                  <xs:element name="init-script" minOccurs="0">
-                    <xs:complexType>
-                      <xs:complexContent>
-                        <xs:extension base="xs:string">
-                          <xs:attribute name="file" type="xs:string"/>
-                        </xs:extension>
-                      </xs:complexContent>
-                    </xs:complexType>
-                  </xs:element>
-                </xs:sequence>
-                <xs:attribute name="name" type="xs:string"/>
-                <xs:attribute name="service-name" type="xs:string"/>
-                <xs:attribute name="version" type="xs:string"/>
-                <xs:attribute name="auto-remove" type="xs:boolean"/>
-                <xs:attribute name="datasource-name" type="xs:string"/>
-                <xs:attribute name="database" type="xs:string"/>
-                <xs:attribute name="username" type="xs:string"/>
-                <xs:attribute name="password" type="xs:string"/>
-                <xs:attribute name="image" type="xs:string"/>
-                <xs:attribute name="command" type="xs:string"/>
-                <xs:attribute name="startup-timeout" type="xs:int"/>
-              </xs:complexType>
-            </xs:element>
-          </xs:choice>
-        </xs:complexType>
-      </xs:element>
-      <xs:element name="stop">
-        <xs:complexType>
-          <xs:attribute name="name" use="required" type="xs:string"/>
-        </xs:complexType>
-      </xs:element>
-    </xs:choice>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:choice>
+        <xs:element name="compose">
+          <xs:complexType>
+            <xs:choice>
+              <xs:element name="up">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="exposedService" minOccurs="0" maxOccurs="unbounded">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="wait-for" minOccurs="0">
+                            <xs:complexType>
+                              <xs:attribute name="log-message" type="xs:string"/>
+                              <xs:attribute name="url" type="xs:string"/>
+                              <xs:attribute name="disabled" type="xs:boolean"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                        <xs:attribute name="name" use="required" type="xs:string"/>
+                        <xs:attribute name="port" use="required" type="xs:string"/>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                  <xs:attribute name="name" type="xs:string"/>
+                  <xs:attribute name="file" type="xs:string"/>
+                  <xs:attribute name="auto-remove" type="xs:boolean"/>
+                  <xs:attribute name="startup-timeout" type="xs:int"/>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="down">
+                <xs:complexType>
+                  <xs:attribute name="name" type="xs:string"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:choice>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="start">
+          <xs:complexType>
+            <xs:choice>
+              <xs:element name="container">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="labels" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="label" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:attribute name="name" use="required" type="xs:string"/>
+                              <xs:attribute name="value" use="required" type="xs:string"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="env" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="variable" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:attribute name="name" use="required" type="xs:string"/>
+                              <xs:attribute name="value" use="required" type="xs:string"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="exposed-ports" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="port" maxOccurs="unbounded" type="xs:int"/>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="port-bindings" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="binding" maxOccurs="unbounded" type="xs:string"/>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="wait-for" minOccurs="0">
+                      <xs:complexType>
+                        <xs:attribute name="log-message" type="xs:string"/>
+                        <xs:attribute name="url" type="xs:string"/>
+                        <xs:attribute name="disabled" type="xs:boolean"/>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="volume-mounts" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="mount" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:attribute name="file" use="required" type="xs:string"/>
+                              <xs:attribute name="mount-path" use="required" type="xs:string"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                  <xs:attribute name="name" type="xs:string"/>
+                  <xs:attribute name="service-name" type="xs:string"/>
+                  <xs:attribute name="image" type="xs:string"/>
+                  <xs:attribute name="auto-remove" type="xs:boolean"/>
+                  <xs:attribute name="command" type="xs:string"/>
+                  <xs:attribute name="startup-timeout" type="xs:int"/>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="localstack">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="labels" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="label" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:attribute name="name" use="required" type="xs:string"/>
+                              <xs:attribute name="value" use="required" type="xs:string"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="env" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="variable" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:attribute name="name" use="required" type="xs:string"/>
+                              <xs:attribute name="value" use="required" type="xs:string"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="services" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="service" maxOccurs="unbounded" type="xs:string"/>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="options" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="option" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:attribute name="name" use="required" type="xs:string"/>
+                              <xs:attribute name="value" use="required" type="xs:string"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                  <xs:attribute name="name" type="xs:string"/>
+                  <xs:attribute name="service-name" type="xs:string"/>
+                  <xs:attribute name="version" type="xs:string"/>
+                  <xs:attribute name="auto-remove" type="xs:boolean"/>
+                  <xs:attribute name="auto-create-clients" type="xs:boolean"/>
+                  <xs:attribute name="services" type="xs:string"/>
+                  <xs:attribute name="image" type="xs:string"/>
+                  <xs:attribute name="command" type="xs:string"/>
+                  <xs:attribute name="startup-timeout" type="xs:int"/>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="mongodb">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="labels" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="label" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:attribute name="name" use="required" type="xs:string"/>
+                              <xs:attribute name="value" use="required" type="xs:string"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="env" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="variable" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:attribute name="name" use="required" type="xs:string"/>
+                              <xs:attribute name="value" use="required" type="xs:string"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                  <xs:attribute name="name" type="xs:string"/>
+                  <xs:attribute name="service-name" type="xs:string"/>
+                  <xs:attribute name="version" type="xs:string"/>
+                  <xs:attribute name="auto-remove" type="xs:boolean"/>
+                  <xs:attribute name="image" type="xs:string"/>
+                  <xs:attribute name="command" type="xs:string"/>
+                  <xs:attribute name="startup-timeout" type="xs:int"/>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="kafka">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="labels" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="label" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:attribute name="name" use="required" type="xs:string"/>
+                              <xs:attribute name="value" use="required" type="xs:string"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="env" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="variable" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:attribute name="name" use="required" type="xs:string"/>
+                              <xs:attribute name="value" use="required" type="xs:string"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                  <xs:attribute name="name" type="xs:string"/>
+                  <xs:attribute name="service-name" type="xs:string"/>
+                  <xs:attribute name="version" type="xs:string"/>
+                  <xs:attribute name="auto-remove" type="xs:boolean"/>
+                  <xs:attribute name="image" type="xs:string"/>
+                  <xs:attribute name="command" type="xs:string"/>
+                  <xs:attribute name="startup-timeout" type="xs:int"/>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="redpanda">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="labels" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="label" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:attribute name="name" use="required" type="xs:string"/>
+                              <xs:attribute name="value" use="required" type="xs:string"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="env" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="variable" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:attribute name="name" use="required" type="xs:string"/>
+                              <xs:attribute name="value" use="required" type="xs:string"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                  <xs:attribute name="name" type="xs:string"/>
+                  <xs:attribute name="service-name" type="xs:string"/>
+                  <xs:attribute name="version" type="xs:string"/>
+                  <xs:attribute name="auto-remove" type="xs:boolean"/>
+                  <xs:attribute name="image" type="xs:string"/>
+                  <xs:attribute name="command" type="xs:string"/>
+                  <xs:attribute name="startup-timeout" type="xs:int"/>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="postgresql">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="labels" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="label" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:attribute name="name" use="required" type="xs:string"/>
+                              <xs:attribute name="value" use="required" type="xs:string"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="env" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="variable" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:attribute name="name" use="required" type="xs:string"/>
+                              <xs:attribute name="value" use="required" type="xs:string"/>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="init-script" minOccurs="0">
+                      <xs:complexType>
+                        <xs:complexContent>
+                          <xs:extension base="xs:string">
+                            <xs:attribute name="file" type="xs:string"/>
+                          </xs:extension>
+                        </xs:complexContent>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                  <xs:attribute name="name" type="xs:string"/>
+                  <xs:attribute name="service-name" type="xs:string"/>
+                  <xs:attribute name="version" type="xs:string"/>
+                  <xs:attribute name="auto-remove" type="xs:boolean"/>
+                  <xs:attribute name="datasource-name" type="xs:string"/>
+                  <xs:attribute name="database" type="xs:string"/>
+                  <xs:attribute name="username" type="xs:string"/>
+                  <xs:attribute name="password" type="xs:string"/>
+                  <xs:attribute name="image" type="xs:string"/>
+                  <xs:attribute name="command" type="xs:string"/>
+                  <xs:attribute name="startup-timeout" type="xs:int"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:choice>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="stop">
+          <xs:complexType>
+            <xs:attribute name="name" use="required" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
     </xs:sequence>
   </xs:complexType>
 

--- a/src/manual/connector-testcontainers.adoc
+++ b/src/manual/connector-testcontainers.adoc
@@ -408,8 +408,11 @@ actions:
 </spring:beans>
 ----
 
-Each LocalStack instance receives a list of enables services.
+Each LocalStack instance receives a list of services that should be enabled.
 In the example above the AWS S3 service is enabled.
+
+[[testcontainers-localstack-settings]]
+=== Exposed connection settings
 
 Citrus exposes special test variables that represent connection settings for the LocalStack container:
 
@@ -441,7 +444,136 @@ For each enabled service on the LocalStack instance these variables are exposed:
 
 |===
 
-You can use these test variables to connect to the LocalStack Testcontainers instance.
+[[testcontainers-localstack-auto-clients]]
+=== Service client auto creation
+
+The Citrus LocalStack container action is able to automatically create clients for the enabled services.
+
+By default, Citrus creates the client instances and stores them in the bean Citrus registry. You can then reference the clients by their name.
+
+The following services support auto creation of clients:
+
+* S3 ("s3Client")
+* SNS ("snsClient")
+* SQS ("sqsClient")
+* KINESIS (kinesisClient)
+* DYNAMODB (dnyamodbClient)
+* EVENT_BRIDGE("eventbridgeClient")
+
+For instance the S3 service creates a client instance called `s3Client`. The clients are automatically configured with the container service settings such as endpointUri, accessKey, secretKey and region for S3.
+
+The underlying client factory is able to handle specific options. For the S3 client factory for instance this is a comma separated list of bucket names to auto create S3 buckets.
+
+.Java
+[source,java,indent=0,role="primary"]
+----
+@CitrusTest
+public void testcontainersTest() {
+    given(testcontainers()
+            .localstack()
+            .start()
+            .withService(LocalStackContainer.Service.S3))
+            .withOption("buckets", "my_bucket_name,another_bucket_name");
+}
+----
+
+.XML
+[source,xml,indent=0,role="secondary"]
+----
+<test name="TestcontainersTest" xmlns="http://citrusframework.org/schema/xml/testcase">
+    <actions>
+        <testcontainers>
+          <start>
+            <localstack services="S3">
+              <options>
+                <option name="buckets" value="my_bucket_name,another_bucket_name"/>
+              </options>
+            </localstack>
+          </start>
+        </testcontainers>
+    </actions>
+</test>
+----
+
+.YAML
+[source,yaml,indent=0,role="secondary"]
+----
+name: TestcontainersTest
+actions:
+  - testcontainers:
+      start:
+        localstack:
+          services:
+            - "S3"
+          options:
+            buckets: "my_bucket_name,another_bucket_name"
+----
+
+.Spring XML
+[source,xml,indent=0,role="secondary"]
+----
+<spring:beans xmlns="http://www.citrusframework.org/schema/testcase"
+              xmlns:spring="http://www.springframework.org/schema/beans">
+    <!-- NOT SUPPORTED -->
+</spring:beans>
+----
+
+Please see this list of supported options on the individual client factories:
+
+|===
+|Client |Option |Description
+
+|s3Client
+|buckets
+|Comma separated list of bucket names that get auto created
+
+|sqsClient
+|queues
+|Comma separated list of queue names that get auto created
+
+|snsClient
+|topics
+|Comma separated list of topic names that get auto created
+
+|kinesisClient
+|streams
+|Comma separated list of stream names that get auto created
+
+|kinesisClient
+|<stream_name>.shard.count
+|Shard count set on the given stream
+
+|dynamodbClient
+|tables
+|Comma separated list of table names that get auto created.
+
+|dynamodbClient
+|<table_name>.id
+|Id attribute name set on the table as a primary id.
+
+|dynamodbClient
+|<table_name>.view.type
+|View type set on the table stream specification (default=NEW_AND_OLD_IMAGES).
+
+|dynamodbClient
+|<table_name>.read.capacity
+|Read capacity set as provisioned throughput (default=1).
+
+|dynamodbClient
+|<table_name>.write.capacity
+|Write capacity set as provisioned throughput (default=1).
+
+|eventbridgeClient
+|eventBusNames
+|Comma separated list of event bus names that get auto created
+
+|===
+
+[[testcontainers-localstack-clients]]
+=== Custom service clients
+
+You can use the exposed connections settings in the test variables to connect to the LocalStack Testcontainers instance.
+
 As an example this S3 client connects to the LocalStack Testcontainers instance and creates a test bucket:
 
 .Java


### PR DESCRIPTION
- Client factory supporting options to auto create entities for the service
- Auto create S3 buckets, SQS queues, SNS topics, Kinesis streams, ...