### PR TITLE
add the `add test-api-core` to `citrus-bom`

### DIFF
--- a/catalog/citrus-bom/pom.xml
+++ b/catalog/citrus-bom/pom.xml
@@ -378,6 +378,13 @@
         <version>4.9.0-SNAPSHOT</version>
       </dependency>
 
+      <!-- OpenAPI Generator -->
+      <dependency>
+        <groupId>org.citrusframework</groupId>
+        <artifactId>citrus-test-api-core</artifactId>
+        <version>4.9.0-SNAPSHOT</version>
+      </dependency>
+
       <!-- Tools -->
       <dependency>
         <groupId>org.citrusframework</groupId>

--- a/test-api-generator/citrus-test-api-core/pom.xml
+++ b/test-api-generator/citrus-test-api-core/pom.xml
@@ -47,6 +47,10 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
         <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
         </dependency>


### PR DESCRIPTION
I've added the `add test-api-core` to `citrus-bom`. and included the `jakarta.validation:jakarta.validation-api` in the project dependencies. this way users don't have to explicitly declare every single dependency. a (non-inclusive) list:
- jackson
- spring framework
- jakarta validation
- swagger annotations

additionally, versions are in sync if declared via bom.

with this change, I am able to just do this:

```xml
<project>
    <dependencyManagement>
        <dependencies>
            <dependency>
                <groupId>org.citrusframework</groupId>
                <artifactId>citrus-bom</artifactId>
                <version>${citrus.version}</version>
            </dependency>
        </dependencies>
    </dependencyManagement>

    <dependencies>
        <dependency>
            <groupId>org.citrusframework</groupId>
            <artifactId>citrus-test-api-core</artifactId>
        </dependency>
    </dependencies>

    <build>
        <plugins>
            <plugin>
                <groupId>org.openapitools</groupId>
                <artifactId>openapi-generator-maven-plugin</artifactId>
                <version>${openapi-generator.version}</version>
                <executions>
                    <!-- executions... -->
                </executions>
            </plugin>
        </plugins>
    </build>
</project>
```

in regards of #1397. wdyt @tschlat?
        