### PR TITLE
feat(#667): add SshMessage helper for citrus-ssh

### DIFF
--- a/endpoints/citrus-ssh/src/main/java/org/citrusframework/ssh/message/SshMessage.java
+++ b/endpoints/citrus-ssh/src/main/java/org/citrusframework/ssh/message/SshMessage.java
@@ -1,0 +1,168 @@
+package org.citrusframework.ssh.message;
+
+import org.citrusframework.message.DefaultMessage;
+import org.citrusframework.message.Message;
+import org.citrusframework.ssh.model.SshMarshaller;
+import org.citrusframework.ssh.model.SshRequest;
+import org.citrusframework.ssh.model.SshResponse;
+import org.citrusframework.xml.StringResult;
+import org.citrusframework.xml.StringSource;
+
+public class SshMessage extends DefaultMessage {
+
+    private SshRequest request;
+    private SshResponse response;
+
+    private SshMarshaller marshaller = new SshMarshaller();
+
+    public SshMessage() {
+        super();
+    }
+
+    public SshMessage(Message message) {
+        super(message);
+    }
+
+    private SshMessage(SshRequest request) {
+        super(request);
+        this.request = request;
+    }
+
+    private SshMessage(SshResponse response) {
+        super(response);
+        this.response = response;
+    }
+
+    public static SshMessage request(String command) {
+        return request(command, "");
+    }
+
+    public static SshMessage request(String command, String stdin) {
+        return new SshMessage(new SshRequest(nvl(command), nvl(stdin)));
+    }
+
+    public static SshMessage response(String stdout, String stderr, int exit) {
+        return new SshMessage(new SshResponse(nvl(stdout), nvl(stderr), exit));
+    }
+
+    public SshMessage command(String command) {
+        SshRequest r = getRequest();
+        this.request = new SshRequest(nvl(command), nvl(r.getStdin()));
+        this.response = null;
+        super.setPayload(this.request);
+        return this;
+    }
+
+    public SshMessage stdin(String stdin) {
+        SshRequest r = getRequest();
+        this.request = new SshRequest(nvl(r.getCommand()), nvl(stdin));
+        this.response = null;
+        super.setPayload(this.request);
+        return this;
+    }
+
+    public SshMessage stdout(String stdout) {
+        SshResponse r = getResponse();
+        this.response = new SshResponse(nvl(stdout), nvl(r.getStderr()), r.getExit());
+        this.request = null;
+        super.setPayload(this.response);
+        return this;
+    }
+
+    public SshMessage stderr(String stderr) {
+        SshResponse r = getResponse();
+        this.response = new SshResponse(nvl(r.getStdout()), nvl(stderr), r.getExit());
+        this.request = null;
+        super.setPayload(this.response);
+        return this;
+    }
+
+    public SshMessage exit(int exit) {
+        SshResponse r = getResponse();
+        this.response = new SshResponse(nvl(r.getStdout()), nvl(r.getStderr()), exit);
+        this.request = null;
+        super.setPayload(this.response);
+        return this;
+    }
+
+    public SshRequest getRequest() {
+        if (request == null) {
+            Object payload = super.getPayload();
+            if (payload instanceof SshRequest sshRequest) {
+                request = sshRequest;
+            } else if (payload instanceof String payloadString) {
+                request = (SshRequest) marshaller.unmarshal(new StringSource(payloadString));
+            } else {
+                request = new SshRequest("", "");
+            }
+            response = null;
+        }
+        return request;
+    }
+
+    public SshResponse getResponse() {
+        if (response == null) {
+            Object payload = super.getPayload();
+            if (payload instanceof SshResponse sshResponse) {
+                response = sshResponse;
+            } else if (payload instanceof String payloadString) {
+                response = (SshResponse) marshaller.unmarshal(new StringSource(payloadString));
+            } else {
+                response = new SshResponse("", "", 0);
+            }
+            request = null;
+        }
+        return response;
+    }
+
+    public boolean isRequest() {
+        return request != null || super.getPayload() instanceof SshRequest;
+    }
+
+    public boolean isResponse() {
+        return response != null || super.getPayload() instanceof SshResponse;
+    }
+
+    @Override
+    public Object getPayload() {
+        StringResult result = new StringResult();
+
+        if (isRequest()) {
+            marshaller.marshal(getRequest(), result);
+            return result.toString();
+        }
+
+        if (isResponse()) {
+            marshaller.marshal(getResponse(), result);
+            return result.toString();
+        }
+
+        return super.getPayload();
+    }
+
+    @Override
+    public <T> T getPayload(Class<T> type) {
+        if (SshRequest.class.isAssignableFrom(type)) {
+            return type.cast(getRequest());
+        }
+
+        if (SshResponse.class.isAssignableFrom(type)) {
+            return type.cast(getResponse());
+        }
+
+        if (String.class.equals(type)) {
+            return type.cast(getPayload());
+        }
+
+        return super.getPayload(type);
+    }
+
+    public SshMessage marshaller(SshMarshaller marshaller) {
+        this.marshaller = marshaller;
+        return this;
+    }
+
+    private static String nvl(String s) {
+        return s == null ? "" : s;
+    }
+}

--- a/endpoints/citrus-ssh/src/test/java/org/citrusframework/ssh/message/SshMessageTest.java
+++ b/endpoints/citrus-ssh/src/test/java/org/citrusframework/ssh/message/SshMessageTest.java
@@ -1,0 +1,250 @@
+package org.citrusframework.ssh.message;
+
+import org.citrusframework.message.DefaultMessage;
+import org.citrusframework.message.Message;
+import org.citrusframework.ssh.model.SshMarshaller;
+import org.citrusframework.ssh.model.SshRequest;
+import org.citrusframework.ssh.model.SshResponse;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+public class SshMessageTest {
+
+    @Test
+    public void shouldWrapExistingMessageUsingMessageConstructor() {
+        Message original = new DefaultMessage().setPayload(new SshRequest("echo", "wrapped"));
+
+        SshMessage message = new SshMessage(original);
+
+        SshRequest request = message.getPayload(SshRequest.class);
+        assertEquals(request.getCommand(), "echo");
+        assertEquals(request.getStdin(), "wrapped");
+    }
+
+    @Test
+    public void shouldCreateRequestAndMarshalToXmlStringPayload() {
+        SshMessage message = SshMessage.request("echo hello", "in");
+
+        String xml = message.getPayload(String.class);
+
+        assertNotNull(xml);
+        assertTrue(xml.contains("<ssh-request"));
+        assertTrue(xml.contains("echo hello"));
+        assertTrue(xml.contains("in"));
+
+        SshRequest request = message.getPayload(SshRequest.class);
+        assertEquals(request.getCommand(), "echo hello");
+        assertEquals(request.getStdin(), "in");
+    }
+
+    @Test
+    public void shouldCreateRequestWithoutStdinAndMarshalToXmlStringPayload() {
+        SshMessage message = SshMessage.request("echo hello");
+
+        String xml = message.getPayload(String.class);
+
+        assertNotNull(xml);
+        assertTrue(xml.contains("<ssh-request"));
+        assertTrue(xml.contains("echo hello"));
+        assertTrue(xml.contains("<stdin></stdin>"));
+
+        SshRequest request = message.getPayload(SshRequest.class);
+        assertEquals(request.getCommand(), "echo hello");
+        assertEquals(request.getStdin(), "");
+    }
+
+    @Test
+    public void shouldCreateResponseAndMarshalToXmlStringPayload() {
+        SshMessage message = SshMessage.response("out", "err", 0);
+
+        String xml = message.getPayload(String.class);
+
+        assertNotNull(xml);
+        assertTrue(xml.contains("<ssh-response"));
+        assertTrue(xml.contains("out"));
+        assertTrue(xml.contains("err"));
+        assertTrue(xml.contains("0"));
+
+        SshResponse response = message.getPayload(SshResponse.class);
+        assertEquals(response.getStdout(), "out");
+        assertEquals(response.getStderr(), "err");
+        assertEquals(response.getExit(), 0);
+    }
+
+    @Test
+    public void shouldSupportFluentRequestRebuildWithoutSetters() {
+        SshMessage message = SshMessage.request("ls", "a");
+
+        message.command("pwd").stdin("b");
+
+        SshRequest request = message.getPayload(SshRequest.class);
+        assertEquals(request.getCommand(), "pwd");
+        assertEquals(request.getStdin(), "b");
+
+        String xml = message.getPayload(String.class);
+        assertTrue(xml.contains("<ssh-request"));
+        assertTrue(xml.contains("pwd"));
+        assertTrue(xml.contains("b"));
+    }
+
+    @Test
+    public void shouldSupportFluentResponseRebuildWithoutSetters() {
+        SshMessage message = SshMessage.response("a", "b", 1);
+
+        message.stdout("x").stderr("y").exit(2);
+
+        SshResponse response = message.getPayload(SshResponse.class);
+        assertEquals(response.getStdout(), "x");
+        assertEquals(response.getStderr(), "y");
+        assertEquals(response.getExit(), 2);
+
+        String xml = message.getPayload(String.class);
+        assertTrue(xml.contains("<ssh-response"));
+        assertTrue(xml.contains("x"));
+        assertTrue(xml.contains("y"));
+        assertTrue(xml.contains("2"));
+    }
+
+    @Test
+    public void shouldUnmarshalRequestFromStringPayload() {
+        String xml = SshMessage.request("whoami", "in").getPayload(String.class);
+
+        SshMessage message = new SshMessage();
+        message.setPayload(xml);
+
+        SshRequest request = message.getPayload(SshRequest.class);
+        assertEquals(request.getCommand(), "whoami");
+        assertEquals(request.getStdin(), "in");
+    }
+
+    @Test
+    public void shouldUnmarshalResponseFromStringPayload() {
+        String xml = SshMessage.response("out", "err", 0).getPayload(String.class);
+
+        SshMessage message = new SshMessage();
+        message.setPayload(xml);
+
+        SshResponse request = message.getPayload(SshResponse.class);
+        assertEquals(request.getStdout(), "out");
+        assertEquals(request.getStderr(), "err");
+        assertEquals(request.getExit(), 0);
+    }
+
+    @Test
+    public void shouldUseDefaultObjectsWhenPayloadIsNeitherModelNorStringInRequest() {
+        SshMessage message = new SshMessage();
+        message.setPayload(42);
+
+        SshRequest req = message.getRequest();
+        assertEquals(req.getCommand(), "");
+        assertEquals(req.getStdin(), "");
+    }
+
+    @Test
+    public void shouldUseDefaultObjectsWhenPayloadIsModelNorStringInResponse() {
+        SshMessage message = new SshMessage();
+        message.setPayload(42);
+
+        SshResponse resp = message.getResponse();
+        assertEquals(resp.getStdout(), "");
+        assertEquals(resp.getStderr(), "");
+        assertEquals(resp.getExit(), 0);
+    }
+
+    @Test
+    public void shouldReturnFalseForIsRequestWhenPayloadIsNotSshRequest() {
+        SshMessage message = new SshMessage();
+        message.setPayload(new SshResponse("out", "err", 0));
+
+        assertFalse(message.isRequest());
+    }
+
+    @Test
+    public void shouldReturnFalseForIsResponseWhenPayloadIsNotSshResponse() {
+        SshMessage message = new SshMessage();
+        message.setPayload(new SshRequest("echo", "in"));
+
+        assertFalse(message.isResponse());
+    }
+
+    @Test
+    public void shouldDefaultNullValuesToEmptyStringsToAvoidMarshallingIssues() {
+        SshMessage request = SshMessage.request(null, null);
+        SshMessage response = SshMessage.response(null, null, 0);
+
+        String requestXml = request.getPayload(String.class);
+        String responseXml = response.getPayload(String.class);
+
+        assertNotNull(requestXml);
+        assertTrue(requestXml.contains("<ssh-request"));
+
+        SshRequest req = request.getPayload(SshRequest.class);
+        assertEquals(req.getCommand(), "");
+        assertEquals(req.getStdin(), "");
+
+        assertNotNull(responseXml);
+        assertTrue(responseXml.contains("<ssh-response"));
+
+        SshResponse resp = response.getPayload(SshResponse.class);
+        assertEquals(resp.getStdout(), "");
+        assertEquals(resp.getStderr(), "");
+        assertEquals(resp.getExit(), 0);
+    }
+
+    @Test
+    public void shouldFallbackToSuperGetPayloadWhenNotRequestOrResponse() {
+        SshMessage message = new SshMessage();
+        message.setPayload(42);
+
+        Object payload = message.getPayload();
+        assertEquals(payload, 42);
+    }
+
+    @Test
+    public void shouldFallbackToSuperTypedGetPayloadWhenNotRequestOrResponse() {
+        SshMessage message = new SshMessage();
+        message.setPayload(42);
+
+        Integer payload = message.getPayload(Integer.class);
+        assertEquals(payload, Integer.valueOf(42));
+    }
+
+    @Test
+    public void shouldReturnSshRequestWhenPayloadIsSshRequest() {
+        SshMessage message = new SshMessage();
+        message.setPayload(new SshRequest("echo", "Hello Citrus"));
+
+        SshRequest request = message.getPayload(SshRequest.class);
+        assertEquals(request.getCommand(), "echo");
+        assertEquals(request.getStdin(), "Hello Citrus");
+    }
+
+    @Test
+    public void shouldReturnSshResponseWhenPayloadIsSshResponse() {
+        SshMessage message = new SshMessage();
+        message.setPayload(new SshResponse("out", "err", 0));
+
+        SshResponse request = message.getPayload(SshResponse.class);
+        assertEquals(request.getStdout(), "out");
+        assertEquals(request.getStderr(), "err");
+        assertEquals(request.getExit(), 0);
+    }
+
+    @Test
+    public void shouldUseCustomMarshallerWhenProvided() {
+        SshMarshaller custom = Mockito.mock(SshMarshaller.class);
+
+        SshRequest expected = new SshRequest("custom-cmd", "custom-stdin");
+        Mockito.when(custom.unmarshal(Mockito.any())).thenReturn(expected);
+
+        SshMessage message = new SshMessage().marshaller(custom);
+        message.setPayload("<ssh-request><command>x</command><stdin>y</stdin></ssh-request>");
+
+        SshRequest actual = message.getPayload(SshRequest.class);
+
+        assertSame(actual, expected);
+        Mockito.verify(custom).unmarshal(Mockito.any());
+    }
+}


### PR DESCRIPTION
**Description**
Adds an `SshMessage` helper to the `citrus-ssh` module to simplify creation of SSH request and response messages without helper functions. The new message wraps `SshRequest` and `SshResponse` and marshals payloads to the existing SSH XML format, integrating it with the current message converter.

**Related issue**
Fixes #667