### PR TITLE
fix(#1371): Add environment property binding support

### DIFF
--- a/connectors/citrus-agent-connector/src/main/java/org/citrusframework/agent/connector/actions/AgentConnectAction.java
+++ b/connectors/citrus-agent-connector/src/main/java/org/citrusframework/agent/connector/actions/AgentConnectAction.java
@@ -24,6 +24,7 @@ import org.citrusframework.http.client.HttpClient;
 import org.citrusframework.http.client.HttpClientBuilder;
 import org.citrusframework.http.message.HttpMessage;
 import org.citrusframework.message.Message;
+import org.citrusframework.util.PropertyUtils;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.client.ResourceAccessException;
 
@@ -57,6 +58,7 @@ public class AgentConnectAction extends AbstractAgentAction {
             httpClient = new HttpClientBuilder()
                     .requestUrl(url)
                     .build();
+            PropertyUtils.configure(clientName, httpClient, context.getReferenceResolver());
             context.getReferenceResolver().bind(clientName, httpClient);
         }
 

--- a/connectors/citrus-knative/src/main/java/org/citrusframework/knative/actions/eventing/CreateBrokerAction.java
+++ b/connectors/citrus-knative/src/main/java/org/citrusframework/knative/actions/eventing/CreateBrokerAction.java
@@ -27,6 +27,7 @@ import org.citrusframework.knative.KnativeSupport;
 import org.citrusframework.knative.KnativeVariableNames;
 import org.citrusframework.knative.actions.AbstractKnativeAction;
 import org.citrusframework.kubernetes.KubernetesSettings;
+import org.citrusframework.util.PropertyUtils;
 
 import static org.citrusframework.knative.actions.KnativeActionBuilder.knative;
 
@@ -67,8 +68,8 @@ public class CreateBrokerAction extends AbstractKnativeAction {
                     .build();
 
             brokerServer.initialize();
-            context.getReferenceResolver()
-                    .bind(resolvedBrokerName, brokerServer);
+            PropertyUtils.configure(resolvedBrokerName, brokerServer, context.getReferenceResolver());
+            context.getReferenceResolver().bind(resolvedBrokerName, brokerServer);
         } else {
             brokerServer = context.getReferenceResolver().resolve(resolvedBrokerName, HttpServer.class);
         }

--- a/connectors/citrus-knative/src/main/java/org/citrusframework/knative/actions/eventing/ReceiveEventAction.java
+++ b/connectors/citrus-knative/src/main/java/org/citrusframework/knative/actions/eventing/ReceiveEventAction.java
@@ -30,6 +30,7 @@ import org.citrusframework.knative.actions.AbstractKnativeAction;
 import org.citrusframework.knative.ce.CloudEvent;
 import org.citrusframework.knative.ce.CloudEventMessage;
 import org.citrusframework.knative.ce.CloudEventSupport;
+import org.citrusframework.util.PropertyUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.RequestMethod;
 
@@ -175,9 +176,11 @@ public class ReceiveEventAction extends AbstractKnativeAction {
                             .timeout(timeout)
                             .port(servicePort)
                             .name(serviceName)
+                            .referenceResolver(referenceResolver)
                             .build();
 
                     httpServer.initialize();
+                    PropertyUtils.configure(serviceName, httpServer, referenceResolver);
                 }
             }
 

--- a/connectors/citrus-knative/src/main/java/org/citrusframework/knative/actions/eventing/SendEventAction.java
+++ b/connectors/citrus-knative/src/main/java/org/citrusframework/knative/actions/eventing/SendEventAction.java
@@ -32,6 +32,7 @@ import org.citrusframework.knative.ce.CloudEvent;
 import org.citrusframework.knative.ce.CloudEventMessage;
 import org.citrusframework.knative.ce.CloudEventSupport;
 import org.citrusframework.spi.ReferenceResolverAware;
+import org.citrusframework.util.PropertyUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.util.StringUtils;
@@ -188,10 +189,15 @@ public class SendEventAction extends AbstractKnativeAction {
                     httpClient = new HttpClientBuilder()
                             .timeout(timeout)
                             .requestUrl(brokerUrl)
+                            .referenceResolver(referenceResolver)
                             .build();
 
                     if (brokerUrl.startsWith("https")) {
                         httpClient.getEndpointConfiguration().setRequestFactory(KnativeSupport.sslRequestFactory());
+                    }
+
+                    if (brokerName != null) {
+                        PropertyUtils.configure(brokerName, httpClient, referenceResolver);
                     }
                 }
             }

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/actions/CreateServiceAction.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/actions/CreateServiceAction.java
@@ -37,6 +37,7 @@ import org.citrusframework.kubernetes.KubernetesSettings;
 import org.citrusframework.kubernetes.KubernetesVariableNames;
 import org.citrusframework.spi.ReferenceResolver;
 import org.citrusframework.spi.ReferenceResolverAware;
+import org.citrusframework.util.PropertyUtils;
 
 import static org.citrusframework.kubernetes.actions.KubernetesActionBuilder.kubernetes;
 
@@ -235,9 +236,11 @@ public class CreateServiceAction extends AbstractKubernetesAction {
                             .autoStart(true)
                             .port(KubernetesSettings.getServicePort())
                             .name(serverName)
+                            .referenceResolver(referenceResolver)
                             .build();
 
                     httpServer.initialize();
+                    PropertyUtils.configure(serverName, httpServer, referenceResolver);
                 }
             }
 

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/actions/ServiceConnectAction.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/actions/ServiceConnectAction.java
@@ -23,6 +23,7 @@ import org.citrusframework.http.client.HttpClient;
 import org.citrusframework.http.client.HttpClientBuilder;
 import org.citrusframework.http.server.HttpServer;
 import org.citrusframework.kubernetes.KubernetesSettings;
+import org.citrusframework.util.PropertyUtils;
 import org.citrusframework.util.StringUtils;
 
 import static org.citrusframework.kubernetes.actions.KubernetesActionBuilder.kubernetes;
@@ -103,7 +104,10 @@ public class ServiceConnectAction extends AbstractKubernetesAction {
         } else {
             HttpClient serviceClient = new HttpClientBuilder()
                     .requestUrl("http://localhost:%d".formatted(localPort))
+                    .referenceResolver(context.getReferenceResolver())
                     .build();
+
+            PropertyUtils.configure(clientName, serviceClient, context.getReferenceResolver());
             context.getReferenceResolver().bind(clientName, serviceClient);
         }
     }

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/StartLocalStackAction.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/StartLocalStackAction.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.testcontainers.TestContainersSettings;
 import org.citrusframework.testcontainers.actions.StartTestcontainersAction;
+import org.citrusframework.util.PropertyUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -63,6 +64,7 @@ public class StartLocalStackAction extends StartTestcontainersAction<LocalStackC
                 Optional<ClientFactory<?>> clientFactory = ClientFactory.lookup(context.getReferenceResolver(), service);
                 if (clientFactory.isPresent()) {
                     Object client = clientFactory.get().createClient(container, context.resolveDynamicValuesInMap(options));
+                    PropertyUtils.configure(clientName, client, context.getReferenceResolver());
                     container.addClient(service, client);
                     logger.debug("Auto create client {} for service {}", clientName, service.name());
                     context.getReferenceResolver().bind(clientName, client);

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/postgresql/StartPostgreSQLAction.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/postgresql/StartPostgreSQLAction.java
@@ -27,6 +27,7 @@ import org.citrusframework.spi.Resources;
 import org.citrusframework.testcontainers.TestContainersSettings;
 import org.citrusframework.testcontainers.actions.StartTestcontainersAction;
 import org.citrusframework.util.FileUtils;
+import org.citrusframework.util.PropertyUtils;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.ext.ScriptUtils;
@@ -81,6 +82,7 @@ public class StartPostgreSQLAction extends StartTestcontainersAction<PostgreSQLC
         postgreSQLDataSource.setUsername(getContainer().getUsername());
         postgreSQLDataSource.setPassword(getContainer().getPassword());
 
+        PropertyUtils.configure(dataSourceName, postgreSQLDataSource, context.getReferenceResolver());
         context.getReferenceResolver().bind(dataSourceName, postgreSQLDataSource);
     }
 

--- a/core/citrus-api/src/main/java/org/citrusframework/CitrusSettings.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/CitrusSettings.java
@@ -218,7 +218,34 @@ public final class CitrusSettings {
      */
     public static final String HTTP_MESSAGE_BUILDER_FORCE_CITRUS_HEADER_UPDATE_ENABLED_PROPERTY = "citrus.http.message.builder.force.citrus.header.update.enabled";
     public static final String HTTP_MESSAGE_BUILDER_FORCE_CITRUS_HEADER_UPDATE_ENABLED_ENV = "CITRUS_HTTP_MESSAGE_BUILDER_FORCE_CITRUS_HEADER_UPDATE_ENABLED";
-    public static final String HTTP_MESSAGE_BUILDER_FORCE_CITRUS_HEADER_UPDATE_ENABLED_DEFAULT = "true";
+    public static final String HTTP_MESSAGE_BUILDER_FORCE_CITRUS_HEADER_UPDATE_ENABLED_DEFAULT = Boolean.TRUE.toString();
+
+    /**
+     * Flag to enable/disable environment variable based endpoint and component configuration.
+     */
+    public static final String ENV_VAR_PROPERTY_BINDING_ENABLED_PROPERTY = "citrus.env.var.property.binding.enabled";
+    public static final String ENV_VAR_PROPERTY_BINDING_ENABLED_ENV = "CITRUS_ENV_VAR_PROPERTY_BINDING_ENABLED";
+    public static final String ENV_VAR_PROPERTY_BINDING_ENABLED_DEFAULT = Boolean.TRUE.toString();
+
+    /**
+     * Flag to enable/disable environment variable based endpoint and component configuration.
+     */
+    public static final String COMPONENT_PROPERTY_BINDING_ENABLED_PROPERTY = "citrus.component.property.binding.enabled";
+    public static final String COMPONENT_PROPERTY_BINDING_ENABLED_ENV = "CITRUS_COMPONENT_PROPERTY_BINDING_ENABLED";
+    public static final String COMPONENT_PROPERTY_BINDING_ENABLED_DEFAULT = getPropertyEnvOrDefault(
+            ENV_VAR_PROPERTY_BINDING_ENABLED_PROPERTY,
+            ENV_VAR_PROPERTY_BINDING_ENABLED_ENV,
+            Boolean.TRUE.toString());
+
+    /**
+     * Flag to enable/disable environment variable based endpoint and component configuration.
+     */
+    public static final String ENDPOINT_PROPERTY_BINDING_ENABLED_PROPERTY = "citrus.endpoint.property.binding.enabled";
+    public static final String ENDPOINT_PROPERTY_BINDING_ENABLED_ENV = "CITRUS_ENDPOINT_PROPERTY_BINDING_ENABLED";
+    public static final String ENDPOINT_PROPERTY_BINDING_ENABLED_DEFAULT = getPropertyEnvOrDefault(
+            ENV_VAR_PROPERTY_BINDING_ENABLED_PROPERTY,
+            ENV_VAR_PROPERTY_BINDING_ENABLED_ENV,
+            Boolean.TRUE.toString());;
 
     /**
      * Default message trace output directory
@@ -406,5 +433,38 @@ public final class CitrusSettings {
      */
     public static String getPropertyEnvOrDefault(String prop, String env, String def) {
         return getProperty(prop, getenv(env) != null ? getenv(env) : def);
+    }
+
+    /**
+     * Gets the setting that marks environment variable property binding enabled/disabled.
+     * If enabled endpoints and components are configured using system properties and environment variables.
+     */
+    public static boolean isEnvVarPropertyBindingEnabled() {
+        return parseBoolean(getPropertyEnvOrDefault(
+                ENV_VAR_PROPERTY_BINDING_ENABLED_PROPERTY,
+                ENV_VAR_PROPERTY_BINDING_ENABLED_ENV,
+                ENV_VAR_PROPERTY_BINDING_ENABLED_DEFAULT));
+    }
+
+    /**
+     * Gets the setting that marks environment variable property binding enabled/disabled for all components.
+     * If enabled components are configured using system properties and environment variables.
+     */
+    public static boolean isComponentPropertyBindingEnabled() {
+        return parseBoolean(getPropertyEnvOrDefault(
+                COMPONENT_PROPERTY_BINDING_ENABLED_PROPERTY,
+                COMPONENT_PROPERTY_BINDING_ENABLED_ENV,
+                COMPONENT_PROPERTY_BINDING_ENABLED_DEFAULT));
+    }
+
+    /**
+     * Gets the setting that marks environment variable property binding enabled/disabled for all endpoints.
+     * If enabled endpoints are configured using system properties and environment variables.
+     */
+    public static boolean isEndpointPropertyBindingEnabled() {
+        return parseBoolean(getPropertyEnvOrDefault(
+                ENDPOINT_PROPERTY_BINDING_ENABLED_PROPERTY,
+                ENDPOINT_PROPERTY_BINDING_ENABLED_ENV,
+                ENDPOINT_PROPERTY_BINDING_ENABLED_DEFAULT));
     }
 }

--- a/core/citrus-api/src/main/java/org/citrusframework/annotations/CitrusEndpointAnnotations.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/annotations/CitrusEndpointAnnotations.java
@@ -60,19 +60,20 @@ public abstract class CitrusEndpointAnnotations {
             logger.debug("Injecting Citrus endpoint on test class field '{}'", field.getName());
             CitrusEndpoint endpointAnnotation = field.getAnnotation(CitrusEndpoint.class);
 
+            ReferenceResolver referenceResolver = context.getReferenceResolver();
             for (Annotation annotation : field.getAnnotations()) {
                 if (annotation.annotationType().getAnnotation(CitrusEndpointConfig.class) != null) {
                     Endpoint endpoint = context.getEndpointFactory().create(getEndpointName(field), annotation, context);
                     ReflectionHelper.setField(field, target, endpoint);
 
                     if (field.isAnnotationPresent(BindToRegistry.class)) {
-                        context.getReferenceResolver().bind(ReferenceRegistry.getName(field.getAnnotation(BindToRegistry.class), endpoint.getName()), endpoint);
+                        String endpointName = ReferenceRegistry.getName(field.getAnnotation(BindToRegistry.class), endpoint.getName());
+                        referenceResolver.bind(endpointName, endpoint);
                     }
                     return;
                 }
             }
 
-            ReferenceResolver referenceResolver = context.getReferenceResolver();
             if (endpointAnnotation.properties().length > 0) {
                 ReflectionHelper.setField(field, target, context.getEndpointFactory().create(getEndpointName(field), endpointAnnotation, field.getType(), context));
             } else if (endpointAnnotation.name() != null && !endpointAnnotation.name().isBlank() &&

--- a/core/citrus-api/src/main/java/org/citrusframework/util/ReflectionHelper.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/util/ReflectionHelper.java
@@ -160,7 +160,7 @@ public class ReflectionHelper {
      * supplied {@code name} and/or {@link Class type}. Searches all superclasses
      * up to {@link Object}.
      * @param clazz the class to introspect
-     * @param name the name of the field (may be {@code null} if type is specified)
+     * @param name the name of the field (maybe {@code null} if type is specified)
      * @return the corresponding Field object, or {@code null} if not found
      */
     public static Field findField(Class<?> clazz, String name) {

--- a/core/citrus-base/src/main/java/org/citrusframework/CitrusContext.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/CitrusContext.java
@@ -45,6 +45,7 @@ import org.citrusframework.spi.ReferenceRegistry;
 import org.citrusframework.spi.ReferenceResolver;
 import org.citrusframework.spi.ReferenceResolverAware;
 import org.citrusframework.spi.SimpleReferenceResolver;
+import org.citrusframework.util.PropertyUtils;
 import org.citrusframework.util.StringUtils;
 import org.citrusframework.util.TypeConverter;
 import org.citrusframework.validation.DefaultMessageValidatorRegistry;
@@ -369,9 +370,11 @@ public class CitrusContext implements TestListenerAware, TestActionListenerAware
             referenceResolverAware.setReferenceResolver(referenceResolver);
         }
 
-        if (component instanceof InitializingPhase c) {
-            c.initialize();
+        if (component instanceof InitializingPhase initializingBean) {
+            initializingBean.initialize();
         }
+
+        PropertyUtils.configure(name, component, referenceResolver);
 
         referenceResolver.bind(name, component);
 

--- a/core/citrus-base/src/main/java/org/citrusframework/endpoint/AbstractEndpointBuilder.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/endpoint/AbstractEndpointBuilder.java
@@ -52,9 +52,9 @@ public abstract class AbstractEndpointBuilder<T extends Endpoint> implements End
      * @return
      */
     public AbstractEndpointBuilder<T> initialize() {
-        if (getEndpoint() instanceof InitializingPhase) {
+        if (getEndpoint() instanceof InitializingPhase initializingBean) {
             try {
-                ((InitializingPhase) getEndpoint()).initialize();
+                initializingBean.initialize();
             } catch (Exception e) {
                 throw new CitrusRuntimeException("Failed to initialize server", e);
             }

--- a/core/citrus-base/src/main/java/org/citrusframework/endpoint/DefaultEndpointFactory.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/endpoint/DefaultEndpointFactory.java
@@ -23,10 +23,13 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.citrusframework.annotations.CitrusEndpoint;
 import org.citrusframework.annotations.CitrusEndpointConfig;
+import org.citrusframework.common.InitializingPhase;
 import org.citrusframework.config.annotation.AnnotationConfigParser;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.spi.ReferenceResolverAware;
+import org.citrusframework.util.PropertyUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,6 +64,16 @@ public class DefaultEndpointFactory implements EndpointFactory {
         if (parser.isPresent()) {
             Endpoint endpoint = parser.get().parse(endpointConfig, context.getReferenceResolver());
             endpoint.setName(endpointName);
+
+            if (endpoint instanceof ReferenceResolverAware referenceResolverAware) {
+                referenceResolverAware.setReferenceResolver(context.getReferenceResolver());
+            }
+
+            if (endpoint instanceof InitializingPhase initializingBean) {
+                initializingBean.initialize();
+            }
+
+            PropertyUtils.configure(endpointName, endpoint, context.getReferenceResolver());
             return endpoint;
         }
 

--- a/core/citrus-base/src/main/java/org/citrusframework/endpoint/StaticEndpoint.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/endpoint/StaticEndpoint.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.endpoint;
+
+import org.citrusframework.context.TestContext;
+import org.citrusframework.message.DefaultMessage;
+import org.citrusframework.message.Message;
+import org.citrusframework.messaging.Consumer;
+import org.citrusframework.messaging.Producer;
+
+/**
+ * Special endpoint implementation that produces/consumes static messages.
+ */
+public class StaticEndpoint extends AbstractEndpoint {
+
+    private Message message;
+
+    public StaticEndpoint() {
+        this(new StaticEndpointConfiguration());
+    }
+
+    /**
+     * Constructor with given static message.
+     */
+    public StaticEndpoint(Message message) {
+        this(message, new StaticEndpointConfiguration());
+    }
+
+    /**
+     * Constructor with empty message and endpoint configuration.
+     */
+    public StaticEndpoint(StaticEndpointConfiguration endpointConfiguration) {
+        this(new DefaultMessage(""), endpointConfiguration);
+    }
+
+    /**
+     * Constructor with given message and endpoint configuration.
+     */
+    public StaticEndpoint(Message message, StaticEndpointConfiguration endpointConfiguration) {
+        super(endpointConfiguration);
+        this.message = message;
+    }
+
+    @Override
+    public Producer createProducer() {
+        return new Producer() {
+            @Override
+            public void send(Message message, TestContext context) {
+                // do nothing
+            }
+
+            @Override
+            public String getName() {
+                return StaticEndpoint.this.getName() + "-producer";
+            }
+        };
+    }
+
+    @Override
+    public Consumer createConsumer() {
+        return new Consumer() {
+            @Override
+            public Message receive(TestContext context) {
+                return getMessage();
+            }
+
+            @Override
+            public Message receive(TestContext context, long timeout) {
+                return getMessage();
+            }
+
+            @Override
+            public String getName() {
+                return StaticEndpoint.this.getName() + "-consumer";
+            }
+        };
+    }
+
+    @Override
+    public StaticEndpointConfiguration getEndpointConfiguration() {
+        return (StaticEndpointConfiguration) super.getEndpointConfiguration();
+    }
+
+    public void setMessage(Message message) {
+        this.message = message;
+    }
+
+    public Message getMessage() {
+        if (getEndpointConfiguration().isReuseMessage()) {
+            return message;
+        } else {
+            return new DefaultMessage(message, true);
+        }
+    }
+
+    public static class StaticEndpointConfiguration extends AbstractEndpointConfiguration {
+
+        private boolean reuseMessage = true;
+
+        public boolean isReuseMessage() {
+            return reuseMessage;
+        }
+
+        public void setReuseMessage(boolean reuseMessage) {
+            this.reuseMessage = reuseMessage;
+        }
+    }
+}

--- a/core/citrus-base/src/main/java/org/citrusframework/endpoint/adapter/EmptyResponseEndpointAdapter.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/endpoint/adapter/EmptyResponseEndpointAdapter.java
@@ -17,7 +17,6 @@
 package org.citrusframework.endpoint.adapter;
 
 import org.citrusframework.message.DefaultMessage;
-import org.citrusframework.message.Message;
 
 /**
  * Endpoint adapter always returning empty response message.
@@ -26,8 +25,7 @@ import org.citrusframework.message.Message;
  */
 public class EmptyResponseEndpointAdapter extends StaticEndpointAdapter {
 
-    @Override
-    public Message handleMessageInternal(Message message) {
-        return new DefaultMessage("");
+    public EmptyResponseEndpointAdapter() {
+        super(new DefaultMessage(""));
     }
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/endpoint/adapter/StaticEndpointAdapter.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/endpoint/adapter/StaticEndpointAdapter.java
@@ -19,7 +19,8 @@ package org.citrusframework.endpoint.adapter;
 import org.citrusframework.endpoint.AbstractEndpointAdapter;
 import org.citrusframework.endpoint.Endpoint;
 import org.citrusframework.endpoint.EndpointConfiguration;
-import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.endpoint.StaticEndpoint;
+import org.citrusframework.message.Message;
 
 /**
  * Static endpoint adapter always responds with static response message. No endpoint is provided as this is a
@@ -27,15 +28,35 @@ import org.citrusframework.exceptions.CitrusRuntimeException;
  *
  * @since 1.4
  */
-public abstract class StaticEndpointAdapter extends AbstractEndpointAdapter {
+public class StaticEndpointAdapter extends AbstractEndpointAdapter {
+
+    private final StaticEndpoint endpoint;
+
+    public StaticEndpointAdapter() {
+        this.endpoint = new StaticEndpoint();
+    }
+
+    public StaticEndpointAdapter(Message message) {
+        this.endpoint = new StaticEndpoint(message);
+    }
+
+    @Override
+    protected Message handleMessageInternal(Message message) {
+        return endpoint.getMessage();
+    }
 
     @Override
     public Endpoint getEndpoint() {
-        throw new CitrusRuntimeException(String.format("Unable to create endpoint for static endpoint adapter type '%s'", getClass()));
+        return endpoint;
     }
 
     @Override
     public EndpointConfiguration getEndpointConfiguration() {
-        throw new CitrusRuntimeException(String.format("Unable to provide endpoint configuration for static endpoint adapter type '%s'", getClass()));
+        return endpoint.getEndpointConfiguration();
+    }
+
+    public StaticEndpointAdapter withReuseMessage(boolean reuseMessage) {
+        this.endpoint.getEndpointConfiguration().setReuseMessage(reuseMessage);
+        return this;
     }
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/endpoint/adapter/TimeoutProducingEndpointAdapter.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/endpoint/adapter/TimeoutProducingEndpointAdapter.java
@@ -16,8 +16,6 @@
 
 package org.citrusframework.endpoint.adapter;
 
-import org.citrusframework.message.Message;
-
 /**
  * Endpoint adapter produces no response message forcing a request timeout on client side.
  *
@@ -25,8 +23,7 @@ import org.citrusframework.message.Message;
  */
 public class TimeoutProducingEndpointAdapter extends StaticEndpointAdapter {
 
-    @Override
-    public Message handleMessageInternal(Message message) {
-        return null;
+    public TimeoutProducingEndpointAdapter() {
+        super(null);
     }
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/endpoint/direct/DirectEndpointComponent.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/endpoint/direct/DirectEndpointComponent.java
@@ -22,6 +22,7 @@ import org.citrusframework.context.TestContext;
 import org.citrusframework.endpoint.AbstractEndpointComponent;
 import org.citrusframework.endpoint.Endpoint;
 import org.citrusframework.message.DefaultMessageQueue;
+import org.citrusframework.util.PropertyUtils;
 
 /**
  * Direct endpoint component creates synchronous or asynchronous channel endpoint and sets configuration properties
@@ -53,7 +54,9 @@ public class DirectEndpointComponent extends AbstractEndpointComponent {
 
         endpoint.getEndpointConfiguration().setQueueName(queueName);
         if (!context.getReferenceResolver().isResolvable(queueName)) {
-            context.getReferenceResolver().bind(queueName, new DefaultMessageQueue(queueName));
+            DefaultMessageQueue messageQueue = new DefaultMessageQueue(queueName);
+            PropertyUtils.configure(queueName, messageQueue, context.getReferenceResolver());
+            context.getReferenceResolver().bind(queueName, messageQueue);
         }
 
         enrichEndpointConfiguration(endpoint.getEndpointConfiguration(), parameters, context);

--- a/core/citrus-base/src/main/java/org/citrusframework/server/AbstractServer.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/server/AbstractServer.java
@@ -38,7 +38,6 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Abstract base class for {@link Server} implementations.
- *
  */
 public abstract class AbstractServer extends AbstractEndpoint
         implements Server, InitializingPhase, ShutdownPhase, ReferenceResolverAware {

--- a/core/citrus-base/src/main/java/org/citrusframework/util/PropertyUtils.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/util/PropertyUtils.java
@@ -17,10 +17,16 @@
 package org.citrusframework.util;
 
 import java.io.IOException;
+import java.util.Locale;
 import java.util.Properties;
 
+import org.citrusframework.CitrusSettings;
+import org.citrusframework.endpoint.Endpoint;
 import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.spi.ReferenceResolver;
 import org.citrusframework.spi.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Utility class supporting property replacement in template files.
@@ -32,6 +38,15 @@ public final class PropertyUtils {
 
     /** Constant marking a property in template files */
     private static final char PROPERTY_MARKER = '@';
+    public static final String BEAN_REF_PREFIX = "#bean:";
+
+    public static final String CITRUS_COMPONENT_ENV_PREFIX = "CITRUS_COMPONENT_";
+    public static final String CITRUS_ENDPOINT_ENV_PREFIX = "CITRUS_ENDPOINT_";
+    public static final String CITRUS_ENDPOINT_CONFIG_ENV_PREFIX = "CITRUS_ENDPOINT_CONFIG_";
+    public static final String CITRUS_COMPONENT_PROPERTY_PREFIX = "citrus.component.";
+    public static final String CITRUS_ENDPOINT_PROPERTY_PREFIX = "citrus.endpoint.";
+
+    private static final Logger logger = LoggerFactory.getLogger(PropertyUtils.class);
 
     /**
      * Prevent instantiation.
@@ -114,5 +129,101 @@ public final class PropertyUtils {
         newStr.append(line.substring(startIndex));
 
         return newStr.toString();
+    }
+
+    /**
+     * Configure the given component with environment variables and system properties if present.
+     * Supports settings on the component/endpoint itself and on the endpoint configuration.
+     */
+    public static void configure(String name, Object component, ReferenceResolver referenceResolver) {
+        if (component == null || name == null && CitrusSettings.isEnvVarPropertyBindingEnabled()) {
+            return;
+        }
+
+        if (System.getenv().keySet().stream().noneMatch(PropertyUtils::isComponentEnvVarSetting) &&
+                System.getProperties().keySet().stream().map(Object::toString).noneMatch(PropertyUtils::isComponentSystemPropertySetting)) {
+            // no matching envVar settings available
+            return;
+        }
+
+        try {
+            if (CitrusSettings.isComponentPropertyBindingEnabled()) {
+                bindProperties(CITRUS_COMPONENT_ENV_PREFIX, name, component, referenceResolver);
+            }
+
+            if (CitrusSettings.isEndpointPropertyBindingEnabled() && component instanceof Endpoint endpoint) {
+                bindProperties(CITRUS_ENDPOINT_ENV_PREFIX, name, endpoint, referenceResolver);
+                bindProperties(CITRUS_ENDPOINT_CONFIG_ENV_PREFIX, name, endpoint.getEndpointConfiguration(), referenceResolver);
+            }
+        } catch (Exception e) {
+            logger.warn("Failed to configure envVar properties on component '{}': {}", name, e.getMessage());
+            throw e;
+        }
+    }
+
+    private static void bindProperties(String prefix, String name, Object component, ReferenceResolver referenceResolver) {
+        if (component == null) {
+            return;
+        }
+
+        if (System.getenv().keySet().stream().noneMatch(key -> isComponentEnvVarSetting(key, prefix, name)) &&
+                System.getProperties().keySet().stream().map(Object::toString).noneMatch(key -> isComponentSystemPropertySetting(key, prefix, name))) {
+            // no matching envVar setting for this component/endpoint
+            return;
+        }
+
+        ReflectionHelper.doWithMethods(component.getClass(), method -> {
+            if (method.getName().startsWith("set") && method.getParameterTypes().length == 1) {
+                // try normal uppercase and exact match property names e.g. logModifier and LOGMODIFIER
+                String propertyName = method.getName().substring(3);
+                String envName = "%s%s_%s".formatted(prefix, name, propertyName).toUpperCase(Locale.US);
+                String sysPropName = "%s%s.%s%s".formatted(prefix.toLowerCase(Locale.US), name,
+                                propertyName.substring(0, 1).toLowerCase(Locale.US), propertyName.substring(1)).replaceAll("_", ".");
+
+                String value = CitrusSettings.getPropertyEnvOrDefault(sysPropName, envName, null);
+                if (value == null) {
+                    // try to use dash style property names e.g. log-modifier and LOG_MODIFIER
+                    envName = "%s%s%s".formatted(prefix, name.replaceAll("([A-Z])", "_$1"), propertyName.replaceAll("([A-Z])", "_$1")).toUpperCase(Locale.US);
+                    sysPropName = "%s%s.%s%s".formatted(prefix.toLowerCase(Locale.US), name, propertyName.substring(0, 1).toLowerCase(Locale.US), propertyName.substring(1).replaceAll("([A-Z])", "-$1").toLowerCase(Locale.US))
+                            .replaceAll("_", ".");
+                    value = CitrusSettings.getPropertyEnvOrDefault(sysPropName, envName, null);
+                }
+
+                if (value == null) {
+                    // no matching envVar setting found
+                    return;
+                }
+
+                if (value.startsWith(BEAN_REF_PREFIX)) {
+                    // resolve bean reference
+                    if (referenceResolver.isResolvable(value.substring(BEAN_REF_PREFIX.length()))) {
+                        ReflectionHelper.invokeMethod(method, component,
+                                TypeConverter.lookupDefault().convertIfNecessary(
+                                        referenceResolver.resolve(value.substring(BEAN_REF_PREFIX.length())), method.getParameterTypes()[0]));
+                    } else {
+                        throw new CitrusRuntimeException("Failed to resolve property bean reference '%s' - no such bean in registry".formatted(value));
+                    }
+                } else {
+                    ReflectionHelper.invokeMethod(method, component,
+                            TypeConverter.lookupDefault().convertIfNecessary(value, method.getParameterTypes()[0]));
+                }
+            }
+        });
+    }
+
+    private static boolean isComponentSystemPropertySetting(String key) {
+        return key.startsWith(CITRUS_COMPONENT_PROPERTY_PREFIX) || key.startsWith(CITRUS_ENDPOINT_PROPERTY_PREFIX);
+    }
+
+    private static boolean isComponentEnvVarSetting(String key) {
+        return key.startsWith(CITRUS_COMPONENT_ENV_PREFIX) || key.startsWith(CITRUS_ENDPOINT_ENV_PREFIX);
+    }
+
+    private static boolean isComponentSystemPropertySetting(String key, String prefix, String name) {
+        return key.startsWith("%s%s".formatted(prefix.toLowerCase(Locale.US), name).replaceAll("_", "."));
+    }
+
+    private static boolean isComponentEnvVarSetting(String key, String prefix, String name) {
+        return key.startsWith("%s%s".formatted(prefix, name)) || key.startsWith("%s%s".formatted(prefix, name.replaceAll("([A-Z])", "_$1")));
     }
 }

--- a/core/citrus-base/src/test/java/org/citrusframework/endpoint/AbstractEndpointAdapterTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/endpoint/AbstractEndpointAdapterTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.*;
 public class AbstractEndpointAdapterTest {
 
     /** Endpoint adapter mock */
-    private EndpointAdapter endpointAdapter = Mockito.mock(EndpointAdapter.class);
+    private final EndpointAdapter endpointAdapter = Mockito.mock(EndpointAdapter.class);
 
     @Test
     public void testEndpointAdapter() {
@@ -79,6 +79,5 @@ public class AbstractEndpointAdapterTest {
 
         Assert.assertNotNull(response);
         Assert.assertEquals(response.getPayload(String.class), "OK");
-
     }
 }

--- a/core/citrus-spring/src/main/java/org/citrusframework/config/ComponentLifecycleProcessor.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/config/ComponentLifecycleProcessor.java
@@ -22,6 +22,7 @@ import org.citrusframework.common.ShutdownPhase;
 import org.citrusframework.context.SpringBeanReferenceResolver;
 import org.citrusframework.spi.ReferenceResolver;
 import org.citrusframework.spi.ReferenceResolverAware;
+import org.citrusframework.util.PropertyUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
@@ -46,10 +47,12 @@ public class ComponentLifecycleProcessor implements DestructionAwareBeanPostProc
             ((ReferenceResolverAware) bean).setReferenceResolver(referenceResolver);
         }
 
-        if (bean instanceof InitializingPhase) {
+        if (bean instanceof InitializingPhase initializingBean) {
             logger.debug("Initializing component '{}'", beanName);
-            ((InitializingPhase) bean).initialize();
+            initializingBean.initialize();
         }
+
+        PropertyUtils.configure(beanName, bean, referenceResolver);
 
         return bean;
     }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CreateCamelComponentAction.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CreateCamelComponentAction.java
@@ -26,6 +26,7 @@ import org.citrusframework.groovy.dsl.GroovySupport;
 import org.citrusframework.spi.ReferenceResolverAware;
 import org.citrusframework.spi.Resource;
 import org.citrusframework.util.FileUtils;
+import org.citrusframework.util.PropertyUtils;
 import org.citrusframework.util.StringUtils;
 
 /**
@@ -53,8 +54,8 @@ public class CreateCamelComponentAction extends AbstractCamelAction implements R
                     .withTestContext(context)
                     .load(context.replaceDynamicContentInString(script), "org.apache.camel.*");
 
-            if (toCreate instanceof InitializingPhase) {
-                ((InitializingPhase) toCreate).initialize();
+            if (toCreate instanceof InitializingPhase initializingBean) {
+                initializingBean.initialize();
             }
         } else {
             toCreate = component;
@@ -64,6 +65,16 @@ public class CreateCamelComponentAction extends AbstractCamelAction implements R
     }
 
     private void bindComponent(String name, Object component) {
+        if (component instanceof ReferenceResolverAware referenceResolverAware) {
+            referenceResolverAware.setReferenceResolver(referenceResolver);
+        }
+
+        if (component instanceof InitializingPhase initializingBean) {
+            initializingBean.initialize();
+        }
+
+        PropertyUtils.configure(name, component, referenceResolver);
+
         if (referenceResolver instanceof CamelReferenceResolver camelReferenceResolver) {
             camelReferenceResolver.bind(name, component);
         } else {

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/config/annotation/HttpServerConfigParserTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/config/annotation/HttpServerConfigParserTest.java
@@ -16,6 +16,10 @@
 
 package org.citrusframework.http.config.annotation;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
 import jakarta.servlet.Filter;
 import org.citrusframework.TestActor;
 import org.citrusframework.annotations.CitrusAnnotations;
@@ -24,6 +28,7 @@ import org.citrusframework.config.annotation.AnnotationConfigParser;
 import org.citrusframework.config.annotation.ChannelEndpointConfigParser;
 import org.citrusframework.config.annotation.ChannelSyncEndpointConfigParser;
 import org.citrusframework.endpoint.EndpointAdapter;
+import org.citrusframework.endpoint.StaticEndpoint;
 import org.citrusframework.endpoint.direct.annotation.DirectEndpointConfigParser;
 import org.citrusframework.endpoint.direct.annotation.DirectSyncEndpointConfigParser;
 import org.citrusframework.http.message.HttpMessageConverter;
@@ -45,17 +50,9 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-
 import static org.citrusframework.config.annotation.AnnotationConfigParser.lookup;
 import static org.mockito.Mockito.when;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.*;
 
 public class HttpServerConfigParserTest extends AbstractTestNGUnitTest {
 
@@ -159,6 +156,9 @@ public class HttpServerConfigParserTest extends AbstractTestNGUnitTest {
         when(referenceResolver.resolve("clientInterceptor2", HandlerInterceptor.class)).thenReturn(clientInterceptor2);
         when(referenceResolver.resolve(new String[]{"clientInterceptor1", "clientInterceptor2"}, HandlerInterceptor.class)).thenReturn(Arrays.asList(clientInterceptor1, clientInterceptor2));
         when(referenceResolver.resolve("endpointAdapter", EndpointAdapter.class)).thenReturn(endpointAdapter);
+
+        when(endpointAdapter.getEndpoint()).thenReturn(new StaticEndpoint());
+        when(endpointAdapter.getEndpointConfiguration()).thenReturn(new StaticEndpoint.StaticEndpointConfiguration());
     }
 
     @BeforeMethod

--- a/endpoints/citrus-http/src/test/resources/org/citrusframework/http/config/xml/HttpServerParserTest-adapter.xml
+++ b/endpoints/citrus-http/src/test/resources/org/citrusframework/http/config/xml/HttpServerParserTest-adapter.xml
@@ -70,10 +70,7 @@
                         port="8086"
                         endpoint-adapter="httpServerAdapter6"/>
 
-    <bean id="httpServerAdapter6" class="org.mockito.Mockito" factory-method="mock">
-        <constructor-arg><value type="java.lang.Class">org.citrusframework.endpoint.EndpointAdapter</value></constructor-arg>
-      <constructor-arg value="httpServerAdapter6"/>
-    </bean>
+    <bean id="httpServerAdapter6" class="org.citrusframework.endpoint.adapter.StaticEndpointAdapter"/>
 
     <bean id="connectionFactory" class="org.mockito.Mockito" factory-method="mock">
         <constructor-arg><value type="java.lang.Class">jakarta.jms.ConnectionFactory</value></constructor-arg>

--- a/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/configuration/beans/QueueConfiguration.java
+++ b/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/configuration/beans/QueueConfiguration.java
@@ -20,6 +20,7 @@ import org.citrusframework.Citrus;
 import org.citrusframework.CitrusContext;
 import org.citrusframework.message.DefaultMessageQueue;
 import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.util.PropertyUtils;
 
 public class QueueConfiguration {
 
@@ -38,6 +39,8 @@ public class QueueConfiguration {
     }
 
     public void queue(String name) {
-        referenceResolver.bind(name, new DefaultMessageQueue(name));
+        DefaultMessageQueue messageQueue = new DefaultMessageQueue(name);
+        PropertyUtils.configure(name, messageQueue, referenceResolver);
+        referenceResolver.bind(name, messageQueue);
     }
 }

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/integration/server/SimpleServer.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/integration/server/SimpleServer.java
@@ -17,6 +17,7 @@
 package org.citrusframework.integration.server;
 
 import org.citrusframework.context.TestContextFactoryBean;
+import org.citrusframework.endpoint.EndpointConfiguration;
 import org.citrusframework.endpoint.direct.DirectEndpoint;
 import org.citrusframework.message.RawMessage;
 import org.citrusframework.server.AbstractServer;
@@ -66,5 +67,10 @@ public class SimpleServer extends AbstractServer {
      */
     public void setStatusEndpoint(DirectEndpoint statusEndpoint) {
         this.statusEndpoint = statusEndpoint;
+    }
+
+    @Override
+    public EndpointConfiguration getEndpointConfiguration() {
+        return statusEndpoint.getEndpointConfiguration();
     }
 }

--- a/src/manual/configuration.adoc
+++ b/src/manual/configuration.adoc
@@ -81,6 +81,124 @@ Same properties are settable via environment variables.
 | File name patterns used for Java test sources package scan (default="/\\**/*Test.java,/**/*IT.java")
 |===
 
+[[configuration-property-binding]]
+== Property binding support
+
+The Citrus project defines components and endpoints in the form of beans in the Citrus registry, which is either the Java configuration or a Spring bean configuration. The beans in the registry provide properties that you can overwrite with environment variables and system properties.
+
+Each bean that is added to the Citrus registry is being post processed with the Citrus property binding support.
+Users can overwrite these properties on components, endpoints and endpoint configuration with environment specific settings.
+
+The Citrus property binding support follows a naming convention that looks like follows:
+
+.Environment variables
+[source, properties]
+----
+CITRUS_COMPONENT_<COMPONENT_NAME>_<PROPERTY_NAME>=<VALUE>
+----
+
+Also, specific to endpoints the naming convention looks like this:
+
+.Environment variables
+[source, properties]
+----
+CITRUS_ENDPOINT_<ENDPOINT_NAME>_<PROPERTY_NAME>=<VALUE>
+CITRUS_ENDPOINT_CONFIG_<ENDPOINT_NAME>_<PROPERTY_NAME>=<VALUE>
+----
+
+According to that users can also use system property settings that follow the same rules:
+
+.System properties
+[source, properties]
+----
+citrus.component.<component-name>.<property-name>=<value>
+citrus.endpoint.<endpoint-name>.<property-name>=<value>
+citrus.endpoint.config.<endpoint-name>.<property-name>=<value>
+----
+
+The difference of using `CITRUS_ENDPOINT` compared to using `CITRUS_ENDPOINT_CONFIG` is that the latter targets the specific endpoint configuration of the bean. The former will just set properties on the endpoint itself.
+
+The component or endpoint name references the bean name that is used to store the object into the Citrus registry.
+The property name is the name of the setter method available on the object (without the `set` prefix)
+
+Given an endpoint named `foo` with a `setPort(int port)` method the environment setting to overwrite the property would be like this:
+
+.Environment variable
+[source, properties]
+----
+CITRUS_ENDPOINT_FOO_PORT=12345
+----
+
+.System property
+[source, properties]
+----
+citrus.endpoint.foo.port=12345
+----
+
+When the bean name or the property name uses camel case style you have multiple ways to represent this in the environment settings.
+
+As an example the given endpoint named `myBean` exposes the method `setRequestUrl(String url)`.
+You have multiple ways to set this property:
+
+.Environment variable
+[source, properties]
+----
+CITRUS_ENDPOINT_MYBEAN_REQUESTURL=http://whatever
+
+CITRUS_ENDPOINT_MY_BEAN_REQUEST_URL=http://whatever
+----
+
+.System properties
+[source, properties]
+----
+citrus.endpoint.myBean.requestUrl=http://whatever
+
+citrus.endpoint.myBean.request-url=http://whatever
+----
+
+The property bindings may reference other beans in the Citrus registry.
+Given a bean named `myLog` of type `org.citrusframework.LogModifier`, that is stored to the Citrus registry, you can be reference the bean with the `#bean:` prefix like this:
+
+[source, properties]
+----
+CITRUS_ENDPOINT_FOO_LOG_MODIFIER=#bean:myLog
+----
+
+This will resolve the bean named `myLog` from the Citrus registry and set this as a reference on the endpoint `foo` with the `setLogModifier()` method.
+
+The property binding support is enabled by default for components, endpoints and endpoint configuration.
+You can disable the bindings with the environment setting:
+
+.System properties
+|===
+|System properties |Description
+
+| citrus.env.var.property.binding.enabled
+| Set this to `false` to disable the property binding completely.
+
+| citrus.component.property.binding.enabled
+| Set this to `false` to disable the property binding for components.
+
+| citrus.endpoint.property.binding.enabled
+| Set this to `false` to disable the property binding for endpoints.
+
+|===
+
+.Environment variables
+|===
+|Environment variable |Description
+
+| CITRUS_ENV_VAR_PROPERTY_BINDING_ENABLED
+| Set this to `false` to disable the property binding completely.
+
+| CITRUS_COMPONENT_PROPERTY_BINDING_ENABLED
+| Set this to `false` to disable the property binding for components.
+
+| CITRUS_ENDPOINT_PROPERTY_BINDING_ENABLED
+| Set this to `false` to disable the property binding for endpoints.
+
+|===
+
 [[configuration-spring]]
 == Spring configuration settings
 


### PR DESCRIPTION
- Components and endpoints added to the Citrus registry are being post processed with environment settings
- Environment variables and system properties may overwrite settings on the component using the available setter methods on the bean
- Property binding works for components, endpoints and endpoint configuration
- Users can enable/disable the property binding support via envVar settings