### PR TITLE
fix(#1363): Support YAML content in LogModifier

### DIFF
--- a/core/citrus-api/src/main/java/org/citrusframework/CitrusSettings.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/CitrusSettings.java
@@ -255,26 +255,6 @@ public final class CitrusSettings {
     public static final String PRETTY_PRINT_ENV = "CITRUS_MESSAGE_PRETTY_PRINT";
     public static final String PRETTY_PRINT_DEFAULT = Boolean.TRUE.toString();
 
-    /**
-     * Flag to enable/disable logger modifier
-     */
-    public static final String LOG_MODIFIER_PROPERTY = "citrus.logger.modifier";
-    public static final String LOG_MODIFIER_ENV = "CITRUS_LOG_MODIFIER";
-    public static final String LOG_MODIFIER_DEFAULT = Boolean.TRUE.toString();
-
-    /**
-     * Default logger modifier mask value
-     */
-    public static final String LOG_MASK_VALUE_PROPERTY = "citrus.logger.mask.value";
-    public static final String LOG_MASK_VALUE_ENV = "CITRUS_LOG_MASK_VALUE";
-    public static final String LOG_MASK_VALUE_DEFAULT = "****";
-
-    /**
-     * Default logger modifier keywords
-     */
-    public static final String LOG_MASK_KEYWORDS_PROPERTY = "citrus.logger.mask.keywords";
-    public static final String LOG_MASK_KEYWORDS_ENV = "CITRUS_LOG_MASK_KEYWORDS";
-    public static final String LOG_MASK_KEYWORDS_DEFAULT = "password,secret,secretKey";
 
     /**
      * File path charset parameter
@@ -376,30 +356,6 @@ public final class CitrusSettings {
     }
 
     /**
-     * Gets the logger modifier enabled/disabled setting.
-     *
-     * @return
-     */
-    public static boolean isLogModifierEnabled() {
-        return parseBoolean(getPropertyEnvOrDefault(
-                LOG_MODIFIER_PROPERTY,
-                LOG_MODIFIER_ENV,
-                LOG_MODIFIER_DEFAULT));
-    }
-
-    /**
-     * Get logger mask value.
-     *
-     * @return
-     */
-    public static String getLogMaskValue() {
-        return getPropertyEnvOrDefault(
-                LOG_MASK_VALUE_PROPERTY,
-                LOG_MASK_VALUE_ENV,
-                LOG_MASK_VALUE_DEFAULT);
-    }
-
-    /**
      * Get the file path charset parameter.
      *
      * @return
@@ -409,21 +365,6 @@ public final class CitrusSettings {
                 FILE_PATH_CHARSET_PARAMETER_PROPERTY,
                 FILE_PATH_CHARSET_PARAMETER_ENV,
                 FILE_PATH_CHARSET_PARAMETER_DEFAULT);
-    }
-
-    /**
-     * Get logger mask keywords.
-     *
-     * @return
-     */
-    public static Set<String> getLogMaskKeywords() {
-        return Stream.of(getPropertyEnvOrDefault(
-                        LOG_MASK_KEYWORDS_PROPERTY,
-                        LOG_MASK_KEYWORDS_ENV,
-                        LOG_MASK_KEYWORDS_DEFAULT)
-                        .split(","))
-                .map(String::trim)
-                .collect(toSet());
     }
 
     /**

--- a/core/citrus-api/src/main/java/org/citrusframework/log/CitrusLogSettings.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/log/CitrusLogSettings.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.log;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.citrusframework.CitrusSettings;
+
+import static java.lang.Boolean.parseBoolean;
+import static java.util.stream.Collectors.toSet;
+
+public final class CitrusLogSettings {
+
+    private static final String CITRUS_LOGGER_PROPERTY_PREFIX = "citrus.logger.";
+    private static final String CITRUS_LOGGER_ENV_PREFIX = "CITRUS_LOG_";
+
+    /**
+     * Default logger modifier keywords
+     */
+    public static final String LOG_MASK_KEYWORDS_PROPERTY = CITRUS_LOGGER_PROPERTY_PREFIX + "mask.keywords";
+    public static final String LOG_MASK_KEYWORDS_ENV = CITRUS_LOGGER_ENV_PREFIX + "MASK_KEYWORDS";
+    public static final String LOG_MASK_KEYWORDS_DEFAULT = "password,secret,secretKey";
+
+    /**
+     * Flag to enable/disable logger modifier
+     */
+    public static final String LOG_MODIFIER_PROPERTY = CITRUS_LOGGER_PROPERTY_PREFIX + "modifier";
+    public static final String LOG_MODIFIER_ENV = CITRUS_LOGGER_ENV_PREFIX + "MODIFIER";
+    public static final String LOG_MODIFIER_DEFAULT = Boolean.TRUE.toString();
+
+    /**
+     * Default logger modifier mask value
+     */
+    public static final String LOG_MASK_VALUE_PROPERTY = CITRUS_LOGGER_PROPERTY_PREFIX + "mask.value";
+    public static final String LOG_MASK_VALUE_ENV = CITRUS_LOGGER_ENV_PREFIX + "MASK_VALUE";
+    public static final String LOG_MASK_VALUE_DEFAULT = "****";
+
+    /**
+     * Flag to enable/disable log mask for XML payload
+     */
+    public static final String LOG_MASK_XML_PROPERTY = CITRUS_LOGGER_PROPERTY_PREFIX + "mask.xml";
+    public static final String LOG_MASK_XML_ENV = CITRUS_LOGGER_ENV_PREFIX + "MASK_XML";
+    public static final String LOG_MASK_XML_DEFAULT = Boolean.TRUE.toString();
+
+    /**
+     * Flag to enable/disable log mask for Json payload
+     */
+    public static final String LOG_MASK_JSON_PROPERTY = CITRUS_LOGGER_PROPERTY_PREFIX + "mask.json";
+    public static final String LOG_MASK_JSON_ENV = CITRUS_LOGGER_ENV_PREFIX + "MASK_JSON";
+    public static final String LOG_MASK_JSON_DEFAULT = Boolean.TRUE.toString();
+
+    /**
+     * Flag to enable/disable log mask for YAML payload
+     */
+    public static final String LOG_MASK_YAML_PROPERTY = CITRUS_LOGGER_PROPERTY_PREFIX + "mask.yaml";
+    public static final String LOG_MASK_YAML_ENV = CITRUS_LOGGER_ENV_PREFIX + "MASK_YAML";
+    public static final String LOG_MASK_YAML_DEFAULT = Boolean.TRUE.toString();
+
+    /**
+     * Flag to enable/disable log mask for key value pairs payload
+     */
+    public static final String LOG_MASK_KEY_VALUE_PROPERTY = CITRUS_LOGGER_PROPERTY_PREFIX + "mask.key.value";
+    public static final String LOG_MASK_KEY_VALUE_ENV = CITRUS_LOGGER_ENV_PREFIX + "MASK_KEY_VALUE";
+    public static final String LOG_MASK_KEY_VALUE_DEFAULT = Boolean.TRUE.toString();
+
+    /**
+     * Flag to enable/disable log mask for form url encoded payload
+     */
+    public static final String LOG_MASK_FORM_URL_ENCODED_PROPERTY = CITRUS_LOGGER_PROPERTY_PREFIX + "mask.form.url.encoded";
+    public static final String LOG_MASK_FORM_URL_ENCODED_ENV = CITRUS_LOGGER_ENV_PREFIX + "MASK_FORM_URL_ENCODED";
+    public static final String LOG_MASK_FORM_URL_ENCODED_DEFAULT = Boolean.TRUE.toString();
+
+    private CitrusLogSettings() {
+        //prevent instantiation of utility class
+    }
+
+    /**
+     * Get logger mask keywords.
+     */
+    public static Set<String> getLogMaskKeywords() {
+        return Stream.of(CitrusSettings.getPropertyEnvOrDefault(
+                        LOG_MASK_KEYWORDS_PROPERTY,
+                        LOG_MASK_KEYWORDS_ENV,
+                        LOG_MASK_KEYWORDS_DEFAULT)
+                        .split(","))
+                .map(String::trim)
+                .collect(toSet());
+    }
+
+    /**
+     * Gets the logger modifier enabled/disabled setting.
+     */
+    public static boolean isLogModifierEnabled() {
+        return parseBoolean(CitrusSettings.getPropertyEnvOrDefault(
+                LOG_MODIFIER_PROPERTY,
+                LOG_MODIFIER_ENV,
+                LOG_MODIFIER_DEFAULT));
+    }
+
+    /**
+     * Get logger mask value.
+     */
+    public static String getLogMaskValue() {
+        return CitrusSettings.getPropertyEnvOrDefault(
+                LOG_MASK_VALUE_PROPERTY,
+                LOG_MASK_VALUE_ENV,
+                LOG_MASK_VALUE_DEFAULT);
+    }
+
+    /**
+     * Gets the mask XML enabled/disabled setting.
+     */
+    public static boolean isMaskXmlEnabled() {
+        return parseBoolean(CitrusSettings.getPropertyEnvOrDefault(
+                LOG_MASK_XML_PROPERTY,
+                LOG_MASK_XML_ENV,
+                LOG_MASK_XML_DEFAULT));
+    }
+
+    /**
+     * Gets the mask Json enabled/disabled setting.
+     */
+    public static boolean isMaskJsonEnabled() {
+        return parseBoolean(CitrusSettings.getPropertyEnvOrDefault(
+                LOG_MASK_JSON_PROPERTY,
+                LOG_MASK_JSON_ENV,
+                LOG_MASK_JSON_DEFAULT));
+    }
+
+    /**
+     * Gets the mask YAML enabled/disabled setting.
+     */
+    public static boolean isMaskYamlEnabled() {
+        return parseBoolean(CitrusSettings.getPropertyEnvOrDefault(
+                LOG_MASK_YAML_PROPERTY,
+                LOG_MASK_YAML_ENV,
+                LOG_MASK_YAML_DEFAULT));
+    }
+
+    /**
+     * Gets the mask kay value pairs enabled/disabled setting.
+     */
+    public static boolean isMaskKeyValueEnabled() {
+        return parseBoolean(CitrusSettings.getPropertyEnvOrDefault(
+                LOG_MASK_KEY_VALUE_PROPERTY,
+                LOG_MASK_KEY_VALUE_ENV,
+                LOG_MASK_KEY_VALUE_DEFAULT));
+    }
+
+    /**
+     * Gets the mask form url encoded enabled/disabled setting.
+     */
+    public static boolean isMaskFormUrlEncodedEnabled() {
+        return parseBoolean(CitrusSettings.getPropertyEnvOrDefault(
+                LOG_MASK_FORM_URL_ENCODED_PROPERTY,
+                LOG_MASK_FORM_URL_ENCODED_ENV,
+                LOG_MASK_FORM_URL_ENCODED_DEFAULT));
+    }
+}

--- a/core/citrus-api/src/main/java/org/citrusframework/log/LogMessageModifier.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/log/LogMessageModifier.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.citrusframework.CitrusSettings;
 import org.citrusframework.message.Message;
 
 /**
@@ -56,7 +55,7 @@ public interface LogMessageModifier extends LogModifier {
 
                     String keyValuePair = String.format("%s=%s", entry.getKey(), entry.getValue());
                     if (!keyValuePair.equals(mask(keyValuePair))) {
-                        return CitrusSettings.getLogMaskValue();
+                        return CitrusLogSettings.getLogMaskValue();
                     }
 
                     return entry.getValue();

--- a/core/citrus-api/src/test/java/org/citrusframework/log/LogMessageModifierTest.java
+++ b/core/citrus-api/src/test/java/org/citrusframework/log/LogMessageModifierTest.java
@@ -18,7 +18,6 @@ package org.citrusframework.log;
 
 import java.util.Collections;
 
-import org.citrusframework.CitrusSettings;
 import org.citrusframework.message.Message;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -52,7 +51,7 @@ public class LogMessageModifierTest {
         Assert.assertEquals(modifier.maskHeaders(message), Collections.singletonMap("key", "value"));
 
         modifier = new MockLogModifier("key=masked");
-        Assert.assertEquals(modifier.maskHeaders(message), Collections.singletonMap("key", CitrusSettings.getLogMaskValue()));
+        Assert.assertEquals(modifier.maskHeaders(message), Collections.singletonMap("key", CitrusLogSettings.getLogMaskValue()));
     }
 
     private static class MockLogModifier implements LogMessageModifier {

--- a/core/citrus-base/src/test/java/org/citrusframework/log/DefaultLogModifierTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/log/DefaultLogModifierTest.java
@@ -16,7 +16,6 @@
 
 package org.citrusframework.log;
 
-import org.citrusframework.CitrusSettings;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -24,16 +23,20 @@ public class DefaultLogModifierTest {
 
     @Test
     public void testMaskKeyValue() {
-        Assert.assertTrue(CitrusSettings.isLogModifierEnabled());
+        Assert.assertTrue(CitrusLogSettings.isLogModifierEnabled());
 
         DefaultLogModifier logModifier = new DefaultLogModifier();
 
         Assert.assertEquals(logModifier.mask("password=foo"), "password=****");
+        Assert.assertEquals(logModifier.mask("PASSWORD=foo"), "PASSWORD=****");
+        Assert.assertEquals(logModifier.mask("SERVICE_PASSWORD=foo"), "SERVICE_PASSWORD=****");
         Assert.assertEquals(logModifier.mask("password=foo bar"), "password=****");
-        Assert.assertEquals(logModifier.mask("password=!@#$%^*() -+[]{};:"), "password=****");
+        Assert.assertEquals(logModifier.mask("password=!@#$%^*() -+[]{}:;"), "password=****");
         Assert.assertEquals(logModifier.mask("password = foo"), "password = ****");
         Assert.assertEquals(logModifier.mask("password = foo  bar"), "password = ****");
         Assert.assertEquals(logModifier.mask("password=\"foo\""), "password=\"****\"");
+        Assert.assertEquals(logModifier.mask("PASSWORD=\"foo\""), "PASSWORD=\"****\"");
+        Assert.assertEquals(logModifier.mask("SERVICE_PASSWORD=\"foo\""), "SERVICE_PASSWORD=\"****\"");
         Assert.assertEquals(logModifier.mask("password=\"\""), "password=\"\"");
         Assert.assertEquals(logModifier.mask("password=\"!@#$%^*() -+[]{};:\""), "password=\"****\"");
         Assert.assertEquals(logModifier.mask("password='foo'"), "password='****'");
@@ -53,7 +56,7 @@ public class DefaultLogModifierTest {
 
     @Test
     public void testMaskFormUrlEncoded() {
-        Assert.assertTrue(CitrusSettings.isLogModifierEnabled());
+        Assert.assertTrue(CitrusLogSettings.isLogModifierEnabled());
 
         DefaultLogModifier logModifier = new DefaultLogModifier();
 
@@ -65,7 +68,7 @@ public class DefaultLogModifierTest {
 
     @Test
     public void testMaskXml() {
-        Assert.assertTrue(CitrusSettings.isLogModifierEnabled());
+        Assert.assertTrue(CitrusLogSettings.isLogModifierEnabled());
 
         DefaultLogModifier logModifier = new DefaultLogModifier();
 
@@ -88,7 +91,7 @@ public class DefaultLogModifierTest {
 
     @Test
     public void testMaskJson() {
-        Assert.assertTrue(CitrusSettings.isLogModifierEnabled());
+        Assert.assertTrue(CitrusLogSettings.isLogModifierEnabled());
 
         DefaultLogModifier logModifier = new DefaultLogModifier();
 
@@ -104,5 +107,84 @@ public class DefaultLogModifierTest {
                 "{\"password\": \"****\", \"secret\": \"****\", \"secretKey\": \"****\"}");
         Assert.assertEquals(logModifier.mask("{\"a\": \"foo\", \"b\": \"foo\", \"secretKey\": \"foo\"}"),
                 "{\"a\": \"foo\", \"b\": \"foo\", \"secretKey\": \"****\"}");
+    }
+
+    @Test
+    public void testMaskYaml() {
+        Assert.assertTrue(CitrusLogSettings.isLogModifierEnabled());
+
+        DefaultLogModifier logModifier = new DefaultLogModifier();
+
+        Assert.assertEquals(logModifier.mask("- password: 'foo'"), "- password: '****'");
+        Assert.assertEquals(logModifier.mask("- password: 'foo bar'"), "- password: '****'");
+        Assert.assertEquals(logModifier.mask("- password: {}"), "- password: ****");
+        Assert.assertEquals(logModifier.mask("- password: '!@#$%^&*() -+[]{};:'"), "- password: '****'");
+
+        Assert.assertEquals(logModifier.mask("- password: \"foo\""), "- password: \"****\"");
+        Assert.assertEquals(logModifier.mask("- password: \"foo bar\""), "- password: \"****\"");
+        Assert.assertEquals(logModifier.mask("- password: \"!@#$%^&*() -+[]{};:\""), "- password: \"****\"");
+
+        Assert.assertEquals(logModifier.mask("- secret: 'foo'"), "- secret: '****'");
+        Assert.assertEquals(logModifier.mask("- secretKey: 'foo'"), "- secretKey: '****'");
+
+        Assert.assertEquals(logModifier.mask("- secret: \"foo\""), "- secret: \"****\"");
+        Assert.assertEquals(logModifier.mask("- secretKey: \"foo\""), "- secretKey: \"****\"");
+
+        Assert.assertEquals(logModifier.mask("""
+            - password: 'foo'
+              secret: 'foo'
+              secretKey: 'foo'
+            """),
+            """
+            - password: '****'
+              secret: '****'
+              secretKey: '****'
+            """);
+        Assert.assertEquals(logModifier.mask("""
+            - password: "foo"
+              secret: "foo"
+              secretKey: "foo"
+            """),
+            """
+            - password: "****"
+              secret: "****"
+              secretKey: "****"
+            """);
+
+        Assert.assertEquals(logModifier.mask("""
+            - nested:
+                password: 'foo'
+                secret: 'foo'
+                secretKey: 'foo'
+            """),
+            """
+            - nested:
+                password: '****'
+                secret: '****'
+                secretKey: '****'
+            """);
+        Assert.assertEquals(logModifier.mask("""
+            - nested:
+                password: "foo"
+                secret: "foo"
+                secretKey: "foo"
+            """),
+            """
+            - nested:
+                password: "****"
+                secret: "****"
+                secretKey: "****"
+            """);
+
+        Assert.assertEquals(logModifier.mask("""
+            - a: 'foo'
+              b: 'foo'
+              secretKey: 'foo'
+            """),
+            """
+            - a: 'foo'
+              b: 'foo'
+              secretKey: '****'
+            """);
     }
 }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/infra/CamelRunInfraAction.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/infra/CamelRunInfraAction.java
@@ -125,7 +125,7 @@ public class CamelRunInfraAction extends AbstractCamelAction {
             if (logger.isDebugEnabled()) {
                 logger.debug("Camel infra service properties: {}", serviceProperties.entrySet()
                         .stream()
-                        .map((entry) -> "%s = %s".formatted(entry.getKey(), entry.getValue()))
+                        .map((entry) -> context.getLogModifier().mask("%s='%s'".formatted(entry.getKey(), entry.getValue().toString())))
                         .collect(Collectors.joining(System.lineSeparator())));
             }
 
@@ -133,9 +133,8 @@ public class CamelRunInfraAction extends AbstractCamelAction {
             serviceProperties.forEach((key, value) -> {
                 String name = "%s%s_%s".formatted(CamelInfraSettings.CAMEL_INFRA_ENV_PREFIX, serviceVariableName, normalizeKey(key));
                 context.setVariable(name, value);
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Exposing service property '{}' with value '{}'", name, value);
-                }
+                logger.info("Exposing service property {}",
+                        context.getLogModifier().mask("%s='%s'".formatted(name, value.toString())));
             });
 
             if (autoRemove) {

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/actions/infra/MyService.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/actions/infra/MyService.java
@@ -20,5 +20,6 @@ public interface MyService {
     String getServerUrl();
     String host();
     int port();
+    String password();
     boolean isFaultTolerant();
 }

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/actions/infra/MyServiceImpl.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/actions/infra/MyServiceImpl.java
@@ -47,6 +47,11 @@ public class MyServiceImpl implements MyService {
     }
 
     @Override
+    public String password() {
+        return "secret";
+    }
+
+    @Override
     public boolean isFaultTolerant() {
         return false;
     }


### PR DESCRIPTION
- Mask sensitive data in YAML message content
- Mask log output when logging Camel infra settings