### PR TITLE
fix(#1452): Improve Camel integration running status verification

### DIFF
--- a/connectors/citrus-jbang-connector/src/main/java/org/citrusframework/jbang/CitrusJBang.java
+++ b/connectors/citrus-jbang-connector/src/main/java/org/citrusframework/jbang/CitrusJBang.java
@@ -212,6 +212,14 @@ public class CitrusJBang {
 
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(output.getBytes(StandardCharsets.UTF_8))))) {
             String line = reader.readLine();
+            //on some operating systems, the first line contains some timestamps and not property names, in this case, skip it
+            while (line != null && !line.trim().startsWith("PID")) {
+                line = reader.readLine();
+            }
+
+            if (line == null) {
+                return properties;
+            }
 
             List<String> names = new ArrayList<>(Arrays.asList(line.trim().split("\\s+")));
 


### PR DESCRIPTION
- Check for Camel integration process status by PID first
- Check for process status with Camel integration name as fallback
- Skip all Camel ps command output lines that are not Camel JBang process list headers