### PR TITLE
fix(#1405): Auto close dynamic endpoints

### DIFF
--- a/core/citrus-api/src/main/java/org/citrusframework/CitrusSettings.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/CitrusSettings.java
@@ -16,16 +16,16 @@
 
 package org.citrusframework;
 
-import org.citrusframework.common.TestLoader;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.File;
 import java.io.InputStream;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Stream;
+
+import org.citrusframework.common.TestLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
@@ -303,6 +303,20 @@ public final class CitrusSettings {
     public static final String DEFAULT_LOGGING_REPORTER_PRINT_STACK_TRACES_DEFAULT = FALSE.toString();
 
     /**
+     * Flag to enable/disable auto close of dynamic endpoints.
+     */
+    public static final String AUTO_CLOSE_DYNAMIC_ENDPOINTS_PROPERTY = "citrus.dynamic.endpoints.auto.close";
+    public static final String AUTO_CLOSE_DYNAMIC_ENDPOINTS_ENV = "CITRUS_DYNAMIC_ENDPOINTS_AUTO_CLOSE";
+    public static final String AUTO_CLOSE_DYNAMIC_ENDPOINTS_DEFAULT = FALSE.toString();
+
+    /**
+     * Flag to enable/disable auto removal of dynamic endpoints.
+     */
+    public static final String AUTO_REMOVE_DYNAMIC_ENDPOINTS_PROPERTY = "citrus.dynamic.endpoints.auto.remove";
+    public static final String AUTO_REMOVE_DYNAMIC_ENDPOINTS_ENV = "CITRUS_DYNAMIC_ENDPOINTS_AUTO_REMOVE";
+    public static final String AUTO_REMOVE_DYNAMIC_ENDPOINTS_DEFAULT = FALSE.toString();
+
+    /**
      * Gets set of file name patterns for Groovy test files.
      */
     public static Set<String> getGroovyTestFileNamePattern() {
@@ -478,6 +492,34 @@ public final class CitrusSettings {
                         DEFAULT_LOGGING_REPORTER_PRINT_STACK_TRACES_PROPERTY,
                         DEFAULT_LOGGING_REPORTER_PRINT_STACK_TRACES_ENV,
                         DEFAULT_LOGGING_REPORTER_PRINT_STACK_TRACES_DEFAULT
+                )
+        );
+    }
+
+    /**
+     * Setting marks auto close for dynamic endpoints.
+     * If set to true all dynamic endpoints will be closed automatically after the test.
+     */
+    public static boolean isAutoCloseDynamicEndpoints() {
+        return parseBoolean(
+                getPropertyEnvOrDefault(
+                        AUTO_CLOSE_DYNAMIC_ENDPOINTS_PROPERTY,
+                        AUTO_CLOSE_DYNAMIC_ENDPOINTS_ENV,
+                        AUTO_CLOSE_DYNAMIC_ENDPOINTS_DEFAULT
+                )
+        );
+    }
+
+    /**
+     * Setting marks auto removal for dynamic endpoints.
+     * If set to true all dynamic endpoints will be closed and removed automatically after the test.
+     */
+    public static boolean isAutoRemoveDynamicEndpoints() {
+        return parseBoolean(
+                getPropertyEnvOrDefault(
+                        AUTO_REMOVE_DYNAMIC_ENDPOINTS_PROPERTY,
+                        AUTO_REMOVE_DYNAMIC_ENDPOINTS_ENV,
+                        AUTO_REMOVE_DYNAMIC_ENDPOINTS_DEFAULT
                 )
         );
     }

--- a/core/citrus-api/src/main/java/org/citrusframework/endpoint/EndpointComponent.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/endpoint/EndpointComponent.java
@@ -38,6 +38,8 @@ public interface EndpointComponent {
     Logger logger = LoggerFactory.getLogger(EndpointComponent.class);
 
     String ENDPOINT_NAME = "endpointName";
+    String AUTO_CLOSE = "autoClose";
+    String AUTO_REMOVE = "autoRemove";
 
     /** Endpoint component resource lookup path */
     String RESOURCE_PATH = "META-INF/citrus/endpoint/component";

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaEndpoint.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaEndpoint.java
@@ -171,6 +171,10 @@ public class KafkaEndpoint extends AbstractEndpoint implements ShutdownPhase {
         } else if (nonNull(kafkaConsumer)) {
             kafkaConsumer.stop();
         }
+
+        if (nonNull(kafkaProducer)) {
+            kafkaProducer.stop();
+        }
     }
 
     public ReceiveMessageBuilderFactory<?, ?> findKafkaEventHeaderEquals(Duration lookbackWindow, String key, String value) {

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaProducer.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaProducer.java
@@ -16,6 +16,13 @@
 
 package org.citrusframework.kafka.endpoint;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;
@@ -24,13 +31,6 @@ import org.citrusframework.message.Message;
 import org.citrusframework.messaging.Producer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 
 import static java.lang.String.format;
 import static java.util.Objects.isNull;
@@ -115,6 +115,12 @@ public class KafkaProducer implements Producer {
         }
 
         context.onOutboundMessage(message);
+    }
+
+    public void stop() {
+        if (producer != null) {
+            producer.close();
+        }
     }
 
     /**


### PR DESCRIPTION
- Add auto close and auto remove settings for dynamic endpoints
- Endpoint factory takes care on adding auto close and auto remove tasks for dynamic endpoints
- Support endpoint parameter to overwrite global setting
- Auto close dynamic endpoint after test has finished
- Auto remove endpoints from dynamic endpoint cache after the test has finished

Fixes #1405