### PR TITLE
feat: optionally disable stacktrace printing

### DIFF
--- a/core/citrus-api/pom.xml
+++ b/core/citrus-api/pom.xml
@@ -18,6 +18,13 @@
       <groupId>jakarta.annotation</groupId>
       <artifactId>jakarta.annotation-api</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>uk.org.webcompere</groupId>
+      <artifactId>system-stubs-testng</artifactId>
+      <version>2.1.8</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/core/citrus-api/src/main/java/org/citrusframework/CitrusSettings.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/CitrusSettings.java
@@ -16,6 +16,10 @@
 
 package org.citrusframework;
 
+import org.citrusframework.common.TestLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.io.InputStream;
 import java.util.Map;
@@ -23,10 +27,8 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import org.citrusframework.common.TestLoader;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
 import static java.lang.Boolean.parseBoolean;
 import static java.lang.System.getProperty;
 import static java.lang.System.getenv;
@@ -43,9 +45,6 @@ import static org.citrusframework.message.MessageType.XML;
 
 public final class CitrusSettings {
 
-    /**
-     * Logger
-     */
     private static final Logger logger = LoggerFactory.getLogger(CitrusSettings.class);
 
     private CitrusSettings() {
@@ -218,14 +217,14 @@ public final class CitrusSettings {
      */
     public static final String HTTP_MESSAGE_BUILDER_FORCE_CITRUS_HEADER_UPDATE_ENABLED_PROPERTY = "citrus.http.message.builder.force.citrus.header.update.enabled";
     public static final String HTTP_MESSAGE_BUILDER_FORCE_CITRUS_HEADER_UPDATE_ENABLED_ENV = "CITRUS_HTTP_MESSAGE_BUILDER_FORCE_CITRUS_HEADER_UPDATE_ENABLED";
-    public static final String HTTP_MESSAGE_BUILDER_FORCE_CITRUS_HEADER_UPDATE_ENABLED_DEFAULT = Boolean.TRUE.toString();
+    public static final String HTTP_MESSAGE_BUILDER_FORCE_CITRUS_HEADER_UPDATE_ENABLED_DEFAULT = TRUE.toString();
 
     /**
      * Flag to enable/disable environment variable based endpoint and component configuration.
      */
     public static final String ENV_VAR_PROPERTY_BINDING_ENABLED_PROPERTY = "citrus.env.var.property.binding.enabled";
     public static final String ENV_VAR_PROPERTY_BINDING_ENABLED_ENV = "CITRUS_ENV_VAR_PROPERTY_BINDING_ENABLED";
-    public static final String ENV_VAR_PROPERTY_BINDING_ENABLED_DEFAULT = Boolean.TRUE.toString();
+    public static final String ENV_VAR_PROPERTY_BINDING_ENABLED_DEFAULT = TRUE.toString();
 
     /**
      * Flag to enable/disable environment variable based endpoint and component configuration.
@@ -235,7 +234,7 @@ public final class CitrusSettings {
     public static final String COMPONENT_PROPERTY_BINDING_ENABLED_DEFAULT = getPropertyEnvOrDefault(
             ENV_VAR_PROPERTY_BINDING_ENABLED_PROPERTY,
             ENV_VAR_PROPERTY_BINDING_ENABLED_ENV,
-            Boolean.TRUE.toString());
+            TRUE.toString());
 
     /**
      * Flag to enable/disable environment variable based endpoint and component configuration.
@@ -245,7 +244,7 @@ public final class CitrusSettings {
     public static final String ENDPOINT_PROPERTY_BINDING_ENABLED_DEFAULT = getPropertyEnvOrDefault(
             ENV_VAR_PROPERTY_BINDING_ENABLED_PROPERTY,
             ENV_VAR_PROPERTY_BINDING_ENABLED_ENV,
-            Boolean.TRUE.toString());;
+            TRUE.toString());
 
     /**
      * Default message trace output directory
@@ -273,14 +272,14 @@ public final class CitrusSettings {
      */
     public static final String CACHE_INPUT_STREAM_PROPERTY = "citrus.message.cache.input.stream";
     public static final String CACHE_INPUT_STREAM_ENV = "CITRUS_MESSAGE_CACHE_INPUT_STREAM";
-    public static final String CACHE_INPUT_STREAM_DEFAULT = Boolean.TRUE.toString();
+    public static final String CACHE_INPUT_STREAM_DEFAULT = TRUE.toString();
 
     /**
      * Flag to enable/disable message pretty print
      */
     public static final String PRETTY_PRINT_PROPERTY = "citrus.message.pretty.print";
     public static final String PRETTY_PRINT_ENV = "CITRUS_MESSAGE_PRETTY_PRINT";
-    public static final String PRETTY_PRINT_DEFAULT = Boolean.TRUE.toString();
+    public static final String PRETTY_PRINT_DEFAULT = TRUE.toString();
 
     /**
      * File path charset parameter
@@ -297,9 +296,14 @@ public final class CitrusSettings {
     public static final String GROOVY_STATIC_IMPORTS_DEFAULT = "print,sleep";
 
     /**
+     * Flag to enable/disable stack trace output in default logging reporter.
+     */
+    public static final String DEFAULT_LOGGING_REPORTER_PRINT_STACK_TRACES_PROPERTY = "citrus.default.logging.reporter.print-stack-traces";
+    public static final String DEFAULT_LOGGING_REPORTER_PRINT_STACK_TRACES_ENV = "CITRUS_DEFAULT_LOGGING_REPORTER_PRINT_STACK_TRACES";
+    public static final String DEFAULT_LOGGING_REPORTER_PRINT_STACK_TRACES_DEFAULT = FALSE.toString();
+
+    /**
      * Gets set of file name patterns for Groovy test files.
-     *
-     * @return
      */
     public static Set<String> getGroovyTestFileNamePattern() {
         return Stream.of(GROOVY_TEST_FILE_NAME_PATTERN.split(",")).collect(toSet());
@@ -307,8 +311,6 @@ public final class CitrusSettings {
 
     /**
      * Gets set of file name patterns for YAML test files.
-     *
-     * @return
      */
     public static Set<String> getYamlTestFileNamePattern() {
         return Stream.of(YAML_TEST_FILE_NAME_PATTERN.split(",")).collect(toSet());
@@ -316,8 +318,6 @@ public final class CitrusSettings {
 
     /**
      * Gets set of file name patterns for XML test files.
-     *
-     * @return
      */
     public static Set<String> getXmlTestFileNamePattern() {
         return Stream.of(XML_TEST_FILE_NAME_PATTERN.split(",")).collect(toSet());
@@ -325,8 +325,6 @@ public final class CitrusSettings {
 
     /**
      * Gets set of file name patterns for Java test files.
-     *
-     * @return
      */
     public static Set<String> getJavaTestFileNamePattern() {
         return Stream.of(JAVA_TEST_FILE_NAME_PATTERN.split(",")).collect(toSet());
@@ -334,8 +332,6 @@ public final class CitrusSettings {
 
     /**
      * Gets the directory where to put message trace files.
-     *
-     * @return
      */
     public static String getMessageTraceDirectory() {
         return getPropertyEnvOrDefault(
@@ -346,8 +342,6 @@ public final class CitrusSettings {
 
     /**
      * Gets the type converter to use by default.
-     *
-     * @return
      */
     public static String getTypeConverter() {
         return getPropertyEnvOrDefault(
@@ -378,8 +372,6 @@ public final class CitrusSettings {
 
     /**
      * Gets the message payload pretty print enabled/disabled setting.
-     *
-     * @return
      */
     public static boolean isPrettyPrintEnabled() {
         return parseBoolean(getPropertyEnvOrDefault(
@@ -390,8 +382,6 @@ public final class CitrusSettings {
 
     /**
      * Get the file path charset parameter.
-     *
-     * @return
      */
     public static String getFilePathCharsetParameter() {
         return getPropertyEnvOrDefault(
@@ -403,8 +393,6 @@ public final class CitrusSettings {
     /**
      * Gets the http message builder force citrus header update enabled/disabled setting, which controls
      * whether the citrus message builder always creates messages with unique ids.
-     *
-     * @return
      */
     public static boolean isHttpMessageBuilderForceCitrusHeaderUpdateEnabled() {
         return parseBoolean(getPropertyEnvOrDefault(
@@ -415,9 +403,6 @@ public final class CitrusSettings {
 
     /**
      * Gets the test file name pattern for given type or empty patterns for unknown type.
-     *
-     * @param type
-     * @return
      */
     public static Set<String> getTestFileNamePattern(String type) {
         return switch (type) {
@@ -482,5 +467,18 @@ public final class CitrusSettings {
                 GROOVY_STATIC_IMPORTS_PROPERTY,
                 GROOVY_STATIC_IMPORTS_ENV,
                 GROOVY_STATIC_IMPORTS_DEFAULT);
+    }
+
+    /**
+     * Whether stack traces should be printed in the default logging reporter or not.
+     */
+    public static boolean isStackTraceOutputEnabled() {
+        return parseBoolean(
+                getPropertyEnvOrDefault(
+                        DEFAULT_LOGGING_REPORTER_PRINT_STACK_TRACES_PROPERTY,
+                        DEFAULT_LOGGING_REPORTER_PRINT_STACK_TRACES_ENV,
+                        DEFAULT_LOGGING_REPORTER_PRINT_STACK_TRACES_DEFAULT
+                )
+        );
     }
 }

--- a/core/citrus-api/src/test/java/org/citrusframework/CitrusSettingsTest.java
+++ b/core/citrus-api/src/test/java/org/citrusframework/CitrusSettingsTest.java
@@ -1,0 +1,52 @@
+package org.citrusframework;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.properties.SystemProperties;
+import uk.org.webcompere.systemstubs.testng.SystemStub;
+import uk.org.webcompere.systemstubs.testng.SystemStubsListener;
+
+import static org.citrusframework.CitrusSettings.DEFAULT_LOGGING_REPORTER_PRINT_STACK_TRACES_ENV;
+import static org.citrusframework.CitrusSettings.DEFAULT_LOGGING_REPORTER_PRINT_STACK_TRACES_PROPERTY;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+@Listeners(SystemStubsListener.class)
+public class CitrusSettingsTest {
+
+    @SystemStub
+    private EnvironmentVariables environmentVariables;
+
+    @SystemStub
+    private SystemProperties systemProperties;
+
+    @BeforeMethod
+    void beforeMethodSetup() {
+        environmentVariables.remove(DEFAULT_LOGGING_REPORTER_PRINT_STACK_TRACES_ENV);
+        systemProperties.remove(DEFAULT_LOGGING_REPORTER_PRINT_STACK_TRACES_PROPERTY);
+    }
+
+    @Test
+    public void isStackTraceOutputEnabled_shouldReturnFalseByDefault() {
+        assertFalse(CitrusSettings.isStackTraceOutputEnabled());
+    }
+
+    @Test
+    public void isStackTraceOutputEnabled_shouldReturnEnvVarValue() {
+        environmentVariables.set(DEFAULT_LOGGING_REPORTER_PRINT_STACK_TRACES_ENV, "true");
+
+        assertTrue(CitrusSettings.isStackTraceOutputEnabled());
+    }
+
+    @Test
+    public void isStackTraceOutputEnabled_shouldReturnPropertyValue_overEnvVarValue() {
+        systemProperties.set(DEFAULT_LOGGING_REPORTER_PRINT_STACK_TRACES_PROPERTY, "true");
+
+        // disregarded due to resolving sequence
+        environmentVariables.set(DEFAULT_LOGGING_REPORTER_PRINT_STACK_TRACES_ENV, "false");
+
+        assertTrue(CitrusSettings.isStackTraceOutputEnabled());
+    }
+}

--- a/core/citrus-base/src/main/java/org/citrusframework/common/DefaultTestLoader.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/common/DefaultTestLoader.java
@@ -102,7 +102,6 @@ public class DefaultTestLoader implements TestLoader {
             // This kind of exception indicates that the error has already been handled. Just throw and end test run.
             throw e;
         } catch (Exception | Error e) {
-
             if (e instanceof  RuntimeException runtimeException && isSkipExceptionType(runtimeException)) {
                 throw runtimeException;
             }
@@ -112,6 +111,7 @@ public class DefaultTestLoader implements TestLoader {
             }
 
             testCase.setTestResult(failed(testCase.getName(), testCase.getTestClass().getName(), e));
+
             throw new TestCaseFailedException(e);
         }  finally {
             runner.stop();

--- a/core/citrus-base/src/main/java/org/citrusframework/report/LoggingReporter.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/report/LoggingReporter.java
@@ -16,9 +16,8 @@
 
 package org.citrusframework.report;
 
-import java.util.Optional;
-
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.citrusframework.CitrusSettings;
 import org.citrusframework.CitrusVersion;
 import org.citrusframework.TestAction;
 import org.citrusframework.TestCase;
@@ -30,6 +29,8 @@ import org.citrusframework.message.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.helpers.NOPLoggerFactory;
+
+import java.util.Optional;
 
 import static java.lang.String.format;
 import static java.time.Duration.ZERO;
@@ -94,6 +95,20 @@ public class LoggingReporter extends AbstractTestReporter implements MessageList
         return nonNull(test.getTestResult()) && nonNull(test.getTestResult().getDuration()) ? " (" + test.getTestResult().getDuration().toString() + ") " : "";
     }
 
+    private final boolean stackTraceOutputEnabled;
+
+    public LoggingReporter() {
+        this(CitrusSettings.isStackTraceOutputEnabled());
+    }
+
+    public LoggingReporter(boolean stackTraceOutputEnabled) {
+        this.stackTraceOutputEnabled = stackTraceOutputEnabled;
+    }
+
+    public boolean isStackTraceOutputEnabled() {
+        return stackTraceOutputEnabled;
+    }
+
     @Override
     public void generate(TestResults testResults) {
         newLine();
@@ -142,7 +157,12 @@ public class LoggingReporter extends AbstractTestReporter implements MessageList
         newLine();
 
         var duration = formatDurationString(testCase);
-        error("TEST FAILED " + testCase.getName() + " <" + testCase.getPackageName() + ">" + duration + " Nested exception is: ", cause);
+
+        if (stackTraceOutputEnabled) {
+            error("TEST FAILED " + testCase.getName() + " <" + testCase.getPackageName() + ">" + duration + " Nested exception is: ", cause);
+        } else {
+            error("TEST FAILED " + testCase.getName() + " <" + testCase.getPackageName() + ">" + duration + " Nested exception is: " + cause.getMessage());
+        }
 
         separator();
         newLine();
@@ -198,7 +218,7 @@ public class LoggingReporter extends AbstractTestReporter implements MessageList
     public void onStart() {
         if (!isInitialized) {
             printBanner();
-            LoggingReporter.initialized();
+            initialized();
         }
 
         separator();

--- a/core/citrus-spring/src/main/java/org/citrusframework/reporter/ReporterConfig.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/reporter/ReporterConfig.java
@@ -19,7 +19,11 @@ package org.citrusframework.reporter;
 import org.citrusframework.report.HtmlReporter;
 import org.citrusframework.report.JUnitReporter;
 import org.citrusframework.report.LoggingReporter;
-import org.springframework.context.annotation.*;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 @Configuration

--- a/core/citrus-spring/src/test/java/org/citrusframework/reporter/ReporterConfigIT.java
+++ b/core/citrus-spring/src/test/java/org/citrusframework/reporter/ReporterConfigIT.java
@@ -16,31 +16,34 @@
 
 package org.citrusframework.reporter;
 
-import static org.citrusframework.reporter.ReporterConfig.CITRUS_HTML_REPORTER;
-import static org.citrusframework.reporter.ReporterConfig.CITRUS_JUNIT_REPORTER;
-import static org.citrusframework.reporter.ReporterConfig.CITRUS_LOGGING_REPORTER;
-
 import org.citrusframework.UnitTestSupport;
 import org.citrusframework.report.HtmlReporter;
 import org.citrusframework.report.JUnitReporter;
 import org.citrusframework.report.LoggingReporter;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
-public class ReporterConfigTest extends UnitTestSupport {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.citrusframework.reporter.ReporterConfig.CITRUS_HTML_REPORTER;
+import static org.citrusframework.reporter.ReporterConfig.CITRUS_JUNIT_REPORTER;
+import static org.citrusframework.reporter.ReporterConfig.CITRUS_LOGGING_REPORTER;
+
+public class ReporterConfigIT extends UnitTestSupport {
 
     @Test
     public void testDefaultLoggingReporter() {
-        Assert.assertTrue(applicationContext.getBean(CITRUS_LOGGING_REPORTER) instanceof  LoggingReporter);
+        assertThat(applicationContext.getBean(CITRUS_LOGGING_REPORTER))
+                .isInstanceOf(LoggingReporter.class);
     }
 
     @Test
     public void testDefaultJunitReporter() {
-        Assert.assertTrue(applicationContext.getBean(CITRUS_JUNIT_REPORTER) instanceof  JUnitReporter);
+        assertThat(applicationContext.getBean(CITRUS_JUNIT_REPORTER))
+                .isInstanceOf(JUnitReporter.class);
     }
 
     @Test
     public void testDefaultHtmlReporter() {
-        Assert.assertTrue(applicationContext.getBean(CITRUS_HTML_REPORTER) instanceof  HtmlReporter);
+        assertThat(applicationContext.getBean(CITRUS_HTML_REPORTER))
+                .isInstanceOf(HtmlReporter.class);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -271,7 +271,6 @@
     <swagger.version>2.2.31</swagger.version>
     <swagger.parser.version>2.1.22</swagger.parser.version>
     <swagger-request-validator.version>2.44.9</swagger-request-validator.version>
-    <system-stubs.version>2.1.7</system-stubs.version>
     <testcontainers.version>1.21.3</testcontainers.version>
     <testng.version>7.11.0</testng.version>
     <!-- bound to https://mvnrepository.com/artifact/io.fabric8/kubernetes-httpclient-vertx/${k8s.client.version} -->

--- a/runtime/citrus-junit5/src/main/java/org/citrusframework/junit/jupiter/CitrusExtension.java
+++ b/runtime/citrus-junit5/src/main/java/org/citrusframework/junit/jupiter/CitrusExtension.java
@@ -16,8 +16,6 @@
 
 package org.citrusframework.junit.jupiter;
 
-import java.lang.reflect.Method;
-
 import org.citrusframework.Citrus;
 import org.citrusframework.CitrusContext;
 import org.citrusframework.CitrusInstanceManager;
@@ -28,6 +26,7 @@ import org.citrusframework.annotations.CitrusResource;
 import org.citrusframework.common.TestLoader;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.exceptions.TestCaseFailedException;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
@@ -40,6 +39,8 @@ import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
 import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
 import org.junit.jupiter.api.extension.TestInstancePostProcessor;
 import org.opentest4j.TestAbortedException;
+
+import java.lang.reflect.Method;
 
 import static org.citrusframework.annotations.CitrusAnnotations.injectCitrusFramework;
 import static org.citrusframework.junit.jupiter.CitrusExtensionHelper.getBaseKey;
@@ -182,7 +183,11 @@ public class CitrusExtension implements BeforeAllCallback, InvocationInterceptor
             }
         });
 
-        testLoader.load();
+        try {
+            testLoader.load();
+        } catch (TestCaseFailedException e) {
+            throw new CitrusJUnitException(e.getMessage());
+        }
     }
 
     @Override

--- a/runtime/citrus-junit5/src/main/java/org/citrusframework/junit/jupiter/CitrusJUnitException.java
+++ b/runtime/citrus-junit5/src/main/java/org/citrusframework/junit/jupiter/CitrusJUnitException.java
@@ -1,0 +1,24 @@
+package org.citrusframework.junit.jupiter;
+
+/**
+ * Special {@link AssertionError} implementation used to fail a JUnit test in Citrus without printing a full stack trace.
+ * <p>
+ * This is useful in scenarios where the failure reason is already clearly communicated through Citrus test reporting or log output, and the additional stack trace would only add noise.
+ * <p>
+ * By overriding {@link #fillInStackTrace()}, this exception avoids populating the stack trace entirely, while still causing the test to be marked as failed by the JUnit engine.
+ *
+ * <p>
+ * <b>Note:</b> The JUnit platform (or Citrus test runner) will still display the exception type and message in its failure summary.
+ * To avoid even that, a different mechanism such as marking the test as skipped would be required.
+ */
+public class CitrusJUnitException extends AssertionError {
+
+    public CitrusJUnitException(String message) {
+        super(message);
+    }
+
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+        return this; // don't populate the stack trace
+    }
+}


### PR DESCRIPTION
stacktraces pollute test logs in case of errors.
error message should be good enough in most cases. and stacktraces should only occur in technical errors, not test errors.

`LogginReporter` has now property to disable printing stacktraces. can also be activated in spring-based tests, using `citrus.default.logging.reporter.print-stack-traces=false`.