### PR TITLE
fix(citrus-openapi): memory leak in openapi specification repository

### DIFF
--- a/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/OpenApiSpecification.java
+++ b/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/OpenApiSpecification.java
@@ -287,8 +287,7 @@ public class OpenApiSpecification implements Specification {
      * @param openApiValidationPolicy the validation policy to apply to the loaded OpenApi
      * @return an OpenApiSpecification instance populated with the document and validation context
      */
-    public static OpenApiSpecification from(Resource resource,
-        OpenApiValidationPolicy openApiValidationPolicy) {
+    public static OpenApiSpecification from(Resource resource, OpenApiValidationPolicy openApiValidationPolicy) {
         OpenApiSpecification specification = new OpenApiSpecification(openApiValidationPolicy);
 
         OasDocument openApiDoc = OpenApiResourceLoader.fromFile(resource);


### PR DESCRIPTION
whenever you added an OpenAPI specification to the `OpenApiRepository`, the object was effectively being saved into the underlying `List`, disregarding whether this exact specifications was already registered earlier. it would leak memory after some ("enough") time,
because these objects will never be dereferences and thus, never be garbage collected.

the root cause for this is effectively the missing "contains" functionality. that functionality has now been exposed throught the `contains` method.

in addition, the `add` method is designed in an idempotent way. only "new" OpenAPI specifications will be persisted into the `List`. the comparison is based on the `getUid()` value.

and lastly,
users have the ability to reset the list using the `withOpenApiSpecifications` method.

this offers a variety of ways to resolve the problem, respecitvely fixes the memory leak.
and adds additional interaction-options for users.