### PR TITLE
Allow DTD as we are in controlled environment

### DIFF
--- a/validation/citrus-validation-groovy/src/main/resources/org/citrusframework/validation/xml-validation-template.groovy
+++ b/validation/citrus-validation-groovy/src/main/resources/org/citrusframework/validation/xml-validation-template.groovy
@@ -11,7 +11,7 @@ public class ValidationScript implements GroovyScriptExecutor{
 
         def root;
         if (payload.length()) {
-            root = new XmlSlurper().parseText(payload)
+            root = new XmlSlurper(false, true, true).parseText(payload)
         } else {
             root = "";
         }


### PR DESCRIPTION
Groovy by default blocks XML with DTD this brakes tests of legacy systems that still work with DTD