### PR TITLE
fix(#1489): Auto resolve additional dependencies in Citrus JBang

### DIFF
--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/xml/CreateCustomResource.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/xml/CreateCustomResource.java
@@ -23,6 +23,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 import org.citrusframework.TestActor;
 import org.citrusframework.kubernetes.actions.AbstractKubernetesAction;
 import org.citrusframework.kubernetes.actions.CreateCustomResourceAction;
+import org.citrusframework.util.ClassLoaderHelper;
 
 @XmlRootElement(name = "create-custom-resource")
 public class CreateCustomResource extends AbstractKubernetesAction.Builder<CreateCustomResourceAction, CreateCustomResource> {
@@ -37,7 +38,7 @@ public class CreateCustomResource extends AbstractKubernetesAction.Builder<Creat
     @XmlAttribute
     public void setType(String resourceType) {
         try {
-            delegate.resourceType(Class.forName(resourceType));
+            delegate.resourceType(Class.forName(resourceType, true, ClassLoaderHelper.getClassLoader(CreateCustomResource.class)));
         } catch(ClassNotFoundException | ClassCastException e) {
             delegate.type(resourceType);
         }

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/xml/DeleteCustomResource.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/xml/DeleteCustomResource.java
@@ -22,6 +22,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 import org.citrusframework.TestActor;
 import org.citrusframework.kubernetes.actions.AbstractKubernetesAction;
 import org.citrusframework.kubernetes.actions.DeleteCustomResourceAction;
+import org.citrusframework.util.ClassLoaderHelper;
 
 @XmlRootElement(name = "delete-custom-resource")
 public class DeleteCustomResource extends AbstractKubernetesAction.Builder<DeleteCustomResourceAction, DeleteCustomResource> {
@@ -36,7 +37,7 @@ public class DeleteCustomResource extends AbstractKubernetesAction.Builder<Delet
     @XmlAttribute
     public void setType(String resourceType) {
         try {
-            delegate.resourceType(Class.forName(resourceType));
+            delegate.resourceType(Class.forName(resourceType, true, ClassLoaderHelper.getClassLoader(DeleteCustomResource.class)));
         } catch(ClassNotFoundException | ClassCastException e) {
             delegate.type(resourceType);
         }

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/xml/VerifyCustomResource.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/xml/VerifyCustomResource.java
@@ -22,6 +22,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 import org.citrusframework.TestActor;
 import org.citrusframework.kubernetes.actions.AbstractKubernetesAction;
 import org.citrusframework.kubernetes.actions.VerifyCustomResourceAction;
+import org.citrusframework.util.ClassLoaderHelper;
 
 @XmlRootElement(name = "verify-custom-resource")
 public class VerifyCustomResource extends AbstractKubernetesAction.Builder<VerifyCustomResourceAction, VerifyCustomResource> {
@@ -36,7 +37,7 @@ public class VerifyCustomResource extends AbstractKubernetesAction.Builder<Verif
     @XmlAttribute
     public void setType(String resourceType) {
         try {
-            delegate.resourceType(Class.forName(resourceType));
+            delegate.resourceType(Class.forName(resourceType, true, ClassLoaderHelper.getClassLoader(VerifyCustomResource.class)));
         } catch(ClassNotFoundException | ClassCastException e) {
             delegate.type(resourceType);
         }

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/yaml/CreateCustomResource.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/yaml/CreateCustomResource.java
@@ -20,6 +20,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import org.citrusframework.TestActor;
 import org.citrusframework.kubernetes.actions.AbstractKubernetesAction;
 import org.citrusframework.kubernetes.actions.CreateCustomResourceAction;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.citrusframework.yaml.SchemaProperty;
 
 public class CreateCustomResource extends AbstractKubernetesAction.Builder<CreateCustomResourceAction, CreateCustomResource> {
@@ -34,7 +35,7 @@ public class CreateCustomResource extends AbstractKubernetesAction.Builder<Creat
     @SchemaProperty
     public void setType(String resourceType) {
         try {
-            delegate.resourceType(Class.forName(resourceType));
+            delegate.resourceType(Class.forName(resourceType, true, ClassLoaderHelper.getClassLoader(CreateCustomResource.class)));
         } catch(ClassNotFoundException | ClassCastException e) {
             delegate.type(resourceType);
         }

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/yaml/DeleteCustomResource.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/yaml/DeleteCustomResource.java
@@ -20,6 +20,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import org.citrusframework.TestActor;
 import org.citrusframework.kubernetes.actions.AbstractKubernetesAction;
 import org.citrusframework.kubernetes.actions.DeleteCustomResourceAction;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.citrusframework.yaml.SchemaProperty;
 
 public class DeleteCustomResource extends AbstractKubernetesAction.Builder<DeleteCustomResourceAction, DeleteCustomResource> {
@@ -34,7 +35,7 @@ public class DeleteCustomResource extends AbstractKubernetesAction.Builder<Delet
     @SchemaProperty
     public void setType(String resourceType) {
         try {
-            delegate.resourceType(Class.forName(resourceType));
+            delegate.resourceType(Class.forName(resourceType, true, ClassLoaderHelper.getClassLoader(DeleteCustomResource.class)));
         } catch(ClassNotFoundException | ClassCastException e) {
             delegate.type(resourceType);
         }

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/yaml/VerifyCustomResource.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/yaml/VerifyCustomResource.java
@@ -20,6 +20,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import org.citrusframework.TestActor;
 import org.citrusframework.kubernetes.actions.AbstractKubernetesAction;
 import org.citrusframework.kubernetes.actions.VerifyCustomResourceAction;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.citrusframework.yaml.SchemaProperty;
 
 public class VerifyCustomResource extends AbstractKubernetesAction.Builder<VerifyCustomResourceAction, VerifyCustomResource> {
@@ -34,7 +35,7 @@ public class VerifyCustomResource extends AbstractKubernetesAction.Builder<Verif
     @SchemaProperty
     public void setType(String resourceType) {
         try {
-            delegate.resourceType(Class.forName(resourceType));
+            delegate.resourceType(Class.forName(resourceType, true, ClassLoaderHelper.getClassLoader(VerifyCustomResource.class)));
         } catch(ClassNotFoundException | ClassCastException e) {
             delegate.type(resourceType);
         }

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/actions/PageAction.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/actions/PageAction.java
@@ -26,6 +26,7 @@ import org.citrusframework.actions.selenium.WebPage;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.selenium.endpoint.SeleniumBrowser;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.citrusframework.util.ReflectionHelper;
 import org.citrusframework.util.StringUtils;
 import org.openqa.selenium.support.PageFactory;
@@ -71,8 +72,8 @@ public class PageAction extends AbstractSeleniumAction {
 
         if (StringUtils.hasText(type)) {
             try {
-                pageToUse = (WebPage) Class.forName(context.replaceDynamicContentInString(type)).newInstance();
-            } catch (ClassNotFoundException | IllegalAccessException | InstantiationException e) {
+                pageToUse = (WebPage) ClassLoaderHelper.instantiateType(context.replaceDynamicContentInString(type), PageAction.class);
+            } catch (CitrusRuntimeException e) {
                 throw new CitrusRuntimeException(String.format("Failed to access page type '%s'", context.replaceDynamicContentInString(type)), e);
             }
         } else {

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/quarkus/TestcontainersResource.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/quarkus/TestcontainersResource.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import org.citrusframework.annotations.CitrusResource;
 import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.testcontainers.containers.GenericContainer;
 
 public class TestcontainersResource<T extends GenericContainer<?>> implements QuarkusTestResourceLifecycleManager {
@@ -44,7 +45,7 @@ public class TestcontainersResource<T extends GenericContainer<?>> implements Qu
         String[] qualifiedClassNames = initArgs.getOrDefault(ContainerLifecycleListener.INIT_ARG, "").split(",");
         for (String qualifiedClassName : qualifiedClassNames) {
             try {
-                Class<?> cls = Class.forName(qualifiedClassName, true, Thread.currentThread().getContextClassLoader());
+                Class<?> cls = Class.forName(qualifiedClassName, true, ClassLoaderHelper.getContextClassLoader());
                 Object instance = cls.getDeclaredConstructor().newInstance();
                 if (instance instanceof ContainerLifecycleListener<?> containerLifecycleListener) {
                     registerContainerLifecycleListener((ContainerLifecycleListener<T>) containerLifecycleListener);

--- a/core/citrus-api/src/main/java/org/citrusframework/CitrusSettings.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/CitrusSettings.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import org.citrusframework.common.TestLoader;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.citrusframework.validation.CustomValidatorStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,9 +58,10 @@ public final class CitrusSettings {
      */
     private static final String APPLICATION_PROPERTY_FILE_PROPERTY = "citrus.application.properties";
     private static final String APPLICATION_PROPERTY_FILE_ENV = "CITRUS_APPLICATION_PROPERTIES";
-    private static final String APPLICATION_PROPERTY_FILE = getProperty(
+    private static final String APPLICATION_PROPERTY_FILE = getPropertyEnvOrDefault(
             APPLICATION_PROPERTY_FILE_PROPERTY,
-            getenv(APPLICATION_PROPERTY_FILE_ENV) != null ? getenv(APPLICATION_PROPERTY_FILE_ENV) : "citrus-application.properties");
+            APPLICATION_PROPERTY_FILE_ENV,
+            "citrus-application.properties");
 
     public static final String OUTBOUND_SCHEMA_VALIDATION_ENABLED_PROPERTY = "citrus.validation.outbound.schema.enabled";
     public static final String OUTBOUND_SCHEMA_VALIDATION_ENABLED_ENV = "CITRUS_VALIDATION_OUTBOUND_SCHEMA_ENABLED";
@@ -77,7 +79,7 @@ public final class CitrusSettings {
             applicationPropertiesFile = applicationPropertiesFile.substring("classpath:".length());
         }
 
-        try (final InputStream in = CitrusSettings.class.getClassLoader().getResourceAsStream(applicationPropertiesFile)) {
+        try (final InputStream in = ClassLoaderHelper.getClassLoader(CitrusSettings.class).getResourceAsStream(applicationPropertiesFile)) {
             Properties applicationProperties = new Properties();
             applicationProperties.load(in);
 
@@ -97,7 +99,7 @@ public final class CitrusSettings {
             }
         }
 
-        try (InputStream is = CitrusSettings.class.getClassLoader().getResourceAsStream("logging.properties")) {
+        try (InputStream is = ClassLoaderHelper.getClassLoader(CitrusSettings.class).getResourceAsStream("logging.properties")) {
             if (is != null) {
                 getLogManager().readConfiguration(is);
             }

--- a/core/citrus-api/src/main/java/org/citrusframework/CitrusVersion.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/CitrusVersion.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
+import org.citrusframework.util.ClassLoaderHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,7 +34,7 @@ public final class CitrusVersion {
 
     /* Load Citrus version */
     static {
-        try (final InputStream in = CitrusVersion.class.getClassLoader().getResourceAsStream("META-INF/citrus.version")) {
+        try (final InputStream in = ClassLoaderHelper.getClassLoader(CitrusVersion.class).getResourceAsStream("META-INF/citrus.version")) {
             Properties versionProperties = new Properties();
             versionProperties.load(in);
             version = versionProperties.get("citrus.version").toString();

--- a/core/citrus-api/src/main/java/org/citrusframework/TestClass.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/TestClass.java
@@ -17,6 +17,7 @@
 package org.citrusframework;
 
 import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.util.ClassLoaderHelper;
 
 /**
  * @since 2.7
@@ -71,10 +72,10 @@ public class TestClass extends TestSource {
             }
 
             if (methodName != null && !methodName.isBlank()) {
-                return new TestClass(Class.forName(className), methodName);
+                return new TestClass(Class.forName(className, false, ClassLoaderHelper.getClassLoader(TestClass.class)), methodName);
             }
 
-            return new TestClass(Class.forName(className));
+            return new TestClass(Class.forName(className, false, ClassLoaderHelper.getClassLoader(TestClass.class)));
         } catch (ClassNotFoundException e) {
             throw new CitrusRuntimeException("Failed to create test class", e);
         }
@@ -89,7 +90,7 @@ public class TestClass extends TestSource {
                 className = testClass;
             }
 
-            Class.forName(className);
+            Class.forName(className, false, ClassLoaderHelper.getClassLoader(TestClass.class));
             return true;
         } catch (ClassNotFoundException e) {
             return false;

--- a/core/citrus-api/src/main/java/org/citrusframework/spi/ClasspathResourceResolver.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/spi/ClasspathResourceResolver.java
@@ -37,6 +37,7 @@ import java.util.jar.JarInputStream;
 import java.util.stream.Collectors;
 
 import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -276,7 +277,7 @@ public class ClasspathResourceResolver {
     private Set<ClassLoader> getClassLoaders() {
         Set<ClassLoader> classLoaders = new LinkedHashSet<>();
         try {
-            ClassLoader ccl = Thread.currentThread().getContextClassLoader();
+            ClassLoader ccl = ClassLoaderHelper.getContextClassLoader();
             if (ccl != null) {
                 classLoaders.add(ccl);
             }
@@ -286,7 +287,7 @@ public class ClasspathResourceResolver {
                 e.getMessage());
         }
 
-        classLoaders.add(ClasspathResourceResolver.class.getClassLoader());
+        classLoaders.add(ClassLoaderHelper.getClassLoader(ClasspathResourceResolver.class));
         return classLoaders;
     }
 }

--- a/core/citrus-api/src/main/java/org/citrusframework/spi/PropertiesLoader.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/spi/PropertiesLoader.java
@@ -16,13 +16,14 @@
 
 package org.citrusframework.spi;
 
-import org.citrusframework.exceptions.CitrusRuntimeException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
+
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.util.ClassLoaderHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class PropertiesLoader {
 
@@ -45,7 +46,8 @@ public final class PropertiesLoader {
 
     public static Properties loadProperties(String path) {
         Properties properties = new Properties();
-        try (InputStream in = ResourcePathTypeResolver.class.getClassLoader().getResourceAsStream(path)) {
+        ClassLoader classLoader = ClassLoaderHelper.getClassLoader(ResourcePathTypeResolver.class);
+        try (InputStream in = classLoader.getResourceAsStream(path)) {
             if (in == null) {
                 throw new CitrusRuntimeException(String.format("Failed to locate resource path '%s'!", path));
             }

--- a/core/citrus-api/src/main/java/org/citrusframework/spi/ResourcePathTypeResolver.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/spi/ResourcePathTypeResolver.java
@@ -18,22 +18,17 @@ package org.citrusframework.spi;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Modifier;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.FileSystem;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
@@ -41,11 +36,10 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 import jakarta.annotation.Nullable;
-import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static java.lang.String.format;
 import static java.nio.file.FileSystems.newFileSystem;
 import static java.util.Collections.singletonMap;
 import static java.util.Collections.synchronizedList;
@@ -85,11 +79,6 @@ public class ResourcePathTypeResolver implements TypeResolver {
      * Logger
      */
     private static final Logger logger = LoggerFactory.getLogger(ResourcePathTypeResolver.class);
-
-    /**
-     * Supported static instance field in target - used as a fallback to the default constructor
-     */
-    private static final String INSTANCE = "INSTANCE";
 
     /**
      * Base path for resources
@@ -164,7 +153,7 @@ public class ResourcePathTypeResolver implements TypeResolver {
             key -> singletonMap(key, resolveProperty(resourcePath, property))
         );
 
-        return (T) instantiateType(map.get(cacheKey), initargs);
+        return (T) ClassLoaderHelper.instantiateType(map.get(cacheKey), initargs);
     }
 
     @Override
@@ -175,7 +164,7 @@ public class ResourcePathTypeResolver implements TypeResolver {
         );
 
         Map<String, T> resources = new HashMap<>();
-        typeLookup.forEach((p, type) -> resources.put(p, (T) instantiateType(type)));
+        typeLookup.forEach((p, type) -> resources.put(p, (T) ClassLoaderHelper.instantiateType(type)));
 
         return resources;
     }
@@ -231,7 +220,7 @@ public class ResourcePathTypeResolver implements TypeResolver {
     }
 
     private Stream<Path> resolveAllFromJar(String path) {
-        ClassLoader classLoader = assertNotNull(ResourcePathTypeResolver.class.getClassLoader());
+        ClassLoader classLoader = assertNotNull(ClassLoaderHelper.getContextClassLoader());
 
         if (rootIsNotCitrusApiJar() && nonNull(rootFs)) {
             return getZipEntries().stream()
@@ -279,50 +268,6 @@ public class ResourcePathTypeResolver implements TypeResolver {
     }
 
     /**
-     * Gets the constructor best matching the given parameter types.
-     */
-    private Constructor<?> getConstructor(Class<?> type, Object[] initargs) {
-        final Class<?>[] parameterTypes = getParameterTypes(initargs);
-
-        Optional<Constructor<?>> exactMatch = Arrays.stream(type.getDeclaredConstructors())
-            .filter(
-                constructor -> Arrays.equals(replacePrimitiveTypes(constructor), parameterTypes))
-            .findFirst();
-
-        if (exactMatch.isPresent()) {
-            return exactMatch.get();
-        }
-
-        Optional<Constructor<?>> match = Arrays.stream(type.getDeclaredConstructors())
-            .filter(constructor -> {
-                if (constructor.getParameterCount() != parameterTypes.length) {
-                    return false;
-                }
-
-                for (int i = 0; i < parameterTypes.length; i++) {
-                    if (!constructor.getParameterTypes()[i].isAssignableFrom(parameterTypes[i])) {
-                        return false;
-                    }
-                }
-
-                return true;
-            })
-            .findFirst();
-
-        if (match.isPresent()) {
-            return match.get();
-        }
-
-        throw new IllegalArgumentException(
-            format(
-                "No matching constructor found for type %s and parameters %s",
-                type.getName(),
-                Arrays.toString(parameterTypes)
-            )
-        );
-    }
-
-    /**
      * Read resource from classpath and load content as properties. The properties found on the
      * classpath will be cached.
      */
@@ -344,77 +289,5 @@ public class ResourcePathTypeResolver implements TypeResolver {
         } else {
             return resourcePath;
         }
-    }
-
-    /**
-     * Get types of init arguments.
-     */
-    private Class<?>[] getParameterTypes(Object... initargs) {
-        return Arrays.stream(initargs)
-            .map(Object::getClass)
-            .toArray(Class[]::new);
-    }
-
-    /**
-     * Instantiate a type by its name.
-     */
-    public <T> T instantiateType(String type, Object... initargs) {
-        try {
-            if (initargs.length == 0) {
-                return (T) Class.forName(type).getDeclaredConstructor().newInstance();
-            } else {
-                return (T) getConstructor(Class.forName(type), initargs).newInstance(initargs);
-            }
-        } catch (ClassNotFoundException | IllegalAccessException | InstantiationException |
-                 NoSuchMethodException | InvocationTargetException e) {
-            try {
-                if (
-                    Arrays.stream(Class.forName(type).getFields())
-                        .anyMatch(field -> field.getName().equals(INSTANCE)
-                            && Modifier.isStatic(field.getModifiers()))
-                ) {
-                    return (T) Class.forName(type).getField(INSTANCE).get(null);
-                }
-            } catch (IllegalAccessException | NoSuchFieldException | ClassNotFoundException e1) {
-                throw new CitrusRuntimeException(
-                    format("Failed to resolve classpath resource of type '%s' - caused by: %s",
-                            type, Optional.ofNullable(e1.getMessage()).orElse(e1.getClass().getName())), e1);
-            }
-
-            logger.warn(
-                "Neither static instance nor accessible default constructor ({}) is given on type '{}'",
-                Arrays.toString(getParameterTypes(initargs)),
-                type
-            );
-
-            throw new CitrusRuntimeException(
-                format("Failed to resolve classpath resource of type '%s' - caused by: %s",
-                        type, Optional.ofNullable(e.getMessage()).orElse(e.getClass().getName())), e);
-        }
-    }
-
-    /**
-     * Get the types of a constructor. Primitive types are converted to their respective object
-     * type.
-     */
-    private static Class<?>[] replacePrimitiveTypes(Constructor<?> constructor) {
-        Class<?>[] constructorParameters = constructor.getParameterTypes();
-        for (int i = 0; i < constructorParameters.length; i++) {
-            if (constructorParameters[i] == int.class) {
-                constructorParameters[i] = Integer.class;
-            } else if (constructorParameters[i] == short.class) {
-                constructorParameters[i] = Short.class;
-            } else if (constructorParameters[i] == double.class) {
-                constructorParameters[i] = Double.class;
-            } else if (constructorParameters[i] == float.class) {
-                constructorParameters[i] = Float.class;
-            } else if (constructorParameters[i] == char.class) {
-                constructorParameters[i] = Character.class;
-            } else if (constructorParameters[i] == boolean.class) {
-                constructorParameters[i] = Boolean.class;
-            }
-        }
-
-        return constructorParameters;
     }
 }

--- a/core/citrus-api/src/main/java/org/citrusframework/spi/Resources.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/spi/Resources.java
@@ -31,6 +31,7 @@ import java.net.URLConnection;
 
 import org.citrusframework.CitrusSettings;
 import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.citrusframework.util.ReflectionHelper;
 
 import static java.lang.String.format;
@@ -160,7 +161,7 @@ public class Resources {
 
         @Override
         public InputStream getInputStream() {
-            return ReflectionHelper.class.getClassLoader()
+            return ClassLoaderHelper.getClassLoader(ReflectionHelper.class)
                 .getResourceAsStream(location);
         }
 
@@ -183,7 +184,7 @@ public class Resources {
 
         @Override
         public URI getURI() {
-            URL url = ReflectionHelper.class.getClassLoader().getResource(location);
+            URL url = ClassLoaderHelper.getClassLoader(ReflectionHelper.class).getResource(location);
             try {
                 return url != null ? url.toURI() : null;
             } catch (URISyntaxException e) {

--- a/core/citrus-api/src/main/java/org/citrusframework/util/ClassLoaderHelper.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/util/ClassLoaderHelper.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.util;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.lang.String.format;
+
+/**
+ * Class loader helper class that is aware of dynamically loaded Maven artifacts.
+ * Helper is able to adapt class loaders with the additional dependencies in the form of artifact URLs.
+ * The helper also provides class instantiation utilities that make sure to also honor the additional artifacts in classpath.
+ */
+public final class ClassLoaderHelper {
+
+    /**
+     * Logger
+     */
+    private static final Logger logger = LoggerFactory.getLogger(ClassLoaderHelper.class);
+
+    /**
+     * Supported static instance field in target - used as a fallback to the default constructor
+     */
+    private static final String INSTANCE = "INSTANCE";
+
+    private static final Map<String, URL> additionalArtifacts = new ConcurrentHashMap<>();
+
+    /**
+     * Reference to the plain original context class loader. Used to restore class loader to its initial state.
+     */
+    private static ClassLoader ccl;
+
+    private ClassLoaderHelper() {
+        // prevent instantiation of utility class
+    }
+
+    /**
+     * Instantiate a type by its name. Uses the current thread context class loader to instantiate.
+     */
+    public static <T> T instantiateType(String type, Object... initargs) {
+        return instantiateType(type, getContextClassLoader(), initargs);
+    }
+
+    /**
+     * Instantiate a type by its name. Use the given caller to resolve the class loader.
+     */
+    public static <T> T instantiateType(String type, Class<?> caller, Object... initargs) {
+        return instantiateType(type, getClassLoader(caller), initargs);
+    }
+
+    /**
+     * Instantiate a type by its name. Uses given class loader to instantiate.
+     */
+    public static <T> T instantiateType(String type, ClassLoader cl, Object... initargs) {
+        try {
+            if (initargs.length == 0) {
+                return (T) Class.forName(type, true, cl).getDeclaredConstructor().newInstance();
+            } else {
+                return (T) getConstructor(Class.forName(type, true, cl), initargs).newInstance(initargs);
+            }
+        } catch (ClassNotFoundException | IllegalAccessException | InstantiationException |
+                 NoSuchMethodException | InvocationTargetException e) {
+            try {
+                if (
+                    Arrays.stream(Class.forName(type, true, cl).getFields())
+                            .anyMatch(field -> field.getName().equals(INSTANCE)
+                                    && Modifier.isStatic(field.getModifiers()))
+                ) {
+                    return (T) Class.forName(type, true, cl).getField(INSTANCE).get(null);
+                }
+            } catch (IllegalAccessException | NoSuchFieldException | ClassNotFoundException e1) {
+                throw new CitrusRuntimeException(
+                        format("Failed to resolve classpath resource of type '%s' - caused by: %s",
+                                type, Optional.ofNullable(e1.getMessage()).orElse(e1.getClass().getName())), e1);
+            }
+
+            logger.warn(
+                    "Neither static instance nor accessible default constructor ({}) is given on type '{}'",
+                    Arrays.toString(getParameterTypes(initargs)),
+                    type
+            );
+
+            throw new CitrusRuntimeException(
+                    format("Failed to resolve classpath resource of type '%s' - caused by: %s",
+                            type, Optional.ofNullable(e.getMessage()).orElse(e.getClass().getName())), e);
+        }
+    }
+
+    /**
+     * Adapt given class loader to also use additional artifacts if any.
+     * Wraps given class loader if additional artifacts are present.
+     */
+    public static ClassLoader adapt(ClassLoader cl) {
+        if (cl == null) {
+            return null;
+        }
+
+        if (additionalArtifacts.isEmpty() || cl instanceof OpenURLClassLoader) {
+            return cl;
+        }
+
+        OpenURLClassLoader openURLClassLoader = new OpenURLClassLoader(cl);
+        additionalArtifacts.values().forEach(openURLClassLoader::addURL);
+        return openURLClassLoader;
+    }
+
+    public static synchronized ClassLoader getContextClassLoader() {
+        if (additionalArtifacts.isEmpty()) {
+            return Thread.currentThread().getContextClassLoader();
+        }
+
+        if (ccl == null) {
+            // save original context class loader for later restore option
+            ccl = Thread.currentThread().getContextClassLoader();
+        }
+
+        return adapt(Thread.currentThread().getContextClassLoader());
+    }
+
+    public static ClassLoader getClassLoader() {
+        return adapt(ClassLoaderHelper.class.getClassLoader());
+    }
+
+    public static ClassLoader getClassLoader(Class<?> type) {
+        return adapt(type.getClassLoader());
+    }
+
+    /**
+     * Gets the constructor best matching the given parameter types.
+     */
+    private static Constructor<?> getConstructor(Class<?> type, Object[] initargs) {
+        final Class<?>[] parameterTypes = getParameterTypes(initargs);
+
+        Optional<Constructor<?>> exactMatch = Arrays.stream(type.getDeclaredConstructors())
+                .filter(
+                        constructor -> Arrays.equals(replacePrimitiveTypes(constructor), parameterTypes))
+                .findFirst();
+
+        if (exactMatch.isPresent()) {
+            return exactMatch.get();
+        }
+
+        Optional<Constructor<?>> match = Arrays.stream(type.getDeclaredConstructors())
+                .filter(constructor -> {
+                    if (constructor.getParameterCount() != parameterTypes.length) {
+                        return false;
+                    }
+
+                    for (int i = 0; i < parameterTypes.length; i++) {
+                        if (!constructor.getParameterTypes()[i].isAssignableFrom(parameterTypes[i])) {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                })
+                .findFirst();
+
+        if (match.isPresent()) {
+            return match.get();
+        }
+
+        throw new IllegalArgumentException(
+                format(
+                        "No matching constructor found for type %s and parameters %s",
+                        type.getName(),
+                        Arrays.toString(parameterTypes)
+                )
+        );
+    }
+
+    /**
+     * Get types of init arguments.
+     */
+    private static Class<?>[] getParameterTypes(Object... initargs) {
+        return Arrays.stream(initargs)
+                .map(Object::getClass)
+                .toArray(Class[]::new);
+    }
+
+    /**
+     * Get the types of a constructor. Primitive types are converted to their respective object
+     * type.
+     */
+    private static Class<?>[] replacePrimitiveTypes(Constructor<?> constructor) {
+        Class<?>[] constructorParameters = constructor.getParameterTypes();
+        for (int i = 0; i < constructorParameters.length; i++) {
+            if (constructorParameters[i] == int.class) {
+                constructorParameters[i] = Integer.class;
+            } else if (constructorParameters[i] == short.class) {
+                constructorParameters[i] = Short.class;
+            } else if (constructorParameters[i] == double.class) {
+                constructorParameters[i] = Double.class;
+            } else if (constructorParameters[i] == float.class) {
+                constructorParameters[i] = Float.class;
+            } else if (constructorParameters[i] == char.class) {
+                constructorParameters[i] = Character.class;
+            } else if (constructorParameters[i] == boolean.class) {
+                constructorParameters[i] = Boolean.class;
+            }
+        }
+
+        return constructorParameters;
+    }
+
+    /**
+     * Adds a dynamic class loader entry in the form of a URL.
+     * When this helper resolves class loaders the dynamic entry will be part of the class loader.
+     */
+    public static synchronized void addArtifact(String gav, URL url) {
+        if (ccl != null) {
+            throw new IllegalStateException("Not allowed to add additional artifacts, " +
+                    "because the context class loader has been adapted already!");
+        }
+
+        additionalArtifacts.putIfAbsent(gav, url);
+    }
+
+    /**
+     * Clears additional artifacts and restores context class loader to its initial state before adapting.
+     */
+    public static synchronized void restore() {
+        if (!additionalArtifacts.isEmpty()) {
+            additionalArtifacts.clear();
+            try {
+                if (ccl != null) {
+                    Thread.currentThread().setContextClassLoader(ccl);
+                    ccl = null;
+                }
+            } catch (Throwable e) {
+                logger.warn("Failed to restore context class loader", e);
+            }
+        }
+    }
+
+    /**
+     * Special URL class loader allows to add new file URLs.
+     */
+    public static class OpenURLClassLoader extends URLClassLoader {
+
+        OpenURLClassLoader() {
+            super(new URL[0]);
+        }
+
+        OpenURLClassLoader(ClassLoader parent) {
+            super(new URL[0], parent);
+        }
+
+        @Override
+        protected void addURL(URL url) {
+            super.addURL(url);
+        }
+    }
+}

--- a/core/citrus-base/src/main/java/org/citrusframework/CitrusContext.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/CitrusContext.java
@@ -46,6 +46,7 @@ import org.citrusframework.spi.ReferenceRegistry;
 import org.citrusframework.spi.ReferenceResolver;
 import org.citrusframework.spi.ReferenceResolverAware;
 import org.citrusframework.spi.SimpleReferenceResolver;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.citrusframework.util.PropertyUtils;
 import org.citrusframework.util.StringUtils;
 import org.citrusframework.util.TypeConverter;
@@ -130,7 +131,7 @@ public class CitrusContext implements TestListenerAware, TestActionListenerAware
 
         if (StringUtils.hasText(CitrusSettings.DEFAULT_CONFIG_CLASS)) {
             try {
-                Class<?> configClass = Class.forName(CitrusSettings.DEFAULT_CONFIG_CLASS);
+                Class<?> configClass = Class.forName(CitrusSettings.DEFAULT_CONFIG_CLASS, true, ClassLoaderHelper.getClassLoader(CitrusContext.class));
                 context.parseConfiguration(configClass);
             } catch (ClassNotFoundException e) {
                 throw new CitrusRuntimeException("Failed to instantiate custom configuration class", e);

--- a/core/citrus-base/src/main/java/org/citrusframework/actions/JavaAction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/actions/JavaAction.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import org.citrusframework.AbstractTestActionBuilder;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.citrusframework.util.ReflectionHelper;
 import org.citrusframework.util.StringUtils;
 import org.slf4j.Logger;
@@ -154,7 +155,7 @@ public class JavaAction extends AbstractTestAction {
 
         logger.info("Instantiating class for name '{}'", className);
 
-        Class<?> classToRun = Class.forName(className);
+        Class<?> classToRun = Class.forName(className, true, ClassLoaderHelper.getClassLoader(JavaAction.class));
 
         Class<?>[] constructorTypes = new Class<?>[constructorArgs.size()];
         Object[] constructorObjects = new Object[constructorArgs.size()];

--- a/core/citrus-base/src/main/java/org/citrusframework/common/JavaTestLoader.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/common/JavaTestLoader.java
@@ -33,6 +33,7 @@ import org.citrusframework.TestSource;
 import org.citrusframework.annotations.CitrusAnnotations;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.spi.Resource;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.citrusframework.util.FileUtils;
 import org.citrusframework.util.ReflectionHelper;
 import org.citrusframework.util.StringUtils;
@@ -60,7 +61,7 @@ public class JavaTestLoader extends DefaultTestLoader implements TestSourceAware
             String qualifiedClassName = StringUtils.hasText(packageName) ? packageName + "." + getClassName() : getClassName();
 
             // Load and instantiate compiled class.
-            URLClassLoader classLoader = URLClassLoader.newInstance(new URL[] { getClassLoaderBaseURL(packageName, javaSource) });
+            URLClassLoader classLoader = URLClassLoader.newInstance(new URL[] { getClassLoaderBaseURL(packageName, javaSource) }, ClassLoaderHelper.getClassLoader(JavaTestLoader.class));
             Class<?> cls = Class.forName(qualifiedClassName, true, classLoader);
             Object instance = cls.getDeclaredConstructor().newInstance();
 

--- a/core/citrus-base/src/main/java/org/citrusframework/container/Assert.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/container/Assert.java
@@ -25,6 +25,7 @@ import org.citrusframework.TestActionBuilder;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.exceptions.ValidationException;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -169,7 +170,7 @@ public class Assert extends AbstractActionContainer {
         @Override
         public Builder exception(String type) {
             try {
-                this.exception = (Class<? extends Throwable>) Class.forName(type);
+                this.exception = (Class<? extends Throwable>) Class.forName(type, false, ClassLoaderHelper.getClassLoader(Assert.class));
             } catch (ClassNotFoundException e) {
                 throw new CitrusRuntimeException(format("Failed to instantiate exception class of type '%s'", type), e);
             }

--- a/core/citrus-base/src/main/java/org/citrusframework/main/scan/ClassPathTestScanner.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/main/scan/ClassPathTestScanner.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 import org.citrusframework.TestClass;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.spi.ClasspathResourceResolver;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.citrusframework.util.FileUtils;
 import org.citrusframework.util.ReflectionHelper;
 import org.slf4j.Logger;
@@ -84,7 +85,7 @@ public class ClassPathTestScanner extends AbstractTestScanner {
         }
 
         try {
-            Class<?> clazz = Class.forName(className);
+            Class<?> clazz = Class.forName(className, true, ClassLoaderHelper.getClassLoader(ClassPathTestScanner.class));
             if (clazz.isAnnotationPresent(annotationType)) {
                 return true;
             }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/infra/CamelRunInfraAction.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/infra/CamelRunInfraAction.java
@@ -35,6 +35,7 @@ import org.citrusframework.camel.actions.AbstractCamelAction;
 import org.citrusframework.camel.jbang.CamelJBangSettings;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.citrusframework.util.ReflectionHelper;
 import org.citrusframework.util.StringUtils;
 import org.slf4j.Logger;
@@ -87,8 +88,9 @@ public class CamelRunInfraAction extends AbstractCamelAction {
 
             logger.info("Starting Camel infra service '{}' ...", fullServiceName);
 
-            Class<?> serviceType = Class.forName(infraService.get().service());
-            Object instance = Class.forName(infraService.get().implementation()).getDeclaredConstructor().newInstance();
+            ClassLoader classLoader = ClassLoaderHelper.getClassLoader(CamelRunInfraAction.class);
+            Class<?> serviceType = Class.forName(infraService.get().service(), true, classLoader);
+            Object instance = Class.forName(infraService.get().implementation(), true, classLoader).getDeclaredConstructor().newInstance();
 
             if (isNotInfrastructureService(instance)) {
                 throw new CitrusRuntimeException("Camel infra service '%s' is not an infrastructure service".formatted(instance.getClass().getName()));
@@ -98,11 +100,11 @@ public class CamelRunInfraAction extends AbstractCamelAction {
                 if (Arrays.stream(instance.getClass().getInterfaces()).anyMatch(c -> c.getName().contains("ContainerService"))) {
                     Path workDir = CamelJBangSettings.getWorkDir();
                     Path logFile = workDir.resolve(String.format("camel-infra-%s-output.txt", fullServiceName));
-                    Object containerLogConsumer = Class.forName("org.apache.camel.test.infra.common.CamelLogConsumer")
+                    Object containerLogConsumer = Class.forName("org.apache.camel.test.infra.common.CamelLogConsumer", true, classLoader)
                             .getConstructor(Path.class, boolean.class).newInstance(logFile, true);
 
                     instance.getClass()
-                            .getMethod("followLog", Class.forName("org.testcontainers.containers.output.BaseConsumer"))
+                            .getMethod("followLog", Class.forName("org.testcontainers.containers.output.BaseConsumer", true, classLoader))
                             .invoke(instance, containerLogConsumer);
                 }
             }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/endpoint/CamelSyncConsumer.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/endpoint/CamelSyncConsumer.java
@@ -28,6 +28,7 @@ import org.citrusframework.message.MessageHeaders;
 import org.citrusframework.message.correlation.CorrelationManager;
 import org.citrusframework.message.correlation.PollingCorrelationManager;
 import org.citrusframework.messaging.ReplyProducer;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.citrusframework.util.ObjectHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -142,7 +143,7 @@ public class CamelSyncConsumer extends CamelConsumer implements ReplyProducer {
             }
 
             try {
-                Class<?> exception = Class.forName(exceptionClass);
+                Class<?> exception = Class.forName(exceptionClass, true, ClassLoaderHelper.getClassLoader(CamelSyncConsumer.class));
                 if (exceptionMsg != null) {
                     exchange.setException((Throwable) exception.getConstructor(String.class).newInstance(exceptionMsg));
                 } else {

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/util/CamelUtils.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/util/CamelUtils.java
@@ -31,6 +31,7 @@ import org.citrusframework.camel.endpoint.CamelEndpointConfiguration;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,7 +55,7 @@ public class CamelUtils {
                 context = JAXBContext.newInstance("org.apache.camel:org.apache.camel.model:org.apache.camel.model.cloud:" +
                         "org.apache.camel.model.config:org.apache.camel.model.dataformat:org.apache.camel.model.language:" +
                         "org.apache.camel.model.loadbalancer:org.apache.camel.model.rest:org.apache.camel.model.transformer:" +
-                        "org.apache.camel.model.validator:org.apache.camel.core.xml:org.apache.camel.spring.xml:org.apache.camel.model", CamelUtils.class.getClassLoader());
+                        "org.apache.camel.model.validator:org.apache.camel.core.xml:org.apache.camel.spring.xml:org.apache.camel.model", ClassLoaderHelper.getClassLoader(CamelUtils.class));
             }
         }
 

--- a/endpoints/citrus-ftp/src/main/java/org/citrusframework/ftp/client/SftpClient.java
+++ b/endpoints/citrus-ftp/src/main/java/org/citrusframework/ftp/client/SftpClient.java
@@ -50,6 +50,7 @@ import org.citrusframework.ftp.model.GetCommand;
 import org.citrusframework.ftp.model.ListCommand;
 import org.citrusframework.ftp.model.PutCommand;
 import org.citrusframework.spi.Resources;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.citrusframework.util.FileUtils;
 import org.citrusframework.util.StringUtils;
 import org.slf4j.Logger;
@@ -309,8 +310,8 @@ public class SftpClient extends FtpClient {
             return null;
         } else if (getEndpointConfiguration().getPrivateKeyPath().startsWith(Resources.CLASSPATH_RESOURCE_PREFIX)) {
             File priv = File.createTempFile("citrus-sftp","priv");
-            try (InputStream is = getClass().getClassLoader().getResourceAsStream(getEndpointConfiguration().getPrivateKeyPath().substring(Resources.CLASSPATH_RESOURCE_PREFIX.length()));
-                    FileOutputStream fos = new FileOutputStream(priv)) {
+            try (InputStream is = ClassLoaderHelper.getClassLoader(getClass()).getResourceAsStream(getEndpointConfiguration().getPrivateKeyPath().substring(Resources.CLASSPATH_RESOURCE_PREFIX.length()));
+                 FileOutputStream fos = new FileOutputStream(priv)) {
                 if (is == null) {
                     throw new CitrusRuntimeException("No private key found at " + getEndpointConfiguration().getPrivateKeyPath());
                 }

--- a/endpoints/citrus-jmx/src/main/java/org/citrusframework/jmx/model/ManagedBeanInvocation.java
+++ b/endpoints/citrus-jmx/src/main/java/org/citrusframework/jmx/model/ManagedBeanInvocation.java
@@ -33,6 +33,7 @@ import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.citrusframework.util.StringUtils;
 import org.citrusframework.util.TypeConverter;
 
@@ -83,7 +84,7 @@ public class ManagedBeanInvocation {
         }
 
         try {
-            Class argType = Class.forName(attribute.getType());
+            Class argType = Class.forName(attribute.getType(), true, ClassLoaderHelper.getClassLoader(ManagedBeanInvocation.class));
             java.lang.Object value = null;
 
             if (attribute.getValue() != null) {
@@ -432,7 +433,7 @@ public class ManagedBeanInvocation {
             try {
                 if (parameter != null) {
                     for (OperationParam operationParam : parameter.getParameter()) {
-                        Class argType = Class.forName(operationParam.getType());
+                        Class argType = Class.forName(operationParam.getType(), true, ClassLoaderHelper.getClassLoader(ManagedBeanInvocation.class));
                         Object value = null;
 
                         if (operationParam.getValueObject() != null) {

--- a/endpoints/citrus-jmx/src/main/java/org/citrusframework/jmx/model/ManagedBeanResult.java
+++ b/endpoints/citrus-jmx/src/main/java/org/citrusframework/jmx/model/ManagedBeanResult.java
@@ -31,6 +31,7 @@ import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.citrusframework.util.StringUtils;
 import org.citrusframework.util.TypeConverter;
 
@@ -85,7 +86,7 @@ public class ManagedBeanResult {
         }
 
         try {
-            Class<?> argType = Class.forName(object.getType());
+            Class<?> argType = Class.forName(object.getType(), true, ClassLoaderHelper.getClassLoader(ManagedBeanResult.class));
             java.lang.Object value = null;
 
             if (object.getValue() != null) {

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaEndpointBuilder.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaEndpointBuilder.java
@@ -24,6 +24,7 @@ import org.citrusframework.endpoint.AbstractEndpointBuilder;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.kafka.message.KafkaMessageConverter;
 import org.citrusframework.kafka.message.KafkaMessageHeaderMapper;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.citrusframework.util.StringUtils;
 import org.citrusframework.yaml.SchemaProperty;
 
@@ -211,7 +212,7 @@ public class KafkaEndpointBuilder extends AbstractEndpointBuilder<KafkaEndpoint>
             description = "Sets the fully qualified key serializer type class name.")
     public void setKeySerializer(String serializerType) {
         try {
-            keySerializer((Class<? extends Serializer>) Class.forName(serializerType));
+            keySerializer((Class<? extends Serializer>) Class.forName(serializerType, true, ClassLoaderHelper.getClassLoader(KafkaEndpointBuilder.class)));
         } catch (ClassNotFoundException e) {
             throw new CitrusRuntimeException("Failed to set key serializer type", e);
         }
@@ -230,7 +231,7 @@ public class KafkaEndpointBuilder extends AbstractEndpointBuilder<KafkaEndpoint>
             description = "Sets the fully qualified value serializer type class name.")
     public void setValueSerializer(String serializerType) {
         try {
-            valueSerializer((Class<? extends Serializer>) Class.forName(serializerType));
+            valueSerializer((Class<? extends Serializer>) Class.forName(serializerType, true, ClassLoaderHelper.getClassLoader(KafkaEndpointBuilder.class)));
         } catch (ClassNotFoundException e) {
             throw new CitrusRuntimeException("Failed to set value serializer type", e);
         }
@@ -249,7 +250,7 @@ public class KafkaEndpointBuilder extends AbstractEndpointBuilder<KafkaEndpoint>
             description = "Sets the fully qualified key deserializer type class name.")
     public void setKeyDeserializer(String serializerType) {
         try {
-            keyDeserializer((Class<? extends Deserializer>) Class.forName(serializerType));
+            keyDeserializer((Class<? extends Deserializer>) Class.forName(serializerType, true, ClassLoaderHelper.getClassLoader(KafkaEndpointBuilder.class)));
         } catch (ClassNotFoundException e) {
             throw new CitrusRuntimeException("Failed to set key deserializer type", e);
         }
@@ -268,7 +269,7 @@ public class KafkaEndpointBuilder extends AbstractEndpointBuilder<KafkaEndpoint>
             description = "Sets the fully qualified value deserializer type class name.")
     public void setValueDeserializer(String serializerType) {
         try {
-            valueDeserializer((Class<? extends Deserializer>) Class.forName(serializerType));
+            valueDeserializer((Class<? extends Deserializer>) Class.forName(serializerType, true, ClassLoaderHelper.getClassLoader(KafkaEndpointBuilder.class)));
         } catch (ClassNotFoundException e) {
             throw new CitrusRuntimeException("Failed to set value deserializer type", e);
         }

--- a/endpoints/citrus-rmi/src/main/java/org/citrusframework/rmi/model/RmiServiceInvocation.java
+++ b/endpoints/citrus-rmi/src/main/java/org/citrusframework/rmi/model/RmiServiceInvocation.java
@@ -33,6 +33,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.citrusframework.util.StringUtils;
 import org.citrusframework.util.TypeConverter;
 
@@ -102,7 +103,7 @@ public class RmiServiceInvocation {
         if (args != null) {
             for (MethodArg arg : args.getArgs()) {
                 try {
-                    types.add(Class.forName(arg.getType()));
+                    types.add(Class.forName(arg.getType(), true, ClassLoaderHelper.getClassLoader(RmiServiceInvocation.class)));
                 } catch (ClassNotFoundException e) {
                     throw new CitrusRuntimeException("Failed to access method argument type", e);
                 }
@@ -122,7 +123,7 @@ public class RmiServiceInvocation {
         try {
             if (args != null) {
                 for (MethodArg methodArg : args.getArgs()) {
-                    Class argType = Class.forName(methodArg.getType());
+                    Class argType = Class.forName(methodArg.getType(), true,  ClassLoaderHelper.getClassLoader(RmiServiceInvocation.class));
                     Object value = null;
 
                     if (methodArg.getValueObject() != null) {

--- a/endpoints/citrus-rmi/src/main/java/org/citrusframework/rmi/model/RmiServiceResult.java
+++ b/endpoints/citrus-rmi/src/main/java/org/citrusframework/rmi/model/RmiServiceResult.java
@@ -31,6 +31,7 @@ import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.citrusframework.util.StringUtils;
 import org.citrusframework.util.TypeConverter;
 
@@ -113,7 +114,7 @@ public class RmiServiceResult {
         }
 
         try {
-            Class<?> argType = Class.forName(object.getType());
+            Class<?> argType = Class.forName(object.getType(), true, ClassLoaderHelper.getClassLoader(RmiServiceResult.class));
             java.lang.Object value = null;
 
             if (object.getValue() != null) {

--- a/endpoints/citrus-ssh/src/main/java/org/citrusframework/ssh/client/SshClient.java
+++ b/endpoints/citrus-ssh/src/main/java/org/citrusframework/ssh/client/SshClient.java
@@ -41,6 +41,7 @@ import org.citrusframework.messaging.SelectiveConsumer;
 import org.citrusframework.spi.Resources;
 import org.citrusframework.ssh.model.SshRequest;
 import org.citrusframework.ssh.model.SshResponse;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.citrusframework.util.FileUtils;
 import org.citrusframework.util.StringUtils;
 
@@ -279,8 +280,8 @@ public class SshClient extends AbstractEndpoint implements Producer, ReplyConsum
             return null;
         } else if (getEndpointConfiguration().getPrivateKeyPath().startsWith(Resources.CLASSPATH_RESOURCE_PREFIX)) {
             File priv = File.createTempFile("citrus-ssh","priv");
-            try (InputStream is = getClass().getClassLoader().getResourceAsStream(getEndpointConfiguration().getPrivateKeyPath().substring(Resources.CLASSPATH_RESOURCE_PREFIX.length()));
-                    FileOutputStream fos = new FileOutputStream(priv)) {
+            try (InputStream is = ClassLoaderHelper.getClassLoader(getClass()).getResourceAsStream(getEndpointConfiguration().getPrivateKeyPath().substring(Resources.CLASSPATH_RESOURCE_PREFIX.length()));
+                 FileOutputStream fos = new FileOutputStream(priv)) {
                 if (is == null) {
                     throw new CitrusRuntimeException("No private key found at " + getEndpointConfiguration().getPrivateKeyPath());
                 }

--- a/pom.xml
+++ b/pom.xml
@@ -962,6 +962,11 @@
         <artifactId>camel-endpointdsl</artifactId>
         <version>${apache.camel.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-tooling-maven</artifactId>
+        <version>${apache.camel.version}</version>
+      </dependency>
 
       <!-- Citrus ftp dependencies -->
       <dependency>

--- a/runtime/citrus-cucumber/src/main/java/org/citrusframework/cucumber/CucumberTestEngine.java
+++ b/runtime/citrus-cucumber/src/main/java/org/citrusframework/cucumber/CucumberTestEngine.java
@@ -48,6 +48,7 @@ import org.citrusframework.main.TestRunConfiguration;
 import org.citrusframework.spi.ClasspathResourceResolver;
 import org.citrusframework.spi.Resource;
 import org.citrusframework.spi.Resources;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.citrusframework.util.FileUtils;
 import org.citrusframework.util.StringUtils;
 import org.slf4j.Logger;
@@ -78,7 +79,7 @@ public class CucumberTestEngine extends AbstractTestEngine {
             try {
                 annotationOptions = new CucumberOptionsAnnotationParser()
                         .withOptionsProvider(GenericCucumberOptions::new)
-                        .parse(Class.forName(javaClass.get().getName()))
+                        .parse(Class.forName(javaClass.get().getName(), true, ClassLoaderHelper.getClassLoader(CucumberTestEngine.class)))
                         .setUuidGeneratorClass(RandomUuidGenerator.class)
                         .addDefaultGlueIfAbsent()
                         .build(propertiesFileOptions);

--- a/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/configuration/ContextConfiguration.java
+++ b/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/configuration/ContextConfiguration.java
@@ -28,6 +28,7 @@ import org.citrusframework.groovy.dsl.configuration.beans.BeansConfiguration;
 import org.citrusframework.groovy.dsl.configuration.beans.QueueConfiguration;
 import org.citrusframework.groovy.dsl.configuration.endpoints.EndpointsConfiguration;
 import org.citrusframework.spi.Resource;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.citrusframework.util.FileUtils;
 import org.codehaus.groovy.control.customizers.ImportCustomizer;
 
@@ -59,7 +60,7 @@ public class ContextConfiguration {
 
                 GroovyShellUtils.run(new ImportCustomizer(), this, FileUtils.readToString(file), citrus, context);
             } else {
-                citrus.getCitrusContext().parseConfiguration(Class.forName(pathOrType));
+                citrus.getCitrusContext().parseConfiguration(Class.forName(pathOrType, true, ClassLoaderHelper.getClassLoader(ContextConfiguration.class)));
             }
         } catch (IOException | ClassNotFoundException e) {
             throw new CitrusRuntimeException(String.format("Failed to load configuration from file '%s'", pathOrType), e);

--- a/runtime/citrus-groovy/src/main/java/org/citrusframework/message/builder/script/GroovyScriptPayloadBuilder.java
+++ b/runtime/citrus-groovy/src/main/java/org/citrusframework/message/builder/script/GroovyScriptPayloadBuilder.java
@@ -16,6 +16,8 @@
 
 package org.citrusframework.message.builder.script;
 
+import java.io.IOException;
+
 import groovy.lang.GroovyClassLoader;
 import groovy.lang.GroovyObject;
 import org.citrusframework.context.TestContext;
@@ -23,10 +25,9 @@ import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.message.ScriptPayloadBuilder;
 import org.citrusframework.spi.Resource;
 import org.citrusframework.spi.Resources;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.citrusframework.validation.script.TemplateBasedScriptBuilder;
 import org.codehaus.groovy.control.CompilationFailedException;
-
-import java.io.IOException;
 
 public class GroovyScriptPayloadBuilder implements ScriptPayloadBuilder {
 
@@ -75,7 +76,7 @@ public class GroovyScriptPayloadBuilder implements ScriptPayloadBuilder {
      * @return
      */
     protected String buildMarkupBuilderScript(String scriptData) {
-        ClassLoader parent = GroovyScriptPayloadBuilder.class.getClassLoader();
+        ClassLoader parent = ClassLoaderHelper.getClassLoader(GroovyScriptPayloadBuilder.class);
         try (GroovyClassLoader loader = new GroovyClassLoader(parent))  {
             Class<?> groovyClass = loader.parseClass(TemplateBasedScriptBuilder.fromTemplateResource(scriptTemplateResource)
                     .withCode(scriptData)

--- a/runtime/citrus-groovy/src/main/java/org/citrusframework/script/GroovyAction.java
+++ b/runtime/citrus-groovy/src/main/java/org/citrusframework/script/GroovyAction.java
@@ -29,6 +29,7 @@ import org.citrusframework.actions.groovy.GroovyRunActionBuilder;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.spi.Resource;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.citrusframework.util.FileUtils;
 import org.citrusframework.util.StringUtils;
 import org.citrusframework.validation.script.TemplateBasedScriptBuilder;
@@ -131,7 +132,7 @@ public class GroovyAction extends AbstractTestAction {
     private GroovyClassLoader getPrivilegedGroovyLoader() {
         return AccessController.doPrivileged(new PrivilegedAction<>() {
             public GroovyClassLoader run() {
-                ClassLoader parent = getClass().getClassLoader();
+                ClassLoader parent = ClassLoaderHelper.getClassLoader(getClass());
                 return new GroovyClassLoader(parent);
             }
         });

--- a/runtime/citrus-junit/src/main/java/org/citrusframework/junit/JUnit4TestEngine.java
+++ b/runtime/citrus-junit/src/main/java/org/citrusframework/junit/JUnit4TestEngine.java
@@ -32,6 +32,7 @@ import org.citrusframework.main.AbstractTestEngine;
 import org.citrusframework.main.TestRunConfiguration;
 import org.citrusframework.main.scan.ClassPathTestScanner;
 import org.citrusframework.main.scan.JarFileTestScanner;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.citrusframework.util.StringUtils;
 import org.junit.Test;
 import org.junit.runner.JUnitCore;
@@ -125,9 +126,9 @@ public class JUnit4TestEngine extends AbstractTestEngine {
                         Class<?> clazz;
                         if (getConfiguration().getTestJar() != null) {
                             clazz = Class.forName(source.getName(), false,
-                                    new URLClassLoader(new URL[]{ getConfiguration().getTestJar().toURI().toURL() }, getClass().getClassLoader()));
+                                    new URLClassLoader(new URL[]{ getConfiguration().getTestJar().toURI().toURL() }, ClassLoaderHelper.getClassLoader(JUnit4TestEngine.class)));
                         } else {
-                            clazz = Class.forName(source.getName());
+                            clazz = Class.forName(source.getName(), false, ClassLoaderHelper.getClassLoader(JUnit4TestEngine.class));
                         }
                         logger.debug("Found test candidate: " + source.getName());
                         return clazz;

--- a/runtime/citrus-junit5/src/main/java/org/citrusframework/junit/jupiter/JUnitJupiterEngine.java
+++ b/runtime/citrus-junit5/src/main/java/org/citrusframework/junit/jupiter/JUnitJupiterEngine.java
@@ -46,6 +46,7 @@ import org.citrusframework.main.scan.JarFileTestScanner;
 import org.citrusframework.spi.ClasspathResourceResolver;
 import org.citrusframework.spi.Resource;
 import org.citrusframework.spi.Resources;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.citrusframework.util.StringUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.engine.DiscoverySelector;
@@ -212,9 +213,9 @@ public class JUnitJupiterEngine extends AbstractTestEngine {
                             Class<?> clazz;
                             if (configuration.getTestJar() != null) {
                                 clazz = Class.forName(testClass.getName(), false,
-                                        new URLClassLoader(new URL[]{configuration.getTestJar().toURI().toURL()}, getClass().getClassLoader()));
+                                        new URLClassLoader(new URL[]{configuration.getTestJar().toURI().toURL()}, ClassLoaderHelper.getClassLoader(JUnitJupiterEngine.class)));
                             } else {
-                                clazz = Class.forName(testClass.getName());
+                                clazz = Class.forName(testClass.getName(), false, ClassLoaderHelper.getClassLoader(JUnitJupiterEngine.class));
                             }
                             return clazz;
                         } catch (ClassNotFoundException | MalformedURLException e) {
@@ -251,9 +252,9 @@ public class JUnitJupiterEngine extends AbstractTestEngine {
                 Class<?> clazz;
                 if (configuration.getTestJar() != null) {
                     clazz = Class.forName(testClass.getName(), false,
-                            new URLClassLoader(new URL[]{configuration.getTestJar().toURI().toURL()}, getClass().getClassLoader()));
+                            new URLClassLoader(new URL[]{configuration.getTestJar().toURI().toURL()}, ClassLoaderHelper.getClassLoader(JUnitJupiterEngine.class)));
                 } else {
-                    clazz = Class.forName(testClass.getName());
+                    clazz = Class.forName(testClass.getName(), false, ClassLoaderHelper.getClassLoader(JUnitJupiterEngine.class));
                 }
 
                 if (StringUtils.hasText(testClass.getMethod())) {

--- a/runtime/citrus-main/src/main/java/org/citrusframework/main/CitrusAppOptions.java
+++ b/runtime/citrus-main/src/main/java/org/citrusframework/main/CitrusAppOptions.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 import org.citrusframework.TestClass;
 import org.citrusframework.TestSource;
 import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.citrusframework.util.FileUtils;
 import org.citrusframework.util.StringUtils;
 import org.slf4j.Logger;
@@ -73,7 +74,7 @@ public class CitrusAppOptions<T extends CitrusAppConfiguration> {
             protected void doProcess(T configuration, String arg, String value, LinkedList<String> remainingArgs) {
                 if (StringUtils.hasText(value)) {
                     try {
-                        Class.forName(value);
+                        Class.forName(value, false, ClassLoaderHelper.getClassLoader(CitrusAppOptions.class));
                     } catch (ClassNotFoundException e) {
                         throw new CitrusRuntimeException("Unable to access config class type: " + value, e);
                     }

--- a/runtime/citrus-quarkus/citrus-quarkus-runtime/src/main/java/org/citrusframework/quarkus/CitrusTestResource.java
+++ b/runtime/citrus-quarkus/citrus-quarkus-runtime/src/main/java/org/citrusframework/quarkus/CitrusTestResource.java
@@ -34,6 +34,7 @@ import org.citrusframework.annotations.CitrusFramework;
 import org.citrusframework.annotations.CitrusResource;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.util.ClassLoaderHelper;
 
 /**
  * Quarkus test resource that takes care of injecting Citrus resources
@@ -66,7 +67,7 @@ public class CitrusTestResource implements QuarkusTestResourceConfigurableLifecy
         String[] qualifiedClassNames = initArgs.getOrDefault(ApplicationPropertiesSupplier.INIT_ARG, "").split(",");
         for (String qualifiedClassName : qualifiedClassNames) {
             try {
-                Class<?> cls = Class.forName(qualifiedClassName, true, Thread.currentThread().getContextClassLoader());
+                Class<?> cls = Class.forName(qualifiedClassName, true, ClassLoaderHelper.getContextClassLoader());
                 Object instance = cls.getDeclaredConstructor().newInstance();
                 if (instance instanceof ApplicationPropertiesSupplier supplier) {
                     applicationPropertiesSupplier.add(supplier);

--- a/runtime/citrus-testng/src/main/java/org/citrusframework/testng/TestNGEngine.java
+++ b/runtime/citrus-testng/src/main/java/org/citrusframework/testng/TestNGEngine.java
@@ -46,6 +46,7 @@ import org.citrusframework.spi.ClasspathResourceResolver;
 import org.citrusframework.spi.Resource;
 import org.citrusframework.spi.Resources;
 import org.citrusframework.testng.main.TestNGCitrusTest;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.citrusframework.util.FileUtils;
 import org.citrusframework.util.StringUtils;
 import org.slf4j.Logger;
@@ -208,9 +209,9 @@ public class TestNGEngine extends AbstractTestEngine {
                             Class<?> clazz;
                             if (configuration.getTestJar() != null) {
                                 clazz = Class.forName(testClass.getName(), false,
-                                        new URLClassLoader(new URL[]{configuration.getTestJar().toURI().toURL()}, getClass().getClassLoader()));
+                                        new URLClassLoader(new URL[]{configuration.getTestJar().toURI().toURL()}, ClassLoaderHelper.getClassLoader(TestNGEngine.class)));
                             } else {
-                                clazz = Class.forName(testClass.getName());
+                                clazz = Class.forName(testClass.getName(), false, ClassLoaderHelper.getClassLoader(TestNGEngine.class));
                             }
                             return clazz;
                         } catch (ClassNotFoundException | MalformedURLException e) {
@@ -246,9 +247,9 @@ public class TestNGEngine extends AbstractTestEngine {
                 Class<?> clazz;
                 if (configuration.getTestJar() != null) {
                     clazz = Class.forName(testClass.getName(), false,
-                            new URLClassLoader(new URL[]{configuration.getTestJar().toURI().toURL()}, getClass().getClassLoader()));
+                            new URLClassLoader(new URL[]{configuration.getTestJar().toURI().toURL()}, ClassLoaderHelper.getClassLoader(TestNGEngine.class)));
                 } else {
-                    clazz = Class.forName(testClass.getName());
+                    clazz = Class.forName(testClass.getName(), false, ClassLoaderHelper.getClassLoader(TestNGEngine.class));
                 }
 
                 XmlClass xmlClass = new XmlClass(clazz);

--- a/test-api-generator/citrus-openapi-codegen-maven-plugin/src/main/java/org/citrusframework/maven/plugin/TestApiGeneratorMojo.java
+++ b/test-api-generator/citrus-openapi-codegen-maven-plugin/src/main/java/org/citrusframework/maven/plugin/TestApiGeneratorMojo.java
@@ -44,6 +44,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 import org.citrusframework.openapi.generator.WsdlToOpenApiTransformer;
 import org.citrusframework.openapi.generator.exception.WsdlToOpenApiTransformationException;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.citrusframework.util.StringUtils;
 import org.openapitools.codegen.plugin.CodeGenMojo;
 import org.sonatype.plexus.build.incremental.BuildContext;
@@ -330,7 +331,7 @@ public class TestApiGeneratorMojo extends AbstractMojo {
                     "File not found at the provided absolute path: " + source);
             }
         } else {
-            URL resourceUrl = getClass().getClassLoader().getResource(source);
+            URL resourceUrl = ClassLoaderHelper.getClassLoader(getClass()).getResource(source);
             if (resourceUrl == null) {
                 throw new MojoExecutionException("Resource not found in classpath: " + source);
             }

--- a/tools/cucumber-steps/citrus-cucumber-core/src/main/java/org/citrusframework/cucumber/steps/core/message/MessageCreators.java
+++ b/tools/cucumber-steps/citrus-cucumber-core/src/main/java/org/citrusframework/cucumber/steps/core/message/MessageCreators.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.message.Message;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.citrusframework.util.ReflectionHelper;
 
 public class MessageCreators {
@@ -83,17 +84,15 @@ public class MessageCreators {
      */
     public void addType(String type) {
         try {
-            Object messageCreator = Class.forName(type).newInstance();
+            Object messageCreator = ClassLoaderHelper.instantiateType(type, MessageCreator.class);
 
             if (messageCreator instanceof MessageCreator) {
                 messageCreators.put(messageCreator.getClass().getSimpleName(), (MessageCreator) messageCreator);
             }
 
             pojoCreators.add(messageCreator);
-        } catch (ClassNotFoundException | IllegalAccessException e) {
+        } catch (CitrusRuntimeException e) {
             throw new CitrusRuntimeException("Unable to access message creator type: " + type, e);
-        } catch (InstantiationException e) {
-            throw new CitrusRuntimeException("Unable to create  message creator instance of type: " + type, e);
         }
     }
 }

--- a/tools/cucumber-steps/citrus-cucumber-jms/src/main/java/org/citrusframework/cucumber/steps/jms/connection/ConnectionFactoryCreator.java
+++ b/tools/cucumber-steps/citrus-cucumber-jms/src/main/java/org/citrusframework/cucumber/steps/jms/connection/ConnectionFactoryCreator.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.ServiceLoader;
 
 import jakarta.jms.ConnectionFactory;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.citrusframework.util.ObjectHelper;
 
 public interface ConnectionFactoryCreator {
@@ -41,7 +42,7 @@ public interface ConnectionFactoryCreator {
      */
     static ConnectionFactoryCreator lookup(String type) throws ClassNotFoundException {
         ObjectHelper.assertNotNull(type, "Missing connection factory type information");
-        Class<?> connectionFactoryType = Class.forName(type);
+        Class<?> connectionFactoryType = Class.forName(type, true, ClassLoaderHelper.getClassLoader(ConnectionFactoryCreator.class));
 
         for (ConnectionFactoryCreator connectionFactoryCreator : SERVICE_LOADER) {
             if (connectionFactoryCreator.supports(connectionFactoryType)) {

--- a/tools/cucumber-steps/citrus-cucumber-jms/src/main/java/org/citrusframework/cucumber/steps/jms/connection/DefaultConnectionFactoryCreator.java
+++ b/tools/cucumber-steps/citrus-cucumber-jms/src/main/java/org/citrusframework/cucumber/steps/jms/connection/DefaultConnectionFactoryCreator.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import jakarta.jms.ConnectionFactory;
 import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.citrusframework.util.ObjectHelper;
 
 /**
@@ -38,7 +39,7 @@ public class DefaultConnectionFactoryCreator implements ConnectionFactoryCreator
         ObjectHelper.assertNotNull(className, "Missing connection factory type information");
 
         try {
-            Class<?> type = Class.forName(className);
+            Class<?> type = Class.forName(className, true, ClassLoaderHelper.getClassLoader(DefaultConnectionFactoryCreator.class));
 
             if (!(ConnectionFactory.class.isAssignableFrom(type))) {
                 throw new IllegalStateException(String.format("Unsupported type information %s - must be of type %s", type.getName(), ConnectionFactory.class.getName()));

--- a/tools/cucumber-steps/citrus-cucumber-selenium/src/main/java/org/citrusframework/cucumber/steps/selenium/SeleniumSteps.java
+++ b/tools/cucumber-steps/citrus-cucumber-selenium/src/main/java/org/citrusframework/cucumber/steps/selenium/SeleniumSteps.java
@@ -37,6 +37,7 @@ import org.citrusframework.selenium.endpoint.SeleniumBrowser;
 import org.citrusframework.selenium.endpoint.SeleniumBrowserBuilder;
 import org.citrusframework.selenium.model.PageValidator;
 import org.citrusframework.selenium.model.WebPage;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.citrusframework.variable.VariableUtils;
 
 import static org.citrusframework.selenium.actions.SeleniumActionBuilder.selenium;
@@ -227,13 +228,13 @@ public class SeleniumSteps {
     @Given("^(?:Browser|browser) page \"([^\"]+)\" of type ([^\\s]+)$")
     public void pageByType(String id, String type) {
         try {
-            Object page = Class.forName(type).newInstance();
+            Object page = ClassLoaderHelper.instantiateType(type, SeleniumSteps.class);
             pages.put(id, (WebPage) page);
 
             if (page instanceof PageValidator) {
                 validators.put(id, (PageValidator<?>) page);
             }
-        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
+        } catch (CitrusRuntimeException e) {
             throw new CitrusRuntimeException("Failed to load page object", e);
         }
     }
@@ -292,8 +293,8 @@ public class SeleniumSteps {
     @Given("^(?:Browser|browser) page validator ([^\\s]+) of type ([^\\s]+)$")
     public void pageValidatorByType(String id, String type) {
         try {
-            validators.put(id, (PageValidator<?>) Class.forName(type).newInstance());
-        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
+            validators.put(id, (PageValidator<?>) ClassLoaderHelper.instantiateType(type, SeleniumSteps.class));
+        } catch (CitrusRuntimeException e) {
             throw new CitrusRuntimeException("Failed to load page object", e);
         }
     }

--- a/tools/jbang/pom.xml
+++ b/tools/jbang/pom.xml
@@ -46,6 +46,12 @@
       <artifactId>ascii-table</artifactId>
     </dependency>
 
+    <!-- Maven dependency resolver -->
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-tooling-maven</artifactId>
+    </dependency>
+
     <!-- Logging -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/tools/jbang/src/main/java/org/citrusframework/jbang/CitrusJBangMain.java
+++ b/tools/jbang/src/main/java/org/citrusframework/jbang/CitrusJBangMain.java
@@ -101,6 +101,12 @@ public class CitrusJBangMain implements Callable<Integer> {
         private static final String REPORT_DIRECTORY_ENV = JBANG_ENV_PREFIX + "REPORT_DIRECTORY";
         private static final String REPORT_DIRECTORY_DEFAULT = getWorkDir() + "/citrus-reports";
 
+        private static final String MODULES_PROPERTY = JBANG_PROPERTY_PREFIX + "modules";
+        private static final String MODULES_ENV = JBANG_ENV_PREFIX + "MODULES";
+
+        private static final String DEPENDENCIES_PROPERTY = JBANG_PROPERTY_PREFIX + "dependencies";
+        private static final String DEPENDENCIES_ENV = JBANG_ENV_PREFIX + "DEPENDENCIES";
+
         private static final Pattern PACKAGE_PATTERN = Pattern.compile(
                 "^\\s*package\\s+([a-zA-Z][\\.\\w]*)\\s*;.*$", Pattern.MULTILINE);
 
@@ -141,6 +147,20 @@ public class CitrusJBangMain implements Callable<Integer> {
          */
         public static String getReportDirectory() {
             return CitrusSettings.getPropertyEnvOrDefault(REPORT_DIRECTORY_PROPERTY, REPORT_DIRECTORY_ENV, REPORT_DIRECTORY_DEFAULT);
+        }
+
+        /**
+         * Gets Citrus modules that should be loaded as additional dependencies and added to the classpath.
+         */
+        public static String[] getModules() {
+            return CitrusSettings.getPropertyEnvOrDefault(MODULES_PROPERTY, MODULES_ENV, "").split(",");
+        }
+
+        /**
+         * Gets additional dependencies in the form of Maven GAVs that should be added to the classpath.
+         */
+        public static String[] getDependencies() {
+            return CitrusSettings.getPropertyEnvOrDefault(DEPENDENCIES_PROPERTY, DEPENDENCIES_ENV, "").split(",");
         }
 
         public static Pattern getClassPattern() {

--- a/tools/jbang/src/main/java/org/citrusframework/jbang/StringPrinter.java
+++ b/tools/jbang/src/main/java/org/citrusframework/jbang/StringPrinter.java
@@ -49,8 +49,6 @@ public class StringPrinter implements Printer {
 
     /**
      * Provides access to the cached output.
-     *
-     * @return
      */
     public String getOutput() {
         return writer.toString().trim();
@@ -58,9 +56,6 @@ public class StringPrinter implements Printer {
 
     /**
      * Provides access to all lines of the cached output.
-     *
-     * @return
-     * @throws IOException
      */
     public List<String> getLines() throws IOException {
         BufferedReader buf = new BufferedReader(new StringReader(getOutput()));

--- a/tools/jbang/src/main/java/org/citrusframework/jbang/commands/Init.java
+++ b/tools/jbang/src/main/java/org/citrusframework/jbang/commands/Init.java
@@ -24,6 +24,7 @@ import java.util.Stack;
 
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.jbang.CitrusJBangMain;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.citrusframework.util.FileUtils;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -34,7 +35,7 @@ import static java.nio.file.Files.writeString;
 @Command(name = "init", description = "Creates a new Citrus test")
 public class Init extends CitrusCommand {
 
-    @Parameters(description = "Name of integration file (or a github link)", arity = "1",
+    @Parameters(description = "Name of test file (or a github link)", arity = "1",
                 paramLabel = "<file>", parameterConsumer = FileConsumer.class)
     private Path filePath; // Defined only for file path completion; the field never used
 
@@ -54,7 +55,7 @@ public class Init extends CitrusCommand {
         String ext = FileUtils.getFileExtension(file);
         String name = FileUtils.getBaseName(file);
         String content;
-        try (InputStream is = Init.class.getClassLoader().getResourceAsStream("templates/" + ext + ".tmpl")) {
+        try (InputStream is = ClassLoaderHelper.getClassLoader(Init.class).getResourceAsStream("templates/" + ext + ".tmpl")) {
             if (is == null) {
                 printer().println("Error: Unsupported file type: " + ext);
                 return 1;

--- a/tools/jbang/src/main/java/org/citrusframework/jbang/commands/Run.java
+++ b/tools/jbang/src/main/java/org/citrusframework/jbang/commands/Run.java
@@ -21,6 +21,7 @@ import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.UnsupportedFlavorException;
 import java.io.File;
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -29,23 +30,28 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Stack;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.camel.tooling.maven.MavenArtifact;
 import org.citrusframework.CitrusInstanceManager;
 import org.citrusframework.agent.CitrusAgentConfiguration;
 import org.citrusframework.agent.util.ConfigurationHelper;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.jbang.CitrusJBangMain;
 import org.citrusframework.jbang.LoggingSupport;
+import org.citrusframework.jbang.maven.MavenDependencyResolver;
 import org.citrusframework.main.TestEngine;
 import org.citrusframework.main.TestRunConfiguration;
 import org.citrusframework.report.TestReporter;
 import org.citrusframework.report.TestReporterSettings;
 import org.citrusframework.report.TestResults;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.citrusframework.util.FileUtils;
 import org.citrusframework.util.StringUtils;
+import org.jetbrains.annotations.NotNull;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
@@ -67,6 +73,18 @@ public class Run extends CitrusCommand {
 
     @Option(names = { "--work-directory" }, description = "The working directory used by the file based test engines to load file resources from.")
     private String workDir;
+
+    @Option(names = { "--repository" }, arity = "0..*", description = "Set of Maven repositories that should be used to resolve dependencies.")
+    private String[] repositories;
+
+    @Option(names = { "--modules" }, description = "Comma delimited list of additional Citrus modules that must be loaded to run the test.")
+    private String modules;
+
+    @Option(names = { "--dep" }, arity = "0..*", description = "Set of additional Maven dependencies that must be loaded to run the test.")
+    private String[] dependencies;
+
+    @Option(names = { "--offline" }, defaultValue = "false", description = "When enabled there will be no attempts to resolve Maven artifacts via internet connection.")
+    private boolean offline;
 
     @Option(names = { "--property" }, arity = "0..*", description = "Default System property to set before the test run.")
     private String[] properties;
@@ -154,8 +172,83 @@ public class Run extends CitrusCommand {
             LoggingSupport.configureLog("off", false, configuration.getEngine());
         }
 
+        if (!offline) {
+            handleAdditionalDependencies();
+        }
+
         engine.run();
         return exitStatus.exitStatus();
+    }
+
+    private void handleAdditionalDependencies() {
+        MavenDependencyResolver resolver = getMavenDependencyResolver();
+        List<MavenArtifact> additionalArtifacts = new ArrayList<>();
+
+        // Handle Citrus modules from envVar settings
+        Arrays.stream(CitrusJBangMain.Settings.getModules())
+                .map(String::trim)
+                .filter(StringUtils::hasText)
+                .forEach(module -> additionalArtifacts.addAll(resolver.resolveModule(module.trim())));
+
+        // Handle Citrus modules from command line options
+        if (StringUtils.hasText(modules)) {
+            for (String module : modules.split(",")) {
+                additionalArtifacts.addAll(resolver.resolveModule(module.trim()));
+            }
+        }
+
+        Predicate<String> isSnapshotArtifact = it -> it.contains("-SNAPSHOT");
+        // Handle Citrus dependencies from envVar settings
+        Arrays.stream(CitrusJBangMain.Settings.getDependencies())
+                .map(String::trim)
+                .filter(StringUtils::hasText)
+                .forEach(dependency ->
+                    additionalArtifacts.addAll(resolver.resolve(dependency.trim(), isSnapshotArtifact.test(dependency), true)));
+
+        // Handle Citrus dependencies from command line options
+        if (dependencies != null) {
+            for (String dependency : dependencies) {
+                additionalArtifacts.addAll(
+                        resolver.resolve(dependency.trim(), isSnapshotArtifact.test(dependency), true));
+            }
+        }
+
+        if (!additionalArtifacts.isEmpty()) {
+            additionalArtifacts.forEach(mavenArtifact -> {
+                try {
+                    ClassLoaderHelper.addArtifact(mavenArtifact.toString(), mavenArtifact.getFile().toURI().toURL());
+                } catch (MalformedURLException e) {
+                    printer().printErr(String.format("Error resolving artifact %s due to '%s'", mavenArtifact, e.getMessage()));
+                }
+            });
+
+            try {
+                // Adapt and set class loader in main thread
+                Thread.currentThread().setContextClassLoader(ClassLoaderHelper.getContextClassLoader());
+            } catch (Throwable e) {
+                printer().printErr("Failed to set context class loader with additional dependencies due to '%s'".formatted(e.getMessage()));
+            }
+        }
+    }
+
+    private @NotNull MavenDependencyResolver getMavenDependencyResolver() {
+        MavenDependencyResolver resolver = new MavenDependencyResolver();
+        if (repositories != null) {
+            for (String repository : repositories) {
+                String name;
+                String url;
+                if (repository.contains(":")) {
+                    String[] parts = repository.split(":");
+                    name = parts[0];
+                    url = parts[1];
+                } else {
+                    name = "custom";
+                    url = repository;
+                }
+                resolver.withRepository(name, url);
+            }
+        }
+        return resolver;
     }
 
     private void resolveTests(String[] files, List<String> tests) throws Exception {

--- a/tools/jbang/src/main/java/org/citrusframework/jbang/maven/MavenDependencyResolver.java
+++ b/tools/jbang/src/main/java/org/citrusframework/jbang/maven/MavenDependencyResolver.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.jbang.maven;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.camel.tooling.maven.MavenArtifact;
+import org.apache.camel.tooling.maven.MavenDownloader;
+import org.apache.camel.tooling.maven.MavenDownloaderImpl;
+import org.citrusframework.CitrusVersion;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Dependency resolver is able to load Maven dependencies as artifacts and add it to the given classloader.
+ */
+public class MavenDependencyResolver {
+
+    /** Logger */
+    private static final Logger logger = LoggerFactory.getLogger(MavenDependencyResolver.class);
+
+    private final MavenDownloader downloader;
+    private final Map<String, String> repositories = new LinkedHashMap<>();
+
+    public MavenDependencyResolver() {
+        this(new MavenDownloaderImpl());
+    }
+
+    public MavenDependencyResolver(MavenDownloader downloader) {
+        this.downloader = downloader;
+
+        downloader.build();
+    }
+
+    /**
+     * Resolves Maven artifact using passed coordinates and use downloaded artifact
+     * as one of the URLs in the classLoader, so classes in the artifact become accessible in the classLoader.
+     */
+    public List<MavenArtifact> resolve(String gav, boolean useSnapshots, boolean transitive) {
+        try {
+            Set<String> extraRepositories = new LinkedHashSet<>(repositories.values());
+
+            logger.info("Resolving Maven dependency: " + gav);
+
+            List<MavenArtifact> artifacts =
+                    downloader.resolveArtifacts(Collections.singletonList(gav), extraRepositories, transitive,
+                            useSnapshots);
+
+            if (logger.isDebugEnabled()) {
+                artifacts.forEach(mavenArtifact -> logger.debug("Loaded Maven artifact: " + mavenArtifact));
+            }
+
+            return artifacts;
+        } catch (Throwable e) {
+            logger.warn(String.format("Error resolving artifact %s due to %s", gav, e.getMessage()), e);
+        }
+
+        return Collections.emptyList();
+    }
+
+    /**
+     * Resolve Citrus module using the current Citrus version.
+     * Automatically adds Maven groupId and version information to build proper Maven gav coordinates for the Citrus module.
+     */
+    public List<MavenArtifact> resolveModule(String module) {
+        String moduleName;
+        if (module.startsWith("citrus-")) {
+            moduleName = module;
+        } else {
+            moduleName = "citrus-" + module;
+        }
+
+        return resolve("org.citrusframework:%s:%s".formatted(moduleName, CitrusVersion.version()),
+                CitrusVersion.version().contains("-SNAPSHOT"), true);
+    }
+
+    public MavenDependencyResolver withRepository(String key, String value) {
+        repositories.put(key, value);
+        return this;
+    }
+}

--- a/utils/citrus-test-support/src/main/java/org/citrusframework/testng/UnitTestConfigImportSelector.java
+++ b/utils/citrus-test-support/src/main/java/org/citrusframework/testng/UnitTestConfigImportSelector.java
@@ -16,6 +16,7 @@
 
 package org.citrusframework.testng;
 
+import org.citrusframework.util.ClassLoaderHelper;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DeferredImportSelector;
 import org.springframework.context.annotation.ImportResource;
@@ -25,7 +26,7 @@ import org.springframework.util.ClassUtils;
 public class UnitTestConfigImportSelector implements DeferredImportSelector {
     @Override
     public String[] selectImports(AnnotationMetadata importingClassMetadata) {
-        if (ClassUtils.isPresent("org.citrusframework.config.ComponentLifecycleProcessor", getClass().getClassLoader())) {
+        if (ClassUtils.isPresent("org.citrusframework.config.ComponentLifecycleProcessor", ClassLoaderHelper.getClassLoader(getClass()))) {
             return new String[]{
                     DefaultUnitTestConfig.class.getName(),
                     ComponentLifecycleConfig.class.getName()

--- a/validation/citrus-validation-groovy/src/main/java/org/citrusframework/validation/script/GroovyScriptMessageValidator.java
+++ b/validation/citrus-validation-groovy/src/main/java/org/citrusframework/validation/script/GroovyScriptMessageValidator.java
@@ -16,6 +16,11 @@
 
 package org.citrusframework.validation.script;
 
+import java.io.IOException;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.List;
+
 import groovy.lang.GroovyClassLoader;
 import groovy.lang.GroovyObject;
 import org.citrusframework.context.TestContext;
@@ -26,17 +31,13 @@ import org.citrusframework.message.MessageType;
 import org.citrusframework.script.ScriptTypes;
 import org.citrusframework.spi.Resource;
 import org.citrusframework.spi.Resources;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.citrusframework.util.StringUtils;
 import org.citrusframework.validation.AbstractMessageValidator;
 import org.citrusframework.validation.context.ValidationContext;
 import org.codehaus.groovy.control.CompilationFailedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.util.List;
 
 /**
  * Groovy script message validator passing the message to a validation script.
@@ -103,7 +104,7 @@ public class GroovyScriptMessageValidator extends AbstractMessageValidator<Scrip
     }
 
     private static GroovyClassLoader getPrivilegedGroovyLoader() {
-        return AccessController.doPrivileged((PrivilegedAction<GroovyClassLoader>) () -> new GroovyClassLoader(GroovyScriptMessageValidator.class.getClassLoader()));
+        return AccessController.doPrivileged((PrivilegedAction<GroovyClassLoader>) () -> new GroovyClassLoader(ClassLoaderHelper.getClassLoader(GroovyScriptMessageValidator.class)));
     }
 
     @Override

--- a/validation/citrus-validation-groovy/src/main/java/org/citrusframework/validation/script/sql/GroovySqlResultSetValidator.java
+++ b/validation/citrus-validation-groovy/src/main/java/org/citrusframework/validation/script/sql/GroovySqlResultSetValidator.java
@@ -16,6 +16,11 @@
 
 package org.citrusframework.validation.script.sql;
 
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+import java.util.Map;
+
 import groovy.lang.GroovyClassLoader;
 import groovy.lang.GroovyObject;
 import org.citrusframework.context.TestContext;
@@ -24,6 +29,7 @@ import org.citrusframework.exceptions.ValidationException;
 import org.citrusframework.script.ScriptTypes;
 import org.citrusframework.spi.Resource;
 import org.citrusframework.spi.Resources;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.citrusframework.util.StringUtils;
 import org.citrusframework.validation.script.GroovyScriptMessageValidator;
 import org.citrusframework.validation.script.ScriptValidationContext;
@@ -31,11 +37,6 @@ import org.citrusframework.validation.script.TemplateBasedScriptBuilder;
 import org.codehaus.groovy.control.CompilationFailedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Groovy script validator capable of validating SQL result sets.
@@ -77,7 +78,7 @@ public class GroovySqlResultSetValidator implements SqlResultSetScriptValidator 
                 if (StringUtils.hasText(validationScript)) {
                     logger.debug("Start groovy SQL result set validation");
 
-                    try (var loader = new GroovyClassLoader(GroovyScriptMessageValidator.class.getClassLoader())) {
+                    try (var loader = new GroovyClassLoader(ClassLoaderHelper.getClassLoader(GroovyScriptMessageValidator.class))) {
                         Class<?> groovyClass = loader.parseClass(TemplateBasedScriptBuilder.fromTemplateResource(scriptTemplateResource)
                                 .withCode(validationScript)
                                 .build());


### PR DESCRIPTION
- Introduce `--module` and `--dependency` options in Citrus JBang run command to declare additional artifacts that should be loaded into the classpath (e.g. citrus-kafka, citrus-camel)
- Uses the Maven downloader implementation from Apache Camel to resolve Maven artifacts and its dependencies
- Adds the resolved artifacts to the classpath with the current context class loader
- Provide a class loader helper utility that is aware of the loaded artifacts in order to construct proper URL class loader instances that honor the additional classpath entries
- Refactor all occurrences of class loader instantiation in Citrus to use the new class loader helper
- Helper makes sure to adapt class loaders with the loaded artifacts
- Enables dynamic loading of additional Maven dependencies at runtime (e.g. in Citrus JBang execution)

Fixes #1489  