### PR TITLE
fix(#1471): Support json output in Camel cmd receive

### DIFF
--- a/core/citrus-api/src/main/java/org/citrusframework/actions/camel/CamelJBangCmdReceiveActionBuilder.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/actions/camel/CamelJBangCmdReceiveActionBuilder.java
@@ -47,6 +47,8 @@ public interface CamelJBangCmdReceiveActionBuilder<T extends TestAction, B exten
 
     B loggingColor(boolean enabled);
 
+    B jsonOutput(boolean enabled);
+
     B grep(String filter);
 
     B since(String duration);

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/Camel.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/Camel.java
@@ -383,6 +383,8 @@ public class Camel implements TestActionBuilder<TestAction>, ReferenceResolverAw
 
                 builder.loggingColor(jbang.getCmd().getReceive().isLoggingColor());
 
+                builder.jsonOutput(jbang.getCmd().getReceive().isJsonOutput());
+
                 if (jbang.getCmd().getReceive().getSince() != null) {
                     builder.since(jbang.getCmd().getReceive().getSince());
                 }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/JBang.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/JBang.java
@@ -1180,6 +1180,8 @@ public class JBang {
             protected String argLine;
             @XmlAttribute(name = "logging-color")
             protected boolean loggingColor;
+            @XmlAttribute(name = "json-output")
+            protected boolean jsonOutput;
             @XmlAttribute(name = "grep")
             protected String grep;
             @XmlAttribute(name = "since")
@@ -1230,6 +1232,14 @@ public class JBang {
 
             public boolean isLoggingColor() {
                 return loggingColor;
+            }
+
+            public void setJsonOutput(boolean jsonOutput) {
+                this.jsonOutput = jsonOutput;
+            }
+
+            public boolean isJsonOutput() {
+                return jsonOutput;
             }
 
             public void setGrep(String grep) {

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/JBang.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/JBang.java
@@ -761,6 +761,8 @@ public class JBang implements CamelActionBuilderWrapper<AbstractCamelJBangAction
 
             builder.loggingColor(receive.isLoggingColor());
 
+            builder.jsonOutput(receive.isJsonOutput());
+
             if (receive.getSince() != null) {
                 builder.since(receive.getSince());
             }
@@ -905,6 +907,7 @@ public class JBang implements CamelActionBuilderWrapper<AbstractCamelJBangAction
             protected String uri;
             protected List<String> args;
             protected boolean loggingColor;
+            protected boolean jsonOutput;
 
             protected String grep;
             protected String since;
@@ -962,6 +965,15 @@ public class JBang implements CamelActionBuilderWrapper<AbstractCamelJBangAction
             @SchemaProperty(advanced = true, description = "When enabled the output uses logging color.", defaultValue = "false")
             public void setLoggingColor(boolean loggingColor) {
                 this.loggingColor = loggingColor;
+            }
+
+            public boolean isJsonOutput() {
+                return loggingColor;
+            }
+
+            @SchemaProperty(advanced = true, description = "When enabled action stores messages from json output.", defaultValue = "false")
+            public void setJsonOutput(boolean loggingColor) {
+                this.jsonOutput = jsonOutput;
             }
 
             public String getGrep() {

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/actions/CamelCmdReceiveActionTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/actions/CamelCmdReceiveActionTest.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.actions;
+
+import java.util.Arrays;
+
+import org.citrusframework.camel.UnitTestSupport;
+import org.citrusframework.camel.jbang.CamelJBang;
+import org.citrusframework.exceptions.ActionTimeoutException;
+import org.citrusframework.jbang.ProcessAndOutput;
+import org.citrusframework.message.Message;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+public class CamelCmdReceiveActionTest extends UnitTestSupport {
+
+    @Mock
+    private CamelJBang camelJBang;
+
+    @Mock
+    private ProcessAndOutput pao;
+
+    @Mock
+    private Process process;
+
+    @BeforeTest
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        when(pao.getProcess()).thenReturn(process);
+    }
+
+    @Test
+    public void shouldReceiveMessage() throws Exception {
+        String output = """
+        Starting to receive messages from existing Camel: my-route (pid: 12345)
+        Waiting for messages ...
+        Received Message: (1)
+          Endpoint  jms://queue:foo
+          Message   (DefaultMessage)
+          Body      (String) (bytes: 5)
+          Hello
+        """;
+
+        String[] expectedArgs = new String[] {
+           "my-route",
+           "--endpoint",
+           "jms:queue:foo",
+           "--tail",
+           "0",
+           "--logging-color=false"
+        };
+        when(process.isAlive()).thenReturn(true);
+        when(process.exitValue()).thenReturn(0);
+
+        when(pao.getOutput()).thenReturn(output);
+        when(camelJBang.receive(any(String[].class))).thenAnswer(invocation -> {
+            String[] args = (String[]) invocation.getRawArguments()[0];
+            Assert.assertEquals(args, expectedArgs);
+            return pao;
+        });
+
+        context.getReferenceResolver().bind("camelJBang", camelJBang);
+
+        CamelCmdReceiveAction action = new CamelCmdReceiveAction.Builder()
+                .integration("my-route")
+                .endpoint("jms:queue:foo")
+                .withReferenceResolver(context.getReferenceResolver())
+                .build();
+
+        action.execute(context);
+    }
+
+    @Test
+    public void shouldReceiveMessageJsonOutput() throws Exception {
+        String output = """
+        Starting to receive messages from existing Camel: my-route (pid: 12345)
+        Waiting for messages ...
+        {
+          "messages": [
+            {
+              "message": {
+                "exchangeType": "org.apache.camel.support.DefaultExchange",
+                "messageType": "org.apache.camel.support.DefaultMessage",
+                "body": {
+                  "type": "java.lang.String",
+                  "value": "Hello"
+                }
+              },
+              "uid": 1,
+              "endpointUri": "jms:\\/\\/queue:foo",
+              "remoteEndpoint": false,
+              "timestamp": 0
+            }
+          ]
+        }
+
+        """;
+
+        String[] expectedArgs = new String[] {
+           "my-route",
+           "--endpoint",
+           "jms:queue:foo",
+           "--tail",
+           "0",
+           "--output=json",
+           "--compact=false",
+           "--pretty",
+           "--logging-color=false"
+        };
+        when(process.isAlive()).thenReturn(true);
+        when(process.exitValue()).thenReturn(0);
+
+        when(pao.getOutput()).thenReturn(output);
+        when(camelJBang.receive(any(String[].class))).thenAnswer(invocation -> {
+            String[] args = (String[]) invocation.getRawArguments()[0];
+            Assert.assertEquals(args, expectedArgs, Arrays.toString(args));
+            return pao;
+        });
+
+        context.getReferenceResolver().bind("camelJBang", camelJBang);
+
+        CamelCmdReceiveAction action = new CamelCmdReceiveAction.Builder()
+                .integration("my-route")
+                .endpoint("jms:queue:foo")
+                .jsonOutput(true)
+                .withReferenceResolver(context.getReferenceResolver())
+                .build();
+
+        action.execute(context);
+
+        Message storedMessage = context.getMessageStore().getMessage("my-route.message");
+        Assert.assertNotNull(storedMessage);
+        Assert.assertTrue(storedMessage.getPayload(String.class).contains("Hello"));
+        Assert.assertTrue(storedMessage.getPayload(String.class).startsWith("{"));
+
+        storedMessage = context.getMessageStore().getMessage("my-route.jms:queue:foo");
+        Assert.assertNotNull(storedMessage);
+        Assert.assertTrue(storedMessage.getPayload(String.class).contains("Hello"));
+        Assert.assertTrue(storedMessage.getPayload(String.class).startsWith("{"));
+    }
+
+    @Test
+    public void shouldStoreLastMessage() throws Exception {
+        String output = """
+        Starting to receive messages from existing Camel: my-route (pid: 12345)
+        Waiting for messages ...
+        {
+          "messages": [
+            {
+              "message": {
+                "exchangeType": "org.apache.camel.support.DefaultExchange",
+                "messageType": "org.apache.camel.support.DefaultMessage",
+                "body": {
+                  "type": "java.lang.String",
+                  "value": "1st message"
+                }
+              },
+              "uid": 1,
+              "endpointUri": "jms:\\/\\/queue:foo",
+              "remoteEndpoint": false,
+              "timestamp": 0
+            }
+          ]
+        }
+
+        {
+          "messages": [
+            {
+              "message": {
+                "exchangeType": "org.apache.camel.support.DefaultExchange",
+                "messageType": "org.apache.camel.support.DefaultMessage",
+                "body": {
+                  "type": "java.lang.String",
+                  "value": "Last message"
+                }
+              },
+              "uid": 1,
+              "endpointUri": "jms:\\/\\/queue:foo",
+              "remoteEndpoint": false,
+              "timestamp": 0
+            }
+          ]
+        }
+
+        """;
+
+        String[] expectedArgs = new String[] {
+           "my-route",
+           "--endpoint",
+           "jms:queue:foo",
+           "--tail",
+           "0",
+           "--output=json",
+           "--compact=false",
+           "--pretty",
+           "--logging-color=false"
+        };
+        when(process.isAlive()).thenReturn(true);
+        when(process.exitValue()).thenReturn(0);
+
+        when(pao.getOutput()).thenReturn(output);
+        when(camelJBang.receive(any(String[].class))).thenAnswer(invocation -> {
+            String[] args = (String[]) invocation.getRawArguments()[0];
+            Assert.assertEquals(args, expectedArgs, Arrays.toString(args));
+            return pao;
+        });
+
+        context.getReferenceResolver().bind("camelJBang", camelJBang);
+
+        CamelCmdReceiveAction action = new CamelCmdReceiveAction.Builder()
+                .integration("my-route")
+                .endpoint("jms:queue:foo")
+                .jsonOutput(true)
+                .withReferenceResolver(context.getReferenceResolver())
+                .build();
+
+        action.execute(context);
+
+        Message storedMessage = context.getMessageStore().getMessage("my-route.message");
+        Assert.assertNotNull(storedMessage);
+        Assert.assertTrue(storedMessage.getPayload(String.class).contains("Last message"));
+        Assert.assertTrue(storedMessage.getPayload(String.class).startsWith("{"));
+    }
+
+    @Test(expectedExceptions = ActionTimeoutException.class)
+    public void shouldTimeoutWhenNoMessage() throws Exception {
+        String output = """
+        Starting to receive messages from existing Camel: my-route (pid: 12345)
+        Waiting for messages ...
+        """;
+
+        when(process.isAlive()).thenReturn(true);
+        when(process.exitValue()).thenReturn(0);
+
+        when(pao.getOutput()).thenReturn(output);
+        when(camelJBang.receive(any(String[].class))).thenReturn(pao);
+
+        context.getReferenceResolver().bind("camelJBang", camelJBang);
+
+        CamelCmdReceiveAction action = new CamelCmdReceiveAction.Builder()
+                .integration("my-route")
+                .endpoint("jms:queue:foo")
+                .maxAttempts(3)
+                .delayBetweenAttempts(1000L)
+                .withReferenceResolver(context.getReferenceResolver())
+                .build();
+
+        action.execute(context);
+    }
+
+    @Test(expectedExceptions = ActionTimeoutException.class)
+    public void shouldTimeoutWhenNoMessageJsonOutput() throws Exception {
+        String output = """
+        Starting to receive messages from existing Camel: my-route (pid: 12345)
+        Waiting for messages ...
+        """;
+
+        when(process.isAlive()).thenReturn(true);
+        when(process.exitValue()).thenReturn(0);
+
+        when(pao.getOutput()).thenReturn(output);
+        when(camelJBang.receive(any(String[].class))).thenReturn(pao);
+
+        context.getReferenceResolver().bind("camelJBang", camelJBang);
+
+        CamelCmdReceiveAction action = new CamelCmdReceiveAction.Builder()
+                .integration("my-route")
+                .endpoint("jms:queue:foo")
+                .maxAttempts(3)
+                .delayBetweenAttempts(1000L)
+                .jsonOutput(true)
+                .withReferenceResolver(context.getReferenceResolver())
+                .build();
+
+        action.execute(context);
+    }
+
+}


### PR DESCRIPTION
- Add option to use Json command output to verify message content
- Store received Json message into message store for later reference