### PR TITLE
combined validation mode

### DIFF
--- a/core/citrus-api/pom.xml
+++ b/core/citrus-api/pom.xml
@@ -22,7 +22,6 @@
     <dependency>
       <groupId>uk.org.webcompere</groupId>
       <artifactId>system-stubs-testng</artifactId>
-      <version>2.1.8</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/core/citrus-api/src/main/java/org/citrusframework/CitrusSettings.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/CitrusSettings.java
@@ -16,16 +16,17 @@
 
 package org.citrusframework;
 
+import org.citrusframework.common.TestLoader;
+import org.citrusframework.validation.CustomValidatorStrategy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.io.InputStream;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Stream;
-
-import org.citrusframework.common.TestLoader;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
@@ -267,6 +268,10 @@ public final class CitrusSettings {
     public static final String PERFORM_DEFAULT_VALIDATION_ENV = "CITRUS_PERFORM_DEFAULT_VALIDATION";
     public static final String PERFORM_DEFAULT_VALIDATION_DEFAULT = Boolean.FALSE.toString();
 
+    public static final String CUSTOM_VALIDATOR_STRATEGY_PROPERTY = "citrus.custom.validator.strategy";
+    public static final String CUSTOM_VALIDATOR_STRATEGY_ENV = "CITRUS_CUSTOM_VALIDATOR_STRATEGY";
+    public static final CustomValidatorStrategy CUSTOM_VALIDATOR_STRATEGY_DEFAULT = CustomValidatorStrategy.EXCLUSIVE;
+
     /**
      * Flag to enable/disable input stream caching
      */
@@ -379,6 +384,15 @@ public final class CitrusSettings {
                 PERFORM_DEFAULT_VALIDATION_PROPERTY,
                 PERFORM_DEFAULT_VALIDATION_ENV,
                 PERFORM_DEFAULT_VALIDATION_DEFAULT));
+    }
+
+    public static CustomValidatorStrategy getCustomValidatorStrategy() {
+        var customValidatorStrategy = getPropertyEnvOrDefault(
+                CUSTOM_VALIDATOR_STRATEGY_PROPERTY,
+                CUSTOM_VALIDATOR_STRATEGY_ENV,
+                CUSTOM_VALIDATOR_STRATEGY_DEFAULT.toString());
+
+        return CustomValidatorStrategy.valueOf(customValidatorStrategy.toUpperCase());
     }
 
     /**

--- a/core/citrus-api/src/main/java/org/citrusframework/validation/CustomValidatorStrategy.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/validation/CustomValidatorStrategy.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.validation;
+
+/**
+ * Defines how custom validators are applied during message validation.
+ *
+ * <p><strong>Historical behavior:</strong><br>
+ * By default, custom validators were executed exclusively.
+ * This meant that when a custom validator was provided, the default validation logic (such as body or JSON validation) was skipped entirely.
+ * For example, in the snippet below the body validation would have no effect on the test result:
+ *
+ * <pre>
+ * ReceiveMessageAction receiveAction = new ReceiveMessageAction.Builder()
+ *         .getMessageBuilderSupport()
+ *         .body("expected body")
+ *         .validate((message, context) -> customValidatorInvoked.set(true))
+ *         .build();
+ * </pre>
+ *
+ * <p>
+ * This behavior originally existed to allow users to fully replace the default validation logic — for example, by providing custom JSON validation that must not be duplicated or interfered with by the built-in validators.
+ *
+ * <p><strong>New behavior option:</strong><br>
+ * In some scenarios this exclusivity can be unexpected or misleading.
+ * For these cases the {@link CustomValidatorStrategy#COMBINED} strategy allows Citrus to run both the default validators and the custom validator logic together.
+ */
+public enum CustomValidatorStrategy {
+
+    COMBINED,
+    EXCLUSIVE;
+}

--- a/core/citrus-api/src/test/java/org/citrusframework/CitrusSettingsTest.java
+++ b/core/citrus-api/src/test/java/org/citrusframework/CitrusSettingsTest.java
@@ -1,6 +1,6 @@
 package org.citrusframework;
 
-import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
@@ -8,10 +8,14 @@ import uk.org.webcompere.systemstubs.properties.SystemProperties;
 import uk.org.webcompere.systemstubs.testng.SystemStub;
 import uk.org.webcompere.systemstubs.testng.SystemStubsListener;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.citrusframework.CitrusSettings.CUSTOM_VALIDATOR_STRATEGY_ENV;
+import static org.citrusframework.CitrusSettings.CUSTOM_VALIDATOR_STRATEGY_PROPERTY;
 import static org.citrusframework.CitrusSettings.DEFAULT_LOGGING_REPORTER_PRINT_STACK_TRACES_ENV;
 import static org.citrusframework.CitrusSettings.DEFAULT_LOGGING_REPORTER_PRINT_STACK_TRACES_PROPERTY;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
+import static org.citrusframework.validation.CustomValidatorStrategy.COMBINED;
+import static org.citrusframework.validation.CustomValidatorStrategy.EXCLUSIVE;
 
 @Listeners(SystemStubsListener.class)
 public class CitrusSettingsTest {
@@ -22,22 +26,22 @@ public class CitrusSettingsTest {
     @SystemStub
     private SystemProperties systemProperties;
 
-    @BeforeMethod
-    void beforeMethodSetup() {
-        environmentVariables.remove(DEFAULT_LOGGING_REPORTER_PRINT_STACK_TRACES_ENV);
-        systemProperties.remove(DEFAULT_LOGGING_REPORTER_PRINT_STACK_TRACES_PROPERTY);
-    }
-
     @Test
     public void isStackTraceOutputEnabled_shouldReturnFalseByDefault() {
-        assertFalse(CitrusSettings.isStackTraceOutputEnabled());
+        systemProperties.remove(DEFAULT_LOGGING_REPORTER_PRINT_STACK_TRACES_PROPERTY);
+        environmentVariables.remove(DEFAULT_LOGGING_REPORTER_PRINT_STACK_TRACES_ENV);
+
+        assertThat(CitrusSettings.isStackTraceOutputEnabled())
+                .isFalse();
     }
 
     @Test
     public void isStackTraceOutputEnabled_shouldReturnEnvVarValue() {
+        systemProperties.remove(DEFAULT_LOGGING_REPORTER_PRINT_STACK_TRACES_PROPERTY);
         environmentVariables.set(DEFAULT_LOGGING_REPORTER_PRINT_STACK_TRACES_ENV, "true");
 
-        assertTrue(CitrusSettings.isStackTraceOutputEnabled());
+        assertThat(CitrusSettings.isStackTraceOutputEnabled())
+                .isTrue();
     }
 
     @Test
@@ -47,6 +51,64 @@ public class CitrusSettingsTest {
         // disregarded due to resolving sequence
         environmentVariables.set(DEFAULT_LOGGING_REPORTER_PRINT_STACK_TRACES_ENV, "false");
 
-        assertTrue(CitrusSettings.isStackTraceOutputEnabled());
+        assertThat(CitrusSettings.isStackTraceOutputEnabled())
+                .isTrue();
+    }
+
+    @Test
+    public void getCustomValidatorStrategy_shouldReturnExclusiveByDefault() {
+        systemProperties.remove(CUSTOM_VALIDATOR_STRATEGY_PROPERTY);
+        environmentVariables.remove(CUSTOM_VALIDATOR_STRATEGY_ENV);
+
+        assertThat(CitrusSettings.getCustomValidatorStrategy())
+                .isEqualTo(EXCLUSIVE);
+    }
+
+    @DataProvider
+    public static String[] combinedPropertyValues() {
+        return new String[]{
+                "combined",
+                "COMBINED"
+        };
+    }
+
+    @Test(dataProvider = "combinedPropertyValues")
+    public void getCustomValidatorStrategy_shouldReturnEnvVarValue(String combinedPropertyValue) {
+        systemProperties.remove(CUSTOM_VALIDATOR_STRATEGY_PROPERTY);
+        environmentVariables.set(CUSTOM_VALIDATOR_STRATEGY_ENV, combinedPropertyValue);
+
+        assertThat(CitrusSettings.getCustomValidatorStrategy())
+                .isEqualTo(COMBINED);
+    }
+
+    @Test(dataProvider = "combinedPropertyValues")
+    public void getCustomValidatorStrategy_shouldReturnPropertyValue_overEnvVarValue(String combinedPropertyValue) {
+        systemProperties.set(CUSTOM_VALIDATOR_STRATEGY_PROPERTY, combinedPropertyValue);
+
+        // disregarded due to resolving sequence
+        environmentVariables.set(CUSTOM_VALIDATOR_STRATEGY_ENV, "invalid");
+
+        assertThat(CitrusSettings.getCustomValidatorStrategy())
+                .isEqualTo(COMBINED);
+    }
+
+    @Test
+    public void getCustomValidatorStrategy_shouldThrow_onInvalidProperty() {
+        systemProperties.set(CUSTOM_VALIDATOR_STRATEGY_PROPERTY, "invalid");
+        environmentVariables.remove(CUSTOM_VALIDATOR_STRATEGY_ENV);
+
+        assertThatThrownBy(CitrusSettings::getCustomValidatorStrategy)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageStartingWith("No enum constant");
+    }
+
+    @Test
+    public void getCustomValidatorStrategy_shouldThrow_OnInvalidEnv() {
+        systemProperties.remove(CUSTOM_VALIDATOR_STRATEGY_PROPERTY);
+        environmentVariables.set(CUSTOM_VALIDATOR_STRATEGY_ENV, "invalid");
+
+        assertThatThrownBy(CitrusSettings::getCustomValidatorStrategy)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageStartingWith("No enum constant");
     }
 }

--- a/core/citrus-base/pom.xml
+++ b/core/citrus-base/pom.xml
@@ -57,6 +57,10 @@
       <artifactId>groovy-xml</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>uk.org.webcompere</groupId>
+      <artifactId>system-stubs-testng</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -273,6 +273,7 @@
     <swagger.version>2.2.37</swagger.version>
     <swagger.parser.version>2.1.22</swagger.parser.version>
     <swagger-request-validator.version>2.46.0</swagger-request-validator.version>
+    <system-stubs.version>2.1.8</system-stubs.version>
     <testcontainers.version>1.21.3</testcontainers.version>
     <testng.version>7.11.0</testng.version>
     <!-- bound to https://mvnrepository.com/artifact/io.fabric8/kubernetes-httpclient-vertx/${k8s.client.version} -->
@@ -1354,6 +1355,13 @@
         <artifactId>maven-plugin-annotations</artifactId>
         <version>${maven.plugin.annotations.version}</version>
         <scope>provided</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>uk.org.webcompere</groupId>
+        <artifactId>system-stubs-testng</artifactId>
+        <version>2.1.8</version>
+        <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/src/manual/validation-custom.adoc
+++ b/src/manual/validation-custom.adoc
@@ -1,14 +1,13 @@
 [[validation-custom]]
 == Custom validation
 
-In a previous section you have seen how to customize the global set of available message validators in a Citrus project using
-the link:#message-validator-registry[validator registry].
+In a previous section you have seen how to customize the global set of available message validators in a Citrus project using the link:#message-validator-registry[validator registry].
 
 [[validation-custom-validator]]
 === Custom message validator
 
-You can also explicitly use a custom message validator in a receive test action. This approach skips the automatic message
-validator resolving mechanism, and the receive action uses the defined validator implementation.
+You can also explicitly use a custom message validator in a receive test action.
+This approach skips the automatic message validator resolving mechanism, and the receive action uses the defined validator implementation.
 
 .Java
 [source,java,indent=0,role="primary"]
@@ -43,17 +42,17 @@ receive("someEndpoint")
 </receive>
 ----
 
-The receive action defines the message validator to use in this specific use case. You can set a custom message validator
-implementation here.
+The receive action defines the message validator to use in this specific use case.
+You can set a custom message validator implementation here.
 
-NOTE: Be careful when overwriting default message validation behavior. Setting a specific message validator has the effect
-that your receive action may not use the other default validators. The explicit validator definition in a receive action
-is exclusive so no further message validator resolving is performed on this receive action.
+IMPORTANT: Be careful when overwriting default message validation behavior.
+Setting a specific message validator has the effect that your receive action may not use the other default validators.
+The explicit validator definition in a receive action is exclusive so no further message validator resolving is performed on this receive action.
+If you wish otherwise, take a look at the link:#validation-custom-validator-strategy[custom validator strategy]
 
-You may want to set multiple validators here in order to meet your validation requirements. For instance when setting a
-`DomXmlMessageValidator` explicitly you may not be able to use the `XpathMessageValidator` capabilities on that specific
-receive action anymore. Fortunately you can set multiple validators on a receive action that will all perform validation
-tasks on the received message.
+You may want to set multiple validators here in order to meet your validation requirements.
+For instance when setting a `DomXmlMessageValidator` explicitly you may not be able to use the `XpathMessageValidator` capabilities on that specific receive action anymore.
+Fortunately you can set multiple validators on a receive action that will all perform validation tasks on the received message.
 
 .Java
 [source,java,indent=0,role="primary"]
@@ -75,6 +74,41 @@ receive("someEndpoint")
     </message>
 </receive>
 ----
+
+[[validation-custom-validator-strategy]]
+=== Custom validator strategy (new)
+
+Historically, Citrus executed **only** the custom validators defined on a receive action.
+This meant that **default validation steps were skipped entirely** when a custom validator was present - even if the test also defined body validation, JSON validation, or other built-in mechanisms.
+
+This exclusive behavior was intentional:
+Users could provide highly specialized validation logic (e.g., custom JSON comparison), and the default validators would stay out of the way to avoid duplicate or conflicting validation.
+
+However, this behavior can be surprising when users expect default validators to *also* run alongside custom logic.
+To address this, Citrus introduces a configurable validator strategy with two modes:
+
+==== Available strategies
+
+* **`EXCLUSIVE` (default)**
+  - Only the custom validator(s) are executed.
+  - Default validators and body assertions are not applied.
+
+* **`COMBINED`**
+  - Both custom validators and the default Citrus validators run.
+  - Useful when custom validation should extend - not replace - the default behavior.
+
+==== Configuration
+
+The strategy can be globally configured using either a system property or an environment variable:
+
+* System property:
+  `citrus.custom.validator.strategy`
+* Environment variable:
+  `CITRUS_CUSTOM_VALIDATOR_STRATEGY`
+
+Default value: `EXCLUSIVE`.
+
+This allows you to switch the behavior project-wide without changing any test cases.
 
 [[validation-custom-processor]]
 === Validation processor


### PR DESCRIPTION
Historically, Citrus executed **only** the custom validators defined on a receive action. This meant that **default validation steps were skipped entirely**. This exclusive behavior was intentional.

However, it can be surprising when users expect default validators to *also* run alongside custom logic. To address this, Citrus introduces a configurable validator strategy with two modes:

* **`EXCLUSIVE` (default)**: Only the custom validator(s) are executed.
* **`COMBINED`**: Both custom validators and the default Citrus validators run.

The strategy can be globally configured using either a system property or an environment variable:

* System property: `citrus.custom.validator.strategy`
* Environment variable: `CITRUS_CUSTOM_VALIDATOR_STRATEGY`

Closes #1419.