### PR TITLE
update dependencies and deprecate MailServer.accept(List)

### DIFF
--- a/connectors/citrus-kubernetes/src/test/resources/org/citrusframework/kubernetes/integration/KubernetesExecuteIT.xml
+++ b/connectors/citrus-kubernetes/src/test/resources/org/citrusframework/kubernetes/integration/KubernetesExecuteIT.xml
@@ -38,7 +38,7 @@
           <k8s:result>
             {
               "result": {
-                "clientVersion": "7.2.0",
+                "clientVersion": "7.3.1",
                 "apiVersion": "${apiVersion}",
                 "kind":"Info",
                 "masterUrl": "@matches('http://(kubernetes\\.docker\\.internal|localhost):[0-9]+/')@",

--- a/connectors/citrus-kubernetes/src/test/resources/org/citrusframework/kubernetes/integration/KubernetesSendReceiveIT.xml
+++ b/connectors/citrus-kubernetes/src/test/resources/org/citrusframework/kubernetes/integration/KubernetesSendReceiveIT.xml
@@ -46,7 +46,7 @@
           <data>{
             "command": "info",
             "result": {
-                "clientVersion": "7.2.0",
+                "clientVersion": "7.3.1",
                 "apiVersion": "${apiVersion}",
                 "kind":"Info",
                 "masterUrl": "@matches('http://(kubernetes\\.docker\\.internal|localhost):[0-9]+/')@",

--- a/endpoints/citrus-mail/src/main/java/org/citrusframework/mail/server/MailServer.java
+++ b/endpoints/citrus-mail/src/main/java/org/citrusframework/mail/server/MailServer.java
@@ -30,7 +30,12 @@ import org.citrusframework.mail.client.MailEndpointConfiguration;
 import org.citrusframework.mail.message.CitrusMailMessageHeaders;
 import org.citrusframework.mail.message.MailMessage;
 import org.citrusframework.mail.message.MailMessageConverter;
-import org.citrusframework.mail.model.*;
+import org.citrusframework.mail.model.AcceptResponse;
+import org.citrusframework.mail.model.AttachmentPart;
+import org.citrusframework.mail.model.BodyPart;
+import org.citrusframework.mail.model.MailMarshaller;
+import org.citrusframework.mail.model.MailRequest;
+import org.citrusframework.mail.model.MailResponse;
 import org.citrusframework.message.Message;
 import org.citrusframework.server.AbstractServer;
 import org.slf4j.Logger;
@@ -38,7 +43,13 @@ import org.slf4j.LoggerFactory;
 import org.springframework.mail.javamail.MimeMailMessage;
 
 import javax.xml.transform.Source;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.Stack;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.isNull;
@@ -172,7 +183,15 @@ public class MailServer extends AbstractServer {
         smtpServer.stop();
     }
 
+    /**
+     * @deprecated use {@link MailServer#accept(String, Set)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public boolean accept(String from, List<MailAddress> recipients) {
+        return accept(from, new HashSet<>(recipients));
+    }
+
+    public boolean accept(String from, Set<MailAddress> recipients) {
         if (autoAccept) {
             return true;
         }

--- a/pom.xml
+++ b/pom.xml
@@ -190,42 +190,41 @@
     <asciidoctor.maven.plugin.version>3.1.1</asciidoctor.maven.plugin.version>
     <jaxb.maven.plugin.version>3.2.0</jaxb.maven.plugin.version>
 
-    <activemq.artemis.version>2.41.0</activemq.artemis.version>
+    <activemq.artemis.version>2.42.0</activemq.artemis.version>
     <angus-mail.version>2.0.2</angus-mail.version>
     <apache.ant.version>1.10.15</apache.ant.version>
-    <apache.camel.version>4.12.0</apache.camel.version>
+    <apache.camel.version>4.13.0</apache.camel.version>
     <apicurio.data-models.version>1.1.27</apicurio.data-models.version>
-    <swagger-request-validator.version>2.44.1</swagger-request-validator.version>
     <ascii-table-version>1.8.0</ascii-table-version>
     <assertj.version>3.27.3</assertj.version>
     <awaitility.version>4.3.0</awaitility.version>
-    <aws-java-sdk2.version>2.31.46</aws-java-sdk2.version>
-    <bouncycastle.version>1.80</bouncycastle.version>
-    <byte.buddy.version>1.17.5</byte.buddy.version>
+    <aws-java-sdk2.version>2.32.18</aws-java-sdk2.version>
+    <bouncycastle.version>1.81</bouncycastle.version>
+    <byte.buddy.version>1.17.6</byte.buddy.version>
     <commons.dbcp2.version>2.13.0</commons.dbcp2.version>
-    <commons.cli.version>1.9.0</commons.cli.version>
-    <commons.codec.version>1.18.0</commons.codec.version>
-    <commons.io.version>2.19.0</commons.io.version>
+    <commons.cli.version>1.10.0</commons.cli.version>
+    <commons.codec.version>1.19.0</commons.codec.version>
+    <commons.io.version>2.20.0</commons.io.version>
     <commons.lang.version>3.18.0</commons.lang.version>
     <commons.logging.version>1.3.5</commons.logging.version>
-    <commons.net.version>3.11.1</commons.net.version>
-    <cucumber.version>7.22.1</cucumber.version>
-    <docker-java.version>3.5.0</docker-java.version>
-    <dropwizard.metrics.version>4.2.30</dropwizard.metrics.version>
+    <commons.net.version>3.12.0</commons.net.version>
+    <cucumber.version>7.27.0</cucumber.version>
+    <docker-java.version>3.5.3</docker-java.version>
+    <dropwizard.metrics.version>4.2.33</dropwizard.metrics.version>
     <ftpserver.version>1.2.1</ftpserver.version>
-    <groovy.version>3.0.24</groovy.version>
-    <greenmail.version>2.1.3</greenmail.version>
+    <groovy.version>3.0.25</groovy.version>
+    <greenmail.version>2.1.4</greenmail.version>
     <hamcrest.version>3.0</hamcrest.version>
     <htmlunit.version>4.13.0</htmlunit.version>
-    <httpclient.version>5.4.4</httpclient.version>
+    <httpclient.version>5.5</httpclient.version>
     <hsqldb.version>2.7.4</hsqldb.version>
-    <jackson.version>2.18.3</jackson.version>
+    <jackson.version>2.19.2</jackson.version>
     <jackson-databind-nullable.version>0.2.6</jackson-databind-nullable.version>
     <jakarta.activation.api.version>2.1.3</jakarta.activation.api.version>
     <jakarta.activation.version>2.0.1</jakarta.activation.version>
     <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>
     <jakarta.jms-api.version>3.1.0</jakarta.jms-api.version>
-    <jakarta.mail.version>2.0.3</jakarta.mail.version>
+    <jakarta.mail.version>2.0.4</jakarta.mail.version>
     <jakarta.servlet-api.version>6.1.0</jakarta.servlet-api.version>
     <jakarta.validation.version>3.1.1</jakarta.validation.version>
     <jakarta.websocket-api.version>2.2.0</jakarta.websocket-api.version>
@@ -234,22 +233,22 @@
     <jansi.version>2.4.2</jansi.version>
     <javapoet.version>1.13.0</javapoet.version>
     <jaxb.version>4.0.5</jaxb.version>
-    <jetty.version>12.0.20</jetty.version>
+    <jetty.version>12.0.23</jetty.version>
     <jetty.websocket-api.version>2.0.0</jetty.websocket-api.version>
     <jsch.version>0.1.55</jsch.version>
     <json-path.version>2.9.0</json-path.version>
-    <json-schema-validator.version>1.5.6</json-schema-validator.version>
-    <json-smart.version>2.5.2</json-smart.version>
+    <json-schema-validator.version>1.5.8</json-schema-validator.version>
+    <json-smart.version>2.6.0</json-smart.version>
     <jtidy.version>r938</jtidy.version>
     <junit.jupiter.version>5.12.2</junit.jupiter.version>
     <junit.platform.version>1.12.2</junit.platform.version>
     <junit.version>4.13.2</junit.version>
     <junixsocket.version>2.10.1</junixsocket.version>
-    <k8s.client.version>7.2.0</k8s.client.version>
+    <k8s.client.version>7.3.1</k8s.client.version>
     <kafka.version>3.9.1</kafka.version>
-    <knative-client.version>7.2.0</knative-client.version>
+    <knative-client.version>7.3.1</knative-client.version>
     <log4j2.version>2.23.1</log4j2.version>
-    <mockito.version>5.17.0</mockito.version>
+    <mockito.version>5.18.0</mockito.version>
     <mockftpserver.version>3.2.0</mockftpserver.version>
     <netty.version>4.2.0.Final</netty.version>
     <okhttp.version>4.12.0</okhttp.version>
@@ -257,13 +256,13 @@
     <jackson-databind-nullable.version>0.2.6</jackson-databind-nullable.version>
     <picoli-version>4.7.7</picoli-version>
     <postgresql.version>42.7.7</postgresql.version>
-    <quarkus.platform.version>3.22.1</quarkus.platform.version>
+    <quarkus.platform.version>3.25.2</quarkus.platform.version>
     <saaj.version>3.0.4</saaj.version>
-    <selenium.version>4.32.0</selenium.version>
+    <selenium.version>4.34.0</selenium.version>
     <slf4j.version>2.0.17</slf4j.version>
-    <snappy.version>1.1.10.7</snappy.version>
+    <snappy.version>1.1.10.8</snappy.version>
     <snakeyaml.version>2.4</snakeyaml.version>
-    <spring.version>6.2.8</spring.version>
+    <spring.version>6.2.9</spring.version>
     <spring.boot.version>3.4.1</spring.boot.version>
     <spring.ws.version>4.0.14</spring.ws.version>
     <spring.integration.version>6.4.4</spring.integration.version>
@@ -271,11 +270,12 @@
     <sshd.version>2.15.0</sshd.version>
     <swagger.version>2.2.31</swagger.version>
     <swagger.parser.version>2.1.22</swagger.parser.version>
-    <swagger-request-validator.version>2.44.1</swagger-request-validator.version>
+    <swagger-request-validator.version>2.44.9</swagger-request-validator.version>
     <system-stubs.version>2.1.7</system-stubs.version>
-    <testcontainers.version>1.21.0</testcontainers.version>
+    <testcontainers.version>1.21.3</testcontainers.version>
     <testng.version>7.11.0</testng.version>
-    <vertx.version>4.5.11</vertx.version>
+    <!-- bound to https://mvnrepository.com/artifact/io.fabric8/kubernetes-httpclient-vertx/${k8s.client.version} -->
+    <vertx.version>4.5.14</vertx.version>
     <wsdl4j.version>1.6.3</wsdl4j.version>
     <xbean-spring.version>4.27</xbean-spring.version>
     <xmlbeans.version>5.2.1</xmlbeans.version>


### PR DESCRIPTION
- Bumped multiple dependencies to their latest versions, including:
  - spring → 6.2.9
  - spring-boot → 3.4.1
  - jackson → 2.19.2
  - cucumber → 7.27.0
  - testcontainers → 1.21.3
  - mockito → 5.18.0
  - And others across Apache, Jetty, Netty, Jakarta, Vert.x, etc.
- Deprecated `MailServer.accept(String, List<MailAddress>)` in favor of a new overload accepting a `Set<MailAddress>`.