### PR TITLE
feat(#1383): implement OpenAPI Codegen improvements

### DIFF
--- a/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/actions/OpenApiClientRequestActionBuilder.java
+++ b/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/actions/OpenApiClientRequestActionBuilder.java
@@ -57,7 +57,6 @@ public class OpenApiClientRequestActionBuilder extends HttpClientRequestActionBu
     private OpenApiOperationToMessageHeadersProcessor openApiOperationToMessageHeadersProcessor;
     private boolean schemaValidation = true;
 
-
     /**
      * Default constructor initializes http request message builder.
      */

--- a/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/validation/OpenApiRequestValidator.java
+++ b/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/validation/OpenApiRequestValidator.java
@@ -20,8 +20,8 @@ import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 import com.atlassian.oai.validator.model.Request;
 import com.atlassian.oai.validator.model.SimpleRequest;
@@ -32,15 +32,15 @@ import org.citrusframework.http.message.HttpMessageHeaders;
 import org.citrusframework.http.message.HttpMessageUtils;
 import org.citrusframework.openapi.OpenApiSpecification;
 import org.citrusframework.openapi.model.OperationPathAdapter;
+import org.citrusframework.util.StringUtils;
 import org.springframework.util.MultiValueMap;
 
 import static org.citrusframework.util.FileUtils.getDefaultCharset;
 
 /**
- * Specific validator that uses Atlassian's Swagger Request Validator
- * underneath. It is responsible for validating HTTP requests against
- * an OpenAPI specification using the
- * provided {@code OpenApiInteractionValidator}.
+ * Specific validator that uses Atlassian's Swagger Request Validator underneath. It is responsible
+ * for validating HTTP requests against an OpenAPI specification using the provided
+ * {@code OpenApiInteractionValidator}.
  */
 public class OpenApiRequestValidator extends OpenApiValidator {
 
@@ -53,29 +53,30 @@ public class OpenApiRequestValidator extends OpenApiValidator {
         return "request";
     }
 
-    public void validateRequest(OperationPathAdapter operationPathAdapter, HttpMessage requestMessage) {
+    public void validateRequest(OperationPathAdapter operationPathAdapter,
+        HttpMessage requestMessage) {
         if (openApiInteractionValidator != null) {
             ValidationReport validationReport = openApiInteractionValidator.validateRequest(
-                    createRequestFromMessage(operationPathAdapter, requestMessage));
+                createRequestFromMessage(operationPathAdapter, requestMessage));
             if (validationReport.hasErrors()) {
                 throw new ValidationException(
-                        constructErrorMessage(operationPathAdapter, validationReport));
+                    constructErrorMessage(operationPathAdapter, validationReport));
             }
         }
     }
 
     public ValidationReport validateRequestToReport(OperationPathAdapter operationPathAdapter,
-                                                    HttpMessage requestMessage) {
+        HttpMessage requestMessage) {
         if (openApiInteractionValidator != null) {
             return openApiInteractionValidator.validateRequest(
-                    createRequestFromMessage(operationPathAdapter, requestMessage));
+                createRequestFromMessage(operationPathAdapter, requestMessage));
         }
 
         return ValidationReport.empty();
     }
 
     Request createRequestFromMessage(OperationPathAdapter operationPathAdapter,
-                                     HttpMessage httpMessage) {
+        HttpMessage httpMessage) {
         var payload = httpMessage.getPayload();
 
         String contextPath = operationPathAdapter.contextPath();
@@ -85,7 +86,7 @@ public class OpenApiRequestValidator extends OpenApiValidator {
         }
 
         SimpleRequest.Builder requestBuilder = new SimpleRequest.Builder(
-                httpMessage.getRequestMethod().asHttpMethod().name(), requestUri
+            httpMessage.getRequestMethod().asHttpMethod().name(), requestUri
         );
 
         if (payload != null) {
@@ -96,20 +97,43 @@ public class OpenApiRequestValidator extends OpenApiValidator {
         finalRequestBuilder.withAccept(httpMessage.getAccept());
 
         HttpMessageUtils.getQueryParameterMap(httpMessage)
-                .forEach((key, value) -> finalRequestBuilder.withQueryParam(key, new ArrayList<>(value)));
+            .forEach((key, value) -> {
+                List<String> queryParamValues = value.stream()
+                    .map(this::urlDecodeIfNeccessary)
+                    .toList();
+                finalRequestBuilder.withQueryParam(key, queryParamValues);
+            });
 
         httpMessage.getHeaders().forEach((key, value) -> {
             if (value instanceof Collection<?> collection) {
-                collection.forEach(v -> finalRequestBuilder.withHeader(key, v != null ? v.toString() : null));
+                collection.forEach(
+                    v -> finalRequestBuilder.withHeader(key, v != null ? v.toString() : null));
             } else {
                 finalRequestBuilder.withHeader(key, value != null ? value.toString() : null);
             }
         });
 
-        httpMessage.getCookies().forEach(cookie -> finalRequestBuilder.withHeader("Cookie", URLDecoder.decode(cookie.getName() + "=" + cookie.getValue(),
+        httpMessage.getCookies().forEach(cookie -> finalRequestBuilder.withHeader("Cookie",
+            URLDecoder.decode(cookie.getName() + "=" + cookie.getValue(),
                 getDefaultCharset())));
 
         return requestBuilder.build();
+    }
+
+    private String urlDecodeIfNeccessary(String value) {
+
+        if (StringUtils.isEmpty(value)) {
+            return value;
+        }
+
+        // We only check for query parameters in json format, as we programmatically URL encode them
+        String valueToTest = value.trim();
+        if ((valueToTest.startsWith("%7B") && valueToTest.endsWith("%7D"))|| (valueToTest.startsWith(
+            "%5B") && valueToTest.endsWith("%5D"))) {
+            return URLDecoder.decode(value, getDefaultCharset());
+        }
+
+        return value;
     }
 
     private String convertPayload(Object payload) {
@@ -121,8 +145,8 @@ public class OpenApiRequestValidator extends OpenApiValidator {
     }
 
     /**
-     * We cannot validate a MultiValueMap. The map will later on be converted to a string representation
-     * by Spring. For validation, we need to mimic this transformation here.
+     * We cannot validate a MultiValueMap. The map will later on be converted to a string
+     * representation by Spring. For validation, we need to mimic this transformation here.
      *
      * @see org.springframework.http.converter.FormHttpMessageConverter
      */

--- a/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/validation/schema/OpenApiSchemaValidation.java
+++ b/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/validation/schema/OpenApiSchemaValidation.java
@@ -54,7 +54,7 @@ public class OpenApiSchemaValidation implements SchemaValidator<OpenApiMessageVa
     @Override
     public void validate(Message message, TestContext context,
         OpenApiMessageValidationContext validationContext) {
-        logger.debug("Starting OpenApi schema validation ...");
+         logger.debug("Starting OpenApi schema validation ...");
 
         // In case we have a redirect header, we cannot  validate the message, as we have to expect, that the message has no valid response.
         if (!(message instanceof HttpMessage httpMessage) || httpMessage.getHeader("Location") != null) {

--- a/test-api-generator/citrus-openapi-codegen-maven-plugin/src/main/java/org/citrusframework/maven/plugin/CodeGenMojoWrapper.java
+++ b/test-api-generator/citrus-openapi-codegen-maven-plugin/src/main/java/org/citrusframework/maven/plugin/CodeGenMojoWrapper.java
@@ -145,20 +145,22 @@ public class CodeGenMojoWrapper extends CodeGenMojo {
             if (configProperties.containsKey(name)) {
                 String valueAsString = configProperties.get(name);
                 Object value;
-                if (valueAsString != null) {
-                    if (field.getType() == String.class) {
-                        value = valueAsString;
-                    } else if (field.getType() == Boolean.class || field.getType() == boolean.class) {
-                        value = Boolean.valueOf(valueAsString);
-                    } else if (field.getType() == File.class) {
-                        value = new File(valueAsString);
-                    } else {
-                        throw new IllegalArgumentException(
-                            format("Cannot convert '%s' to type '%s'", valueAsString,
-                                field.getType()));
-                    }
-                    setPrivateField(name, value);
+                if (valueAsString == null) {
+                    // Allow null values, e.g. to suppress generation of models
+                    // (generateModels=null -> <generateModels/>
+                    value = null;
+                } else if (field.getType() == String.class) {
+                    value = valueAsString;
+                } else if (field.getType() == Boolean.class || field.getType() == boolean.class) {
+                    value = Boolean.valueOf(valueAsString);
+                } else if (field.getType() == File.class) {
+                    value = new File(valueAsString);
+                } else {
+                    throw new IllegalArgumentException(
+                        format("Cannot convert '%s' to type '%s'", valueAsString,
+                            field.getType()));
                 }
+                setPrivateField(name, value);
             }
         }
     }

--- a/test-api-generator/citrus-openapi-codegen-maven-plugin/src/main/java/org/citrusframework/maven/plugin/TestApiGeneratorMojo.java
+++ b/test-api-generator/citrus-openapi-codegen-maven-plugin/src/main/java/org/citrusframework/maven/plugin/TestApiGeneratorMojo.java
@@ -19,6 +19,7 @@ package org.citrusframework.maven.plugin;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -333,7 +334,12 @@ public class TestApiGeneratorMojo extends AbstractMojo {
             if (resourceUrl == null) {
                 throw new MojoExecutionException("Resource not found in classpath: " + source);
             }
-            resourceFile = new File(resourceUrl.getFile());
+
+            try {
+                resourceFile = Paths.get(resourceUrl.toURI()).toFile();
+            } catch (URISyntaxException e) {
+                throw new MojoExecutionException("Invalid URI for resource: " + source, e);
+            }
         }
 
         File tmpDir = new File(mavenProject.getBuild().getDirectory() + "/wsdlToOpenApi");
@@ -345,7 +351,7 @@ public class TestApiGeneratorMojo extends AbstractMojo {
 
         try {
             WsdlToOpenApiTransformer transformer = new WsdlToOpenApiTransformer(
-                resourceFile.toURI());
+                Paths.get(resourceFile.toURI()).toUri());
 
             String openApiContent = transformer.transformToOpenApi();
 

--- a/test-api-generator/citrus-openapi-codegen-maven-plugin/src/test/resources/TestApiGeneratorMojoIntegrationTest/pom-no-model-config.xml
+++ b/test-api-generator/citrus-openapi-codegen-maven-plugin/src/test/resources/TestApiGeneratorMojoIntegrationTest/pom-no-model-config.xml
@@ -1,0 +1,37 @@
+<project
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>multi-config</artifactId>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>citrus-openapi-codegen-maven-plugin</artifactId>
+                <configuration>
+                    <apis>
+                        <api>
+                            <prefix>NoModel</prefix>
+                            <source>api/test-api.yml</source>
+                            <apiConfigOptions>
+                                <!-- configure no model generation -->
+                                <generateModels></generateModels>
+                                <generateModelTests>false</generateModelTests>
+                            </apiConfigOptions>
+                        </api>
+                    </apis>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>create-test-api</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/test-api-generator/citrus-openapi-codegen-maven-plugin/src/test/resources/TestApiGeneratorMojoIntegrationTest/pom-suppress-validation-error-config.xml
+++ b/test-api-generator/citrus-openapi-codegen-maven-plugin/src/test/resources/TestApiGeneratorMojoIntegrationTest/pom-suppress-validation-error-config.xml
@@ -1,0 +1,36 @@
+<project
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>full-config</artifactId>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>citrus-openapi-codegen-maven-plugin</artifactId>
+                <configuration>
+                    <apis>
+                        <api>
+                            <prefix>Minimal</prefix>
+                            <source>api/test-api-with-validation-error.yml</source>
+                            <apiConfigOptions>
+                                <!-- Skip the validation of the spec before generation process starts -->
+                                <skipValidateSpec>true</skipValidateSpec>
+                            </apiConfigOptions>
+                        </api>
+                    </apis>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>create-test-api</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/test-api-generator/citrus-openapi-codegen-maven-plugin/src/test/resources/api/test-api-with-validation-error.yml
+++ b/test-api-generator/citrus-openapi-codegen-maven-plugin/src/test/resources/api/test-api-with-validation-error.yml
@@ -1,0 +1,125 @@
+openapi: 3.0.3
+info:
+    title: Schema Test API
+    version: 1.0.0
+    description: |
+        A very simple test OpenAPI specification that is compliant with the random response generator (e.g. only contains responses of
+        media-type `application/json`).
+
+servers:
+    - url: http://localhost:9000/services/rest/ping/v1
+    - url: http://localhost:9000/ping/v1
+
+paths:
+    /ping/{id}:
+        put:
+            tags:
+                - ping
+            summary: Do the ping
+            operationId: doPing
+            parameters:
+                - name: id
+                  in: path
+                  description: Id to ping
+                  required: true
+                  explode: true
+                  schema:
+                      type: integer
+                      format: int64
+                - name: q1
+                  in: query
+                  description: Some queryParameter
+                  required: true
+                  explode: true
+                  schema:
+                      type: integer
+                      format: int64
+                - name: api_key
+                  in: header
+                  required: true
+                  schema:
+                      type: string
+            requestBody:
+                description: ping data
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/PingReqType'
+                required: true
+            responses:
+                200:
+# no description causes a validation error
+                    headers:
+                        Ping-Time:
+                            required: false
+                            description: response time
+                            schema:
+                                type: integer
+                                format: int64
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/PingRespType'
+                201:
+                    description: successful operation
+                    headers:
+                        Ping-Time:
+                            required: false
+                            description: response time
+                            schema:
+                                type: integer
+                                format: int64
+                    content:
+                        application/xml:
+                            schema:
+                                $ref: '#/components/schemas/PingRespType'
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/PingRespType'
+                400:
+                    description: Some error
+                    content:
+                        text/plain:
+                            schema:
+                                type: string
+    /pung/{id}:
+        get:
+            tags:
+                - pung
+            summary: Do the pung
+            operationId: doPung
+            parameters:
+                - name: id
+                  in: path
+                  description: Id to pung
+                  required: true
+                  explode: true
+                  schema:
+                      type: integer
+                      format: int64
+            responses:
+                200:
+                    description: successful operation
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/PingRespType'
+                400:
+                    description: Invalid status value
+                    content: {}
+components:
+    schemas:
+        PingReqType:
+            type: object
+            properties:
+                id:
+                    type: integer
+                    format: int64
+        PingRespType:
+            type: object
+            properties:
+                id:
+                    type: integer
+                    format: int64
+                value:
+                    type: string

--- a/test-api-generator/citrus-openapi-codegen/pom.xml
+++ b/test-api-generator/citrus-openapi-codegen/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>citrus-openapi-codegen</artifactId>
     <packaging>jar</packaging>
 
-    <name>Citrus :: Test API Generator :: Core</name>
+    <name>Citrus :: Test API Generator :: Codegen</name>
     <description>Generates a Citrus Test-API for OpenAPI and WSDL specifications.</description>
 
     <properties>

--- a/test-api-generator/citrus-openapi-codegen/src/main/java/org/citrusframework/openapi/generator/CitrusJavaCodegen.java
+++ b/test-api-generator/citrus-openapi-codegen/src/main/java/org/citrusframework/openapi/generator/CitrusJavaCodegen.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -35,10 +36,12 @@ import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.parameters.RequestBody;
 import io.swagger.v3.oas.models.servers.Server;
 import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.openapi.testapi.ParameterStyle;
 import org.citrusframework.openapi.testapi.RestApiReceiveMessageActionBuilder;
 import org.citrusframework.openapi.testapi.RestApiSendMessageActionBuilder;
 import org.citrusframework.openapi.testapi.SoapApiReceiveMessageActionBuilder;
 import org.citrusframework.openapi.testapi.SoapApiSendMessageActionBuilder;
+import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.CodegenOperation;
 import org.openapitools.codegen.CodegenParameter;
 import org.openapitools.codegen.CodegenSecurity;
@@ -456,6 +459,14 @@ public class CitrusJavaCodegen extends AbstractJavaCodegen {
             codegenParameter.dataType = "Resource";
         }
 
+        // Extension to allow encoding a query parameter as plain json.
+        // This is not officially supported by the OpenAPI spec, but common
+        // practice.
+        if (parameter.getExtensions() != null && TRUE.equals(
+            parameter.getExtensions().get("x-encodeAsJson"))) {
+            codegenParameter.style = ParameterStyle.X_ENCODE_AS_JSON.toString();
+        }
+
         return convertToCustomCodegenParameter(codegenParameter);
     }
 
@@ -465,6 +476,13 @@ public class CitrusJavaCodegen extends AbstractJavaCodegen {
      */
     private CustomCodegenParameter convertToCustomCodegenParameter(
         CodegenParameter codegenParameter) {
+
+        // In case we do not generate models, we expect the parameter to be set as string
+        if (!isGenerateModels() && codegenParameter.isModel) {
+            codegenParameter.dataType = "String";
+            codegenParameter.baseType = "String";
+        }
+
         CustomCodegenParameter customCodegenParameter = new CustomCodegenParameter();
         copyFields(CodegenParameter.class, codegenParameter, customCodegenParameter);
 
@@ -472,6 +490,10 @@ public class CitrusJavaCodegen extends AbstractJavaCodegen {
             codegenParameter.isString || "String".equals(codegenParameter.baseType);
 
         return customCodegenParameter;
+    }
+
+    private boolean isGenerateModels() {
+        return Boolean.TRUE == additionalProperties.get(CodegenConstants.GENERATE_MODELS);
     }
 
     @Override
@@ -489,6 +511,7 @@ public class CitrusJavaCodegen extends AbstractJavaCodegen {
      */
     private CustomCodegenOperation convertToCustomCodegenOperation(
         CodegenOperation codegenOperation) {
+
         CustomCodegenOperation customOperation = new CustomCodegenOperation();
 
         copyFields(CodegenOperation.class, codegenOperation, customOperation);
@@ -498,11 +521,15 @@ public class CitrusJavaCodegen extends AbstractJavaCodegen {
             .filter(param -> !param.isBodyParam)
             .toList());
 
+        // If we do not generate models, we do not need a string parameter constructor, as we have
+        // already changed the specific model types to string, so this is already covered by the
+        // requiredNonBodyParams constructor.
         customOperation.needsConstructorWithAllStringParameter =
-            !customOperation.requiredParams.isEmpty() &&
-                customOperation.requiredParams
-                    .stream()
-                    .anyMatch(param -> !param.isBodyParam && !"String".equals(param.dataType));
+            isGenerateModels()
+                && !customOperation.requiredParams.isEmpty()
+                && customOperation.requiredParams
+                .stream()
+                .anyMatch(param -> !param.isBodyParam && !"String".equals(param.dataType));
 
         if (customOperation.optionalParams != null) {
             customOperation.optionalAndAuthParameterNames.addAll(
@@ -529,6 +556,22 @@ public class CitrusJavaCodegen extends AbstractJavaCodegen {
                 }
             });
         }
+
+        if (!isGenerateModels()) {
+            // Need to remove all model imports
+            List<Map<String, String>> imports = objs.getImports();
+
+            Iterator<Map<String, String>> iterator = imports.iterator();
+            while (iterator.hasNext()) {
+                Map<String, String> next = iterator.next();
+                String importValue = next.get("import");
+                if (importValue.startsWith(modelPackage)) {
+                    iterator.remove();
+                }
+            }
+        }
+
+
 
         return operationsMap;
     }

--- a/test-api-generator/citrus-openapi-codegen/src/test/java/org/citrusframework/openapi/generator/GeneratedRestApiIT.java
+++ b/test-api-generator/citrus-openapi-codegen/src/test/java/org/citrusframework/openapi/generator/GeneratedRestApiIT.java
@@ -1450,6 +1450,58 @@ class GeneratedRestApiIT {
         class QueryParameter {
 
             @Nested
+            class RefencedObjectQueryParameter {
+
+                // Asserts that a nested json can be sent as query parameter.
+                @Test
+                void java_non_url_encoded(@CitrusResource TestCaseRunner runner) {
+
+                    String owner = """
+                    {"name":"Max Mustermann","email":"maxmuster@muster.de","phone":"+491234567890","address":{"street":"Musterstreet","town":"Mustertown"}}""";
+
+                    runner.variable("owner", owner);
+                    runner.when(extPetApi.sendPostOwner$("${owner}")
+                        .fork(true));
+
+                    runner.then(http().server(httpServer)
+                        .receive()
+                        .post("/api/v3/ext/pet/owner")
+                        .message().queryParam("owner", "citrus:urlEncode('${owner}')"));
+
+                    runner.then(http().server(httpServer)
+                        .send()
+                        .response(OK));
+
+                    runner.when(extPetApi.receivePostOwner("200"));
+
+                }
+
+                // Asserts that a nested json can be sent as query parameter.
+                @Test
+                void java_url_encoded(@CitrusResource TestCaseRunner runner) {
+
+                    String owner = """
+                    {"name":"Max Mustermann","email":"maxmuster@muster.de","phone":"+491234567890","address":{"street":"Musterstreet","town":"Mustertown"}}""";
+
+                    runner.variable("owner", owner);
+                    runner.when(extPetApi.sendPostOwner$("citrus:urlEncode('${owner}')")
+                        .fork(true));
+
+                    runner.then(http().server(httpServer)
+                        .receive()
+                        .post("/api/v3/ext/pet/owner")
+                        .message().queryParam("owner", "citrus:urlEncode('${owner}')"));
+
+                    runner.then(http().server(httpServer)
+                        .send()
+                        .response(OK));
+
+                    runner.when(extPetApi.receivePostOwner("200"));
+
+                }
+            }
+
+            @Nested
             class FormStyle {
 
                 @Nested
@@ -1513,7 +1565,7 @@ class GeneratedRestApiIT {
                     }
 
                     @Test
-                    void java_arrya_value_non_type_safe_with_variables(
+                    void java_array_value_non_type_safe_with_variables(
                         @CitrusResource TestCaseRunner runner) {
                         runner.variable("one", "1");
                         runner.variable("two", "2");

--- a/test-api-generator/citrus-openapi-codegen/src/test/resources/apis/petstore-extended-v3.yaml
+++ b/test-api-generator/citrus-openapi-codegen/src/test/resources/apis/petstore-extended-v3.yaml
@@ -1262,6 +1262,25 @@ paths:
                     description: Bad Request - Invalid form data
                 '500':
                     description: Internal Server Error
+    /pet/owner:
+        post:
+            tags:
+                - extPet
+            operationId: postOwner
+            summary: Add pet owner
+            description: |
+                Example that uses a parameter reference to an object parameter that is deeply nested 
+                and uses x-extendAsJson style. This allows encoding of nested json objects as query
+                parameter. Not officially supported by OpenAPI but common practice.
+            parameters:
+                -   $ref: "#/components/parameters/OwnerParameter"
+            responses:
+                '201':
+                    description: Owner  successfully submitted
+                '400':
+                    description: Bad Request - Invalid form data
+                '500':
+                    description: Internal Server Error
 
 components:
     securitySchemes:
@@ -1315,3 +1334,34 @@ components:
                     type: string
                 alias:
                     type: string
+        Address:
+            description: An address
+            type: object
+            properties:
+                street:
+                    type: string
+                town:
+                    type: string
+        Owner:
+            description: Object containing Owner data
+            type: object
+            properties:
+                name:
+                    type: string
+                email:
+                    type: string
+                phone:
+                    type: string
+                address:
+                    $ref: "#/components/schemas/Address"
+
+    parameters:
+        OwnerParameter:
+            name: owner
+            in: query
+            required: true
+            x-encodeAsJson: true
+            schema:
+                $ref: "#/components/schemas/Owner"
+
+

--- a/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/extpetstore/model/Address.java
+++ b/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/extpetstore/model/Address.java
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-package org.citrusframework.openapi.generator.rest.petstore.model;
+package org.citrusframework.openapi.generator.rest.extpetstore.model;
 
 import java.util.Objects;
 import java.util.Arrays;
@@ -22,21 +22,15 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
 /**
- * Address
+ * An address
  */
-@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-07-25T13:14:37.509644+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
+@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-07-25T13:14:38.461661900+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
 public class Address {
   @jakarta.annotation.Nullable
   private String street;
 
   @jakarta.annotation.Nullable
-  private String city;
-
-  @jakarta.annotation.Nullable
-  private String state;
-
-  @jakarta.annotation.Nullable
-  private String zip;
+  private String town;
 
   public Address() {
   }
@@ -62,67 +56,25 @@ public class Address {
     this.street = street;
   }
 
-  public Address city(@jakarta.annotation.Nullable String city) {
+  public Address town(@jakarta.annotation.Nullable String town) {
     
-    this.city = city;
+    this.town = town;
     return this;
   }
 
   /**
-   * Get city
-   * @return city
+   * Get town
+   * @return town
    */
   @jakarta.annotation.Nullable
 
-  public String getCity() {
-    return city;
+  public String getTown() {
+    return town;
   }
 
 
-  public void setCity(@jakarta.annotation.Nullable String city) {
-    this.city = city;
-  }
-
-  public Address state(@jakarta.annotation.Nullable String state) {
-    
-    this.state = state;
-    return this;
-  }
-
-  /**
-   * Get state
-   * @return state
-   */
-  @jakarta.annotation.Nullable
-
-  public String getState() {
-    return state;
-  }
-
-
-  public void setState(@jakarta.annotation.Nullable String state) {
-    this.state = state;
-  }
-
-  public Address zip(@jakarta.annotation.Nullable String zip) {
-    
-    this.zip = zip;
-    return this;
-  }
-
-  /**
-   * Get zip
-   * @return zip
-   */
-  @jakarta.annotation.Nullable
-
-  public String getZip() {
-    return zip;
-  }
-
-
-  public void setZip(@jakarta.annotation.Nullable String zip) {
-    this.zip = zip;
+  public void setTown(@jakarta.annotation.Nullable String town) {
+    this.town = town;
   }
 
   @Override
@@ -135,14 +87,12 @@ public class Address {
     }
     Address address = (Address) o;
     return Objects.equals(this.street, address.street) &&
-        Objects.equals(this.city, address.city) &&
-        Objects.equals(this.state, address.state) &&
-        Objects.equals(this.zip, address.zip);
+        Objects.equals(this.town, address.town);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(street, city, state, zip);
+    return Objects.hash(street, town);
   }
 
   @Override
@@ -150,9 +100,7 @@ public class Address {
     StringBuilder sb = new StringBuilder();
     sb.append("class Address {\n");
     sb.append("    street: ").append(toIndentedString(street)).append("\n");
-    sb.append("    city: ").append(toIndentedString(city)).append("\n");
-    sb.append("    state: ").append(toIndentedString(state)).append("\n");
-    sb.append("    zip: ").append(toIndentedString(zip)).append("\n");
+    sb.append("    town: ").append(toIndentedString(town)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/extpetstore/model/Category.java
+++ b/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/extpetstore/model/Category.java
@@ -24,7 +24,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * Category
  */
-@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-06-29T17:00:47.279105500+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
+@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-07-25T13:14:38.461661900+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
 public class Category {
   @jakarta.annotation.Nullable
   private Long id;

--- a/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/extpetstore/model/HistoricalData.java
+++ b/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/extpetstore/model/HistoricalData.java
@@ -25,7 +25,7 @@ import java.time.LocalDate;
 /**
  * Additional historical data for a vaccination report, not contained in internal storage. 
  */
-@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-06-29T17:00:47.279105500+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
+@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-07-25T13:14:38.461661900+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
 public class HistoricalData {
   @jakarta.annotation.Nullable
   private LocalDate lastVaccinationDate;

--- a/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/extpetstore/model/Owner.java
+++ b/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/extpetstore/model/Owner.java
@@ -20,22 +20,29 @@ import java.util.Objects;
 import java.util.Arrays;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.citrusframework.openapi.generator.rest.extpetstore.model.Address;
 
 /**
- * PetIdentifier
+ * Object containing Owner data
  */
 @jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-07-25T13:14:38.461661900+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
-public class PetIdentifier {
+public class Owner {
   @jakarta.annotation.Nullable
   private String _name;
 
   @jakarta.annotation.Nullable
-  private String alias;
+  private String email;
 
-  public PetIdentifier() {
+  @jakarta.annotation.Nullable
+  private String phone;
+
+  @jakarta.annotation.Nullable
+  private Address address;
+
+  public Owner() {
   }
 
-  public PetIdentifier _name(@jakarta.annotation.Nullable String _name) {
+  public Owner _name(@jakarta.annotation.Nullable String _name) {
     
     this._name = _name;
     return this;
@@ -56,25 +63,67 @@ public class PetIdentifier {
     this._name = _name;
   }
 
-  public PetIdentifier alias(@jakarta.annotation.Nullable String alias) {
+  public Owner email(@jakarta.annotation.Nullable String email) {
     
-    this.alias = alias;
+    this.email = email;
     return this;
   }
 
   /**
-   * Get alias
-   * @return alias
+   * Get email
+   * @return email
    */
   @jakarta.annotation.Nullable
 
-  public String getAlias() {
-    return alias;
+  public String getEmail() {
+    return email;
   }
 
 
-  public void setAlias(@jakarta.annotation.Nullable String alias) {
-    this.alias = alias;
+  public void setEmail(@jakarta.annotation.Nullable String email) {
+    this.email = email;
+  }
+
+  public Owner phone(@jakarta.annotation.Nullable String phone) {
+    
+    this.phone = phone;
+    return this;
+  }
+
+  /**
+   * Get phone
+   * @return phone
+   */
+  @jakarta.annotation.Nullable
+
+  public String getPhone() {
+    return phone;
+  }
+
+
+  public void setPhone(@jakarta.annotation.Nullable String phone) {
+    this.phone = phone;
+  }
+
+  public Owner address(@jakarta.annotation.Nullable Address address) {
+    
+    this.address = address;
+    return this;
+  }
+
+  /**
+   * Get address
+   * @return address
+   */
+  @jakarta.annotation.Nullable
+
+  public Address getAddress() {
+    return address;
+  }
+
+
+  public void setAddress(@jakarta.annotation.Nullable Address address) {
+    this.address = address;
   }
 
   @Override
@@ -85,22 +134,26 @@ public class PetIdentifier {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    PetIdentifier petIdentifier = (PetIdentifier) o;
-    return Objects.equals(this._name, petIdentifier._name) &&
-        Objects.equals(this.alias, petIdentifier.alias);
+    Owner owner = (Owner) o;
+    return Objects.equals(this._name, owner._name) &&
+        Objects.equals(this.email, owner.email) &&
+        Objects.equals(this.phone, owner.phone) &&
+        Objects.equals(this.address, owner.address);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_name, alias);
+    return Objects.hash(_name, email, phone, address);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
-    sb.append("class PetIdentifier {\n");
+    sb.append("class Owner {\n");
     sb.append("    _name: ").append(toIndentedString(_name)).append("\n");
-    sb.append("    alias: ").append(toIndentedString(alias)).append("\n");
+    sb.append("    email: ").append(toIndentedString(email)).append("\n");
+    sb.append("    phone: ").append(toIndentedString(phone)).append("\n");
+    sb.append("    address: ").append(toIndentedString(address)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/extpetstore/model/Pet.java
+++ b/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/extpetstore/model/Pet.java
@@ -29,7 +29,7 @@ import org.citrusframework.openapi.generator.rest.extpetstore.model.Tag;
 /**
  * Pet
  */
-@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-06-29T17:00:47.279105500+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
+@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-07-25T13:14:38.461661900+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
 public class Pet {
   @jakarta.annotation.Nullable
   private Long id;

--- a/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/extpetstore/model/Tag.java
+++ b/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/extpetstore/model/Tag.java
@@ -24,7 +24,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * Tag
  */
-@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-06-29T17:00:47.279105500+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
+@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-07-25T13:14:38.461661900+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
 public class Tag {
   @jakarta.annotation.Nullable
   private Long id;

--- a/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/extpetstore/model/VaccinationDocumentResult.java
+++ b/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/extpetstore/model/VaccinationDocumentResult.java
@@ -24,7 +24,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * VaccinationDocumentResult
  */
-@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-06-29T17:00:47.279105500+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
+@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-07-25T13:14:38.461661900+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
 public class VaccinationDocumentResult {
   @jakarta.annotation.Nullable
   private String documentId;

--- a/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/extpetstore/request/ExtPetApi.java
+++ b/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/extpetstore/request/ExtPetApi.java
@@ -37,13 +37,14 @@ import org.citrusframework.openapi.generator.rest.extpetstore.ExtPetStoreOpenApi
 import java.math.BigDecimal;
 import org.citrusframework.openapi.generator.rest.extpetstore.model.HistoricalData;
 import java.time.LocalDate;
+import org.citrusframework.openapi.generator.rest.extpetstore.model.Owner;
 import org.citrusframework.openapi.generator.rest.extpetstore.model.Pet;
 import org.citrusframework.openapi.generator.rest.extpetstore.model.PetIdentifier;
 import java.util.UUID;
 import org.citrusframework.openapi.generator.rest.extpetstore.model.VaccinationDocumentResult;
 
 @SuppressWarnings("unused")
-@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-06-29T17:00:47.279105500+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
+@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-07-25T13:14:38.461661900+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
 public class ExtPetApi implements GeneratedApi
 {
 
@@ -835,6 +836,28 @@ public class ExtPetApi implements GeneratedApi
 
     public PetWithoutOperationIdPetIdGetReceiveActionBuilder receivePetWithoutOperationIdPetIdGet(@NotNull String statusCode)   {
         return new PetWithoutOperationIdPetIdGetReceiveActionBuilder(this,  statusCode);
+    }
+
+    /**
+     * Builder with type safe required parameters.
+     */
+    public PostOwnerSendActionBuilder sendPostOwner(Owner owner)   {
+            return new PostOwnerSendActionBuilder(this, owner);
+    }
+
+    /**
+     * Builder with required parameters as string, allowing dynamic content using citrus expressions.
+     */
+    public PostOwnerSendActionBuilder sendPostOwner$(String ownerExpression )   {
+            return new PostOwnerSendActionBuilder(ownerExpression, this);
+    }
+
+    public PostOwnerReceiveActionBuilder receivePostOwner(@NotNull HttpStatus statusCode)   {
+        return new PostOwnerReceiveActionBuilder(this, Integer.toString(statusCode.value()));
+    }
+
+    public PostOwnerReceiveActionBuilder receivePostOwner(@NotNull String statusCode)   {
+        return new PostOwnerReceiveActionBuilder(this,  statusCode);
     }
 
     /**
@@ -4856,6 +4879,119 @@ public class ExtPetApi implements GeneratedApi
         }
 
         public PetWithoutOperationIdPetIdGetReceiveActionBuilder(ExtPetApi extPetApi, OpenApiClientResponseMessageBuilder messageBuilder) {
+            super(extPetApi, extPetStoreSpecification, messageBuilder, messageBuilder.getMessage(), METHOD, ENDPOINT, OPERATION_NAME);
+        }
+
+        @Override
+        public String getOperationName() {
+            return OPERATION_NAME;
+        }
+
+        @Override
+        public String getMethod() {
+            return METHOD;
+        }
+
+        @Override
+        public String getPath() {
+            return ENDPOINT;
+        }
+
+        @Override
+        public ReceiveMessageAction doBuild() {
+
+            if (getCustomizers() != null) {
+                getCustomizers().forEach(customizer -> customizer.customizeResponseBuilder(this, this));
+            }
+
+            return super.doBuild();
+        }
+
+    }
+
+    public static class PostOwnerSendActionBuilder extends
+                RestApiSendMessageActionBuilder implements GeneratedApiOperationInfo {
+
+        private static final String METHOD = "POST";
+
+        private static final String ENDPOINT = "/api/v3/ext/pet/owner";
+
+        private static final String OPERATION_NAME = "postOwner";
+
+        /**
+         * Constructor with type safe required parameters.
+         */
+        public PostOwnerSendActionBuilder(ExtPetApi extPetApi, Owner owner) {
+            super(extPetApi, extPetStoreSpecification, METHOD, ENDPOINT, OPERATION_NAME);
+                queryParameter("owner", owner, ParameterStyle.X_ENCODE_AS_JSON, true, true);
+        }
+
+        /**
+         * Constructor with required parameters as string to allow for dynamic content.
+         */
+            public PostOwnerSendActionBuilder(String ownerExpression, ExtPetApi extPetApi) {
+            super(extPetApi, extPetStoreSpecification,  METHOD, ENDPOINT, OPERATION_NAME);
+            queryParameter("owner", ownerExpression, ParameterStyle.X_ENCODE_AS_JSON, true, true);
+        }
+
+        @Override
+        public String getOperationName() {
+            return OPERATION_NAME;
+        }
+
+        @Override
+        public String getMethod() {
+            return METHOD;
+        }
+
+        @Override
+        public String getPath() {
+            return ENDPOINT;
+        }
+
+        /**
+         * Constructor with required parameters as string to allow for dynamic content.
+         */
+        public PostOwnerSendActionBuilder(ExtPetApi extPetApi, TestApiClientRequestMessageBuilder messageBuilder, String ownerExpression) {
+            super(extPetApi, extPetStoreSpecification, messageBuilder, messageBuilder.getMessage(), METHOD, ENDPOINT, OPERATION_NAME);
+            queryParameter("owner", ownerExpression, ParameterStyle.X_ENCODE_AS_JSON, true, true);
+        }
+
+        public PostOwnerSendActionBuilder owner(Owner owner) {
+            queryParameter("owner", owner, ParameterStyle.X_ENCODE_AS_JSON, true, true);
+            return this;
+        }
+
+        public PostOwnerSendActionBuilder owner(String ownerExpression) {
+            queryParameter("owner", ownerExpression, ParameterStyle.X_ENCODE_AS_JSON, true, true);
+                return this;
+        }
+
+        @Override
+        public SendMessageAction doBuild() {
+
+            if (getCustomizers() != null) {
+                getCustomizers().forEach(customizer -> customizer.customizeRequestBuilder(this, this));
+            }
+
+            return super.doBuild();
+        }
+    }
+
+    public static class PostOwnerReceiveActionBuilder extends
+                        RestApiReceiveMessageActionBuilder implements GeneratedApiOperationInfo {
+
+        private static final String METHOD = "POST";
+
+        private static final String ENDPOINT = "/api/v3/ext/pet/owner";
+
+        private static final String OPERATION_NAME = "postOwner";
+
+        public PostOwnerReceiveActionBuilder(ExtPetApi extPetApi,  String statusCode) {
+            super(extPetApi, extPetStoreSpecification, METHOD, ENDPOINT, OPERATION_NAME, statusCode);
+        }
+
+        public PostOwnerReceiveActionBuilder(ExtPetApi extPetApi, OpenApiClientResponseMessageBuilder messageBuilder) {
             super(extPetApi, extPetStoreSpecification, messageBuilder, messageBuilder.getMessage(), METHOD, ENDPOINT, OPERATION_NAME);
         }
 

--- a/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/extpetstore/spring/ExtPetStoreBeanConfiguration.java
+++ b/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/extpetstore/spring/ExtPetStoreBeanConfiguration.java
@@ -15,7 +15,7 @@ import org.springframework.context.annotation.Configuration;
 import org.citrusframework.openapi.generator.rest.extpetstore.ExtPetStoreOpenApi;
 
 @Configuration
-@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-06-29T17:00:47.279105500+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
+@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-07-25T13:14:38.461661900+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
 public class ExtPetStoreBeanConfiguration {
 
     @Bean

--- a/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/extpetstore/spring/ExtPetStoreNamespaceHandler.java
+++ b/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/extpetstore/spring/ExtPetStoreNamespaceHandler.java
@@ -12,7 +12,7 @@ import org.citrusframework.openapi.generator.rest.extpetstore.ExtPetStoreOpenApi
 import org.citrusframework.openapi.testapi.GeneratedApi;
 import org.springframework.beans.factory.xml.NamespaceHandlerSupport;
 
-@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-06-29T17:00:47.279105500+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
+@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-07-25T13:14:38.461661900+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
 public class ExtPetStoreNamespaceHandler extends NamespaceHandlerSupport {
 
     @Override
@@ -208,6 +208,12 @@ public class ExtPetStoreNamespaceHandler extends NamespaceHandlerSupport {
                 ExtPetApi.PetWithoutOperationIdPetIdGetSendActionBuilder.class,
                 ExtPetApi.PetWithoutOperationIdPetIdGetReceiveActionBuilder.class,
                 new String[]{ "petId" },
+            new String[]{  });
+
+            registerOperationParsers(ExtPetApi.class,"post-owner", "postOwner", "/pet/owner",
+                ExtPetApi.PostOwnerSendActionBuilder.class,
+                ExtPetApi.PostOwnerReceiveActionBuilder.class,
+                new String[]{ "owner" },
             new String[]{  });
 
             registerOperationParsers(ExtPetApi.class,"post-vaccination-document", "postVaccinationDocument", "/pet/vaccination/{bucket}/{filename}",

--- a/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/petstore/model/Category.java
+++ b/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/petstore/model/Category.java
@@ -24,7 +24,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * Category
  */
-@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-06-29T17:00:42.828969400+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
+@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-07-25T13:14:37.509644+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
 public class Category {
   @jakarta.annotation.Nullable
   private Long id;

--- a/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/petstore/model/Customer.java
+++ b/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/petstore/model/Customer.java
@@ -28,7 +28,7 @@ import org.citrusframework.openapi.generator.rest.petstore.model.Address;
 /**
  * Customer
  */
-@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-06-29T17:00:42.828969400+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
+@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-07-25T13:14:37.509644+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
 public class Customer {
   @jakarta.annotation.Nullable
   private Long id;

--- a/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/petstore/model/ModelApiResponse.java
+++ b/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/petstore/model/ModelApiResponse.java
@@ -24,7 +24,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * ModelApiResponse
  */
-@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-06-29T17:00:42.828969400+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
+@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-07-25T13:14:37.509644+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
 public class ModelApiResponse {
   @jakarta.annotation.Nullable
   private Integer code;

--- a/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/petstore/model/Order.java
+++ b/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/petstore/model/Order.java
@@ -25,7 +25,7 @@ import java.time.OffsetDateTime;
 /**
  * Order
  */
-@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-06-29T17:00:42.828969400+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
+@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-07-25T13:14:37.509644+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
 public class Order {
   @jakarta.annotation.Nullable
   private Long id;

--- a/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/petstore/model/Pet.java
+++ b/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/petstore/model/Pet.java
@@ -29,7 +29,7 @@ import org.citrusframework.openapi.generator.rest.petstore.model.Tag;
 /**
  * Pet
  */
-@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-06-29T17:00:42.828969400+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
+@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-07-25T13:14:37.509644+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
 public class Pet {
   @jakarta.annotation.Nullable
   private Long id;

--- a/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/petstore/model/Tag.java
+++ b/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/petstore/model/Tag.java
@@ -24,7 +24,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * Tag
  */
-@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-06-29T17:00:42.828969400+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
+@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-07-25T13:14:37.509644+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
 public class Tag {
   @jakarta.annotation.Nullable
   private Long id;

--- a/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/petstore/model/User.java
+++ b/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/petstore/model/User.java
@@ -24,7 +24,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * User
  */
-@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-06-29T17:00:42.828969400+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
+@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-07-25T13:14:37.509644+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
 public class User {
   @jakarta.annotation.Nullable
   private Long id;

--- a/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/petstore/request/PetApi.java
+++ b/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/petstore/request/PetApi.java
@@ -38,7 +38,7 @@ import org.citrusframework.openapi.generator.rest.petstore.model.ModelApiRespons
 import org.citrusframework.openapi.generator.rest.petstore.model.Pet;
 
 @SuppressWarnings("unused")
-@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-06-29T17:00:42.828969400+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
+@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-07-25T13:14:37.509644+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
 public class PetApi implements GeneratedApi
 {
 

--- a/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/petstore/request/StoreApi.java
+++ b/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/petstore/request/StoreApi.java
@@ -37,7 +37,7 @@ import org.citrusframework.openapi.generator.rest.petstore.PetStoreOpenApi;
 import org.citrusframework.openapi.generator.rest.petstore.model.Order;
 
 @SuppressWarnings("unused")
-@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-06-29T17:00:42.828969400+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
+@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-07-25T13:14:37.509644+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
 public class StoreApi implements GeneratedApi
 {
 

--- a/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/petstore/request/UserApi.java
+++ b/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/petstore/request/UserApi.java
@@ -38,7 +38,7 @@ import java.time.OffsetDateTime;
 import org.citrusframework.openapi.generator.rest.petstore.model.User;
 
 @SuppressWarnings("unused")
-@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-06-29T17:00:42.828969400+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
+@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-07-25T13:14:37.509644+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
 public class UserApi implements GeneratedApi
 {
 

--- a/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/petstore/spring/PetStoreBeanConfiguration.java
+++ b/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/petstore/spring/PetStoreBeanConfiguration.java
@@ -17,7 +17,7 @@ import org.springframework.context.annotation.Configuration;
 import org.citrusframework.openapi.generator.rest.petstore.PetStoreOpenApi;
 
 @Configuration
-@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-06-29T17:00:42.828969400+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
+@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-07-25T13:14:37.509644+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
 public class PetStoreBeanConfiguration {
 
     @Bean

--- a/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/petstore/spring/PetStoreNamespaceHandler.java
+++ b/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/rest/petstore/spring/PetStoreNamespaceHandler.java
@@ -14,7 +14,7 @@ import org.citrusframework.openapi.generator.rest.petstore.PetStoreOpenApi;
 import org.citrusframework.openapi.testapi.GeneratedApi;
 import org.springframework.beans.factory.xml.NamespaceHandlerSupport;
 
-@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-06-29T17:00:42.828969400+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
+@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-07-25T13:14:37.509644+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
 public class PetStoreNamespaceHandler extends NamespaceHandlerSupport {
 
     @Override

--- a/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/soap/bookservice/request/BookServiceSoapApi.java
+++ b/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/soap/bookservice/request/BookServiceSoapApi.java
@@ -17,7 +17,7 @@ import org.citrusframework.openapi.testapi.SoapApiReceiveMessageActionBuilder;
 import org.citrusframework.openapi.testapi.SoapApiSendMessageActionBuilder;
 
 @SuppressWarnings("unused")
-@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-06-29T17:00:48.787357800+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
+@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-07-25T13:14:45.154485300+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
 public class BookServiceSoapApi implements GeneratedApi
 {
 

--- a/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/soap/bookservice/spring/BookServiceBeanConfiguration.java
+++ b/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/soap/bookservice/spring/BookServiceBeanConfiguration.java
@@ -15,7 +15,7 @@ import org.springframework.context.annotation.Configuration;
 import org.citrusframework.openapi.generator.soap.bookservice.BookServiceOpenApi;
 
 @Configuration
-@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-06-29T17:00:48.787357800+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
+@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-07-25T13:14:45.154485300+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
 public class BookServiceBeanConfiguration {
 
     @Bean

--- a/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/soap/bookservice/spring/BookServiceNamespaceHandler.java
+++ b/test-api-generator/citrus-openapi-codegen/src/test/resources/org/citrusframework/openapi/generator/ExpectedCodeGenIT/expectedgen/soap/bookservice/spring/BookServiceNamespaceHandler.java
@@ -10,7 +10,7 @@ import org.citrusframework.openapi.generator.soap.bookservice.BookServiceOpenApi
 import org.citrusframework.openapi.testapi.GeneratedApi;
 import org.springframework.beans.factory.xml.NamespaceHandlerSupport;
 
-@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-06-29T17:00:48.787357800+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
+@jakarta.annotation.Generated(value = "org.citrusframework.openapi.generator.CitrusJavaCodegen", date = "2025-07-25T13:14:45.154485300+02:00[Europe/Zurich]", comments = "Generator version: 7.14.0")
 public class BookServiceNamespaceHandler extends NamespaceHandlerSupport {
 
     @Override

--- a/test-api-generator/citrus-test-api-core/src/main/java/org/citrusframework/openapi/testapi/OpenApiParameterFormatter.java
+++ b/test-api-generator/citrus-test-api-core/src/main/java/org/citrusframework/openapi/testapi/OpenApiParameterFormatter.java
@@ -21,6 +21,8 @@ import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -33,22 +35,30 @@ import java.util.stream.Stream;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 
+import static java.lang.String.format;
+import static java.net.URLDecoder.decode;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.joining;
 import static org.citrusframework.openapi.testapi.ParameterStyle.DEEPOBJECT;
 import static org.citrusframework.openapi.testapi.ParameterStyle.NONE;
+import static org.citrusframework.openapi.testapi.ParameterStyle.X_ENCODE_AS_JSON;
 
 class OpenApiParameterFormatter {
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
     private static final FormatParameters DEFAULT_FORMAT_PARAMETERS = new FormatParameters("", ",");
-    private static final FormatParameters DEFAULT_LABEL_FORMAT_PARAMETERS = new FormatParameters(".", ",");
-    private static final FormatParameters DEFAULT_LABEL_EXPLODED_PARAMETERS = new FormatParameters(".", ".");
+    private static final FormatParameters PIPE_DELIMITED_FORMAT_PARAMETERS = new FormatParameters(
+        "", "|");
+    private static final FormatParameters SPACE_DELIMITED_FORMAT_PARAMETERS = new FormatParameters(
+        "", " ");
+    private static final FormatParameters DEFAULT_LABEL_FORMAT_PARAMETERS = new FormatParameters(
+        ".", ",");
+    private static final FormatParameters DEFAULT_LABEL_EXPLODED_PARAMETERS = new FormatParameters(
+        ".", ".");
 
     private OpenApiParameterFormatter() {
         // Static access only.
@@ -58,27 +68,87 @@ class OpenApiParameterFormatter {
      * Formats a list of values as a single String based on the separator and other settings.
      */
     static String formatArray(String parameterName,
-                              Object parameterValue,
-                              ParameterStyle parameterStyle,
-                              boolean explode,
-                              boolean isObject) {
+        Object parameterValue,
+        ParameterStyle parameterStyle,
+        boolean explode,
+        boolean isObject) {
+
+        if (X_ENCODE_AS_JSON.equals(parameterStyle)) {
+            return encodeAsJson(parameterName, parameterValue);
+        } else {
+            return encodeAccordingToSpec(parameterName, parameterValue, parameterStyle, explode,
+                isObject);
+        }
+    }
+
+    private static String encodeAccordingToSpec(String parameterName, Object parameterValue,
+        ParameterStyle parameterStyle, boolean explode, boolean isObject) {
         List<String> values = toList(parameterValue, isObject);
 
-        if (NONE.equals(parameterStyle))  {
-            return parameterName + "="+ (parameterValue != null ? parameterValue.toString() : null);
+        if (NONE.equals(parameterStyle)) {
+            return parameterName + "=" + (parameterValue != null ? parameterValue.toString()
+                : null);
         }
 
         if (DEEPOBJECT.equals(parameterStyle)) {
             return formatDeepObject(parameterName, values);
         }
 
-        FormatParameters formatParameters = determineFormatParameters(parameterName, parameterStyle, explode, isObject);
+        FormatParameters formatParameters = determineFormatParameters(parameterName, parameterStyle,
+            explode, isObject);
 
         if (isObject && explode) {
             return formatParameters.prefix + explode(values, formatParameters.separator);
         } else {
             return formatParameters.prefix + values.stream()
-                    .collect(joining(formatParameters.separator));
+                .collect(joining(formatParameters.separator));
+        }
+    }
+
+    /**
+     * This is an extension to the standard OpenAPI spec, that supports a common coding style for
+     * deeply nested objects, where the json itself is serialized as string.
+     */
+    private static String encodeAsJson(String parameterName, Object parameterValue) {
+        if (parameterValue == null) {
+            return "";
+        }
+
+        JsonNode jsonNode;
+
+        // If it's a string, try parsing as JSON, fallback to URL decoding, as the user might have
+        // encoded the content already.
+        if (parameterValue instanceof String stringValue) {
+            jsonNode = tryParseJson(stringValue);
+            if (jsonNode == null) {
+                String decoded = decode(stringValue, StandardCharsets.UTF_8);
+                jsonNode = tryParseJson(decoded);
+                if (jsonNode == null) {
+                    throw new IllegalArgumentException(format(
+                        "Unable to convert string to JSON. Is this a valid JSON or URL-encoded JSON string?%n%s",
+                        stringValue));
+                }
+            }
+        } else {
+            // If not a string, try to convert object directly
+            jsonNode = objectMapper.valueToTree(parameterValue);
+        }
+
+        try {
+            String compactJson = objectMapper.writeValueAsString(jsonNode).replaceAll("\\R", "");
+
+            // There is no other way to pass this into a query parameter, then URL encoding it.
+            return parameterName + "=" + URLEncoder.encode(compactJson, StandardCharsets.UTF_8);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Unable to serialize object to JSON string.", e);
+        }
+    }
+
+    private static JsonNode tryParseJson(String input) {
+        try {
+            return objectMapper.readTree(input);
+        } catch (JsonProcessingException e) {
+            return null;
         }
     }
 
@@ -99,18 +169,21 @@ class OpenApiParameterFormatter {
     }
 
     private static FormatParameters determineFormatParameters(String parameterName,
-                                                              ParameterStyle parameterStyle,
-                                                              boolean explode,
-                                                              boolean isObject) {
+        ParameterStyle parameterStyle,
+        boolean explode,
+        boolean isObject) {
         return switch (parameterStyle) {
             case MATRIX -> matrixFormatParameters(parameterName, explode, isObject);
             case LABEL -> labelFormatParameters(explode);
             case FORM -> formFormatParameters(parameterName, explode, isObject);
-            case NONE, SIMPLE, DEEPOBJECT -> DEFAULT_FORMAT_PARAMETERS;
+            case PIPEDELIMITED -> PIPE_DELIMITED_FORMAT_PARAMETERS;
+            case SPACEDELIMITED -> SPACE_DELIMITED_FORMAT_PARAMETERS;
+            case NONE, SIMPLE, DEEPOBJECT, X_ENCODE_AS_JSON -> DEFAULT_FORMAT_PARAMETERS;
         };
     }
 
-    private static FormatParameters formFormatParameters(String parameterName, boolean explode, boolean isObject) {
+    private static FormatParameters formFormatParameters(String parameterName, boolean explode,
+        boolean isObject) {
         if (explode) {
             if (isObject) {
                 return new FormatParameters("", "&");
@@ -125,7 +198,8 @@ class OpenApiParameterFormatter {
         return explode ? DEFAULT_LABEL_EXPLODED_PARAMETERS : DEFAULT_LABEL_FORMAT_PARAMETERS;
     }
 
-    private static FormatParameters matrixFormatParameters(String parameterName, boolean explode, boolean isObject) {
+    private static FormatParameters matrixFormatParameters(String parameterName, boolean explode,
+        boolean isObject) {
         String prefix;
         String separator = ",";
         if (explode) {
@@ -144,8 +218,8 @@ class OpenApiParameterFormatter {
 
     private static String explode(List<String> values, String delimiter) {
         return IntStream.range(0, values.size() / 2)
-                .mapToObj(i -> values.get(2 * i) + "=" + values.get(2 * i + 1))
-                .collect(joining(delimiter));
+            .mapToObj(i -> values.get(2 * i) + "=" + values.get(2 * i + 1))
+            .collect(joining(delimiter));
     }
 
     private static List<String> toList(Object value, boolean isObject) {
@@ -165,8 +239,8 @@ class OpenApiParameterFormatter {
             return list.stream().map(Object::toString).toList();
         } else if (value instanceof Map<?, ?> map) {
             return map.entrySet().stream()
-                    .flatMap(entry -> Stream.of(entry.getKey().toString(), entry.getValue().toString()))
-                    .toList();
+                .flatMap(entry -> Stream.of(entry.getKey().toString(), entry.getValue().toString()))
+                .toList();
         } else if (isObject && value instanceof String jsonString) {
             return toList(convertJsonToMap(jsonString), true);
         } else if (isObject) {
@@ -176,22 +250,22 @@ class OpenApiParameterFormatter {
         }
     }
 
-    public static Map<String, Object> convertJsonToMap(String jsonString) {
+    private static Map<String, Object> convertJsonToMap(String jsonString) {
         JsonNode rootNode;
         try {
             rootNode = objectMapper.readTree(jsonString);
         } catch (JsonProcessingException e) {
-            throw new IllegalArgumentException("Unable to convert jsonString to JSON object.", e);
+            throw new IllegalArgumentException("Unable to convert jsonString to Json object.", e);
         }
 
         if (!rootNode.isObject()) {
-            throw new IllegalArgumentException("The provided string is not a valid JSON object.");
+            throw new IllegalArgumentException("The provided string is not a valid Json object.");
         }
 
-        return convertNodeToMap((ObjectNode) rootNode);
+        return convertNodeToMap(rootNode);
     }
 
-    private static Map<String, Object> convertNodeToMap(ObjectNode objectNode) {
+    private static Map<String, Object> convertNodeToMap(JsonNode objectNode) {
         Map<String, Object> resultMap = new TreeMap<>();
 
         Iterator<Entry<String, JsonNode>> fields = objectNode.fields();
@@ -200,10 +274,10 @@ class OpenApiParameterFormatter {
             JsonNode valueNode = field.getValue();
 
             if (valueNode.isObject() || valueNode.isArray()) {
-                throw new IllegalArgumentException(
-                        "Nested objects or arrays are not allowed in the JSON.");
+                resultMap.put(field.getKey(), convertNodeToMap(valueNode));
+            } else {
+                resultMap.put(field.getKey(), valueNode.asText());
             }
-            resultMap.put(field.getKey(), valueNode.asText());
         }
 
         return resultMap;
@@ -213,7 +287,7 @@ class OpenApiParameterFormatter {
         Map<String, Object> map = new TreeMap<>();
         try {
             for (PropertyDescriptor propertyDescriptor : Introspector.getBeanInfo(
-                    bean.getClass(), Object.class).getPropertyDescriptors()) {
+                bean.getClass(), Object.class).getPropertyDescriptors()) {
                 String propertyName = propertyDescriptor.getName();
                 Object propertyValue = propertyDescriptor.getReadMethod().invoke(bean);
                 if (propertyValue != null) {

--- a/test-api-generator/citrus-test-api-core/src/main/java/org/citrusframework/openapi/testapi/ParameterStyle.java
+++ b/test-api-generator/citrus-test-api-core/src/main/java/org/citrusframework/openapi/testapi/ParameterStyle.java
@@ -17,10 +17,25 @@
 package org.citrusframework.openapi.testapi;
 
 public enum ParameterStyle {
-    NONE,
-    SIMPLE,
-    LABEL,
-    MATRIX,
-    FORM,
-    DEEPOBJECT
+
+    NONE(io.swagger.v3.oas.annotations.enums.ParameterStyle.DEFAULT.toString()),
+    MATRIX(io.swagger.v3.oas.annotations.enums.ParameterStyle.MATRIX.toString()),
+    LABEL(io.swagger.v3.oas.annotations.enums.ParameterStyle.LABEL.toString()),
+    FORM(io.swagger.v3.oas.annotations.enums.ParameterStyle.FORM.toString()),
+    SPACEDELIMITED(io.swagger.v3.oas.annotations.enums.ParameterStyle.SPACEDELIMITED.toString()),
+    PIPEDELIMITED(io.swagger.v3.oas.annotations.enums.ParameterStyle.PIPEDELIMITED.toString()),
+    DEEPOBJECT(io.swagger.v3.oas.annotations.enums.ParameterStyle.DEEPOBJECT.toString()),
+    SIMPLE(io.swagger.v3.oas.annotations.enums.ParameterStyle.SIMPLE.toString()),
+    X_ENCODE_AS_JSON("x_encode_as_json");
+
+    private final String styleString;
+
+    ParameterStyle(String styleString) {
+        this.styleString = styleString;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(this.styleString);
+    }
 }

--- a/tools/jbang/dist/CitrusJBang.java
+++ b/tools/jbang/dist/CitrusJBang.java
@@ -18,10 +18,10 @@
 
 //JAVA 17+
 //REPOS mavencentral
-//DEPS org.citrusframework:citrus-bom:${citrus.jbang.version:4.7.0}@pom
-//DEPS org.citrusframework:citrus-jbang:${citrus.jbang.version:4.7.0}
-//DEPS org.citrusframework:citrus-agent:${citrus.jbang.version:4.7.0}
-//DEPS org.citrusframework:citrus-agent-connector:${citrus.jbang.version:4.7.0}
+//DEPS org.citrusframework:citrus-bom:${citrus.jbang.version:4.8.0-SNAPSHOT}@pom
+//DEPS org.citrusframework:citrus-jbang:${citrus.jbang.version:4.8.0-SNAPSHOT}
+//DEPS org.citrusframework:citrus-agent:${citrus.jbang.version:4.8.0-SNAPSHOT}
+//DEPS org.citrusframework:citrus-agent-connector:${citrus.jbang.version:4.8.0-SNAPSHOT}
 //DEPS org.citrusframework:citrus-jbang-connector
 //DEPS org.citrusframework:citrus-groovy
 //DEPS org.citrusframework:citrus-xml


### PR DESCRIPTION
- allow sending nested json objects as query parameters using "x-encodeAsJson: true"
- allow api generation without model objects (e.g. for pure xml usage or if model generation is errorneous)
- allow skipping of OpenAPI validation that would otherwise stop the generation procsess