### PR TITLE
critical dependency update + citrusframework/citrus-simulator fix

### DIFF
--- a/connectors/citrus-openapi/pom.xml
+++ b/connectors/citrus-openapi/pom.xml
@@ -49,6 +49,17 @@
       <groupId>com.atlassian.oai</groupId>
       <artifactId>swagger-request-validator-core</artifactId>
     </dependency>
+
+    <!--
+        Include mail API (and API only!) so com.atlassian.oai:swagger-request-validator-core builds correctly.
+        Note that this is a legacy dependency and should not be managed globally.
+    -->
+    <dependency>
+      <groupId>javax.mail</groupId>
+      <artifactId>javax.mail-api</artifactId>
+      <version>1.6.2</version>
+    </dependency>
+
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>

--- a/endpoints/citrus-mail/pom.xml
+++ b/endpoints/citrus-mail/pom.xml
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>org.citrusframework</groupId>
       <artifactId>citrus-base</artifactId>
-  		<version>${project.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.citrusframework</groupId>
@@ -84,8 +84,20 @@
       <artifactId>greenmail</artifactId>
     </dependency>
     <dependency>
+      <groupId>jakarta.activation</groupId>
+      <artifactId>jakarta.activation-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.angus</groupId>
-      <artifactId>jakarta.mail</artifactId>
+      <artifactId>angus-activation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.mail</groupId>
+      <artifactId>jakarta.mail-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.angus</groupId>
+      <artifactId>angus-mail</artifactId>
     </dependency>
 
     <!-- Test scoped dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -249,7 +249,6 @@
     <kafka.version>3.9.1</kafka.version>
     <knative-client.version>7.4.0</knative-client.version>
     <log4j2.version>2.25.1</log4j2.version>
-    <mailapi.version>2.0.2</mailapi.version>
     <mockito.version>5.20.0</mockito.version>
     <mockftpserver.version>3.2.0</mockftpserver.version>
     <netty.version>4.2.0.Final</netty.version>

--- a/pom.xml
+++ b/pom.xml
@@ -736,11 +736,6 @@
           </exclusion>
         </exclusions>
       </dependency>
-      <dependency>
-        <groupId>com.sun.mail</groupId>
-        <artifactId>mailapi</artifactId>
-        <version>${mailapi.version}</version>
-      </dependency>
 
       <dependency>
         <groupId>org.awaitility</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,7 @@
     <jaxb.maven.plugin.version>3.3.0</jaxb.maven.plugin.version>
 
     <activemq.artemis.version>2.42.0</activemq.artemis.version>
+    <angus-activation.version>2.0.3</angus-activation.version>
     <angus-mail.version>2.0.2</angus-mail.version>
     <apache.ant.version>1.10.15</apache.ant.version>
     <apache.camel.version>4.14.0</apache.camel.version>
@@ -220,11 +221,11 @@
     <jackson.version>2.20.0</jackson.version>
     <jackson.version.short>2.20</jackson.version.short>
     <jackson-databind-nullable.version>0.2.6</jackson-databind-nullable.version>
-    <jakarta.activation.api.version>2.1.3</jakarta.activation.api.version>
-    <jakarta.activation.version>2.0.1</jakarta.activation.version>
+    <jakarta-activation.version>2.0.1</jakarta-activation.version>
+    <jakarta-activation-api.version>2.1.3</jakarta-activation-api.version>
     <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>
     <jakarta.jms-api.version>3.1.0</jakarta.jms-api.version>
-    <jakarta.mail.version>2.0.4</jakarta.mail.version>
+    <jakarta-mail.version>2.1.5</jakarta-mail.version>
     <jakarta.servlet-api.version>6.1.0</jakarta.servlet-api.version>
     <jakarta.validation.version>3.1.1</jakarta.validation.version>
     <jakarta.websocket-api.version>2.2.0</jakarta.websocket-api.version>
@@ -232,7 +233,7 @@
     <jakarta.xml.soap-api.version>3.0.2</jakarta.xml.soap-api.version>
     <jansi.version>2.4.2</jansi.version>
     <javapoet.version>1.13.0</javapoet.version>
-    <jaxb.version>4.0.5</jaxb.version>
+    <jaxb.version>4.0.6</jaxb.version>
     <jetty.version>12.0.27</jetty.version>
     <jetty.websocket-api.version>2.0.0</jetty.websocket-api.version>
     <jsch.version>0.1.55</jsch.version>
@@ -248,6 +249,7 @@
     <kafka.version>3.9.1</kafka.version>
     <knative-client.version>7.4.0</knative-client.version>
     <log4j2.version>2.25.1</log4j2.version>
+    <mailapi.version>2.0.2</mailapi.version>
     <mockito.version>5.20.0</mockito.version>
     <mockftpserver.version>3.2.0</mockftpserver.version>
     <netty.version>4.2.0.Final</netty.version>
@@ -270,7 +272,7 @@
     <sshd.version>2.15.0</sshd.version>
     <swagger.version>2.2.37</swagger.version>
     <swagger.parser.version>2.1.22</swagger.parser.version>
-    <swagger-request-validator.version>2.45.1</swagger-request-validator.version>
+    <swagger-request-validator.version>2.46.0</swagger-request-validator.version>
     <testcontainers.version>1.21.3</testcontainers.version>
     <testng.version>7.11.0</testng.version>
     <!-- bound to https://mvnrepository.com/artifact/io.fabric8/kubernetes-httpclient-vertx/${k8s.client.version} -->
@@ -306,12 +308,12 @@
       <dependency>
         <groupId>jakarta.activation</groupId>
         <artifactId>jakarta.activation-api</artifactId>
-        <version>${jakarta.activation.api.version}</version>
+        <version>${jakarta-activation-api.version}</version>
       </dependency>
       <dependency>
         <groupId>com.sun.activation</groupId>
         <artifactId>jakarta.activation</artifactId>
-        <version>${jakarta.activation.version}</version>
+        <version>${jakarta-activation.version}</version>
       </dependency>
 
       <dependency>
@@ -719,11 +721,26 @@
         <artifactId>swagger-request-validator-core</artifactId>
         <version>${swagger-request-validator.version}</version>
         <exclusions>
+          <!--
+            force com.sun.mail:mailapi to v2 major.
+            this causes trouble when citrus-openapi is being used with citrus-mail.
+            greenmail already includes v2 major.
+            this is the case in citrusframework/citrus-simulator, which won't build otherwise.
+          -->
+          <exclusion>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>mailapi</artifactId>
+          </exclusion>
           <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>com.sun.mail</groupId>
+        <artifactId>mailapi</artifactId>
+        <version>${mailapi.version}</version>
       </dependency>
 
       <dependency>
@@ -861,13 +878,18 @@
         <version>${greenmail.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.eclipse.angus</groupId>
-        <artifactId>jakarta.mail</artifactId>
-        <version>${jakarta.mail.version}</version>
+        <groupId>jakarta.mail</groupId>
+        <artifactId>jakarta.mail-api</artifactId>
+        <version>${jakarta-mail.version}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.angus</groupId>
         <artifactId>angus-activation</artifactId>
+        <version>${angus-activation.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.angus</groupId>
+        <artifactId>angus-mail</artifactId>
         <version>${angus-mail.version}</version>
       </dependency>
 
@@ -1649,7 +1671,7 @@
             <dependency>
               <groupId>jakarta.activation</groupId>
               <artifactId>jakarta.activation-api</artifactId>
-              <version>${jakarta.activation.api.version}</version>
+              <version>${jakarta-activation-api.version}</version>
             </dependency>
             <dependency>
               <groupId>jakarta.xml.bind</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -258,7 +258,7 @@
     <jackson-databind-nullable.version>0.2.7</jackson-databind-nullable.version>
     <picoli-version>4.7.7</picoli-version>
     <postgresql.version>42.7.8</postgresql.version>
-    <quarkus.platform.version>3.26.0</quarkus.platform.version>
+    <quarkus.platform.version>3.28.0</quarkus.platform.version>
     <saaj.version>3.0.4</saaj.version>
     <selenium.version>4.35.0</selenium.version>
     <slf4j.version>2.0.17</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
     <ascii-table-version>1.8.0</ascii-table-version>
     <assertj.version>3.27.3</assertj.version>
     <awaitility.version>4.3.0</awaitility.version>
-    <aws-java-sdk2.version>2.34.0</aws-java-sdk2.version>
+    <aws-java-sdk2.version>2.34.2</aws-java-sdk2.version>
     <bouncycastle.version>1.82</bouncycastle.version>
     <byte.buddy.version>1.17.7</byte.buddy.version>
     <commons.dbcp2.version>2.13.0</commons.dbcp2.version>


### PR DESCRIPTION
detected incompatibility in `citrus-mail` dependency, whenever `citrus-openapi` is also available on the classpath.
with this commits, https://github.com/citrusframework/citrus-simulator/pull/315 is finally mergeable.

additionally fixes reported `https://github.com/advisories/GHSA-fghv-69vj-qj49`.
original MR: https://github.com/citrusframework/citrus/pull/1399.