### PR TITLE
chore: Add propagation of beans to Camel registry

### DIFF
--- a/core/citrus-api/src/main/java/org/citrusframework/endpoint/DefaultEndpointFactory.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/endpoint/DefaultEndpointFactory.java
@@ -113,12 +113,12 @@ public class DefaultEndpointFactory implements EndpointFactory {
         String componentName = tok.nextToken();
         Optional<EndpointComponent> component = Optional.ofNullable(getEndpointComponents(context.getReferenceResolver()).get(componentName));
 
-        if (!component.isPresent()) {
+        if (component.isEmpty()) {
             // try to get component from default Citrus modules
             component = EndpointComponent.lookup(componentName);
         }
 
-        if (!component.isPresent()) {
+        if (component.isEmpty()) {
             throw new CitrusRuntimeException(String.format("Unable to create endpoint component with name '%s'", componentName));
         }
 

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/AbstractCamelAction.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/AbstractCamelAction.java
@@ -17,12 +17,11 @@
 package org.citrusframework.camel.actions;
 
 import org.apache.camel.CamelContext;
-import org.apache.camel.impl.DefaultCamelContext;
 import org.citrusframework.AbstractTestActionBuilder;
 import org.citrusframework.actions.AbstractTestAction;
-import org.citrusframework.camel.CamelSettings;
 import org.citrusframework.camel.CamelTestActor;
 import org.citrusframework.camel.context.CamelReferenceResolver;
+import org.citrusframework.camel.util.CamelUtils;
 import org.citrusframework.spi.ReferenceResolver;
 import org.citrusframework.spi.ReferenceResolverAware;
 import org.citrusframework.util.ObjectHelper;
@@ -84,21 +83,9 @@ public abstract class AbstractCamelAction extends AbstractTestAction implements 
         @Override
         public final T build() {
             if (camelContext == null) {
-                ObjectHelper.assertNotNull(referenceResolver, "Insufficient Camel action configuration - either set Camel context or proper reference resolver!");
-
-                if (referenceResolver.isResolvable(CamelSettings.getContextName())) {
-                    camelContext = referenceResolver.resolve(CamelSettings.getContextName(), CamelContext.class);
-                } else if (referenceResolver.isResolvable(CamelContext.class)) {
-                    camelContext = referenceResolver.resolve(CamelContext.class);
-                } else {
-                    camelContext = new DefaultCamelContext();
-                    try {
-                        camelContext.start();
-                    } catch (Exception e) {
-                        throw new IllegalStateException("Failed to start Camel context '%s'".formatted(CamelSettings.getContextName()), e);
-                    }
-                    referenceResolver.bind(CamelSettings.getContextName(), camelContext);
-                }
+                ObjectHelper.assertNotNull(referenceResolver, "Insufficient Camel action configuration - " +
+                        "either set Camel context or proper reference resolver!");
+                camelContext = CamelUtils.resolveCamelContext(referenceResolver, null);
             }
 
             if (referenceResolver == null) {

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/context/CamelReferenceResolver.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/context/CamelReferenceResolver.java
@@ -19,6 +19,7 @@ package org.citrusframework.camel.context;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.camel.NoSuchBeanException;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.spi.ReferenceResolver;
 import org.citrusframework.spi.SimpleReferenceResolver;
@@ -59,24 +60,31 @@ public class CamelReferenceResolver implements ReferenceResolver {
 
     @Override
     public <T> T resolve(String name, Class<T> type) {
-        T component = camelContext.getRegistry().lookupByNameAndType(name, type);
-
-        if (component != null) {
-            return component;
+        try {
+            T component = camelContext.getRegistry().lookupByNameAndType(name, type);
+            if (component != null) {
+                return component;
+            }
+        } catch (NoSuchBeanException e) {
+            // do nothing
         }
 
         if (fallback.isResolvable(name)) {
             return fallback.resolve(name, type);
         }
+
         throw new CitrusRuntimeException(String.format("Unable to find bean reference for name '%s'", name));
     }
 
     @Override
     public Object resolve(String name) {
-        Object component = camelContext.getRegistry().lookupByName(name);
-
-        if (component != null) {
-            return component;
+        try {
+            Object component = camelContext.getRegistry().lookupByName(name);
+            if (component != null) {
+                return component;
+            }
+        } catch (NoSuchBeanException e) {
+            // do nothing
         }
 
         if (fallback.isResolvable(name)) {
@@ -93,17 +101,29 @@ public class CamelReferenceResolver implements ReferenceResolver {
 
     @Override
     public boolean isResolvable(String name) {
-        return camelContext.getRegistry().lookupByName(name) != null || fallback.isResolvable(name);
+        try {
+            return camelContext.getRegistry().lookupByName(name) != null || fallback.isResolvable(name);
+        } catch (NoSuchBeanException e) {
+            return fallback.isResolvable(name);
+        }
     }
 
     @Override
     public boolean isResolvable(Class<?> type) {
-        return !camelContext.getRegistry().findByType(type).isEmpty() || fallback.isResolvable(type);
+        try {
+            return !camelContext.getRegistry().findByType(type).isEmpty() || fallback.isResolvable(type);
+        } catch (NoSuchBeanException e) {
+            return fallback.isResolvable(type);
+        }
     }
 
     @Override
     public boolean isResolvable(String name, Class<?> type) {
-        return camelContext.getRegistry().lookupByNameAndType(name, type) != null || fallback.isResolvable(name, type);
+        try {
+            return camelContext.getRegistry().lookupByNameAndType(name, type) != null || fallback.isResolvable(name, type);
+        } catch (NoSuchBeanException e) {
+            return fallback.isResolvable(name, type);
+        }
     }
 
     /**

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/endpoint/CamelEndpointComponent.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/endpoint/CamelEndpointComponent.java
@@ -18,10 +18,7 @@ package org.citrusframework.camel.endpoint;
 
 import java.util.Map;
 
-import org.apache.camel.CamelContext;
-import org.apache.camel.impl.DefaultCamelContext;
-import org.citrusframework.camel.CamelSettings;
-import org.citrusframework.camel.context.CamelReferenceResolver;
+import org.citrusframework.camel.util.CamelUtils;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.endpoint.AbstractEndpointComponent;
 import org.citrusframework.endpoint.Endpoint;
@@ -48,22 +45,17 @@ public class CamelEndpointComponent extends AbstractEndpointComponent {
             endpoint.getEndpointConfiguration().setEndpointUri(resourcePath.substring("inOut:".length()) + getParameterString(parameters, CamelSyncEndpointConfiguration.class));
         } else if (resourcePath.startsWith("inOnly:")) {
             endpoint = new CamelEndpoint();
-            endpoint.getEndpointConfiguration().setEndpointUri(resourcePath.substring("inOnly:".length()) + getParameterString(parameters, CamelEndpointConfiguration.class));
+            endpoint.getEndpointConfiguration().setEndpointUri(
+                    resourcePath.substring("inOnly:".length()) + getParameterString(parameters, CamelEndpointConfiguration.class));
         } else {
             endpoint = new CamelEndpoint();
-            endpoint.getEndpointConfiguration().setEndpointUri(resourcePath + getParameterString(parameters, CamelEndpointConfiguration.class));
+            endpoint.getEndpointConfiguration().setEndpointUri(
+                    resourcePath + getParameterString(parameters, CamelEndpointConfiguration.class));
         }
 
         if (context.getReferenceResolver() != null) {
-            if (context.getReferenceResolver() instanceof CamelReferenceResolver camelReferenceResolver) {
-                endpoint.getEndpointConfiguration().setCamelContext(camelReferenceResolver.getCamelContext());
-            } else if (context.getReferenceResolver().resolveAll(CamelContext.class).size() == 1) {
-                endpoint.getEndpointConfiguration().setCamelContext(context.getReferenceResolver().resolve(CamelContext.class));
-            } else if (context.getReferenceResolver().isResolvable(CamelSettings.getContextName(), CamelContext.class)) {
-                endpoint.getEndpointConfiguration().setCamelContext(context.getReferenceResolver().resolve(CamelSettings.getContextName(), CamelContext.class));
-            } else {
-                endpoint.getEndpointConfiguration().setCamelContext(new DefaultCamelContext());
-            }
+            endpoint.getEndpointConfiguration().setCamelContext(
+                    CamelUtils.resolveCamelContext(context.getReferenceResolver(), endpoint.getEndpointConfiguration()));
         }
 
         enrichEndpointConfiguration(endpoint.getEndpointConfiguration(),

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/endpoint/CamelProducer.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/endpoint/CamelProducer.java
@@ -21,6 +21,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.citrusframework.camel.CamelSettings;
+import org.citrusframework.camel.util.CamelUtils;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.message.Message;
@@ -57,14 +58,7 @@ public class CamelProducer implements Producer {
 
     @Override
     public void send(final Message message, final TestContext context) {
-        String endpointUri;
-        if (endpointConfiguration.getEndpointUri() != null) {
-            endpointUri = context.replaceDynamicContentInString(endpointConfiguration.getEndpointUri());
-        } else if (endpointConfiguration.getEndpoint() != null) {
-            endpointUri = endpointConfiguration.getEndpoint().getEndpointUri();
-        } else {
-            throw new CitrusRuntimeException("Missing endpoint or endpointUri on Camel producer");
-        }
+        String endpointUri = CamelUtils.resolveEndpointUri(context, endpointConfiguration);
 
         if (logger.isDebugEnabled()) {
             logger.debug("Sending message to camel endpoint: '" + endpointUri + "'");

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/endpoint/CamelSyncProducer.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/endpoint/CamelSyncProducer.java
@@ -16,6 +16,7 @@
 
 package org.citrusframework.camel.endpoint;
 
+import org.citrusframework.camel.util.CamelUtils;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.exceptions.ReplyMessageTimeoutException;
@@ -60,14 +61,7 @@ public class CamelSyncProducer extends CamelProducer implements ReplyConsumer {
 
     @Override
     public void send(final Message message, final TestContext context) {
-        String endpointUri;
-        if (endpointConfiguration.getEndpointUri() != null) {
-            endpointUri = context.replaceDynamicContentInString(endpointConfiguration.getEndpointUri());
-        } else if (endpointConfiguration.getEndpoint() != null){
-            endpointUri = endpointConfiguration.getEndpoint().getEndpointUri();
-        } else {
-            throw new CitrusRuntimeException("Missing endpoint or endpointUri on Camel producer");
-        }
+        String endpointUri = CamelUtils.resolveEndpointUri(context, endpointConfiguration);
 
         if (logger.isDebugEnabled()) {
             logger.debug("Sending message to camel endpoint: '" + endpointUri + "'");

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/util/CamelUtils.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/util/CamelUtils.java
@@ -16,13 +16,30 @@
 
 package org.citrusframework.camel.util;
 
+import java.net.URISyntaxException;
+import java.util.Objects;
+
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
+import org.apache.camel.CamelContext;
+import org.apache.camel.NoSuchBeanException;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.util.URISupport;
+import org.citrusframework.camel.CamelSettings;
+import org.citrusframework.camel.context.CamelReferenceResolver;
+import org.citrusframework.camel.endpoint.CamelEndpointConfiguration;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.spi.ReferenceResolver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Camel utilities.
  */
 public class CamelUtils {
+
+    private static final Logger logger = LoggerFactory.getLogger(CamelUtils.class);
 
     private static volatile JAXBContext context;
 
@@ -42,5 +59,85 @@ public class CamelUtils {
         }
 
         return context;
+    }
+
+    /**
+     * Resolves endpoint uri with bean reference support, that resolves beans from Citrus context.
+     */
+    public static String resolveEndpointUri(TestContext context, CamelEndpointConfiguration endpointConfiguration) {
+        String endpointUri;
+        if (endpointConfiguration.getEndpointUri() != null) {
+            endpointUri = context.replaceDynamicContentInString(endpointConfiguration.getEndpointUri()).trim();
+
+            // check for bean references in endpoint uri
+            if (endpointUri.contains("=#")) {
+                CamelContext camelContext = resolveCamelContext(context.getReferenceResolver(), endpointConfiguration);
+                if (camelContext != null) {
+                    try {
+                        URISupport.parseQuery(endpointUri).values().stream()
+                                .filter(Objects::nonNull)
+                                .filter(it -> it instanceof String)
+                                .filter(it -> it.toString().startsWith("#"))
+                                .peek(it -> logger.debug("Resolving bean reference '{}' in Camel endpoint uri", it))
+                                .map(it -> it.toString().substring(1))
+                                .forEach(beanRef -> {
+                                    boolean missing;
+                                    try {
+                                        missing = camelContext.getRegistry().lookupByName(beanRef) == null;
+                                    } catch (NoSuchBeanException e) {
+                                        missing = true;
+                                    }
+
+                                    if (missing && context.getReferenceResolver().isResolvable(beanRef)) {
+                                        logger.info("Propagating bean reference '{}' to Camel registry", beanRef);
+                                        camelContext.getRegistry().bind(beanRef,
+                                                context.getReferenceResolver().resolve(beanRef));
+                                    }
+                                });
+                    } catch (URISyntaxException e) {
+                        logger.warn("Failed to parse Camel endpoint uri", e);
+                    }
+                }
+            }
+        } else if (endpointConfiguration.getEndpoint() != null) {
+            endpointUri = endpointConfiguration.getEndpoint().getEndpointUri();
+        } else {
+            throw new CitrusRuntimeException("Missing endpoint or endpointUri on Camel producer");
+        }
+
+        return endpointUri;
+    }
+
+    /**
+     * Resolves Camel context from given Citrus test context.
+     */
+    public static CamelContext resolveCamelContext(ReferenceResolver referenceResolver,
+                                                   CamelEndpointConfiguration endpointConfiguration) {
+        if (endpointConfiguration != null && endpointConfiguration.getCamelContext() != null) {
+            return endpointConfiguration.getCamelContext();
+        }
+
+        if (referenceResolver instanceof CamelReferenceResolver camelReferenceResolver &&
+                camelReferenceResolver.getCamelContext() != null) {
+            return camelReferenceResolver.getCamelContext();
+        }
+
+        if (referenceResolver.resolveAll(CamelContext.class).size() == 1) {
+            return referenceResolver.resolve(CamelContext.class);
+        }
+
+        if (referenceResolver.isResolvable(CamelSettings.getContextName(), CamelContext.class)) {
+            return referenceResolver.resolve(CamelSettings.getContextName(), CamelContext.class);
+        }
+
+        CamelContext camelContext = new DefaultCamelContext();
+        try {
+            camelContext.start();
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to start Camel context '%s'".formatted(CamelSettings.getContextName()), e);
+        }
+        referenceResolver.bind(CamelSettings.getContextName(), camelContext);
+
+        return camelContext;
     }
 }

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/util/CamelUtilsTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/util/CamelUtilsTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.util;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.support.SimpleRegistry;
+import org.citrusframework.camel.UnitTestSupport;
+import org.citrusframework.camel.context.CamelReferenceResolver;
+import org.citrusframework.camel.endpoint.CamelEndpointConfiguration;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.when;
+
+public class CamelUtilsTest extends UnitTestSupport {
+
+    @Mock
+    private CamelContext camelContext;
+
+    @BeforeClass
+    public void init() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void testCamelBeanPropagation() {
+        SimpleRegistry registry = new SimpleRegistry();
+
+        when(camelContext.getRegistry()).thenReturn(registry);
+
+        Object myBean = new Object();
+        context.getReferenceResolver().bind("myBean", myBean);
+
+        CamelReferenceResolver resolver = new CamelReferenceResolver(camelContext).withFallback(context.getReferenceResolver());
+        context.setReferenceResolver(resolver);
+
+        CamelEndpointConfiguration endpointConfiguration = new CamelEndpointConfiguration();
+        endpointConfiguration.setCamelContext(camelContext);
+        endpointConfiguration.setEndpointUri("direct:test?otherProp=foo&factory=#myBean&anotherProp=bar");
+        CamelUtils.resolveEndpointUri(context, endpointConfiguration);
+
+        Assert.assertEquals(registry.lookupByName("myBean"), myBean);
+    }
+
+    @Test
+    public void testCamelBeanPropagationNotFound() {
+        SimpleRegistry registry = new SimpleRegistry();
+
+        when(camelContext.getRegistry()).thenReturn(registry);
+
+        CamelReferenceResolver resolver = new CamelReferenceResolver(camelContext).withFallback(context.getReferenceResolver());
+        context.setReferenceResolver(resolver);
+
+        CamelEndpointConfiguration endpointConfiguration = new CamelEndpointConfiguration();
+        endpointConfiguration.setCamelContext(camelContext);
+        endpointConfiguration.setEndpointUri("direct:test?otherProp=foo&factory=#myBean&anotherProp=bar");
+        CamelUtils.resolveEndpointUri(context, endpointConfiguration);
+
+        Assert.assertNull(registry.lookupByName("myBean"));
+    }
+
+    @Test
+    public void testExistingCamelBean() {
+        SimpleRegistry registry = new SimpleRegistry();
+
+        Object existingBean = new Object();
+        registry.bind("myBean", existingBean);
+
+        when(camelContext.getRegistry()).thenReturn(registry);
+
+        Object myBean = new Object();
+        context.getReferenceResolver().bind("myBean", myBean);
+
+        CamelReferenceResolver resolver = new CamelReferenceResolver(camelContext).withFallback(context.getReferenceResolver());
+        context.setReferenceResolver(resolver);
+
+        CamelEndpointConfiguration endpointConfiguration = new CamelEndpointConfiguration();
+        endpointConfiguration.setCamelContext(camelContext);
+        endpointConfiguration.setEndpointUri("direct:test?otherProp=foo&factory=#myBean&anotherProp=bar");
+        CamelUtils.resolveEndpointUri(context, endpointConfiguration);
+
+        Assert.assertEquals(registry.lookupByName("myBean"), existingBean);
+    }
+}


### PR DESCRIPTION
- Auto propagate beans from Citrus registry to Camel registry
- Resolves Camel bean references in endpoint uris and propagates beans from Citrus to the Camel registry