### PR TITLE
fix(#1452): Robust way of receiving PID from camel-jbang (using json)

### DIFF
--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelStopIntegrationAction.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelStopIntegrationAction.java
@@ -63,8 +63,8 @@ public class CamelStopIntegrationAction extends AbstractCamelJBangAction {
                 pid = context.getVariable(name + ":pid", Long.class);
             } else {
                 pid = camelJBang().getAll().stream()
-                        .filter(props -> name.equals(props.get("NAME")) && !props.getOrDefault("PID", "").isBlank())
-                        .map(props -> Long.valueOf(props.get("PID"))).findFirst()
+                        .filter(props -> name.equals(props.get("name")) && !props.getOrDefault("pid", "").isBlank())
+                        .map(props -> Long.valueOf(props.get("pid"))).findFirst()
                         .orElseThrow(() -> new CitrusRuntimeException(String.format("Missing process id for Camel integration %s:pid", name)));
             }
 

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelVerifyIntegrationAction.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelVerifyIntegrationAction.java
@@ -189,10 +189,10 @@ public class CamelVerifyIntegrationAction extends AbstractCamelJBangAction {
     }
 
     private boolean verifyStatus(Long pid, String name, String phase, Map<String, String> properties) {
-        if ((phase.equals("Stopped") && properties.isEmpty()) || (!properties.isEmpty() && properties.getOrDefault("status", "").equals(phase))) {
+        if ((phase.equalsIgnoreCase("Stopped") && properties.isEmpty()) || (!properties.isEmpty() && properties.getOrDefault("status", "").equals(phase))) {
             logger.info(String.format("Verified Camel integration '%s' (pid:%d) state '%s' - All values OK!", name, pid, phase));
             return true;
-        } else if (properties.getOrDefault("STATUS", "").equals("Error")) {
+        } else if (properties.getOrDefault("status", "").equals("Error")) {
             logger.info(String.format("Camel integration '%s' (pid:%d) is in state 'Error'", name, pid));
             if (stopOnErrorStatus) {
                 throw new CitrusRuntimeException(String.format("Failed to verify Camel integration '%s' (pid:%d) - is in state 'Error'", name, pid));


### PR DESCRIPTION
- Fallback to parsing pure plaintext Camel ps command output when no Json is returned
- Make sure to read proper integration details Json properties (lowercase keys)

Fixes #1452 
Closes #1455 