### PR TITLE
chore: Add support for Camel JBang receive command

### DIFF
--- a/core/citrus-api/src/main/java/org/citrusframework/actions/camel/CamelIntegrationRunActionBuilder.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/actions/camel/CamelIntegrationRunActionBuilder.java
@@ -104,4 +104,6 @@ public interface CamelIntegrationRunActionBuilder<T extends TestAction, B extend
     B autoRemove(boolean enabled);
 
     B waitForRunningState(boolean enabled);
+
+    B stub(String... components);
 }

--- a/core/citrus-api/src/main/java/org/citrusframework/actions/camel/CamelJBangCmdActionBuilder.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/actions/camel/CamelJBangCmdActionBuilder.java
@@ -28,4 +28,8 @@ public interface CamelJBangCmdActionBuilder<T extends TestAction, B extends Came
      */
     CamelJBangCmdSendActionBuilder<?, ?> send();
 
+    /**
+     * Runs Camel JBang receive command.
+     */
+    CamelJBangCmdReceiveActionBuilder<?, ?> receive();
 }

--- a/core/citrus-api/src/main/java/org/citrusframework/actions/camel/CamelJBangCmdReceiveActionBuilder.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/actions/camel/CamelJBangCmdReceiveActionBuilder.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.actions.camel;
+
+import org.citrusframework.TestAction;
+
+public interface CamelJBangCmdReceiveActionBuilder<T extends TestAction, B extends CamelJBangCmdReceiveActionBuilder<T, B>>
+        extends CamelJBangActionBuilderBase<T, B> {
+
+    /**
+     * Sets the integration name.
+     */
+    B integration(String name);
+
+    B endpoint(String endpoint);
+
+    B endpointUri(String uri);
+
+    /**
+     * Adds a command argument.
+     */
+    B withArg(String arg);
+
+    /**
+     * Adds a command argument with name and value.
+     */
+    B withArg(String name, String value);
+
+    /**
+     * Adds command arguments.
+     */
+    B withArgs(String... args);
+
+    B loggingColor(boolean enabled);
+
+    B grep(String filter);
+
+    B since(String duration);
+
+    B tail(String numberOfMessages);
+
+    B maxAttempts(int maxAttempts);
+
+    B delayBetweenAttempts(long delayBetweenAttempts);
+
+    B printLogs(boolean printLogs);
+
+    B stopOnErrorStatus(boolean stopOnErrorStatus);
+}

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelCmdActionBuilder.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelCmdActionBuilder.java
@@ -32,6 +32,13 @@ public class CamelCmdActionBuilder extends AbstractReferenceResolverAwareTestAct
     }
 
     @Override
+    public CamelCmdReceiveAction.Builder receive() {
+        CamelCmdReceiveAction.Builder builder = new CamelCmdReceiveAction.Builder();
+        this.delegate = builder;
+        return builder;
+    }
+
+    @Override
     public CamelCmdActionBuilder withReferenceResolver(ReferenceResolver referenceResolver) {
         this.referenceResolver = referenceResolver;
         return this;

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelCmdReceiveAction.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelCmdReceiveAction.java
@@ -1,0 +1,296 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.actions;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.citrusframework.actions.camel.CamelJBangCmdReceiveActionBuilder;
+import org.citrusframework.camel.CamelSettings;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.exceptions.ActionTimeoutException;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.jbang.ProcessAndOutput;
+import org.citrusframework.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.citrusframework.jbang.JBangSupport.OK_EXIT_CODE;
+
+/**
+ * Camel JBang receive command.
+ */
+public class CamelCmdReceiveAction extends AbstractCamelJBangAction {
+
+    /** Logger */
+    private static final Logger logger = LoggerFactory.getLogger(CamelCmdReceiveAction.class);
+
+    private static final Logger CAMEL_JBANG_LOG = LoggerFactory.getLogger("CAMEL_JBANG_CMD_RECEIVE_LOGS");
+
+    /** Camel integration name */
+    private final String integrationName;
+
+    /** Endpoint to invoke */
+    private final String endpoint;
+
+    /** Endpoint URI to invoke */
+    private final String endpointUri;
+
+    /** Filter messages based on this expression */
+    private final String grep;
+
+    /** Return messages newer than a relative duration */
+    private final String since;
+
+    /** The number of messages from the end to show */
+    private final String tail;
+
+    /** Camel JBang command arguments */
+    private final List<String> args;
+
+    /** Polling configuration */
+    private final int maxAttempts;
+    private final long delayBetweenAttempts;
+
+    private final boolean printLogs;
+    private final boolean stopOnErrorStatus;
+
+    /**
+     * Default constructor.
+     */
+    public CamelCmdReceiveAction(CamelCmdReceiveAction.Builder builder) {
+        super("cmd-receive", builder);
+        this.integrationName = builder.integrationName;
+        this.endpoint = builder.endpoint;
+        this.endpointUri = builder.endpointUri;
+        this.args = builder.args;
+        this.grep = builder.grep;
+        this.since = builder.since;
+        this.tail = builder.tail;
+        this.maxAttempts = builder.maxAttempts;
+        this.delayBetweenAttempts = builder.delayBetweenAttempts;
+        this.printLogs = builder.printLogs;
+        this.stopOnErrorStatus = builder.stopOnErrorStatus;
+    }
+
+    @Override
+    public void doExecute(TestContext context) {
+        List<String> commandArgs = new ArrayList<>();
+
+        if (StringUtils.hasText(integrationName)) {
+            logger.info("Camel JBang cmd receiving message from integration '%s'".formatted(integrationName));
+            commandArgs.add(context.replaceDynamicContentInString(integrationName));
+        } else {
+            logger.info("Camel JBang cmd receiving message from current Camel integration");
+        }
+
+        if (StringUtils.hasText(endpoint)) {
+            commandArgs.add("--endpoint");
+            commandArgs.add(endpoint);
+        }
+
+        if (StringUtils.hasText(endpointUri)) {
+            commandArgs.add("--uri");
+            commandArgs.add(endpointUri);
+        }
+
+        if (StringUtils.hasText(grep)) {
+            commandArgs.add("--grep");
+            commandArgs.add(grep);
+        }
+
+        if (StringUtils.hasText(since)) {
+            commandArgs.add("--since");
+            commandArgs.add(since);
+        }
+
+        if (StringUtils.hasText(tail)) {
+            commandArgs.add("--tail");
+            commandArgs.add(tail);
+        }
+
+        if (!args.contains("--logging-color") && args.stream().noneMatch(it -> it.startsWith("--logging-color"))) {
+            // disable logging colors by default
+            commandArgs.add("--logging-color=false");
+        }
+
+        if (!args.isEmpty()) {
+            commandArgs.addAll(context.resolveDynamicValuesInList(args));
+        }
+
+        ProcessAndOutput pao = null;
+        try {
+            pao = camelJBang().receive(commandArgs.toArray(new String[0]));
+            logger.info("Receive messages from Camel JBang receive command ...");
+
+            String log;
+            for (int i = 0; i < maxAttempts; i++) {
+                if (!pao.getProcess().isAlive()) {
+                    int exitValue = pao.getProcess().exitValue();
+                    if (exitValue != OK_EXIT_CODE) {
+                        logger.warn("Failed to receive message via Camel JBang command:%n\t camel cmd receive %s".formatted(String.join(" ", commandArgs)));
+                        throw new CitrusRuntimeException("Error while receiving messages via Camel JBang: '%s' Exit code: %d"
+                                .formatted(pao.getOutput(), exitValue));
+                    }
+                }
+
+                log = pao.getOutput();
+
+                if (printLogs) {
+                    CAMEL_JBANG_LOG.info(log);
+                }
+
+                if (log.contains("Received Message:")) {
+                    logger.info("Verified Camel received message - All values OK!");
+                    return;
+                }
+
+                if (log.contains("STACK-TRACE") && stopOnErrorStatus) {
+                    throw new CitrusRuntimeException("Error while receiving messages via Camel JBang - detected error state in Camel receive operation");
+                }
+
+                logger.warn(String.format("Waiting for Camel message '%s' - retry in %s ms", integrationName, delayBetweenAttempts));
+
+                try {
+                    Thread.sleep(delayBetweenAttempts);
+                } catch (InterruptedException e) {
+                    logger.warn("Interrupted while waiting for Camel message", e);
+                }
+            }
+
+            throw new ActionTimeoutException((maxAttempts * delayBetweenAttempts),
+                    new CitrusRuntimeException(String.format("Failed to verify Camel receive command '%s' - " +
+                            "has not received message with matching '%s' after %d attempts", integrationName, grep, maxAttempts)));
+        } finally {
+            if (pao != null && pao.getProcess().isAlive()) {
+                pao.getProcess().destroy();
+            }
+        }
+    }
+
+    /**
+     * Action builder.
+     */
+    public static final class Builder extends AbstractCamelJBangAction.Builder<CamelCmdReceiveAction, Builder>
+            implements CamelJBangCmdReceiveActionBuilder<CamelCmdReceiveAction, Builder> {
+
+        private String integrationName;
+        private String endpoint;
+        private String endpointUri;
+        private String grep;
+        private String since;
+        private String tail = "0";
+        private final List<String> args = new ArrayList<>();
+
+        private int maxAttempts = CamelSettings.getMaxAttempts();
+        private long delayBetweenAttempts = CamelSettings.getDelayBetweenAttempts();
+
+        private boolean printLogs = CamelSettings.isPrintLogs();
+        private boolean stopOnErrorStatus = true;
+
+        @Override
+        public Builder integration(String name) {
+            this.integrationName = name;
+            return this;
+        }
+
+        @Override
+        public Builder endpoint(String endpoint) {
+            this.endpoint = endpoint;
+            return this;
+        }
+
+        @Override
+        public Builder endpointUri(String uri) {
+            this.endpointUri = uri;
+            return this;
+        }
+
+        @Override
+        public Builder withArg(String arg) {
+            this.args.add(arg);
+            return this;
+        }
+
+        @Override
+        public Builder withArg(String name, String value) {
+            this.args.add(name);
+            this.args.add(value);
+            return this;
+        }
+
+        @Override
+        public Builder withArgs(String... args) {
+            this.args.addAll(Arrays.asList(args));
+            return this;
+        }
+
+        @Override
+        public Builder loggingColor(boolean enabled) {
+            this.withArg("--logging-color=%s".formatted(enabled));
+            return this;
+        }
+
+        @Override
+        public Builder grep(String filter) {
+            this.grep = filter;
+            return this;
+        }
+
+        @Override
+        public Builder since(String duration) {
+            this.since = duration;
+            return this;
+        }
+
+        @Override
+        public Builder tail(String numberOfMessages) {
+            this.tail = numberOfMessages;
+            return this;
+        }
+
+        @Override
+        public Builder maxAttempts(int maxAttempts) {
+            this.maxAttempts = maxAttempts;
+            return this;
+        }
+
+        @Override
+        public Builder delayBetweenAttempts(long delayBetweenAttempts) {
+            this.delayBetweenAttempts = delayBetweenAttempts;
+            return this;
+        }
+
+        @Override
+        public Builder printLogs(boolean printLogs) {
+            this.printLogs = printLogs;
+            return this;
+        }
+
+        @Override
+        public Builder stopOnErrorStatus(boolean stopOnErrorStatus) {
+            this.stopOnErrorStatus = stopOnErrorStatus;
+            return this;
+        }
+
+        @Override
+        public CamelCmdReceiveAction doBuild() {
+            return new CamelCmdReceiveAction(this);
+        }
+    }
+}

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelRunIntegrationAction.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelRunIntegrationAction.java
@@ -205,6 +205,8 @@ public class CamelRunIntegrationAction extends AbstractCamelJBangAction {
         private final Map<String, String> systemProperties = new HashMap<>();
         private Resource systemPropertiesFile;
 
+        private String stub;
+
         private boolean autoRemoveResources = CamelJBangSettings.isAutoRemoveResources();
         private boolean waitForRunningState = CamelJBangSettings.isWaitForRunningState();
         private boolean dumpIntegrationOutput = CamelJBangSettings.isDumpIntegrationOutput();
@@ -323,6 +325,12 @@ public class CamelRunIntegrationAction extends AbstractCamelJBangAction {
         }
 
         @Override
+        public Builder stub(String... components) {
+            this.stub = String.join(",", components);
+            return this;
+        }
+
+        @Override
         public CamelRunIntegrationAction doBuild() {
             if (systemPropertiesFile != null) {
                 Properties props = new Properties();
@@ -342,6 +350,10 @@ public class CamelRunIntegrationAction extends AbstractCamelJBangAction {
                 } catch (IOException e) {
                     throw new CitrusRuntimeException("Failed to read properties file", e);
                 }
+            }
+
+            if (StringUtils.hasText(stub)) {
+                args.add("--stub=%s".formatted(stub));
             }
 
             return new CamelRunIntegrationAction(this);

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/jbang/CamelJBang.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/jbang/CamelJBang.java
@@ -363,6 +363,14 @@ public class CamelJBang {
         return pao;
     }
 
+    public ProcessAndOutput receive(String ... args) {
+        List<String> fullArgs = new ArrayList<>();
+        fullArgs.add("receive");
+        fullArgs.addAll(Arrays.asList(args));
+
+        return app.runAsync("cmd", fullArgs);
+    }
+
     public KubernetesPlugin kubernetes() {
         return new KubernetesPlugin(app);
     }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/Camel.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/Camel.java
@@ -197,6 +197,14 @@ public class Camel implements TestActionBuilder<TestAction>, ReferenceResolverAw
                 builder.withArgs(jbang.getRun().getArgs().getArgs().toArray(String[]::new));
             }
 
+            if (jbang.getRun().getStub() != null) {
+                builder.stub(jbang.getRun().getStub().split(" "));
+            }
+
+            if (jbang.getRun().getStubs() != null) {
+                builder.stub(jbang.getRun().getStubs().getStubs().toArray(String[]::new));
+            }
+
             if (jbang.getRun().getResources() != null) {
                 jbang.getRun().getResources().getResources().forEach(builder::addResource);
             }
@@ -348,6 +356,40 @@ public class Camel implements TestActionBuilder<TestAction>, ReferenceResolverAw
                 }
 
                 builder.reply(jbang.getCmd().getSend().isReply());
+
+                this.builder = builder;
+            } else if (jbang.getCmd().getReceive() != null) {
+                CamelCmdReceiveAction.Builder builder = new CamelCmdReceiveAction.Builder();
+                builder.integration(jbang.getCmd().getReceive().getIntegration());
+
+                if (jbang.getCmd().getReceive().getEndpoint() != null) {
+                    builder.endpoint(jbang.getCmd().getReceive().getEndpoint());
+                }
+
+                if (jbang.getCmd().getReceive().getUri() != null) {
+                    builder.endpointUri(jbang.getCmd().getReceive().getUri());
+                }
+
+                if (jbang.getCmd().getReceive().getArgLine() != null) {
+                    builder.withArgs(jbang.getCmd().getReceive().getArgLine().split(" "));
+                }
+
+                if (jbang.getCmd().getReceive().getGrep() != null) {
+                    builder.grep(jbang.getCmd().getReceive().getGrep());
+                }
+
+                builder.loggingColor(jbang.getCmd().getReceive().isLoggingColor());
+
+                if (jbang.getCmd().getReceive().getSince() != null) {
+                    builder.since(jbang.getCmd().getReceive().getSince());
+                }
+
+                if (jbang.getCmd().getReceive().getTail() != null) {
+                    builder.tail(jbang.getCmd().getReceive().getTail());
+                }
+
+                builder.maxAttempts(jbang.getCmd().getReceive().getMaxAttempts());
+                builder.delayBetweenAttempts(jbang.getCmd().getReceive().getDelayBetweenAttempts());
 
                 this.builder = builder;
             }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/JBang.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/JBang.java
@@ -142,7 +142,8 @@ public class JBang {
     @XmlType(name = "", propOrder = {
             "args",
             "integration",
-            "resources"
+            "resources",
+            "stubs"
     })
     public static class RunIntegration {
 
@@ -155,6 +156,9 @@ public class JBang {
         @XmlAttribute(name = "args")
         protected String argLine;
 
+        @XmlAttribute
+        protected String stub;
+
         @XmlAttribute(name = "wait-for-running-state")
         protected boolean waitForRunningState = CamelJBangSettings.isWaitForRunningState();
 
@@ -163,6 +167,9 @@ public class JBang {
 
         @XmlElement
         protected Args args;
+
+        @XmlElement
+        protected Stubs stubs;
 
         @XmlElement
         protected Resources resources;
@@ -223,6 +230,22 @@ public class JBang {
             this.args = args;
         }
 
+        public String getStub() {
+            return stub;
+        }
+
+        public void setStub(String stub) {
+            this.stub = stub;
+        }
+
+        public Stubs getStubs() {
+            return stubs;
+        }
+
+        public void setStubs(Stubs stubs) {
+            this.stubs = stubs;
+        }
+
         @XmlAccessorType(XmlAccessType.FIELD)
         @XmlType(name = "", propOrder = {
                 "args",
@@ -241,6 +264,27 @@ public class JBang {
 
             public void setArgs(List<String> args) {
                 this.args = args;
+            }
+        }
+
+        @XmlAccessorType(XmlAccessType.FIELD)
+        @XmlType(name = "", propOrder = {
+                "stubs",
+        })
+        public static class Stubs {
+
+            @XmlElement(name = "stub")
+            protected List<String> stubs;
+
+            public List<String> getStubs() {
+                if (stubs == null) {
+                    stubs = new ArrayList<>();
+                }
+                return stubs;
+            }
+
+            public void setStubs(List<String> args) {
+                this.stubs = args;
             }
         }
 
@@ -929,12 +973,16 @@ public class JBang {
 
     @XmlAccessorType(XmlAccessType.FIELD)
     @XmlType(name = "", propOrder = {
-            "send"
+            "send",
+            "receive"
     })
     public static class Cmd {
 
         @XmlElement
         protected Send send;
+
+        @XmlElement
+        protected Receive receive;
 
         public void setSend(Send send) {
             this.send = send;
@@ -942,6 +990,14 @@ public class JBang {
 
         public Send getSend() {
             return this.send;
+        }
+
+        public void setReceive(Receive receive) {
+            this.receive = receive;
+        }
+
+        public Receive getReceive() {
+            return receive;
         }
 
         @XmlAccessorType(XmlAccessType.FIELD)
@@ -1107,6 +1163,113 @@ public class JBang {
                 public void setFile(String file) {
                     this.file = file;
                 }
+            }
+        }
+
+        @XmlAccessorType(XmlAccessType.FIELD)
+        @XmlType(name = "", propOrder = {})
+        public static class Receive {
+
+            @XmlAttribute(name = "integration")
+            protected String integration;
+            @XmlAttribute
+            protected String endpoint;
+            @XmlAttribute(name = "uri")
+            protected String uri;
+            @XmlAttribute(name = "args")
+            protected String argLine;
+            @XmlAttribute(name = "logging-color")
+            protected boolean loggingColor;
+            @XmlAttribute(name = "grep")
+            protected String grep;
+            @XmlAttribute(name = "since")
+            protected String since;
+            @XmlAttribute(name = "tail")
+            protected String tail;
+
+            @XmlAttribute(name = "max-attempts")
+            private int maxAttempts = CamelSettings.getMaxAttempts();
+            @XmlAttribute(name = "delay-between-attempts")
+            private long delayBetweenAttempts = CamelSettings.getDelayBetweenAttempts();
+
+            public String getIntegration() {
+                return integration;
+            }
+
+            public void setIntegration(String integration) {
+                this.integration = integration;
+            }
+
+            public String getEndpoint() {
+                return endpoint;
+            }
+
+            public void setEndpoint(String endpoint) {
+                this.endpoint = endpoint;
+            }
+
+            public String getUri() {
+                return uri;
+            }
+
+            public void setUri(String uri) {
+                this.uri = uri;
+            }
+
+            public String getArgLine() {
+                return argLine;
+            }
+
+            public void setArgLine(String argLine) {
+                this.argLine = argLine;
+            }
+
+            public void setLoggingColor(boolean loggingColor) {
+                this.loggingColor = loggingColor;
+            }
+
+            public boolean isLoggingColor() {
+                return loggingColor;
+            }
+
+            public void setGrep(String grep) {
+                this.grep = grep;
+            }
+
+            public String getGrep() {
+                return grep;
+            }
+
+            public void setSince(String since) {
+                this.since = since;
+            }
+
+            public String getSince() {
+                return since;
+            }
+
+            public void setTail(String tail) {
+                this.tail = tail;
+            }
+
+            public String getTail() {
+                return tail;
+            }
+
+            public int getMaxAttempts() {
+                return maxAttempts;
+            }
+
+            public void setMaxAttempts(int maxAttempts) {
+                this.maxAttempts = maxAttempts;
+            }
+
+            public long getDelayBetweenAttempts() {
+                return delayBetweenAttempts;
+            }
+
+            public void setDelayBetweenAttempts(long delayBetweenAttempts) {
+                this.delayBetweenAttempts = delayBetweenAttempts;
             }
         }
     }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/JBang.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/JBang.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import org.citrusframework.camel.CamelSettings;
 import org.citrusframework.camel.actions.AbstractCamelJBangAction;
 import org.citrusframework.camel.actions.AddCamelPluginAction;
+import org.citrusframework.camel.actions.CamelCmdReceiveAction;
 import org.citrusframework.camel.actions.CamelCmdSendAction;
 import org.citrusframework.camel.actions.CamelCustomizedRunIntegrationAction;
 import org.citrusframework.camel.actions.CamelKubernetesDeleteIntegrationAction;
@@ -131,6 +132,11 @@ public class JBang implements CamelActionBuilderWrapper<AbstractCamelJBangAction
         @SchemaProperty(advanced = true, description = "Optional command arguments.")
         public void setArgs(List<String> args) {
             builder.withArgs(args.toArray(String[]::new));
+        }
+
+        @SchemaProperty(advanced = true, description = "Optional stubbed components.")
+        public void setStub(List<String> stub) {
+            builder.stub(stub.toArray(String[]::new));
         }
 
         @SchemaProperty(advanced = true, description = "Optional list of resources added to the Camel JBang process.")
@@ -711,6 +717,47 @@ public class JBang implements CamelActionBuilderWrapper<AbstractCamelJBangAction
             this.builder = builder;
         }
 
+        @SchemaProperty(kind = ACTION, group = CAMEL_JBANG_CMD_GROUP, description = "Receives a message from a Camel JBang integration.")
+        public void setReceive(Receive receive) {
+            CamelCmdReceiveAction.Builder builder = new CamelCmdReceiveAction.Builder();
+
+            builder.integration(receive.getIntegration());
+
+            if (receive.getEndpoint() != null) {
+                builder.endpoint(receive.getEndpoint());
+            }
+
+            if (receive.getUri() != null) {
+                builder.endpointUri(receive.getUri());
+            }
+
+            if (receive.getArgs() != null) {
+                receive.getArgs().forEach(builder::withArg);
+            }
+
+            if (receive.getGrep() != null) {
+                builder.grep(receive.getGrep());
+            }
+
+            builder.loggingColor(receive.isLoggingColor());
+
+            if (receive.getSince() != null) {
+                builder.since(receive.getSince());
+            }
+
+            if (receive.getTail() != null) {
+                builder.tail(receive.getTail());
+            }
+
+            builder.maxAttempts(receive.getMaxAttempts());
+            builder.delayBetweenAttempts(receive.getDelayBetweenAttempts());
+
+            builder.printLogs(receive.isPrintLogs());
+            builder.stopOnErrorStatus(receive.isStopOnErrorStatus());
+
+            this.builder = builder;
+        }
+
         @Override
         public AbstractCamelJBangAction.Builder<?, ?> getBuilder() {
             return builder;
@@ -828,6 +875,136 @@ public class JBang implements CamelActionBuilderWrapper<AbstractCamelJBangAction
                 public void setFile(String file) {
                     this.file = file;
                 }
+            }
+        }
+
+        public static class Receive {
+
+            protected String integration;
+            protected String endpoint;
+            protected String uri;
+            protected List<String> args;
+            protected boolean loggingColor;
+
+            protected String grep;
+            protected String since;
+            protected String tail;
+
+            protected int maxAttempts = CamelSettings.getMaxAttempts();
+            protected long delayBetweenAttempts = CamelSettings.getDelayBetweenAttempts();
+
+            protected boolean printLogs = CamelSettings.isPrintLogs();
+            protected boolean stopOnErrorStatus = true;
+
+            public String getIntegration() {
+                return integration;
+            }
+
+            @SchemaProperty(description = "The Camel integration to send the message to.")
+            public void setIntegration(String integration) {
+                this.integration = integration;
+            }
+
+            public String getEndpoint() {
+                return endpoint;
+            }
+
+            @SchemaProperty(advanced = true, description = "Optional endpoint in the Camel integration.")
+            public void setEndpoint(String endpoint) {
+                this.endpoint = endpoint;
+            }
+
+            public String getUri() {
+                return uri;
+            }
+
+            @SchemaProperty(advanced = true, description = "Camel endpoint URI to send message to.")
+            public void setUri(String uri) {
+                this.uri = uri;
+            }
+
+            public List<String> getArgs() {
+                if (args == null) {
+                    args = new ArrayList<>();
+                }
+                return this.args;
+            }
+
+            @SchemaProperty(advanced = true, description = "Command arguments.")
+            public void setArgs(List<String> args) {
+                this.args = args;
+            }
+
+            public boolean isLoggingColor() {
+                return loggingColor;
+            }
+
+            @SchemaProperty(advanced = true, description = "When enabled the output uses logging color.", defaultValue = "false")
+            public void setLoggingColor(boolean loggingColor) {
+                this.loggingColor = loggingColor;
+            }
+
+            public String getGrep() {
+                return grep;
+            }
+
+            @SchemaProperty(description = "Filter messages based on this expression.")
+            public void setGrep(String grep) {
+                this.grep = grep;
+            }
+
+            public String getSince() {
+                return since;
+            }
+
+            @SchemaProperty(advanced = true, description = "Return messages newer than a relative duration.")
+            public void setSince(String since) {
+                this.since = since;
+            }
+
+            public String getTail() {
+                return tail;
+            }
+
+            @SchemaProperty(advanced = true, description = "The number of messages from the end to show.", defaultValue = "0")
+            public void setTail(String tail) {
+                this.tail = tail;
+            }
+
+            public int getMaxAttempts() {
+                return maxAttempts;
+            }
+
+            @SchemaProperty(advanced = true, description = "Maximum number of validation attempts.", defaultValue = "60")
+            public void setMaxAttempts(int maxAttempts) {
+                this.maxAttempts = maxAttempts;
+            }
+
+            public long getDelayBetweenAttempts() {
+                return delayBetweenAttempts;
+            }
+
+            @SchemaProperty(advanced = true, description = "The delay in milliseconds to wait between validation attempts.", defaultValue = "1000")
+            public void setDelayBetweenAttempts(long delayBetweenAttempts) {
+                this.delayBetweenAttempts = delayBetweenAttempts;
+            }
+
+            public boolean isPrintLogs() {
+                return printLogs;
+            }
+
+            @SchemaProperty(advanced = true, description = "When enabled the Camel integration log output is added to the test log output.")
+            public void setPrintLogs(boolean printLogs) {
+                this.printLogs = printLogs;
+            }
+
+            @SchemaProperty(advanced = true, description = "When enabled the validation attempts stop when error state is reported.", defaultValue = "true")
+            public void setStopOnErrorStatus(boolean stopOnErrorStatus) {
+                this.stopOnErrorStatus = stopOnErrorStatus;
+            }
+
+            public boolean isStopOnErrorStatus() {
+                return stopOnErrorStatus;
             }
         }
     }

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/xml/JBangCmdReceiveTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/xml/JBangCmdReceiveTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.xml;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.camel.CamelSettings;
+import org.citrusframework.camel.actions.CamelCmdReceiveAction;
+import org.citrusframework.camel.actions.CamelRunIntegrationAction;
+import org.citrusframework.util.TestUtils;
+import org.citrusframework.xml.XmlTestLoader;
+import org.testng.Assert;
+import org.testng.SkipException;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class JBangCmdReceiveTest extends AbstractXmlActionTest {
+
+    @BeforeClass
+    public static void beforeClass() {
+        if (!TestUtils.isNetworkReachable()) {
+            throw new SkipException("Test skipped because network is not reachable. We are probably running behind a proxy and JBang download is not possible.");
+        }
+    }
+
+    @Test
+    public void shouldLoadCamelActions() throws Exception {
+        XmlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/camel/xml/camel-jbang-cmd-receive-test.xml");
+
+        CamelContext citrusCamelContext = new DefaultCamelContext();
+        citrusCamelContext.start();
+
+        context.getReferenceResolver().bind(CamelSettings.getContextName(), citrusCamelContext);
+        context.getReferenceResolver().bind("camelContext", citrusCamelContext);
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "CamelJBangCmdReceiveTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 5L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), CamelRunIntegrationAction.class);
+        Assert.assertEquals(result.getTestAction(2).getClass(), CamelCmdReceiveAction.class);
+        Assert.assertEquals(result.getTestAction(2).getName(), "camel-cmd-receive");
+    }
+
+}

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/yaml/JBangCmdReceiveTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/yaml/JBangCmdReceiveTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.yaml;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.camel.CamelSettings;
+import org.citrusframework.camel.actions.CamelCmdReceiveAction;
+import org.citrusframework.camel.actions.CamelRunIntegrationAction;
+import org.citrusframework.util.TestUtils;
+import org.citrusframework.yaml.YamlTestLoader;
+import org.testng.Assert;
+import org.testng.SkipException;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class JBangCmdReceiveTest extends AbstractYamlActionTest {
+
+    @BeforeClass
+    public static void beforeClass() {
+        if (!TestUtils.isNetworkReachable()) {
+            throw new SkipException("Test skipped because network is not reachable. We are probably running behind a proxy and JBang download is not possible.");
+        }
+    }
+
+    @Test
+    public void shouldLoadCamelActions() throws Exception {
+        YamlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/camel/yaml/camel-jbang-cmd-receive-test.yaml");
+
+        CamelContext citrusCamelContext = new DefaultCamelContext();
+        citrusCamelContext.start();
+
+        context.getReferenceResolver().bind(CamelSettings.getContextName(), citrusCamelContext);
+        context.getReferenceResolver().bind("camelContext", citrusCamelContext);
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "CamelJBangCmdReceiveTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 5L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), CamelRunIntegrationAction.class);
+        Assert.assertEquals(result.getTestAction(2).getClass(), CamelCmdReceiveAction.class);
+        Assert.assertEquals(result.getTestAction(2).getName(), "camel-cmd-receive");
+    }
+
+}

--- a/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/integration/echo-events.yaml
+++ b/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/integration/echo-events.yaml
@@ -1,0 +1,7 @@
+- from:
+    uri: "direct:echo"
+    steps:
+      - wireTap:
+          uri: "log:info"
+      - to:
+          uri: "kafka:info?brokers=localhost:9092"

--- a/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/xml/camel-jbang-cmd-receive-test.xml
+++ b/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/xml/camel-jbang-cmd-receive-test.xml
@@ -1,0 +1,82 @@
+<!--
+  ~ Copyright the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<test name="CamelJBangCmdReceiveTest" author="Christoph" status="FINAL" xmlns="http://citrusframework.org/schema/xml/testcase"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://citrusframework.org/schema/xml/testcase http://citrusframework.org/schema/xml/testcase/citrus-testcase.xsd
+                          http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
+  <description>Sample test in XML</description>
+  <actions>
+    <camel>
+      <jbang>
+        <run stub="kafka">
+          <integration name="echo-events-xml"
+                       file="classpath:org/citrusframework/camel/integration/echo-events.yaml">
+          </integration>
+        </run>
+      </jbang>
+    </camel>
+
+    <timer id="send-events" fork="true" delay="5000" interval="1000">
+      <actions>
+        <camel>
+          <jbang>
+            <cmd>
+              <send integration="echo-events-xml" endpoint="direct:echo">
+                <body>
+                  <data>citrus:randomEnumValue('Hello Camel', 'Camel rocks!', 'Good Bye Camel!')</data>
+                </body>
+              </send>
+            </cmd>
+          </jbang>
+        </camel>
+      </actions>
+    </timer>
+
+    <camel>
+      <jbang>
+        <cmd>
+          <receive integration="echo-events-xml" endpoint="kafka:info" tail="1" grep="Hello Camel"/>
+        </cmd>
+      </jbang>
+    </camel>
+
+    <camel>
+      <jbang>
+        <cmd>
+          <receive integration="echo-events-xml" endpoint="kafka:info" tail="1" grep="Camel rocks!"/>
+        </cmd>
+      </jbang>
+    </camel>
+
+    <camel>
+      <jbang>
+        <cmd>
+          <receive integration="echo-events-xml" endpoint="kafka:info" tail="1" grep="Good Bye Camel!"/>
+        </cmd>
+      </jbang>
+    </camel>
+  </actions>
+  <finally>
+    <stop-timer id="send-events"/>
+
+    <camel>
+      <jbang>
+        <stop integration="echo-events-xml"/>
+      </jbang>
+    </camel>
+  </finally>
+</test>

--- a/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/yaml/camel-jbang-cmd-receive-test.yaml
+++ b/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/yaml/camel-jbang-cmd-receive-test.yaml
@@ -1,0 +1,62 @@
+name: "CamelJBangCmdReceiveTest"
+author: "Christoph"
+status: "FINAL"
+actions:
+  - camel:
+      jbang:
+        run:
+          stub:
+            - kafka
+          integration:
+            name: "echo-events-yaml"
+            file: "classpath:org/citrusframework/camel/integration/echo-events.yaml"
+
+  - timer:
+      id: send-events
+      fork: true
+      delay: 5000
+      interval: 1000
+      actions:
+        - camel:
+            jbang:
+              cmd:
+                send:
+                  integration: "echo-events-yaml"
+                  body:
+                    data: "citrus:randomEnumValue('Hello Camel', 'Camel rocks!', 'Good Bye Camel!')"
+
+  - camel:
+      jbang:
+        cmd:
+          receive:
+            integration: "echo-events-yaml"
+            endpoint: "kafka:info"
+            tail: 1
+            grep: "Hello Camel"
+
+  - camel:
+      jbang:
+        cmd:
+          receive:
+            integration: "echo-events-yaml"
+            endpoint: "kafka:info"
+            tail: 1
+            grep: "Camel rocks!"
+
+  - camel:
+      jbang:
+        cmd:
+          receive:
+            integration: "echo-events-yaml"
+            endpoint: "kafka:info"
+            tail: 1
+            grep: "Good Bye Camel!"
+
+finally:
+  - stopTimer:
+      id: send-events
+
+  - camel:
+      jbang:
+        stop:
+          integration: "echo-events-yaml"

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-4.9.0-SNAPSHOT.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-4.9.0-SNAPSHOT.xsd
@@ -1144,6 +1144,25 @@
                         <xs:attribute name="args" type="xs:string"/>
                       </xs:complexType>
                     </xs:element>
+                    <xs:element name="receive">
+                      <xs:complexType>
+                        <xs:annotation>
+                          <xs:documentation>Receive a message via Camel JBang.</xs:documentation>
+                        </xs:annotation>
+                        <xs:attribute name="integration" type="xs:string"/>
+                        <xs:attribute name="endpoint" type="xs:string"/>
+                        <xs:attribute name="uri" type="xs:string"/>
+                        <xs:attribute name="logging-color" type="xs:boolean"/>
+                        <xs:attribute name="args" type="xs:string"/>
+                        <xs:attribute name="grep" type="xs:string"/>
+                        <xs:attribute name="since" type="xs:string"/>
+                        <xs:attribute name="tail" type="xs:string"/>
+                        <xs:attribute name="max-attempts" type="xs:int"/>
+                        <xs:attribute name="delay-between-attempts" type="xs:int"/>
+                        <xs:attribute name="print-logs" type="xs:boolean"/>
+                        <xs:attribute name="stop-on-error-status" type="xs:boolean"/>
+                      </xs:complexType>
+                    </xs:element>
                   </xs:choice>
                 </xs:complexType>
               </xs:element>
@@ -1329,7 +1348,15 @@
                         </xs:sequence>
                       </xs:complexType>
                     </xs:element>
+                    <xs:element name="stubs" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="stub" type="xs:string" maxOccurs="unbounded"/>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
                   </xs:sequence>
+                  <xs:attribute name="stub" type="xs:string"/>
                   <xs:attribute name="args" type="xs:string"/>
                   <xs:attribute name="auto-remove" type="xs:boolean"/>
                   <xs:attribute name="wait-for-running-state" type="xs:boolean"/>

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
@@ -1144,6 +1144,25 @@
                         <xs:attribute name="args" type="xs:string"/>
                       </xs:complexType>
                     </xs:element>
+                    <xs:element name="receive">
+                      <xs:complexType>
+                        <xs:annotation>
+                          <xs:documentation>Receive a message via Camel JBang.</xs:documentation>
+                        </xs:annotation>
+                        <xs:attribute name="integration" type="xs:string"/>
+                        <xs:attribute name="endpoint" type="xs:string"/>
+                        <xs:attribute name="uri" type="xs:string"/>
+                        <xs:attribute name="logging-color" type="xs:boolean"/>
+                        <xs:attribute name="args" type="xs:string"/>
+                        <xs:attribute name="grep" type="xs:string"/>
+                        <xs:attribute name="since" type="xs:string"/>
+                        <xs:attribute name="tail" type="xs:string"/>
+                        <xs:attribute name="max-attempts" type="xs:int"/>
+                        <xs:attribute name="delay-between-attempts" type="xs:int"/>
+                        <xs:attribute name="print-logs" type="xs:boolean"/>
+                        <xs:attribute name="stop-on-error-status" type="xs:boolean"/>
+                      </xs:complexType>
+                    </xs:element>
                   </xs:choice>
                 </xs:complexType>
               </xs:element>
@@ -1329,7 +1348,15 @@
                         </xs:sequence>
                       </xs:complexType>
                     </xs:element>
+                    <xs:element name="stubs" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="stub" type="xs:string" maxOccurs="unbounded"/>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
                   </xs:sequence>
+                  <xs:attribute name="stub" type="xs:string"/>
                   <xs:attribute name="args" type="xs:string"/>
                   <xs:attribute name="auto-remove" type="xs:boolean"/>
                   <xs:attribute name="wait-for-running-state" type="xs:boolean"/>

--- a/src/manual/endpoint-camel.adoc
+++ b/src/manual/endpoint-camel.adoc
@@ -998,6 +998,8 @@ You can skip the waiting state with the `waitForRunningState=false` option.
 
 TIP: The test action has an `autoRemove` option that is enabled by default. This means that the test will automatically stop and remove the Camel integration after the test.
 
+TIP: You may choose to add the `--stub` option to the Camel JBang run command. This allows you to stub endpoints in the Camel integration route. The stubbed endpoint uses a local internal message queue instead of connecting to the real endpoint. This is very useful when an endpoint raises quite complex connection efforts. For instance, you may stub an SQL endpoint or a message broker connection endpoint such as Kafka or JMS when running the Camel integration. You may access the messages processed by the stubbed endpoint in the test with a `cmd receive` test action that is described later in this guide.
+
 === Stop Camel integrations
 
 You may want to explicitly stop the Camel integration.
@@ -1122,7 +1124,7 @@ The action provides options such as `maxAttempts` and `pollingInterval` to stop 
 
 === Send messages
 
-The Camel Jbang tooling allows you to send messages to running Camel integrations.
+The Camel JBang tooling allows you to send messages to running Camel integrations.
 You can use the `send` command to send messages to any running route.
 
 Give the following Camel integration that is running in Camel JBang:
@@ -1357,6 +1359,187 @@ actions:
 TIP: You can also use the Kamelets sources to send messages with Camel JBang. The Kamelets provide easy to use properties for comfortable connection options.
 
 Please see the Camel JBang send command help for more configuration options.
+
+.Camel JBang cmd send options
+[source,shell]
+----
+camel cmd send --help
+----
+
+=== Receive messages
+
+The Camel JBang tooling allows you to access stubbed messages in a running Camel integration.
+You can use the `receive` command to list messages that an endpoint in Camel has been processing.
+
+Give the following Camel integration that is running in Camel JBang:
+
+.echo.yaml
+[source,yaml,indent=0]
+----
+- from:
+    uri: "direct:echo"
+    steps:
+      - transform:
+          simple: "${body.toUpperCase()}"
+      - to: "kafka:inbox?brokers=localhost:9092"
+----
+
+The Camel route listens for messages on the `direct:echo` endpoint and connects with a Kafka message broker.
+With Camel JBang you can start the route with a stubbed Kafka endpoint like this:
+
+.Run Camel integration with --stub option
+[source,shell]
+----
+camel run my-route.yaml --stub=kafka
+----
+
+This makes Camel use an internal message queue instead of connecting with the Kafka message broker.
+The messages received by the stubbed Kafka component in Camel can be accessed with the `receive` command:
+
+.Java
+[source,java,indent=0,role="primary"]
+----
+public class CamelJBangTest extends TestNGCitrusSupport implements TestActionSupport {
+
+    @Test
+    @CitrusTest
+    public void shouldSendMessage() {
+        then(camel().jbang().cmd()
+                    .receive()
+                    .integration("my-route")
+                    .tail(1)
+                    .endpoint("kafka:inbox"));
+    }
+}
+----
+
+.YAML
+[source,yaml,indent=0,role="secondary"]
+----
+name: "CamelJBangTest"
+actions:
+  - camel:
+      jbang:
+        cmd:
+          receive:
+            integration: "my-route"
+            tail: 1
+            endpoint: "kafka:inbox"
+----
+
+.XML
+[source,xml,indent=0,role="secondary"]
+----
+<test name="CamelJBangTest" xmlns="http://citrusframework.org/schema/xml/testcase"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://citrusframework.org/schema/xml/testcase http://citrusframework.org/schema/xml/testcase/citrus-testcase.xsd">
+  <actions>
+    <camel>
+      <jbang>
+        <cmd>
+          <receive integration="my-route" tail="1" endpoint="kafka:inbox"/>
+        </cmd>
+      </jbang>
+    </camel>
+  </actions>
+</test>
+----
+
+.Spring XML
+[source,xml,indent=0,role="secondary"]
+----
+<spring:beans xmlns="http://www.citrusframework.org/schema/testcase"
+              xmlns:spring="http://www.springframework.org/schema/beans">
+    <!-- NOT SUPPORTED -->
+</spring:beans>
+----
+
+The `receive` action connects with the running Camel integration called `my-route` and receives messages on the stubbed `kafka:inbox` endpoint.
+The `tail` setting defines how many messages that have been received before will be included.
+This means a setting of `tail=1` includes the last message that was processed by the stubbed endpoint.
+By default, the operation will wait only for new messages to arrive (tail=0).
+
+The test action monitors the `receive` command output and waits for messages to arrive.
+You can use the `grep` option to wait for very specific messages that match the given expression.
+Also, you can specify the `since` option that allows you to include messages that have arrived in a given time span (e.g. 5s, 2m, 1h)
+
+.Java
+[source,java,indent=0,role="primary"]
+----
+public class CamelJBangTest extends TestNGCitrusSupport implements TestActionSupport {
+
+    @Test
+    @CitrusTest
+    public void shouldSendMessage() {
+        then(camel().jbang().cmd()
+                    .receive()
+                    .integration("my-route")
+                    .tail(1)
+                    .since("1h")
+                    .grep("HELLO CAMEL")
+                    .endpoint("kafka:inbox"));
+    }
+}
+----
+
+.YAML
+[source,yaml,indent=0,role="secondary"]
+----
+name: "CamelJBangTest"
+actions:
+  - camel:
+      jbang:
+        cmd:
+          receive:
+            integration: "my-route"
+            tail: 1
+            since: 1h
+            grep: HELLO CAMEL
+            endpoint: "kafka:inbox"
+----
+
+.XML
+[source,xml,indent=0,role="secondary"]
+----
+<test name="CamelJBangTest" xmlns="http://citrusframework.org/schema/xml/testcase"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://citrusframework.org/schema/xml/testcase http://citrusframework.org/schema/xml/testcase/citrus-testcase.xsd">
+  <actions>
+    <camel>
+      <jbang>
+        <cmd>
+          <receive integration="my-route"
+                    tail="1"
+                    since="1h"
+                    grep="HELLO CAMEL"
+                    endpoint="kafka:inbox"/>
+        </cmd>
+      </jbang>
+    </camel>
+  </actions>
+</test>
+----
+
+.Spring XML
+[source,xml,indent=0,role="secondary"]
+----
+<spring:beans xmlns="http://www.citrusframework.org/schema/testcase"
+              xmlns:spring="http://www.springframework.org/schema/beans">
+    <!-- NOT SUPPORTED -->
+</spring:beans>
+----
+
+The `grep`, `tail` and `since` options help you to verify that a specific message has been processed on the stubbed endpoint.
+The test action polls the command output for the message and throws a timeout error in case the message does not arrive in time.
+You can use the `maxAttempts` and `delayBetweeAttempts` settings to specify the waiting and polling configuration.
+
+Please see the Camel JBang receive command help for more configuration options.
+
+.Camel JBang cmd receive options
+[source,shell]
+----
+camel cmd receive --help
+----
 
 [[camel-jbang-kubernetes]]
 == Camel JBang Kubernetes support


### PR DESCRIPTION
- Simplify the usage of --stub option when running a Camel integration via Citrus
- Add CamelCmdReceiveAction test action that uses the cmd receive JBang command to receive messages from stubbed endpoints