### PR TITLE
chore: Improve YAML DSL support

### DIFF
--- a/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/actions/OpenApiActionBuilder.java
+++ b/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/actions/OpenApiActionBuilder.java
@@ -40,6 +40,7 @@ public class OpenApiActionBuilder extends AbstractReferenceResolverAwareTestActi
     private OpenApiSpecificationSource openApiSpecificationSource;
 
     public OpenApiActionBuilder() {
+        this.openApiSpecificationSource = new OpenApiSpecificationSource();
     }
 
     public OpenApiActionBuilder(OpenApiSpecification specification) {
@@ -123,6 +124,16 @@ public class OpenApiActionBuilder extends AbstractReferenceResolverAwareTestActi
                 .withReferenceResolver(referenceResolver);
         this.delegate = clientActionBuilder;
         return clientActionBuilder;
+    }
+
+    @Override
+    public OpenApiServerActionBuilder server() {
+        assertSpecification();
+
+        OpenApiServerActionBuilder serverActionBuilder = new OpenApiServerActionBuilder(openApiSpecificationSource)
+                .withReferenceResolver(referenceResolver);
+        this.delegate = serverActionBuilder;
+        return serverActionBuilder;
     }
 
     @Override

--- a/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/actions/OpenApiClientActionBuilder.java
+++ b/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/actions/OpenApiClientActionBuilder.java
@@ -17,6 +17,8 @@
 package org.citrusframework.openapi.actions;
 
 import org.citrusframework.TestAction;
+import org.citrusframework.actions.ReceiveActionBuilder;
+import org.citrusframework.actions.SendActionBuilder;
 import org.citrusframework.endpoint.Endpoint;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.spi.AbstractReferenceResolverAwareTestActionBuilder;
@@ -65,6 +67,20 @@ public class OpenApiClientActionBuilder extends AbstractReferenceResolverAwareTe
     @Override
     public OpenApiSpecificationSource getOpenApiSpecificationSource() {
         return openApiSpecificationSource;
+    }
+
+    @Override
+    public OpenApiClientActionBuilder client(String httpClient) {
+        this.httpClientUri = httpClient;
+        getOpenApiSpecificationSource().setHttpClient(httpClient);
+        return this;
+    }
+
+    @Override
+    public OpenApiClientActionBuilder client(Endpoint httpClient) {
+        this.httpClient = httpClient;
+        getOpenApiSpecificationSource().setHttpClient(httpClient);
+        return this;
     }
 
     @Override
@@ -135,6 +151,23 @@ public class OpenApiClientActionBuilder extends AbstractReferenceResolverAwareTe
     @Override
     public TestAction build() {
         ObjectHelper.assertNotNull(delegate, "Missing delegate action to build");
+
+        if (delegate instanceof SendActionBuilder<?, ?, ?> messageActionBuilder) {
+            if (httpClient != null) {
+                messageActionBuilder.endpoint(httpClient);
+            } else if (httpClientUri != null) {
+                messageActionBuilder.endpoint(httpClientUri);
+            }
+        }
+
+        if (delegate instanceof ReceiveActionBuilder<?, ?, ?> messageActionBuilder) {
+            if (httpClient != null) {
+                messageActionBuilder.endpoint(httpClient);
+            } else if (httpClientUri != null) {
+                messageActionBuilder.endpoint(httpClientUri);
+            }
+        }
+
         return delegate.build();
     }
 }

--- a/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/actions/OpenApiServerActionBuilder.java
+++ b/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/actions/OpenApiServerActionBuilder.java
@@ -17,6 +17,8 @@
 package org.citrusframework.openapi.actions;
 
 import org.citrusframework.TestAction;
+import org.citrusframework.actions.ReceiveActionBuilder;
+import org.citrusframework.actions.SendActionBuilder;
 import org.citrusframework.endpoint.Endpoint;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.spi.AbstractReferenceResolverAwareTestActionBuilder;
@@ -59,9 +61,25 @@ public class OpenApiServerActionBuilder extends
         this.openApiSpecificationSource = specification;
     }
 
+    public OpenApiServerActionBuilder(OpenApiSpecificationSource openApiSpecificationSource) {
+        this.openApiSpecificationSource = openApiSpecificationSource;
+    }
+
     @Override
     public OpenApiSpecificationSource getOpenApiSpecificationSource() {
         return openApiSpecificationSource;
+    }
+
+    @Override
+    public OpenApiServerActionBuilder server(String httpServer) {
+        this.httpServerUri = httpServer;
+        return this;
+    }
+
+    @Override
+    public OpenApiServerActionBuilder server(Endpoint httpServer) {
+        this.httpServer = httpServer;
+        return this;
     }
 
     @Override
@@ -145,6 +163,23 @@ public class OpenApiServerActionBuilder extends
     @Override
     public TestAction build() {
         ObjectHelper.assertNotNull(delegate, "Missing delegate action to build");
+
+        if (delegate instanceof SendActionBuilder<?, ?, ?> messageActionBuilder) {
+            if (httpServer != null) {
+                messageActionBuilder.endpoint(httpServer);
+            } else if (httpServerUri != null) {
+                messageActionBuilder.endpoint(httpServerUri);
+            }
+        }
+
+        if (delegate instanceof ReceiveActionBuilder<?, ?, ?> messageActionBuilder) {
+            if (httpServer != null) {
+                messageActionBuilder.endpoint(httpServer);
+            } else if (httpServerUri != null) {
+                messageActionBuilder.endpoint(httpServerUri);
+            }
+        }
+
         return delegate.build();
     }
 }

--- a/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/actions/OpenApiSpecificationSource.java
+++ b/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/actions/OpenApiSpecificationSource.java
@@ -41,6 +41,9 @@ public class OpenApiSpecificationSource {
 
     private String httpClient;
 
+    public OpenApiSpecificationSource() {
+    }
+
     public OpenApiSpecificationSource(OpenApiSpecification openApiSpecification) {
         this.openApiSpecification = openApiSpecification;
     }
@@ -63,12 +66,12 @@ public class OpenApiSpecificationSource {
                         .findFirst()
                         .orElseThrow(() ->
                             new CitrusRuntimeException(
-                                "Unable to resolve OpenApiSpecification from alias '%s'. Known aliases for open api specs are '%s'".formatted(
+                                "Unable to resolve OpenAPI specification from alias '%s'. Known aliases are '%s'".formatted(
                                     openApiAlias, getKnownOpenApiAliases(resolver)))
                         ));
             } else {
                 throw new CitrusRuntimeException(
-                    "Unable to resolve OpenApiSpecification. Neither OpenAPI spec, nor OpenAPI  alias are specified.");
+                    "Unable to resolve OpenApiSpecification. Neither OpenAPI specification, nor OpenAPI alias are specified.");
             }
         }
 
@@ -89,5 +92,13 @@ public class OpenApiSpecificationSource {
                 this.httpClient = client.getEndpointConfiguration().getRequestUrl();
             }
         }
+    }
+
+    public void setOpenApiAlias(String openApiAlias) {
+        this.openApiAlias = openApiAlias;
+    }
+
+    public void setOpenApiSpecification(OpenApiSpecification openApiSpecification) {
+        this.openApiSpecification = openApiSpecification;
     }
 }

--- a/connectors/citrus-openapi/src/test/resources/org/citrusframework/openapi/yaml/openapi-client-test.yaml
+++ b/connectors/citrus-openapi/src/test/resources/org/citrusframework/openapi/yaml/openapi-client-test.yaml
@@ -13,17 +13,17 @@ actions:
       sendRequest:
         operation: getPetById
   - openapi:
-      specification: ${petstoreSpec}
       client: "httpClient"
       receiveResponse:
         operation: getPetById
         status: 200
+      specification: ${petstoreSpec}
 
   - openapi:
-      specification: ${petstoreSpec}
-      client: "httpClient"
       sendRequest:
         operation: addPet
+      specification: ${petstoreSpec}
+      client: "httpClient"
   - openapi:
       specification: ${petstoreSpec}
       client: "httpClient"

--- a/connectors/citrus-openapi/src/test/resources/org/citrusframework/openapi/yaml/openapi-server-test.yaml
+++ b/connectors/citrus-openapi/src/test/resources/org/citrusframework/openapi/yaml/openapi-server-test.yaml
@@ -13,18 +13,18 @@ actions:
       receiveRequest:
         operation: getPetById
   - openapi:
-      specification: ${petstoreSpec}
-      server: "httpServer"
       sendResponse:
         operation: getPetById
         status: 200
+      specification: ${petstoreSpec}
+      server: "httpServer"
 
   - openapi:
-      specification: ${petstoreSpec}
       server: "httpServer"
       receiveRequest:
         operation: addPet
         timeout: 2000
+      specification: ${petstoreSpec}
   - openapi:
       specification: ${petstoreSpec}
       server: "httpServer"

--- a/core/citrus-api/src/main/java/org/citrusframework/actions/http/HttpActionBuilder.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/actions/http/HttpActionBuilder.java
@@ -27,12 +27,22 @@ public interface HttpActionBuilder<T extends TestAction, B extends TestActionBui
     /**
      * Initiate http client action.
      */
+    HttpClientActionBuilder<?, ?> client();
+
+    /**
+     * Initiate http client action.
+     */
     HttpClientActionBuilder<?, ?> client(Endpoint endpoint);
 
     /**
      * Initiate http client action.
      */
     HttpClientActionBuilder<?, ?> client(String endpoint);
+
+    /**
+     * Initiate http server action.
+     */
+    HttpServerActionBuilder<?, ?> server();
 
     /**
      * Initiate http server action.

--- a/core/citrus-api/src/main/java/org/citrusframework/actions/openapi/OpenApiActionBuilder.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/actions/openapi/OpenApiActionBuilder.java
@@ -65,6 +65,11 @@ public interface OpenApiActionBuilder<T extends TestAction, S extends Specificat
     /**
      * Initiate http server action.
      */
+    OpenApiServerActionBuilder<?, ?> server();
+
+    /**
+     * Initiate http server action.
+     */
     OpenApiServerActionBuilder<?, ?> server(Endpoint endpoint);
 
     /**

--- a/core/citrus-api/src/main/java/org/citrusframework/actions/openapi/OpenApiClientActionBuilder.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/actions/openapi/OpenApiClientActionBuilder.java
@@ -21,9 +21,20 @@ import org.citrusframework.TestActionBuilder;
 import org.citrusframework.actions.ReferenceResolverAwareBuilder;
 import org.citrusframework.actions.http.HttpReceiveResponseMessageBuilderFactory;
 import org.citrusframework.actions.http.HttpSendRequestMessageBuilderFactory;
+import org.citrusframework.endpoint.Endpoint;
 
 public interface OpenApiClientActionBuilder<T extends TestAction, B extends TestActionBuilder.DelegatingTestActionBuilder<T>>
         extends ReferenceResolverAwareBuilder<T, B> {
+
+    /**
+     * Sets the  Http client.
+     */
+    OpenApiClientActionBuilder<T, B> client(String client);
+
+    /**
+     * Sets the  Http client.
+     */
+    OpenApiClientActionBuilder<T, B> client(Endpoint client);
 
     /**
      * Sends Http requests as client.

--- a/core/citrus-api/src/main/java/org/citrusframework/actions/openapi/OpenApiServerActionBuilder.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/actions/openapi/OpenApiServerActionBuilder.java
@@ -21,9 +21,20 @@ import org.citrusframework.TestActionBuilder;
 import org.citrusframework.actions.ReferenceResolverAwareBuilder;
 import org.citrusframework.actions.http.HttpReceiveRequestMessageBuilderFactory;
 import org.citrusframework.actions.http.HttpSendResponseMessageBuilderFactory;
+import org.citrusframework.endpoint.Endpoint;
 
 public interface OpenApiServerActionBuilder<T extends TestAction, B extends TestActionBuilder<T>>
         extends ReferenceResolverAwareBuilder<T, B> {
+
+    /**
+     * Sets the  Http server.
+     */
+    OpenApiServerActionBuilder<T, B> server(String server);
+
+    /**
+     * Sets the  Http server.
+     */
+    OpenApiServerActionBuilder<T, B> server(Endpoint server);
 
     /**
      * Sends Http response messages as server. Uses default Http status 200 OK.

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/actions/HttpActionBuilder.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/actions/HttpActionBuilder.java
@@ -32,10 +32,17 @@ public class HttpActionBuilder extends AbstractReferenceResolverAwareTestActionB
 
 	/**
 	 * Static entrance method for the Http fluent action builder.
-	 * @return
 	 */
 	public static HttpActionBuilder http() {
 		return new HttpActionBuilder();
+	}
+
+	@Override
+	public HttpClientActionBuilder client() {
+		HttpClientActionBuilder clientActionBuilder = new HttpClientActionBuilder()
+				.withReferenceResolver(referenceResolver);
+		this.delegate = clientActionBuilder;
+		return clientActionBuilder;
 	}
 
 	@Override
@@ -52,6 +59,14 @@ public class HttpActionBuilder extends AbstractReferenceResolverAwareTestActionB
 				.withReferenceResolver(referenceResolver);
 		this.delegate = clientActionBuilder;
 		return clientActionBuilder;
+	}
+
+	@Override
+	public HttpServerActionBuilder server() {
+		HttpServerActionBuilder serverActionBuilder = new HttpServerActionBuilder()
+				.withReferenceResolver(referenceResolver);
+		this.delegate = serverActionBuilder;
+		return serverActionBuilder;
 	}
 
 	@Override

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/actions/HttpClientActionBuilder.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/actions/HttpClientActionBuilder.java
@@ -17,7 +17,9 @@
 package org.citrusframework.http.actions;
 
 import org.citrusframework.TestAction;
+import org.citrusframework.actions.ReceiveActionBuilder;
 import org.citrusframework.actions.ReceiveMessageAction;
+import org.citrusframework.actions.SendActionBuilder;
 import org.citrusframework.actions.SendMessageAction;
 import org.citrusframework.endpoint.Endpoint;
 import org.citrusframework.exceptions.CitrusRuntimeException;
@@ -39,6 +41,12 @@ public class HttpClientActionBuilder extends AbstractReferenceResolverAwareTestA
     /** Target http client instance */
     private Endpoint httpClient;
     private String httpClientUri;
+
+    /**
+     * Default constructor.
+     */
+    public HttpClientActionBuilder() {
+    }
 
     /**
      * Default constructor.
@@ -245,6 +253,23 @@ public class HttpClientActionBuilder extends AbstractReferenceResolverAwareTestA
     @Override
     public TestAction build() {
         ObjectHelper.assertNotNull(delegate, "Missing delegate action to build");
+
+        if (delegate instanceof SendActionBuilder<?, ?, ?> messageActionBuilder) {
+            if (httpClient != null) {
+                messageActionBuilder.endpoint(httpClient);
+            } else if (httpClientUri != null) {
+                messageActionBuilder.endpoint(httpClientUri);
+            }
+        }
+
+        if (delegate instanceof ReceiveActionBuilder<?, ?, ?> messageActionBuilder) {
+            if (httpClient != null) {
+                messageActionBuilder.endpoint(httpClient);
+            } else if (httpClientUri != null) {
+                messageActionBuilder.endpoint(httpClientUri);
+            }
+        }
+
         return delegate.build();
     }
 }

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/actions/HttpServerActionBuilder.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/actions/HttpServerActionBuilder.java
@@ -19,7 +19,9 @@ package org.citrusframework.http.actions;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.citrusframework.TestAction;
+import org.citrusframework.actions.ReceiveActionBuilder;
 import org.citrusframework.actions.ReceiveMessageAction;
+import org.citrusframework.actions.SendActionBuilder;
 import org.citrusframework.actions.SendMessageAction;
 import org.citrusframework.endpoint.Endpoint;
 import org.citrusframework.exceptions.CitrusRuntimeException;
@@ -47,6 +49,12 @@ public class HttpServerActionBuilder extends AbstractReferenceResolverAwareTestA
     /** Target http client instance */
     private Endpoint httpServer;
     private String httpServerUri;
+
+    /**
+     * Default constructor.
+     */
+    public HttpServerActionBuilder() {
+    }
 
     /**
      * Default constructor.
@@ -328,6 +336,23 @@ public class HttpServerActionBuilder extends AbstractReferenceResolverAwareTestA
     @Override
     public TestAction build() {
         ObjectHelper.assertNotNull(delegate, "Missing delegate action to build");
+
+        if (delegate instanceof SendActionBuilder<?, ?, ?> messageActionBuilder) {
+            if (httpServer != null) {
+                messageActionBuilder.endpoint(httpServer);
+            } else if (httpServerUri != null) {
+                messageActionBuilder.endpoint(httpServerUri);
+            }
+        }
+
+        if (delegate instanceof ReceiveActionBuilder<?, ?, ?> messageActionBuilder) {
+            if (httpServer != null) {
+                messageActionBuilder.endpoint(httpServer);
+            } else if (httpServerUri != null) {
+                messageActionBuilder.endpoint(httpServerUri);
+            }
+        }
+
         return delegate.build();
     }
 }

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/client/HttpClient.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/client/HttpClient.java
@@ -16,6 +16,9 @@
 
 package org.citrusframework.http.client;
 
+import java.net.URI;
+import java.util.Optional;
+
 import org.citrusframework.context.TestContext;
 import org.citrusframework.endpoint.AbstractEndpoint;
 import org.citrusframework.exceptions.MessageTimeoutException;
@@ -36,9 +39,6 @@ import org.springframework.http.InvalidMediaTypeException;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMethod;
-
-import java.net.URI;
-import java.util.Optional;
 
 /**
  * Http client sends messages via Http protocol to some Http server instance, defined by a request endpoint url. Synchronous response
@@ -100,7 +100,9 @@ public class HttpClient extends AbstractEndpoint implements Producer, ReplyConsu
         context.setVariable(MessageHeaders.MESSAGE_REPLY_TO + "_" + correlationKeyName, endpointUri);
 
         logger.info("Sending HTTP message to: '{}'", endpointUri);
-        logger.debug("Message to send:\n{}", httpMessage.getPayload(String.class));
+        if (logger.isDebugEnabled()) {
+            logger.debug("Message to send:\n{}", httpMessage.getPayload(String.class));
+        }
 
         RequestMethod method = getEndpointConfiguration().getRequestMethod();
         if (httpMessage.getRequestMethod() != null) {

--- a/endpoints/citrus-http/src/test/resources/org/citrusframework/http/yaml/http-client-test.yaml
+++ b/endpoints/citrus-http/src/test/resources/org/citrusframework/http/yaml/http-client-test.yaml
@@ -14,7 +14,6 @@ actions:
       receiveResponse: {}
 
   - http:
-      client: "httpClient"
       sendRequest:
         uri: "http://localhost:${port}/test"
         fork: "true"
@@ -28,6 +27,7 @@ actions:
               value: "${id}"
             - name: "type"
               value: "gold"
+      client: "httpClient"
   - sleep:
       milliseconds: "1000"
   - http:

--- a/endpoints/citrus-http/src/test/resources/org/citrusframework/http/yaml/http-server-test.yaml
+++ b/endpoints/citrus-http/src/test/resources/org/citrusframework/http/yaml/http-server-test.yaml
@@ -6,9 +6,9 @@ variables:
     value: "12345"
 actions:
   - http:
-      server: "httpServer"
       receiveRequest:
         GET: {}
+      server: "httpServer"
   - http:
       server: "httpServer"
       sendResponse: {}

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/actions/SoapClientActionBuilder.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/actions/SoapClientActionBuilder.java
@@ -18,6 +18,8 @@ package org.citrusframework.ws.actions;
 
 import org.citrusframework.TestAction;
 import org.citrusframework.TestActionBuilder;
+import org.citrusframework.actions.ReceiveActionBuilder;
+import org.citrusframework.actions.SendActionBuilder;
 import org.citrusframework.endpoint.Endpoint;
 import org.citrusframework.spi.AbstractReferenceResolverAwareTestActionBuilder;
 import org.citrusframework.spi.ReferenceResolver;
@@ -114,6 +116,23 @@ public class SoapClientActionBuilder extends AbstractReferenceResolverAwareTestA
     @Override
     public TestAction build() {
         ObjectHelper.assertNotNull(delegate, "Missing delegate action to build");
+
+        if (delegate instanceof SendActionBuilder<?, ?, ?> messageActionBuilder) {
+            if (soapClient != null) {
+                messageActionBuilder.endpoint(soapClient);
+            } else if (soapClientUri != null) {
+                messageActionBuilder.endpoint(soapClientUri);
+            }
+        }
+
+        if (delegate instanceof ReceiveActionBuilder<?, ?, ?> messageActionBuilder) {
+            if (soapClient != null) {
+                messageActionBuilder.endpoint(soapClient);
+            } else if (soapClientUri != null) {
+                messageActionBuilder.endpoint(soapClientUri);
+            }
+        }
+
         return delegate.build();
     }
 }

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/actions/SoapServerActionBuilder.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/actions/SoapServerActionBuilder.java
@@ -17,6 +17,8 @@
 package org.citrusframework.ws.actions;
 
 import org.citrusframework.TestAction;
+import org.citrusframework.actions.ReceiveActionBuilder;
+import org.citrusframework.actions.SendActionBuilder;
 import org.citrusframework.endpoint.Endpoint;
 import org.citrusframework.spi.AbstractReferenceResolverAwareTestActionBuilder;
 import org.citrusframework.spi.ReferenceResolver;
@@ -108,6 +110,23 @@ public class SoapServerActionBuilder extends AbstractReferenceResolverAwareTestA
     @Override
     public TestAction build() {
         ObjectHelper.assertNotNull(delegate, "Missing delegate action to build");
+
+        if (delegate instanceof SendActionBuilder<?, ?, ?> messageActionBuilder) {
+            if (soapServer != null) {
+                messageActionBuilder.endpoint(soapServer);
+            } else if (soapServerUri != null) {
+                messageActionBuilder.endpoint(soapServerUri);
+            }
+        }
+
+        if (delegate instanceof ReceiveActionBuilder<?, ?, ?> messageActionBuilder) {
+            if (soapServer != null) {
+                messageActionBuilder.endpoint(soapServer);
+            } else if (soapServerUri != null) {
+                messageActionBuilder.endpoint(soapServerUri);
+            }
+        }
+
         return delegate.build();
     }
 }

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/yaml/Soap.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/yaml/Soap.java
@@ -23,7 +23,9 @@ import java.util.Optional;
 import org.citrusframework.TestAction;
 import org.citrusframework.TestActionBuilder;
 import org.citrusframework.TestActionContainerBuilder;
+import org.citrusframework.actions.ReceiveActionBuilder;
 import org.citrusframework.actions.ReceiveMessageAction;
+import org.citrusframework.actions.SendActionBuilder;
 import org.citrusframework.actions.SendMessageAction;
 import org.citrusframework.endpoint.resolver.EndpointUriResolver;
 import org.citrusframework.exceptions.CitrusRuntimeException;
@@ -73,12 +75,26 @@ public class Soap implements TestActionBuilder<TestAction>, ReferenceResolverAwa
 
     @SchemaProperty(description = "Sets the SOAP Http client.")
     public void setClient(String soapClient) {
-        builder = new SoapActionBuilder().client(soapClient);
+        if (builder == null) {
+            builder = new SoapActionBuilder().client(soapClient);
+        } else if (builder instanceof SendActionBuilder<?,?,?> messageActionBuilder) {
+            messageActionBuilder.endpoint(soapClient);
+        } else if (builder instanceof ReceiveActionBuilder<?,?,?> messageActionBuilder) {
+            messageActionBuilder.endpoint(soapClient);
+        } else if (builder instanceof AssertSoapFault.Builder assertSoapFaultBuilder) {
+            assertSoapFaultBuilder.endpoint(soapClient);
+        }
     }
 
     @SchemaProperty(description = "Sets the SOAP Http server.")
     public void setServer(String soapServer) {
-        builder = new SoapActionBuilder().server(soapServer);
+        if (builder == null) {
+            builder = new SoapActionBuilder().server(soapServer);
+        } else if (builder instanceof SendActionBuilder<?,?,?> messageActionBuilder) {
+            messageActionBuilder.endpoint(soapServer);
+        } else if (builder instanceof ReceiveActionBuilder<?,?,?> messageActionBuilder) {
+            messageActionBuilder.endpoint(soapServer);
+        }
     }
 
     @SchemaProperty(kind = ACTION, group = SOAP_GROUP, description = "Sends a SOAP request as a client.")
@@ -479,9 +495,12 @@ public class Soap implements TestActionBuilder<TestAction>, ReferenceResolverAwa
 
     /**
      * Converts current builder to client builder.
-     * @return
      */
     private SoapClientActionBuilder asClientBuilder() {
+        if (builder == null) {
+            builder = new SoapActionBuilder().client();
+        }
+
         if (builder instanceof SoapClientActionBuilder) {
             return (SoapClientActionBuilder) builder;
         }
@@ -492,9 +511,12 @@ public class Soap implements TestActionBuilder<TestAction>, ReferenceResolverAwa
 
     /**
      * Converts current builder to client builder.
-     * @return
      */
     private SoapServerActionBuilder asServerBuilder() {
+        if (builder == null) {
+            builder = new SoapActionBuilder().server();
+        }
+
         if (builder instanceof SoapServerActionBuilder) {
             return (SoapServerActionBuilder) builder;
         }

--- a/endpoints/citrus-ws/src/test/resources/org/citrusframework/ws/yaml/soap-client-test.yaml
+++ b/endpoints/citrus-ws/src/test/resources/org/citrusframework/ws/yaml/soap-client-test.yaml
@@ -15,7 +15,6 @@ actions:
               content: |
                 This is an attachment!
   - soap:
-      client: "soapClient"
       receiveResponse:
         message:
           body:
@@ -25,6 +24,7 @@ actions:
               contentType: "text/plain"
               content: |
                 This is an attachment!
+      client: "soapClient"
 
   - soap:
       client: "soapClient"

--- a/endpoints/citrus-ws/src/test/resources/org/citrusframework/ws/yaml/soap-server-test.yaml
+++ b/endpoints/citrus-ws/src/test/resources/org/citrusframework/ws/yaml/soap-server-test.yaml
@@ -15,7 +15,6 @@ actions:
               content: |
                 This is an attachment!
   - soap:
-      server: "soapServer"
       sendResponse:
         message:
           body:
@@ -25,6 +24,7 @@ actions:
               contentType: "text/plain"
               content: |
                 This is an attachment!
+      server: "soapServer"
 
   - soap:
       server: "soapServer"


### PR DESCRIPTION
- Allow any ordering of YAML properties when defining test actions
- Improve Http test action builder allowing to set client and server endpoint at a later state
- Improve OpenAPI test action builder allowing to set the specification source at a later state
- Improve SOAP test action builder allowing to set client and server endpoint at a later state