### PR TITLE
chore: Add JBang test engine

### DIFF
--- a/connectors/citrus-jbang-connector/src/main/java/org/citrusframework/jbang/engine/JBangTestEngine.java
+++ b/connectors/citrus-jbang-connector/src/main/java/org/citrusframework/jbang/engine/JBangTestEngine.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.jbang.engine;
+
+import java.awt.*;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.StringSelection;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.citrusframework.TestSource;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.jbang.CitrusJBang;
+import org.citrusframework.jbang.ProcessOutputListener;
+import org.citrusframework.main.AbstractTestEngine;
+import org.citrusframework.main.TestRunConfiguration;
+import org.citrusframework.spi.Resource;
+import org.citrusframework.spi.Resources;
+import org.citrusframework.util.FileUtils;
+import org.citrusframework.util.StringUtils;
+
+/**
+ * Test engine implementation runs tests via Citrus JBang as a separate JVM process.
+ */
+public class JBangTestEngine extends AbstractTestEngine {
+
+    private Path workingDir;
+    private ProcessOutputListener outputListener;
+
+    public JBangTestEngine(TestRunConfiguration configuration) {
+        super(configuration);
+    }
+
+    @Override
+    public void run() {
+        CitrusJBang citrus = new CitrusJBang()
+                .workingDir(Optional.ofNullable(getConfiguration().getWorkDir())
+                        .filter(StringUtils::isNotEmpty)
+                        .map(FileUtils::getFileResource)
+                        .map(Resource::getFile)
+                        .map(File::toPath)
+                        .orElse(workingDir));
+
+        if (outputListener != null) {
+            citrus.withOutputListener(outputListener);
+        }
+
+        if (getConfiguration().getTestSources().isEmpty()) {
+            runTestPackages(citrus, getConfiguration());
+        } else {
+            runTestSources(citrus, getConfiguration());
+        }
+    }
+
+    private void runTestPackages(CitrusJBang citrus, TestRunConfiguration configuration) {
+        List<String> packagesToRun = Optional.ofNullable(configuration.getPackages())
+                .orElseGet(Collections::emptyList)
+                .stream()
+                .map(packageName -> packageName.replace(".", "/"))
+                .collect(Collectors.toList());
+
+        if (packagesToRun.isEmpty()) {
+            packagesToRun = Collections.singletonList("");
+            logger.info("Running all tests in project");
+        }
+
+        for (String packageName : packagesToRun) {
+            if (StringUtils.hasText(packageName)) {
+                logger.info(String.format("Running tests in directory %s", packageName));
+            } else {
+                logger.info(String.format("Running tests in current working directory %s",
+                        Optional.ofNullable(workingDir).map(Path::toString).orElse(".")));
+            }
+
+            citrus.run(packageName, Collections.emptyMap());
+        }
+    }
+
+    private void runTestSources(CitrusJBang citrus, TestRunConfiguration configuration) {
+        List<TestSource> directories = configuration.getTestSources().stream()
+                .filter(source -> "directory".equals(source.getType()))
+                .toList();
+
+        for (TestSource directory : directories) {
+            logger.info(String.format("Running tests in directory %s", directory.getName()));
+            citrus.run(directory.getFilePath(), Collections.emptyMap());
+        }
+
+        List<TestSource> sources = configuration.getTestSources().stream()
+                .filter(source -> !"directory".equals(source.getType()))
+                .toList();
+
+        for (TestSource source : sources) {
+            try {
+                logger.info(String.format("Running test source %s", source.getName()));
+
+                if (StringUtils.hasText(source.getFilePath())) {
+                    citrus.run(source.getFilePath(), Collections.emptyMap());
+                } else if (source.getSourceFile() instanceof Resources.ByteArrayResource) {
+                    Clipboard c = Toolkit.getDefaultToolkit().getSystemClipboard();
+                    c.setContents(new StringSelection(FileUtils.readToString(source.getSourceFile())), null);
+
+                    String fileExt = Optional.of(FileUtils.getFileExtension(source.getName()))
+                            .filter(ext -> !ext.isEmpty())
+                            .orElse(".yaml");
+                    citrus.run("clipboard" + fileExt, Collections.emptyMap());
+                } else {
+                    citrus.run(source.getSourceFile().getLocation(), Collections.emptyMap());
+                }
+            } catch (IOException e) {
+                throw new CitrusRuntimeException("Failed to run test source: %s".formatted(source.getName()), e);
+            }
+        }
+    }
+
+    public JBangTestEngine withWorkingDir(Path workingDir) {
+        this.workingDir = workingDir;
+        return this;
+    }
+
+    public JBangTestEngine withOutputListener(ProcessOutputListener outputListener) {
+        this.outputListener = outputListener;
+        return this;
+    }
+}

--- a/connectors/citrus-jbang-connector/src/main/resources/META-INF/citrus/engine/jbang
+++ b/connectors/citrus-jbang-connector/src/main/resources/META-INF/citrus/engine/jbang
@@ -1,0 +1,1 @@
+type=org.citrusframework.jbang.engine.JBangTestEngine

--- a/connectors/citrus-jbang-connector/src/test/java/org/citrusframework/jbang/engine/JBangTestEngineTest.java
+++ b/connectors/citrus-jbang-connector/src/test/java/org/citrusframework/jbang/engine/JBangTestEngineTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.jbang.engine;
+
+import java.nio.file.Path;
+import java.util.Collections;
+
+import org.citrusframework.TestSource;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.main.TestEngine;
+import org.citrusframework.main.TestRunConfiguration;
+import org.citrusframework.spi.Resources;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class JBangTestEngineTest {
+
+    @Test
+    public void testRunFromWorkDirectory() {
+        TestRunConfiguration configuration = new TestRunConfiguration();
+        runTestEngine(configuration, Resources.fromClasspath("org/citrusframework/jbang/sample").getFile().toPath());
+    }
+
+    @Test
+    public void testRunDirectory() {
+        TestRunConfiguration configuration = new TestRunConfiguration();
+        configuration.setPackages(Collections.singletonList(Resources.fromClasspath("org/citrusframework/jbang/sample").getFile().getAbsolutePath()));
+        runTestEngine(configuration);
+    }
+
+    @Test
+    public void testRunSource() {
+        TestRunConfiguration configuration = new TestRunConfiguration();
+        configuration.setTestSources(Collections.singletonList(new TestSource("yaml", "hello",
+                Resources.fromClasspath("org/citrusframework/jbang/sample/hello.it.yaml").getFile().getAbsolutePath())));
+
+        runTestEngine(configuration);
+    }
+
+    @Test(expectedExceptions = CitrusRuntimeException.class)
+    public void testRunNoMatch() {
+        TestRunConfiguration configuration = new TestRunConfiguration();
+        configuration.setPackages(Collections.singletonList("some.foo.directory"));
+        runTestEngine(configuration);
+    }
+
+    @Test
+    public void shouldResolveJBangEngine() {
+        TestRunConfiguration configuration = new TestRunConfiguration();
+        configuration.setEngine("jbang");
+        TestEngine engine = TestEngine.lookup(configuration);
+
+        Assert.assertEquals(engine.getClass(), JBangTestEngine.class);
+    }
+
+    private void runTestEngine(TestRunConfiguration configuration, Path workDir) {
+        JBangTestEngine engine = new JBangTestEngine(configuration);
+        engine.withOutputListener(System.out::print);
+        engine.withWorkingDir(workDir);
+        engine.run();
+    }
+
+    private void runTestEngine(TestRunConfiguration configuration) {
+        JBangTestEngine engine = new JBangTestEngine(configuration);
+        engine.withOutputListener(System.out::print);
+        engine.run();
+    }
+}

--- a/connectors/citrus-jbang-connector/src/test/resources/org/citrusframework/jbang/sample/hello.it.yaml
+++ b/connectors/citrus-jbang-connector/src/test/resources/org/citrusframework/jbang/sample/hello.it.yaml
@@ -1,0 +1,9 @@
+name: hello.it
+variables: []
+actions:
+  - createVariables:
+      variables:
+        - name: user
+          value: Citrus
+  - print:
+      message: Hello from ${user}

--- a/core/citrus-api/src/main/java/org/citrusframework/main/TestRunConfiguration.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/main/TestRunConfiguration.java
@@ -47,6 +47,9 @@ public class TestRunConfiguration {
     /** Optional test jar artifact holding tests */
     private File testJar;
 
+    /** Optional working directory for file system read */
+    private String workDir;
+
     /** Should test engine print verbose summary details */
     private boolean verbose = true;
 
@@ -155,5 +158,13 @@ public class TestRunConfiguration {
 
     public void setReset(boolean reset) {
         this.reset = reset;
+    }
+
+    public void setWorkDir(String workDir) {
+        this.workDir = workDir;
+    }
+
+    public String getWorkDir() {
+        return workDir;
     }
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/main/AbstractTestEngine.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/main/AbstractTestEngine.java
@@ -29,8 +29,6 @@ public abstract class AbstractTestEngine implements TestEngine {
 
     /**
      * Gets the configuration.
-     *
-     * @return
      */
     public TestRunConfiguration getConfiguration() {
         return configuration;

--- a/tools/agent/src/main/java/org/citrusframework/agent/CitrusAgentConfiguration.java
+++ b/tools/agent/src/main/java/org/citrusframework/agent/CitrusAgentConfiguration.java
@@ -45,6 +45,7 @@ public class CitrusAgentConfiguration extends CitrusAppConfiguration {
         setPackages(configuration.getPackages());
         setTestSources(configuration.getTestSources());
         setIncludes(configuration.getIncludes());
+        setWorkDir(configuration.getWorkDir());
         setVerbose(configuration.isVerbose());
         setReset(configuration.isReset());
         addDefaultProperties(configuration.getDefaultProperties());

--- a/tools/agent/src/main/java/org/citrusframework/agent/CitrusAgentSettings.java
+++ b/tools/agent/src/main/java/org/citrusframework/agent/CitrusAgentSettings.java
@@ -35,6 +35,9 @@ public final class CitrusAgentSettings {
     private static final String TEST_ENGINE_ENV = AGENT_ENV_PREFIX + "TEST_ENGINE";
     private static final String TEST_ENGINE_DEFAULT = "junit5";
 
+    private static final String WORK_DIRECTORY_PROPERTY = AGENT_PROPERTY_PREFIX + "work.directory";
+    private static final String WORK_DIRECTORY_ENV = AGENT_ENV_PREFIX + "WORK_DIRECTORY";
+
     private static final String SERVER_PORT_PROPERTY = AGENT_PROPERTY_PREFIX + "server.port";
     private static final String SERVER_PORT_ENV = AGENT_ENV_PREFIX + "SERVER_PORT";
     private static final String SERVER_PORT_DEFAULT = "4567";
@@ -89,7 +92,6 @@ public final class CitrusAgentSettings {
 
     /**
      * Citrus agent name.
-     * @return
      */
     public static String getAgentName() {
         return System.getProperty(AGENT_NAME_PROPERTY,
@@ -99,6 +101,10 @@ public final class CitrusAgentSettings {
     public static String getTestEngine() {
         return Optional.ofNullable(System.getProperty(TEST_ENGINE_PROPERTY, System.getenv(TEST_ENGINE_ENV)))
                 .orElse(TEST_ENGINE_DEFAULT);
+    }
+
+    public static String getWorkDir() {
+        return System.getProperty(WORK_DIRECTORY_PROPERTY, System.getenv(WORK_DIRECTORY_ENV));
     }
 
     public static int getServerPort() {

--- a/tools/agent/src/main/java/org/citrusframework/agent/util/ConfigurationHelper.java
+++ b/tools/agent/src/main/java/org/citrusframework/agent/util/ConfigurationHelper.java
@@ -63,6 +63,10 @@ public final class ConfigurationHelper {
                     .split(","));
         }
 
+        if (queryParams.contains("workDir")) {
+            options.setWorkDir(URLDecoder.decode(queryParams.get("workDir"), StandardCharsets.UTF_8));
+        }
+
         if (queryParams.contains("package")) {
             options.setPackages(Collections.singletonList(
                     URLDecoder.decode(queryParams.get("package"), StandardCharsets.UTF_8)));
@@ -117,6 +121,7 @@ public final class ConfigurationHelper {
 
         configuration.setEngine(CitrusAgentSettings.getTestEngine());
         configuration.setIncludes(CitrusAgentSettings.getIncludes());
+        configuration.setWorkDir(CitrusAgentSettings.getWorkDir());
         configuration.setSystemExit(CitrusAgentSettings.isSystemExit());
         configuration.setSkipTests(CitrusAgentSettings.isSkipTests());
         configuration.setConfigClass(CitrusAgentSettings.getConfigClass());

--- a/tools/jbang/src/main/java/org/citrusframework/jbang/commands/AgentStart.java
+++ b/tools/jbang/src/main/java/org/citrusframework/jbang/commands/AgentStart.java
@@ -68,6 +68,9 @@ public class AgentStart extends CitrusCommand {
     @Option(names = { "--property" }, arity = "0..*", description = "Default System property to set before the test run.")
     private String[] properties;
 
+    @Option(names = { "--work-directory" }, description = "The working directory used by the file based test engines to load file resources from.")
+    private String workDir;
+
     public AgentStart(CitrusJBangMain main) {
         super(main);
     }
@@ -127,6 +130,10 @@ public class AgentStart extends CitrusCommand {
 
         if (includes != null) {
             configuration.setIncludes(includes);
+        }
+
+        if (workDir != null) {
+            configuration.setWorkDir(workDir);
         }
 
         if (packages != null) {

--- a/tools/jbang/src/main/java/org/citrusframework/jbang/commands/Run.java
+++ b/tools/jbang/src/main/java/org/citrusframework/jbang/commands/Run.java
@@ -81,6 +81,9 @@ public class Run extends CitrusCommand {
     @Option(names = { "--includes" }, arity = "0..*", description = "Includes test name pattern.")
     private String[] includes;
 
+    @Option(names = { "--work-directory" }, description = "The working directory used by the file based test engines to load file resources from.")
+    private String workDir;
+
     @Option(names = { "--property" }, arity = "0..*", description = "Default System property to set before the test run.")
     private String[] properties;
 
@@ -230,6 +233,10 @@ public class Run extends CitrusCommand {
 
         if (includes != null) {
             configuration.setIncludes(includes);
+        }
+
+        if (workDir != null) {
+            configuration.setWorkDir(workDir);
         }
 
         if (properties != null) {

--- a/tools/maven/citrus-agent-maven-plugin/src/main/java/org/citrusframework/agent/plugin/RunTestMojo.java
+++ b/tools/maven/citrus-agent-maven-plugin/src/main/java/org/citrusframework/agent/plugin/RunTestMojo.java
@@ -237,6 +237,10 @@ public class RunTestMojo extends AbstractAgentMojo {
             options.setIncludes(getRunConfig().getIncludes().toArray(new String[0]));
         }
 
+        if (getRunConfig().getWorkDir() != null) {
+            options.setWorkDir(getRunConfig().getWorkDir());
+        }
+
         if (getRunConfig().getSystemProperties() != null) {
             options.addDefaultProperties(getRunConfig().getSystemProperties());
         }
@@ -281,6 +285,10 @@ public class RunTestMojo extends AbstractAgentMojo {
 
         if (getRunConfig().getIncludes() != null) {
             options.setIncludes(getRunConfig().getIncludes().toArray(new String[0]));
+        }
+
+        if (getRunConfig().getWorkDir() != null) {
+            options.setWorkDir(getRunConfig().getWorkDir());
         }
 
         if (getRunConfig().getSystemProperties() != null) {

--- a/tools/maven/citrus-agent-maven-plugin/src/main/java/org/citrusframework/agent/plugin/config/RunConfiguration.java
+++ b/tools/maven/citrus-agent-maven-plugin/src/main/java/org/citrusframework/agent/plugin/config/RunConfiguration.java
@@ -53,6 +53,9 @@ public class RunConfiguration {
     @Parameter(property = "citrus.agent.run.engine", defaultValue = "testng")
     private String engine;
 
+    @Parameter(property = "citrus.agent.run.work.directory")
+    private String workDir;
+
     public RunConfiguration() {
         engine = "testng";
         pollingInterval = 2000L;
@@ -128,6 +131,14 @@ public class RunConfiguration {
 
     public void setEngine(String engine) {
         this.engine = engine;
+    }
+
+    public String getWorkDir() {
+        return workDir;
+    }
+
+    public void setWorkDir(String workDir) {
+        this.workDir = workDir;
     }
 
     public boolean isVerbose() {


### PR DESCRIPTION
- JBang test engine runs tests via new JBang process
- Calls Citrus JBang CLI to run the tests in a working directory
- Adds working directory option to test run configuration