### PR TITLE
fix(#1491): Add inspect command in Citrus JBang

### DIFF
--- a/catalog/citrus-catalog-schema/pom.xml
+++ b/catalog/citrus-catalog-schema/pom.xml
@@ -16,6 +16,9 @@
   <build>
     <resources>
       <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+      <resource>
         <directory>${project.build.directory}/generated-resources</directory>
       </resource>
     </resources>

--- a/connectors/citrus-agent-connector/src/main/java/org/citrusframework/agent/connector/yaml/Agent.java
+++ b/connectors/citrus-agent-connector/src/main/java/org/citrusframework/agent/connector/yaml/Agent.java
@@ -44,7 +44,7 @@ public class Agent implements TestActionBuilder<AbstractAgentAction> {
         this.agentName = name;
     }
 
-    @SchemaProperty(kind = ACTION, group = "agent")
+    @SchemaProperty(kind = ACTION, group = "agent", module = "citrus-agent-connector")
     public void setConnect(Connect connect) {
         AgentConnectAction.Builder builder = new AgentConnectAction.Builder();
 
@@ -54,7 +54,7 @@ public class Agent implements TestActionBuilder<AbstractAgentAction> {
         delegate = builder;
     }
 
-    @SchemaProperty(kind = ACTION, group = "agent")
+    @SchemaProperty(kind = ACTION, group = "agent", module = "citrus-agent-connector")
     public void setRun(Run run) {
         AgentRunAction.Builder builder = new AgentRunAction.Builder();
         if (run.getSource() != null) {

--- a/connectors/citrus-jbang-connector/src/main/java/org/citrusframework/jbang/CitrusJBang.java
+++ b/connectors/citrus-jbang-connector/src/main/java/org/citrusframework/jbang/CitrusJBang.java
@@ -61,7 +61,6 @@ public class CitrusJBang {
 
     /**
      * Static entrance method to retrieve instance of Citrus JBang.
-     * @return
      */
     public static CitrusJBang citrus() {
         return new CitrusJBang();
@@ -196,6 +195,21 @@ public class CitrusJBang {
     public String ls() {
         ProcessAndOutput p = app.run("ls");
         return p.getOutput();
+    }
+
+    /**
+     * Inspect the given test source file and return detailed information.
+     */
+    public String inspect(String fileNameOrDir) {
+        ProcessAndOutput p = app.run("inspect", fileNameOrDir);
+
+        // expects a Json output, remove anything printed before the actual Json
+        String json = p.getOutput();
+        if (json.contains("{")) {
+            json = json.substring(json.indexOf("{")).trim();
+        }
+
+        return json;
     }
 
     /**

--- a/connectors/citrus-knative/src/main/java/org/citrusframework/knative/yaml/Knative.java
+++ b/connectors/citrus-knative/src/main/java/org/citrusframework/knative/yaml/Knative.java
@@ -34,6 +34,9 @@ import static org.citrusframework.yaml.SchemaProperty.Kind.ACTION;
 
 public class Knative implements TestActionBuilder<KnativeAction>, ReferenceResolverAware {
 
+    private static final String KNATIVE_GROUP = "knative";
+    private static final String KNATIVE_MODULE = "citrus-knative";
+
     private AbstractKnativeAction.Builder<?, ?> builder;
 
     private String description;
@@ -83,62 +86,62 @@ public class Knative implements TestActionBuilder<KnativeAction>, ReferenceResol
         this.knativeClient = client;
     }
 
-    @SchemaProperty(kind = ACTION, group = "knative")
+    @SchemaProperty(kind = ACTION, group = KNATIVE_GROUP, module = KNATIVE_MODULE)
     public void setCreateBroker(CreateBroker builder) {
         this.builder = builder;
     }
 
-    @SchemaProperty(kind = ACTION, group = "knative")
+    @SchemaProperty(kind = ACTION, group = KNATIVE_GROUP, module = KNATIVE_MODULE)
     public void setDeleteBroker(DeleteBroker builder) {
         this.builder = builder;
     }
 
-    @SchemaProperty(kind = ACTION, group = "knative")
+    @SchemaProperty(kind = ACTION, group = KNATIVE_GROUP, module = KNATIVE_MODULE)
     public void setVerifyBroker(VerifyBroker builder) {
         this.builder = builder;
     }
 
-    @SchemaProperty(kind = ACTION, group = "knative")
+    @SchemaProperty(kind = ACTION, group = KNATIVE_GROUP, module = KNATIVE_MODULE)
     public void setCreateTrigger(CreateTrigger builder) {
         this.builder = builder;
     }
 
-    @SchemaProperty(kind = ACTION, group = "knative")
+    @SchemaProperty(kind = ACTION, group = KNATIVE_GROUP, module = KNATIVE_MODULE)
     public void setDeleteTrigger(DeleteTrigger builder) {
         this.builder = builder;
     }
 
-    @SchemaProperty(kind = ACTION, group = "knative")
+    @SchemaProperty(kind = ACTION, group = KNATIVE_GROUP, module = KNATIVE_MODULE)
     public void setCreateChannel(CreateChannel builder) {
         this.builder = builder;
     }
 
-    @SchemaProperty(kind = ACTION, group = "knative")
+    @SchemaProperty(kind = ACTION, group = KNATIVE_GROUP, module = KNATIVE_MODULE)
     public void setDeleteChannel(DeleteChannel builder) {
         this.builder = builder;
     }
 
-    @SchemaProperty(kind = ACTION, group = "knative")
+    @SchemaProperty(kind = ACTION, group = KNATIVE_GROUP, module = KNATIVE_MODULE)
     public void setCreateSubscription(CreateSubscription builder) {
         this.builder = builder;
     }
 
-    @SchemaProperty(kind = ACTION, group = "knative")
+    @SchemaProperty(kind = ACTION, group = KNATIVE_GROUP, module = KNATIVE_MODULE)
     public void setDeleteSubscription(DeleteSubscription builder) {
         this.builder = builder;
     }
 
-    @SchemaProperty(kind = ACTION, group = "knative")
+    @SchemaProperty(kind = ACTION, group = KNATIVE_GROUP, module = KNATIVE_MODULE)
     public void setSendEvent(SendEvent builder) {
         this.builder = builder;
     }
 
-    @SchemaProperty(kind = ACTION, group = "knative")
+    @SchemaProperty(kind = ACTION, group = KNATIVE_GROUP, module = KNATIVE_MODULE)
     public void setReceiveEvent(ReceiveEvent builder) {
         this.builder = builder;
     }
 
-    @SchemaProperty(kind = ACTION, group = "knative")
+    @SchemaProperty(kind = ACTION, group = KNATIVE_GROUP, module = KNATIVE_MODULE)
     public void setDeleteResource(DeleteResource builder) {
         this.builder = builder;
     }

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/yaml/Kubernetes.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/yaml/Kubernetes.java
@@ -32,6 +32,9 @@ import static org.citrusframework.yaml.SchemaProperty.Kind.ACTION;
 
 public class Kubernetes implements TestActionBuilder<KubernetesAction>, ReferenceResolverAware {
 
+    private static final String KUBERNETES_GROUP = "kubernetes";
+    private static final String KUBERNETES_MODULE = "citrus-kubernetes";
+
     private AbstractKubernetesAction.Builder<?, ?> builder;
 
     private String description;
@@ -69,102 +72,102 @@ public class Kubernetes implements TestActionBuilder<KubernetesAction>, Referenc
         this.kubernetesClient = client;
     }
 
-    @SchemaProperty(kind = ACTION, group = "kubernetes")
+    @SchemaProperty(kind = ACTION, group = KUBERNETES_GROUP, module=KUBERNETES_MODULE)
     public void setAgent(Agent builder) {
         this.builder = builder;
     }
 
-    @SchemaProperty(kind = ACTION, group = "kubernetes")
+    @SchemaProperty(kind = ACTION, group = KUBERNETES_GROUP, module=KUBERNETES_MODULE)
     public void setConnect(Connect builder) {
         this.builder = builder;
     }
 
-    @SchemaProperty(kind = ACTION, group = "kubernetes")
+    @SchemaProperty(kind = ACTION, group = KUBERNETES_GROUP, module=KUBERNETES_MODULE)
     public void setDisconnect(Disconnect builder) {
         this.builder = builder;
     }
 
-    @SchemaProperty(kind = ACTION, group = "kubernetes")
+    @SchemaProperty(kind = ACTION, group = KUBERNETES_GROUP, module=KUBERNETES_MODULE)
     public void setConnectService(ConnectService builder) {
         this.builder = builder;
     }
 
-    @SchemaProperty(kind = ACTION, group = "kubernetes")
+    @SchemaProperty(kind = ACTION, group = KUBERNETES_GROUP, module=KUBERNETES_MODULE)
     public void setDisconnectService(DisconnectService builder) {
         this.builder = builder;
     }
 
-    @SchemaProperty(kind = ACTION, group = "kubernetes")
+    @SchemaProperty(kind = ACTION, group = KUBERNETES_GROUP, module=KUBERNETES_MODULE)
     public void setCreateService(CreateService builder) {
         this.builder = builder;
     }
 
-    @SchemaProperty(kind = ACTION, group = "kubernetes")
+    @SchemaProperty(kind = ACTION, group = KUBERNETES_GROUP, module=KUBERNETES_MODULE)
     public void setCreateSecret(CreateSecret builder) {
         this.builder = builder;
     }
 
-    @SchemaProperty(kind = ACTION, group = "kubernetes")
+    @SchemaProperty(kind = ACTION, group = KUBERNETES_GROUP, module=KUBERNETES_MODULE)
     public void setCreateConfigMap(CreateConfigMap builder) {
         this.builder = builder;
     }
 
-    @SchemaProperty(kind = ACTION, group = "kubernetes")
+    @SchemaProperty(kind = ACTION, group = KUBERNETES_GROUP, module=KUBERNETES_MODULE)
     public void setCreateResource(CreateResource builder) {
         this.builder = builder;
     }
 
-    @SchemaProperty(kind = ACTION, group = "kubernetes")
+    @SchemaProperty(kind = ACTION, group = KUBERNETES_GROUP, module=KUBERNETES_MODULE)
     public void setCreateCustomResource(CreateCustomResource builder) {
         this.builder = builder;
     }
 
-    @SchemaProperty(kind = ACTION, group = "kubernetes")
+    @SchemaProperty(kind = ACTION, group = KUBERNETES_GROUP, module=KUBERNETES_MODULE)
     public void setCreateLabels(CreateLabels builder) {
         this.builder = builder;
     }
 
-    @SchemaProperty(kind = ACTION, group = "kubernetes")
+    @SchemaProperty(kind = ACTION, group = KUBERNETES_GROUP, module=KUBERNETES_MODULE)
     public void setCreateAnnotations(CreateAnnotations builder) {
         this.builder = builder;
     }
 
-    @SchemaProperty(kind = ACTION, group = "kubernetes")
+    @SchemaProperty(kind = ACTION, group = KUBERNETES_GROUP, module=KUBERNETES_MODULE)
     public void setDeleteService(DeleteService builder) {
         this.builder = builder;
     }
 
-    @SchemaProperty(kind = ACTION, group = "kubernetes")
+    @SchemaProperty(kind = ACTION, group = KUBERNETES_GROUP, module=KUBERNETES_MODULE)
     public void setDeleteSecret(DeleteSecret builder) {
         this.builder = builder;
     }
 
-    @SchemaProperty(kind = ACTION, group = "kubernetes")
+    @SchemaProperty(kind = ACTION, group = KUBERNETES_GROUP, module=KUBERNETES_MODULE)
     public void setDeleteConfigMap(DeleteConfigMap builder) {
         this.builder = builder;
     }
 
-    @SchemaProperty(kind = ACTION, group = "kubernetes")
+    @SchemaProperty(kind = ACTION, group = KUBERNETES_GROUP, module=KUBERNETES_MODULE)
     public void setDeleteResource(DeleteResource builder) {
         this.builder = builder;
     }
 
-    @SchemaProperty(kind = ACTION, group = "kubernetes")
+    @SchemaProperty(kind = ACTION, group = KUBERNETES_GROUP, module=KUBERNETES_MODULE)
     public void setDeleteCustomResource(DeleteCustomResource builder) {
         this.builder = builder;
     }
 
-    @SchemaProperty(kind = ACTION, group = "kubernetes")
+    @SchemaProperty(kind = ACTION, group = KUBERNETES_GROUP, module=KUBERNETES_MODULE)
     public void setVerifyPod(VerifyPod builder) {
         this.builder = builder;
     }
 
-    @SchemaProperty(kind = ACTION, group = "kubernetes")
+    @SchemaProperty(kind = ACTION, group = KUBERNETES_GROUP, module=KUBERNETES_MODULE)
     public void setVerifyCustomResource(VerifyCustomResource builder) {
         this.builder = builder;
     }
 
-    @SchemaProperty(kind = ACTION, group = "kubernetes")
+    @SchemaProperty(kind = ACTION, group = KUBERNETES_GROUP, module=KUBERNETES_MODULE)
     public void setWatchPodLogs(WatchPodLogs builder) {
         this.builder = builder;
     }

--- a/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/yaml/OpenApi.java
+++ b/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/yaml/OpenApi.java
@@ -56,6 +56,7 @@ import static org.citrusframework.yaml.SchemaProperty.Kind.ACTION;
 public class OpenApi implements TestActionBuilder<TestAction>, ReferenceResolverAware {
 
     private static final String OPENAPI_GROUP = "openapi";
+    private static final String OPENAPI_MODULE = "citrus-openapi";
 
     private OpenApiSpecificationSourceAwareBuilder<?> builder;
 
@@ -117,7 +118,8 @@ public class OpenApi implements TestActionBuilder<TestAction>, ReferenceResolver
         }
     }
 
-    @SchemaProperty(kind = ACTION, group = OPENAPI_GROUP, description = "Send a request as a client.")
+    @SchemaProperty(kind = ACTION, group = OPENAPI_GROUP, module=OPENAPI_MODULE,
+            description = "Send a request as a client.")
     public void setSendRequest(ClientRequest request) {
         OpenApiClientRequestActionBuilder requestBuilder =
             asClientBuilder().send(request.getOperation());
@@ -156,7 +158,8 @@ public class OpenApi implements TestActionBuilder<TestAction>, ReferenceResolver
         builder = requestBuilder;
     }
 
-    @SchemaProperty(kind = ACTION, group = OPENAPI_GROUP, description = "Receives a response as a client.")
+    @SchemaProperty(kind = ACTION, group = OPENAPI_GROUP, module=OPENAPI_MODULE,
+            description = "Receives a response as a client.")
     public void setReceiveResponse(ClientResponse response) {
         OpenApiClientResponseActionBuilder responseBuilder =
                 asClientBuilder().receive(response.getOperation(), response.getStatus());
@@ -201,7 +204,8 @@ public class OpenApi implements TestActionBuilder<TestAction>, ReferenceResolver
         builder = responseBuilder;
     }
 
-    @SchemaProperty(kind = ACTION, group = OPENAPI_GROUP, description = "Receives a client request as a server.")
+    @SchemaProperty(kind = ACTION, group = OPENAPI_GROUP, module=OPENAPI_MODULE,
+            description = "Receives a client request as a server.")
     public void setReceiveRequest(ServerRequest request) {
         OpenApiServerRequestActionBuilder requestBuilder =
                 asServerBuilder().receive(request.getOperation());
@@ -244,7 +248,8 @@ public class OpenApi implements TestActionBuilder<TestAction>, ReferenceResolver
         builder = requestBuilder;
     }
 
-    @SchemaProperty(kind = ACTION, group = OPENAPI_GROUP, description = "Sends a response as a server.")
+    @SchemaProperty(kind = ACTION, group = OPENAPI_GROUP, module=OPENAPI_MODULE,
+            description = "Sends a response as a server.")
     public void setSendResponse(ServerResponse response) {
         OpenApiServerResponseActionBuilder responseBuilder =
                 asServerBuilder().send(response.getOperation(), response.getStatus());

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/Selenium.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/yaml/Selenium.java
@@ -31,6 +31,9 @@ import static org.citrusframework.yaml.SchemaProperty.Kind.ACTION;
 
 public class Selenium implements TestActionBuilder<SeleniumAction>, ReferenceResolverAware {
 
+    private static final String SELENIUM_GROUP = "selenium";
+    private static final String SELENIUM_MODULE = "citrus-selenium";
+
     private AbstractSeleniumAction.Builder<?, ?> builder;
 
     private String description;
@@ -61,7 +64,7 @@ public class Selenium implements TestActionBuilder<SeleniumAction>, ReferenceRes
     /**
      * Start browser instance.
      */
-    @SchemaProperty(kind = ACTION, group = "selenium")
+    @SchemaProperty(kind = ACTION, group = SELENIUM_GROUP, module = SELENIUM_MODULE)
     public void setStart(StartBrowser builder) {
         this.builder = builder;
     }
@@ -69,7 +72,7 @@ public class Selenium implements TestActionBuilder<SeleniumAction>, ReferenceRes
     /**
      * Stop browser instance.
      */
-    @SchemaProperty(kind = ACTION, group = "selenium")
+    @SchemaProperty(kind = ACTION, group = SELENIUM_GROUP, module = SELENIUM_MODULE)
     public void setStop(StopBrowser builder) {
         this.builder = builder;
     }
@@ -77,7 +80,7 @@ public class Selenium implements TestActionBuilder<SeleniumAction>, ReferenceRes
     /**
      * Alert element.
      */
-    @SchemaProperty(kind = ACTION, group = "selenium")
+    @SchemaProperty(kind = ACTION, group = SELENIUM_GROUP, module = SELENIUM_MODULE)
     public void setAlert(Alert builder) {
         this.builder = builder;
     }
@@ -85,7 +88,7 @@ public class Selenium implements TestActionBuilder<SeleniumAction>, ReferenceRes
     /**
      * Navigate action.
      */
-    @SchemaProperty(kind = ACTION, group = "selenium")
+    @SchemaProperty(kind = ACTION, group = SELENIUM_GROUP, module = SELENIUM_MODULE)
     public void setNavigate(Navigate builder) {
         this.builder = builder;
     }
@@ -93,7 +96,7 @@ public class Selenium implements TestActionBuilder<SeleniumAction>, ReferenceRes
     /**
      * Page action.
      */
-    @SchemaProperty(kind = ACTION, group = "selenium")
+    @SchemaProperty(kind = ACTION, group = SELENIUM_GROUP, module = SELENIUM_MODULE)
     public void setPage(Page builder) {
         this.builder = builder;
     }
@@ -101,7 +104,7 @@ public class Selenium implements TestActionBuilder<SeleniumAction>, ReferenceRes
     /**
      * Finds element.
      */
-    @SchemaProperty(kind = ACTION, group = "selenium")
+    @SchemaProperty(kind = ACTION, group = SELENIUM_GROUP, module = SELENIUM_MODULE)
     public void setFind(FindElement builder) {
         this.builder = builder;
     }
@@ -109,7 +112,7 @@ public class Selenium implements TestActionBuilder<SeleniumAction>, ReferenceRes
     /**
      * Dropdown select single option action.
      */
-    @SchemaProperty(kind = ACTION, group = "selenium")
+    @SchemaProperty(kind = ACTION, group = SELENIUM_GROUP, module = SELENIUM_MODULE)
     public void setDropdownSelect(DropDownSelect builder) {
         this.builder = builder;
     }
@@ -117,7 +120,7 @@ public class Selenium implements TestActionBuilder<SeleniumAction>, ReferenceRes
     /**
      * Set input action.
      */
-    @SchemaProperty(kind = ACTION, group = "selenium")
+    @SchemaProperty(kind = ACTION, group = SELENIUM_GROUP, module = SELENIUM_MODULE)
     public void setSetInput(SetInput builder) {
         this.builder = builder;
     }
@@ -125,7 +128,7 @@ public class Selenium implements TestActionBuilder<SeleniumAction>, ReferenceRes
     /**
      * Fill form action.
      */
-    @SchemaProperty(kind = ACTION, group = "selenium")
+    @SchemaProperty(kind = ACTION, group = SELENIUM_GROUP, module = SELENIUM_MODULE)
     public void setFillForm(FillForm builder) {
         this.builder = builder;
     }
@@ -133,7 +136,7 @@ public class Selenium implements TestActionBuilder<SeleniumAction>, ReferenceRes
     /**
      * Check input action.
      */
-    @SchemaProperty(kind = ACTION, group = "selenium")
+    @SchemaProperty(kind = ACTION, group = SELENIUM_GROUP, module = SELENIUM_MODULE)
     public void setCheckInput(CheckInput builder) {
         this.builder = builder;
     }
@@ -141,7 +144,7 @@ public class Selenium implements TestActionBuilder<SeleniumAction>, ReferenceRes
     /**
      * Clicks element.
      */
-    @SchemaProperty(kind = ACTION, group = "selenium")
+    @SchemaProperty(kind = ACTION, group = SELENIUM_GROUP, module = SELENIUM_MODULE)
     public void setClick(Click builder) {
         this.builder = builder;
     }
@@ -149,7 +152,7 @@ public class Selenium implements TestActionBuilder<SeleniumAction>, ReferenceRes
     /**
      * Hover element.
      */
-    @SchemaProperty(kind = ACTION, group = "selenium")
+    @SchemaProperty(kind = ACTION, group = SELENIUM_GROUP, module = SELENIUM_MODULE)
     public void setHover(Hover builder) {
         this.builder = builder;
     }
@@ -157,7 +160,7 @@ public class Selenium implements TestActionBuilder<SeleniumAction>, ReferenceRes
     /**
      * Clear browser cache.
      */
-    @SchemaProperty(kind = ACTION, group = "selenium")
+    @SchemaProperty(kind = ACTION, group = SELENIUM_GROUP, module = SELENIUM_MODULE)
     public void setClearCache(ClearBrowserCache builder) {
         this.builder = builder;
     }
@@ -165,7 +168,7 @@ public class Selenium implements TestActionBuilder<SeleniumAction>, ReferenceRes
     /**
      * Make screenshot.
      */
-    @SchemaProperty(kind = ACTION, group = "selenium")
+    @SchemaProperty(kind = ACTION, group = SELENIUM_GROUP, module = SELENIUM_MODULE)
     public void setScreenshot(MakeScreenshot builder) {
         this.builder = builder;
     }
@@ -173,7 +176,7 @@ public class Selenium implements TestActionBuilder<SeleniumAction>, ReferenceRes
     /**
      * Store file.
      */
-    @SchemaProperty(kind = ACTION, group = "selenium")
+    @SchemaProperty(kind = ACTION, group = SELENIUM_GROUP, module = SELENIUM_MODULE)
     public void setStoreFile(StoreFile builder) {
         this.builder = builder;
     }
@@ -181,7 +184,7 @@ public class Selenium implements TestActionBuilder<SeleniumAction>, ReferenceRes
     /**
      * Get stored file.
      */
-    @SchemaProperty(kind = ACTION, group = "selenium")
+    @SchemaProperty(kind = ACTION, group = SELENIUM_GROUP, module = SELENIUM_MODULE)
     public void setGetStoredFile(GetStoredFile builder) {
         this.builder = builder;
     }
@@ -189,7 +192,7 @@ public class Selenium implements TestActionBuilder<SeleniumAction>, ReferenceRes
     /**
      * Wait until element meets condition.
      */
-    @SchemaProperty(kind = ACTION, group = "selenium")
+    @SchemaProperty(kind = ACTION, group = SELENIUM_GROUP, module = SELENIUM_MODULE)
     public void setWaitUntil(WaitUntil builder) {
         this.builder = builder;
     }
@@ -197,7 +200,7 @@ public class Selenium implements TestActionBuilder<SeleniumAction>, ReferenceRes
     /**
      * Execute JavaScript.
      */
-    @SchemaProperty(kind = ACTION, group = "selenium")
+    @SchemaProperty(kind = ACTION, group = SELENIUM_GROUP, module = SELENIUM_MODULE)
     public void setJavaScript(JavaScript builder) {
         this.builder = builder;
     }
@@ -205,7 +208,7 @@ public class Selenium implements TestActionBuilder<SeleniumAction>, ReferenceRes
     /**
      * Open window.
      */
-    @SchemaProperty(kind = ACTION, group = "selenium")
+    @SchemaProperty(kind = ACTION, group = SELENIUM_GROUP, module = SELENIUM_MODULE)
     public void setOpenWindow(OpenWindow builder) {
         this.builder = builder;
     }
@@ -213,7 +216,7 @@ public class Selenium implements TestActionBuilder<SeleniumAction>, ReferenceRes
     /**
      * Close window.
      */
-    @SchemaProperty(kind = ACTION, group = "selenium")
+    @SchemaProperty(kind = ACTION, group = SELENIUM_GROUP, module = SELENIUM_MODULE)
     public void setCloseWindow(CloseWindow builder) {
         this.builder = builder;
     }
@@ -221,7 +224,7 @@ public class Selenium implements TestActionBuilder<SeleniumAction>, ReferenceRes
     /**
      * Focus window.
      */
-    @SchemaProperty(kind = ACTION, group = "selenium")
+    @SchemaProperty(kind = ACTION, group = SELENIUM_GROUP, module = SELENIUM_MODULE)
     public void setFocusWindow(SwitchWindow builder) {
         this.builder = builder;
     }
@@ -229,7 +232,7 @@ public class Selenium implements TestActionBuilder<SeleniumAction>, ReferenceRes
     /**
      * Switch window.
      */
-    @SchemaProperty(kind = ACTION, group = "selenium")
+    @SchemaProperty(kind = ACTION, group = SELENIUM_GROUP, module = SELENIUM_MODULE)
     public void setSwitchWindow(SwitchWindow builder) {
         this.builder = builder;
     }

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/yaml/Testcontainers.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/yaml/Testcontainers.java
@@ -48,17 +48,17 @@ public class Testcontainers implements TestActionBuilder<TestcontainersAction>, 
         this.actor = actor;
     }
 
-    @SchemaProperty(kind = GROUP, group = "testcontainers")
+    @SchemaProperty(kind = GROUP, group = "testcontainers", module = "citrus-testcontainers")
     public void setCompose(Compose builder) {
         this.builder = builder;
     }
 
-    @SchemaProperty(kind = GROUP, group = "testcontainers")
+    @SchemaProperty(kind = GROUP, group = "testcontainers", module = "citrus-testcontainers")
     public void setStart(Start builder) {
         this.builder = builder;
     }
 
-    @SchemaProperty(kind = ACTION, group = "testcontainers")
+    @SchemaProperty(kind = ACTION, group = "testcontainers", module = "citrus-testcontainers")
     public void setStop(Stop builder) {
         this.builder = builder;
     }

--- a/core/citrus-api/src/main/java/org/citrusframework/yaml/SchemaProperty.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/yaml/SchemaProperty.java
@@ -39,6 +39,11 @@ public @interface SchemaProperty {
     String group() default "";
 
     /**
+     * Citrus module information.
+     */
+    String module() default "";
+
+    /**
      * Name of the property
      */
     String name() default "";

--- a/core/citrus-api/src/main/java/org/citrusframework/yaml/SchemaType.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/yaml/SchemaType.java
@@ -28,5 +28,13 @@ import java.lang.annotation.Target;
 @Target({ElementType.TYPE, ElementType.METHOD})
 public @interface SchemaType {
 
+    /**
+     * Citrus module information.
+     */
+    String module() default "";
+
+    /**
+     * Declare one of association of multiple properties.
+     */
     String[] oneOf() default {};
 }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/endpoint/CamelEndpointsBuilder.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/endpoint/CamelEndpointsBuilder.java
@@ -25,7 +25,7 @@ import org.citrusframework.spi.ReferenceResolverAware;
 import org.citrusframework.yaml.SchemaProperty;
 import org.citrusframework.yaml.SchemaType;
 
-@SchemaType(oneOf = { "asynchronous", "synchronous" })
+@SchemaType(oneOf = { "asynchronous", "synchronous" }, module = "citrus-camel")
 public class CamelEndpointsBuilder implements EndpointBuilder<Endpoint>, ReferenceResolverAware {
 
     private EndpointBuilder<?> delegate;

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/Camel.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/Camel.java
@@ -33,6 +33,7 @@ import static org.citrusframework.yaml.SchemaProperty.Kind.GROUP;
 public class Camel implements TestActionBuilder<TestAction>, ReferenceResolverAware {
 
     private static final String CAMEL_GROUP = "camel";
+    private static final String CAMEL_MODULE = "citrus-camel";
     private CamelActionBuilderWrapper<?> delegate;
 
     private String description;
@@ -41,7 +42,8 @@ public class Camel implements TestActionBuilder<TestAction>, ReferenceResolverAw
 
     private ReferenceResolver referenceResolver;
 
-    @SchemaProperty(advanced = true, description = "Test action description printed when the action is executed.")
+    @SchemaProperty(advanced = true,
+            description = "Test action description printed when the action is executed.")
     public void setDescription(String value) {
         this.description = value;
     }
@@ -56,57 +58,68 @@ public class Camel implements TestActionBuilder<TestAction>, ReferenceResolverAw
         this.camelContext = camelContext;
     }
 
-    @SchemaProperty(kind = ACTION, group = CAMEL_GROUP, description = "Connects with the Camel control bus to run operations.")
+    @SchemaProperty(kind = ACTION, group = CAMEL_GROUP, module=CAMEL_MODULE,
+            description = "Connects with the Camel control bus to run operations.")
     public void setControlBus(ControlBus builder) {
         this.delegate = builder;
     }
 
-    @SchemaProperty(kind = ACTION, group = CAMEL_GROUP, description = "Create components in the Camel registry.")
+    @SchemaProperty(kind = ACTION, group = CAMEL_GROUP, module=CAMEL_MODULE,
+            description = "Create components in the Camel registry.")
     public void setCreateComponent(CreateComponent builder) {
         this.delegate = builder;
     }
 
-    @SchemaProperty(kind = ACTION, group = CAMEL_GROUP, description = "Create a new Camel context.")
+    @SchemaProperty(kind = ACTION, group = CAMEL_GROUP, module=CAMEL_MODULE,
+            description = "Create a new Camel context.")
     public void setCreateContext(CreateContext builder) {
         this.delegate = builder;
     }
 
-    @SchemaProperty(kind = ACTION, group = CAMEL_GROUP, description = "Starts the given Camel context.")
+    @SchemaProperty(kind = ACTION, group = CAMEL_GROUP, module=CAMEL_MODULE,
+            description = "Starts the given Camel context.")
     public void setStartContext(StartContext builder) {
         this.delegate = builder;
     }
 
-    @SchemaProperty(kind = ACTION, group = CAMEL_GROUP, description = "Stops the given Camel context.")
+    @SchemaProperty(kind = ACTION, group = CAMEL_GROUP, module=CAMEL_MODULE,
+            description = "Stops the given Camel context.")
     public void setStopContext(StopContext builder) {
         this.delegate = builder;
     }
 
-    @SchemaProperty(kind = ACTION, group = CAMEL_GROUP, description = "Create a new Camel route in the context.")
+    @SchemaProperty(kind = ACTION, group = CAMEL_GROUP, module=CAMEL_MODULE,
+            description = "Create a new Camel route in the context.")
     public void setCreateRoutes(CreateRoutes builder) {
         this.delegate = builder;
     }
 
-    @SchemaProperty(kind = ACTION, group = CAMEL_GROUP, description = "Start existing Camel routes in the context.")
+    @SchemaProperty(kind = ACTION, group = CAMEL_GROUP, module=CAMEL_MODULE,
+            description = "Start existing Camel routes in the context.")
     public void setStartRoutes(StartRoutes builder) {
         this.delegate = builder;
     }
 
-    @SchemaProperty(kind = ACTION, group = CAMEL_GROUP, description = "Stop given Camel routes.")
+    @SchemaProperty(kind = ACTION, group = CAMEL_GROUP, module=CAMEL_MODULE,
+            description = "Stop given Camel routes.")
     public void setStopRoutes(StopRoutes builder) {
         this.delegate = builder;
     }
 
-    @SchemaProperty(kind = ACTION, group = CAMEL_GROUP, description = "Remove given Camel routes.")
+    @SchemaProperty(kind = ACTION, group = CAMEL_GROUP, module=CAMEL_MODULE,
+            description = "Remove given Camel routes.")
     public void setRemoveRoutes(RemoveRoutes builder) {
         this.delegate = builder;
     }
 
-    @SchemaProperty(kind = GROUP, group = CAMEL_GROUP, description = "Manage Camel infra services.")
+    @SchemaProperty(kind = GROUP, group = CAMEL_GROUP, module=CAMEL_MODULE,
+            description = "Manage Camel infra services.")
     public void setInfra(Infra builder) {
         this.delegate = builder;
     }
 
-    @SchemaProperty(kind = GROUP, group = CAMEL_GROUP, description = "Connect with Camel JBang to run commands.")
+    @SchemaProperty(kind = GROUP, group = CAMEL_GROUP, module=CAMEL_MODULE,
+            description = "Connect with Camel JBang to run commands.")
     public void setJbang(JBang builder) {
         this.delegate = builder;
     }

--- a/endpoints/citrus-ftp/src/main/java/org/citrusframework/ftp/endpoint/builder/FtpEndpointBuilder.java
+++ b/endpoints/citrus-ftp/src/main/java/org/citrusframework/ftp/endpoint/builder/FtpEndpointBuilder.java
@@ -27,7 +27,7 @@ import org.citrusframework.spi.ReferenceResolverAware;
 import org.citrusframework.yaml.SchemaProperty;
 import org.citrusframework.yaml.SchemaType;
 
-@SchemaType(oneOf = { "client", "server" })
+@SchemaType(oneOf = { "client", "server" }, module = "citrus-ftp")
 public class FtpEndpointBuilder implements EndpointBuilder<Endpoint>, ReferenceResolverAware {
 
     private EndpointBuilder<?> delegate;

--- a/endpoints/citrus-ftp/src/main/java/org/citrusframework/ftp/endpoint/builder/ScpEndpointBuilder.java
+++ b/endpoints/citrus-ftp/src/main/java/org/citrusframework/ftp/endpoint/builder/ScpEndpointBuilder.java
@@ -27,7 +27,7 @@ import org.citrusframework.spi.ReferenceResolverAware;
 import org.citrusframework.yaml.SchemaProperty;
 import org.citrusframework.yaml.SchemaType;
 
-@SchemaType(oneOf = { "client", "server" })
+@SchemaType(oneOf = { "client", "server" }, module = "citrus-ftp")
 public class ScpEndpointBuilder implements EndpointBuilder<Endpoint>, ReferenceResolverAware {
 
     private EndpointBuilder<?> delegate;

--- a/endpoints/citrus-ftp/src/main/java/org/citrusframework/ftp/endpoint/builder/SftpEndpointBuilder.java
+++ b/endpoints/citrus-ftp/src/main/java/org/citrusframework/ftp/endpoint/builder/SftpEndpointBuilder.java
@@ -27,7 +27,7 @@ import org.citrusframework.spi.ReferenceResolverAware;
 import org.citrusframework.yaml.SchemaProperty;
 import org.citrusframework.yaml.SchemaType;
 
-@SchemaType(oneOf = { "client", "server" })
+@SchemaType(oneOf = { "client", "server" }, module = "citrus-ftp")
 public class SftpEndpointBuilder implements EndpointBuilder<Endpoint>, ReferenceResolverAware {
 
     private EndpointBuilder<?> delegate;

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/endpoint/builder/HttpEndpointBuilder.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/endpoint/builder/HttpEndpointBuilder.java
@@ -30,7 +30,7 @@ import org.citrusframework.yaml.SchemaType;
 /**
  * Endpoint builder delegates to either client od server endpoint builder.
  */
-@SchemaType(oneOf = { "client", "server" })
+@SchemaType(oneOf = { "client", "server" }, module = "citrus-http")
 public class HttpEndpointBuilder implements EndpointBuilder<Endpoint>, ReferenceResolverAware {
 
     private EndpointBuilder<?> delegate;

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/yaml/Http.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/yaml/Http.java
@@ -49,6 +49,7 @@ import static org.citrusframework.yaml.SchemaProperty.Kind.ACTION;
 public class Http implements TestActionBuilder<TestAction>, ReferenceResolverAware {
 
     private static final String HTTP_GROUP = "http";
+    private static final String HTTP_MODULE = "citrus-http";
 
     private TestActionBuilder<?> builder;
 
@@ -92,7 +93,8 @@ public class Http implements TestActionBuilder<TestAction>, ReferenceResolverAwa
         }
     }
 
-    @SchemaProperty(kind = ACTION, group = HTTP_GROUP, description = "Send a Http request as a client.")
+    @SchemaProperty(kind = ACTION, group = HTTP_GROUP, module=HTTP_MODULE,
+            description = "Send a Http request as a client.")
     public void setSendRequest(ClientRequest request) {
         HttpClientRequestActionBuilder requestBuilder;
         HttpRequest requestMessage;
@@ -172,7 +174,8 @@ public class Http implements TestActionBuilder<TestAction>, ReferenceResolverAwa
         builder = requestBuilder;
     }
 
-    @SchemaProperty(kind = ACTION, group = HTTP_GROUP, description = "Receive an Http response as a client.")
+    @SchemaProperty(kind = ACTION, group = HTTP_GROUP, module=HTTP_MODULE,
+            description = "Receive an Http response as a client.")
     public void setReceiveResponse(ClientResponse response) {
         HttpClientResponseActionBuilder responseBuilder = asClientBuilder().receive().response().name("http:receive-response");
 
@@ -229,7 +232,8 @@ public class Http implements TestActionBuilder<TestAction>, ReferenceResolverAwa
         builder = responseBuilder;
     }
 
-    @SchemaProperty(kind = ACTION, group = HTTP_GROUP, description = "Receive an Http request as a server.")
+    @SchemaProperty(kind = ACTION, group = HTTP_GROUP, module=HTTP_MODULE,
+            description = "Receive an Http request as a server.")
     public void setReceiveRequest(ServerRequest request) {
         HttpServerRequestActionBuilder requestBuilder;
         HttpRequest requestMessage;
@@ -317,7 +321,8 @@ public class Http implements TestActionBuilder<TestAction>, ReferenceResolverAwa
         builder = requestBuilder;
     }
 
-    @SchemaProperty(kind = ACTION, group = HTTP_GROUP, description = "Send an Http response as a server.")
+    @SchemaProperty(kind = ACTION, group = HTTP_GROUP, module=HTTP_MODULE,
+            description = "Send an Http response as a server.")
     public void setSendResponse(ServerResponse response) {
         HttpServerResponseActionBuilder responseBuilder = asServerBuilder().send().response().name("http:send-response");
 

--- a/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/endpoint/JmsEndpointsBuilder.java
+++ b/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/endpoint/JmsEndpointsBuilder.java
@@ -25,7 +25,7 @@ import org.citrusframework.spi.ReferenceResolverAware;
 import org.citrusframework.yaml.SchemaProperty;
 import org.citrusframework.yaml.SchemaType;
 
-@SchemaType(oneOf = { "asynchronous", "synchronous" })
+@SchemaType(oneOf = { "asynchronous", "synchronous" }, module = "citrus-jms")
 public class JmsEndpointsBuilder implements EndpointBuilder<Endpoint>, ReferenceResolverAware {
 
     private EndpointBuilder<?> delegate;

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/builder/KafkaEndpointsBuilder.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/builder/KafkaEndpointsBuilder.java
@@ -26,7 +26,7 @@ import org.citrusframework.spi.ReferenceResolverAware;
 import org.citrusframework.yaml.SchemaProperty;
 import org.citrusframework.yaml.SchemaType;
 
-@SchemaType(oneOf = { "asynchronous", "synchronous" })
+@SchemaType(oneOf = { "asynchronous", "synchronous" }, module = "citrus-kafka")
 public class KafkaEndpointsBuilder implements EndpointBuilder<Endpoint>, ReferenceResolverAware {
 
     private EndpointBuilder<?> delegate;

--- a/endpoints/citrus-mail/src/main/java/org/citrusframework/mail/endpoint/builder/MailEndpointBuilder.java
+++ b/endpoints/citrus-mail/src/main/java/org/citrusframework/mail/endpoint/builder/MailEndpointBuilder.java
@@ -27,7 +27,7 @@ import org.citrusframework.spi.ReferenceResolverAware;
 import org.citrusframework.yaml.SchemaProperty;
 import org.citrusframework.yaml.SchemaType;
 
-@SchemaType(oneOf = { "client", "server" })
+@SchemaType(oneOf = { "client", "server" }, module = "citrus-mail")
 public class MailEndpointBuilder implements EndpointBuilder<Endpoint>, ReferenceResolverAware {
 
     private EndpointBuilder<?> delegate;

--- a/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/channel/endpoint/builder/MessageChannelEndpointsBuilder.java
+++ b/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/channel/endpoint/builder/MessageChannelEndpointsBuilder.java
@@ -27,7 +27,7 @@ import org.citrusframework.spi.ReferenceResolverAware;
 import org.citrusframework.yaml.SchemaProperty;
 import org.citrusframework.yaml.SchemaType;
 
-@SchemaType(oneOf = { "asynchronous", "synchronous" })
+@SchemaType(oneOf = { "asynchronous", "synchronous" }, module = "citrus-spring-integration")
 public class MessageChannelEndpointsBuilder implements EndpointBuilder<Endpoint>, ReferenceResolverAware {
 
     private EndpointBuilder<?> delegate;

--- a/endpoints/citrus-vertx/src/main/java/org/citrusframework/vertx/endpoint/builder/VertxEndpointsBuilder.java
+++ b/endpoints/citrus-vertx/src/main/java/org/citrusframework/vertx/endpoint/builder/VertxEndpointsBuilder.java
@@ -27,7 +27,7 @@ import org.citrusframework.vertx.endpoint.VertxSyncEndpointBuilder;
 import org.citrusframework.yaml.SchemaProperty;
 import org.citrusframework.yaml.SchemaType;
 
-@SchemaType(oneOf = { "asynchronous", "synchronous" })
+@SchemaType(oneOf = { "asynchronous", "synchronous" }, module = "citrus-vertx")
 public class VertxEndpointsBuilder implements EndpointBuilder<Endpoint>, ReferenceResolverAware {
 
     private EndpointBuilder<?> delegate;

--- a/endpoints/citrus-websocket/src/main/java/org/citrusframework/websocket/endpoint/builder/WebSocketEndpointBuilder.java
+++ b/endpoints/citrus-websocket/src/main/java/org/citrusframework/websocket/endpoint/builder/WebSocketEndpointBuilder.java
@@ -27,7 +27,7 @@ import org.citrusframework.websocket.server.WebSocketServerBuilder;
 import org.citrusframework.yaml.SchemaProperty;
 import org.citrusframework.yaml.SchemaType;
 
-@SchemaType(oneOf = { "client", "server" })
+@SchemaType(oneOf = { "client", "server" }, module = "citrus-websocket")
 public class WebSocketEndpointBuilder implements EndpointBuilder<Endpoint>, ReferenceResolverAware {
 
     private EndpointBuilder<?> delegate;

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/endpoint/builder/SoapWebServiceEndpointBuilder.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/endpoint/builder/SoapWebServiceEndpointBuilder.java
@@ -27,7 +27,7 @@ import org.citrusframework.ws.server.WebServiceServerBuilder;
 import org.citrusframework.yaml.SchemaProperty;
 import org.citrusframework.yaml.SchemaType;
 
-@SchemaType(oneOf = { "client", "server" })
+@SchemaType(oneOf = { "client", "server" }, module = "citrus-ws")
 public class SoapWebServiceEndpointBuilder implements EndpointBuilder<Endpoint>, ReferenceResolverAware {
 
     private EndpointBuilder<?> delegate;

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/yaml/Soap.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/yaml/Soap.java
@@ -52,6 +52,7 @@ import static org.citrusframework.yaml.SchemaProperty.Kind.CONTAINER;
 public class Soap implements TestActionBuilder<TestAction>, ReferenceResolverAware {
 
     private static final String SOAP_GROUP = "soap";
+    private static final String SOAP_MODULE = "citrus-ws";
 
     private TestActionBuilder<?> builder;
 
@@ -97,7 +98,8 @@ public class Soap implements TestActionBuilder<TestAction>, ReferenceResolverAwa
         }
     }
 
-    @SchemaProperty(kind = ACTION, group = SOAP_GROUP, description = "Sends a SOAP request as a client.")
+    @SchemaProperty(kind = ACTION, group = SOAP_GROUP, module = SOAP_MODULE,
+            description = "Sends a SOAP request as a client.")
     public void setSendRequest(ClientRequest request) {
         SendSoapMessageAction.Builder requestBuilder = asClientBuilder().send();
         requestBuilder.name("soap:send-request");
@@ -158,7 +160,8 @@ public class Soap implements TestActionBuilder<TestAction>, ReferenceResolverAwa
         builder = requestBuilder;
     }
 
-    @SchemaProperty(kind = ACTION, group = SOAP_GROUP, description = "Receives a SOAP response as a client.")
+    @SchemaProperty(kind = ACTION, group = SOAP_GROUP, module = SOAP_MODULE,
+            description = "Receives a SOAP response as a client.")
     public void setReceiveResponse(ClientResponse response) {
         ReceiveSoapMessageAction.Builder responseBuilder = asClientBuilder().receive();
 
@@ -230,7 +233,8 @@ public class Soap implements TestActionBuilder<TestAction>, ReferenceResolverAwa
         builder = responseBuilder;
     }
 
-    @SchemaProperty(kind = ACTION, group = SOAP_GROUP, description = "Receives a SOAP request as a server.")
+    @SchemaProperty(kind = ACTION, group = SOAP_GROUP, module = SOAP_MODULE,
+            description = "Receives a SOAP request as a server.")
     public void setReceiveRequest(ServerRequest request) {
         ReceiveSoapMessageAction.Builder requestBuilder = asServerBuilder().receive();
 
@@ -300,7 +304,8 @@ public class Soap implements TestActionBuilder<TestAction>, ReferenceResolverAwa
         builder = requestBuilder;
     }
 
-    @SchemaProperty(kind = ACTION, group = SOAP_GROUP, description = "Sends a SOAP response as a server.")
+    @SchemaProperty(kind = ACTION, group = SOAP_GROUP, module = SOAP_MODULE,
+            description = "Sends a SOAP response as a server.")
     public void setSendResponse(ServerResponse response) {
         SendSoapMessageAction.Builder responseBuilder = asServerBuilder().send();
 
@@ -350,7 +355,8 @@ public class Soap implements TestActionBuilder<TestAction>, ReferenceResolverAwa
         builder = responseBuilder;
     }
 
-    @SchemaProperty(kind = ACTION, group = SOAP_GROUP, description = "Sends a SOAP fault response as a server")
+    @SchemaProperty(kind = ACTION, group = SOAP_GROUP, module = SOAP_MODULE,
+            description = "Sends a SOAP fault response as a server")
     public void setSendFault(ServerFaultResponse response) {
         SendSoapFaultAction.Builder responseBuilder = asServerBuilder().sendFault();
         responseBuilder.name("soap:send-fault");
@@ -417,7 +423,8 @@ public class Soap implements TestActionBuilder<TestAction>, ReferenceResolverAwa
         builder = responseBuilder;
     }
 
-    @SchemaProperty(kind = CONTAINER, group = SOAP_GROUP, description = "Expects a SOAP fault response as a client.")
+    @SchemaProperty(kind = CONTAINER, group = SOAP_GROUP, module = SOAP_MODULE,
+            description = "Expects a SOAP fault response as a client.")
     public void setAssertFault(ClientAssertFault soapFault) {
         AssertSoapFault.Builder assertFault = asClientBuilder().assertFault();
 

--- a/tools/jbang/pom.xml
+++ b/tools/jbang/pom.xml
@@ -84,6 +84,53 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+      <resource>
+        <directory>${project.build.directory}/generated-resources</directory>
+      </resource>
+    </resources>
+
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>generate-schema</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>java</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <includeProjectDependencies>false</includeProjectDependencies>
+          <includePluginDependencies>true</includePluginDependencies>
+          <executableDependency>
+            <groupId>org.citrusframework</groupId>
+            <artifactId>citrus-schema-generator</artifactId>
+          </executableDependency>
+          <mainClass>org.citrusframework.dsl.schema.generator.CitrusSchemaGenerator</mainClass>
+          <arguments>
+            <argument>${project.build.directory}/generated-resources/citrus-catalog</argument>
+            <argument>${project.version}</argument>
+          </arguments>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.citrusframework</groupId>
+            <artifactId>citrus-schema-generator</artifactId>
+            <version>${project.version}</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>release-central</id>

--- a/tools/jbang/src/main/java/org/citrusframework/jbang/CitrusJBangMain.java
+++ b/tools/jbang/src/main/java/org/citrusframework/jbang/CitrusJBangMain.java
@@ -26,6 +26,7 @@ import org.citrusframework.jbang.commands.AgentStart;
 import org.citrusframework.jbang.commands.AgentStop;
 import org.citrusframework.jbang.commands.Complete;
 import org.citrusframework.jbang.commands.Init;
+import org.citrusframework.jbang.commands.Inspect;
 import org.citrusframework.jbang.commands.ListTests;
 import org.citrusframework.jbang.commands.Run;
 import picocli.CommandLine;
@@ -41,6 +42,7 @@ public class CitrusJBangMain implements Callable<Integer> {
         CitrusJBangMain main = new CitrusJBangMain();
         commandLine = new CommandLine(main)
                 .addSubcommand("init", new CommandLine(new Init(main)))
+                .addSubcommand("inspect", new CommandLine(new Inspect(main)))
                 .addSubcommand("run", new CommandLine(new Run(main)))
                 .addSubcommand("ls", new CommandLine(new ListTests(main)))
                 .addSubcommand("agent", new CommandLine(new Agent(main))

--- a/tools/jbang/src/main/java/org/citrusframework/jbang/commands/Inspect.java
+++ b/tools/jbang/src/main/java/org/citrusframework/jbang/commands/Inspect.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.jbang.commands;
+
+import java.nio.file.Path;
+import java.util.Stack;
+
+import org.citrusframework.jbang.CitrusJBangMain;
+import org.citrusframework.jbang.JsonSupport;
+import org.citrusframework.jbang.util.CodeAnalyzer;
+import org.citrusframework.jbang.util.DelegatingCodeAnalyzer;
+import org.citrusframework.message.MessagePayloadUtils;
+import org.citrusframework.spi.Resource;
+import org.citrusframework.spi.Resources;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+@Command(name = "inspect", description = "Inspect a Citrus test and its source code in order to provide detailed information " +
+        "such as used endpoints as well as required modules and dependencies.")
+public class Inspect extends CitrusCommand {
+
+    @Parameters(description = "Path to the test file (or a github link)", arity = "1",
+            paramLabel = "<file>", parameterConsumer = Inspect.FileConsumer.class)
+    private Path filePath; // Defined only for file path completion; the field never used
+
+    private String file;
+
+    public Inspect(CitrusJBangMain main) {
+        super(main);
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        Resource sourceFile = Resources.create(file);
+        CodeAnalyzer.ScanResult result = new DelegatingCodeAnalyzer().scan(sourceFile);
+
+        printer().println(MessagePayloadUtils.prettyPrintJson(JsonSupport.json().writeValueAsString(result)));
+
+        return 0;
+    }
+
+    private String[] inspectEndpoints(String content) {
+        return new String[]{};
+    }
+
+    static class FileConsumer extends CitrusCommand.ParameterConsumer<Inspect> {
+        @Override
+        protected void doConsumeParameters(Stack<String> args, Inspect cmd) {
+            cmd.file = args.pop();
+        }
+    }
+}

--- a/tools/jbang/src/main/java/org/citrusframework/jbang/commands/Run.java
+++ b/tools/jbang/src/main/java/org/citrusframework/jbang/commands/Run.java
@@ -27,10 +27,11 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.Stack;
-import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -43,6 +44,8 @@ import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.jbang.CitrusJBangMain;
 import org.citrusframework.jbang.LoggingSupport;
 import org.citrusframework.jbang.maven.MavenDependencyResolver;
+import org.citrusframework.jbang.util.CodeAnalyzer;
+import org.citrusframework.jbang.util.DelegatingCodeAnalyzer;
 import org.citrusframework.main.TestEngine;
 import org.citrusframework.main.TestRunConfiguration;
 import org.citrusframework.report.TestReporter;
@@ -85,6 +88,9 @@ public class Run extends CitrusCommand {
 
     @Option(names = { "--offline" }, defaultValue = "false", description = "When enabled there will be no attempts to resolve Maven artifacts via internet connection.")
     private boolean offline;
+
+    @Option(names = { "--inspect-code" }, defaultValue = "true", description = "When enabled the source code gets analyzed for required modules and dependencies that are added to the classpath.")
+    private boolean inspectCode = true;
 
     @Option(names = { "--property" }, arity = "0..*", description = "Default System property to set before the test run.")
     private String[] properties;
@@ -173,45 +179,76 @@ public class Run extends CitrusCommand {
         }
 
         if (!offline) {
-            handleAdditionalDependencies();
+            handleAdditionalDependencies(tests);
         }
 
         engine.run();
         return exitStatus.exitStatus();
     }
 
-    private void handleAdditionalDependencies() {
+    private void handleAdditionalDependencies(List<String> tests) {
         MavenDependencyResolver resolver = getMavenDependencyResolver();
+        Set<String> allModules = new HashSet<>();
+        Set<String> allDependencies = new HashSet<>();
+
         List<MavenArtifact> additionalArtifacts = new ArrayList<>();
 
         // Handle Citrus modules from envVar settings
         Arrays.stream(CitrusJBangMain.Settings.getModules())
                 .map(String::trim)
                 .filter(StringUtils::hasText)
-                .forEach(module -> additionalArtifacts.addAll(resolver.resolveModule(module.trim())));
+                .forEach(allModules::add);
 
         // Handle Citrus modules from command line options
         if (StringUtils.hasText(modules)) {
-            for (String module : modules.split(",")) {
-                additionalArtifacts.addAll(resolver.resolveModule(module.trim()));
-            }
+            Arrays.stream(modules.split(","))
+                    .map(String::trim)
+                    .filter(StringUtils::hasText)
+                    .forEach(allModules::add);
         }
 
-        Predicate<String> isSnapshotArtifact = it -> it.contains("-SNAPSHOT");
         // Handle Citrus dependencies from envVar settings
         Arrays.stream(CitrusJBangMain.Settings.getDependencies())
                 .map(String::trim)
                 .filter(StringUtils::hasText)
-                .forEach(dependency ->
-                    additionalArtifacts.addAll(resolver.resolve(dependency.trim(), isSnapshotArtifact.test(dependency), true)));
+                .forEach(allDependencies::add);
 
         // Handle Citrus dependencies from command line options
         if (dependencies != null) {
-            for (String dependency : dependencies) {
-                additionalArtifacts.addAll(
-                        resolver.resolve(dependency.trim(), isSnapshotArtifact.test(dependency), true));
+            Arrays.stream(dependencies)
+                    .map(String::trim)
+                    .filter(StringUtils::hasText)
+                    .forEach(allDependencies::add);
+        }
+
+        if (inspectCode) {
+            // Analyze code for additional modules and dependencies
+            CodeAnalyzer analyzer = new DelegatingCodeAnalyzer();
+            for (String test : tests) {
+                try {
+                    CodeAnalyzer.ScanResult scanResult = analyzer.scan(FileUtils.getFileResource(test));
+                    allModules.addAll(Arrays.asList(scanResult.modules()));
+                    allDependencies.addAll(Arrays.asList(scanResult.dependencies()));
+                } catch (Exception e) {
+                    printer().printErr(String.format("Failed to analyze test file %s due to '%s'", test, e.getMessage()));
+                }
             }
         }
+
+        String systemClasspath = System.getProperty("java.class.path");
+        allModules.stream()
+                .map(module -> {
+                    if (module.startsWith("citrus-")) {
+                        return module;
+                    } else {
+                        return "citrus-" + module;
+                    }
+                })
+                .filter(module -> !systemClasspath.contains(module))
+                .forEach(module -> additionalArtifacts.addAll(resolver.resolveModule(module)));
+
+        allDependencies.forEach(dependency -> additionalArtifacts.addAll(
+                resolver.resolve(dependency.trim(), dependency.contains("-SNAPSHOT"), true)));
 
         if (!additionalArtifacts.isEmpty()) {
             additionalArtifacts.forEach(mavenArtifact -> {

--- a/tools/jbang/src/main/java/org/citrusframework/jbang/util/CodeAnalyzer.java
+++ b/tools/jbang/src/main/java/org/citrusframework/jbang/util/CodeAnalyzer.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.jbang.util;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.jbang.JsonSupport;
+import org.citrusframework.spi.Resource;
+import org.citrusframework.util.ClassLoaderHelper;
+import org.citrusframework.util.FileUtils;
+import org.citrusframework.util.StringUtils;
+
+public interface CodeAnalyzer {
+
+    /**
+     * Inspects the given source code and provides detailed information about it as a result.
+     */
+    default ScanResult scan(Resource sourceFile) throws IOException {
+        return scan(FileUtils.getFileName(sourceFile.getLocation()), FileUtils.readToString(sourceFile));
+    }
+
+    /**
+     * Inspects the given source code and provides detailed information about it as a result.
+     */
+    default ScanResult scan(Path sourceFile) throws IOException {
+        String code = Files.readString(sourceFile);
+        return scan(sourceFile.getFileName().toString(), code);
+    }
+
+    /**
+     * Inspects the given source code and provides detailed information about it as a result.
+     */
+    default ScanResult scan(String fileName, String code) throws IOException {
+        Set<String> modules = scanModules(code);
+        Set<String> dependencies = scanDependencies(code);
+        Set<String> actions = scanTestActions(code, modules);
+        Set<String> containers = scanTestContainers(code, modules);
+        Set<String> endpoints = scanEndpoints(code, modules);
+        Set<String> functions = scanFunctions(code, modules);
+        Set<String> validationMatcher = scanValidationMatcher(code, modules);
+
+        return new ScanResult(fileName,
+                modules.toArray(String[]::new),
+                dependencies.toArray(String[]::new),
+                actions.toArray(String[]::new),
+                containers.toArray(String[]::new),
+                endpoints.toArray(String[]::new),
+                functions.toArray(String[]::new),
+                validationMatcher.toArray(String[]::new)
+        );
+    }
+
+    Set<String> scanModules(String code);
+
+    Set<String> scanDependencies(String code);
+
+    Set<String> scanTestActions(String code, Set<String> modules);
+
+    Set<String> scanTestContainers(String code, Set<String> modules);
+
+    Set<String> scanEndpoints(String code, Set<String> modules);
+
+    default Set<String> scanFunctions(String code, Set<String> modules) {
+        Map<String, ComponentDefinition> components = getKnownFunctions();
+
+        Set<String> items = new HashSet<>();
+        for (Map.Entry<String, ComponentDefinition> entry : components.entrySet()) {
+            ComponentDefinition component = components.get(entry.getKey());
+            String name = entry.getKey();
+
+            if (code.contains("%s:%s(".formatted(component.group(), name))) {
+                items.add("%s:%s".formatted(component.group(), name));
+                if (StringUtils.hasText(component.module())) {
+                    modules.add(component.module());
+                }
+            }
+        }
+
+        return items;
+    }
+
+    default Set<String> scanValidationMatcher(String code, Set<String> modules) {
+        Map<String, ComponentDefinition> components = getKnownValidationMatcher();
+
+        Set<String> items = new HashSet<>();
+        for (Map.Entry<String, ComponentDefinition> entry : components.entrySet()) {
+            ComponentDefinition component = components.get(entry.getKey());
+            String name = entry.getKey();
+
+            if (component.group().equals("citrus")) {
+                if (code.contains("@%s(".formatted(name)) || code.contains("@%s@".formatted(name))) {
+                    items.add(name);
+                    if (StringUtils.hasText(component.module())) {
+                        modules.add(component.module());
+                    }
+                    continue;
+                }
+            }
+
+            if (code.contains("@%s:%s(".formatted(component.group(), name)) || code.contains("@%s:%s@".formatted(component.group(), name))) {
+                items.add(name);
+                if (StringUtils.hasText(component.module())) {
+                    modules.add(component.module());
+                }
+            }
+        }
+
+        return items;
+    }
+
+    default Map<String, ComponentDefinition> getKnownTestActions() {
+        return getComponentDefinitions("test-actions");
+    }
+
+    default Map<String, ComponentDefinition> getKnownTestContainers() {
+        return getComponentDefinitions("test-containers");
+    }
+
+    default Map<String, ComponentDefinition> getKnownEndpoints() {
+        return getComponentDefinitions("endpoints");
+    }
+
+    default Map<String, ComponentDefinition> getKnownFunctions() {
+        return getComponentDefinitions("functions");
+    }
+
+    default Map<String, ComponentDefinition> getKnownValidationMatcher() {
+        return getComponentDefinitions("validation-matcher");
+    }
+
+    default Map<String, ComponentDefinition> getComponentDefinitions(String kind) {
+        try {
+            Map<String, ComponentDefinition> components = new HashMap<>();
+            JsonNode raw = JsonSupport.json().readTree(ClassLoaderHelper.getContextClassLoader().getResourceAsStream("citrus-catalog/citrus/citrus-catalog-aggregate-%s.json".formatted(kind)));
+            raw.fieldNames().forEachRemaining(name -> {
+                components.put(name, JsonSupport.json().convertValue(raw.get(name), ComponentDefinition.class));
+            });
+
+            return components;
+        } catch (IOException e) {
+            throw new CitrusRuntimeException("Failed to read component aggregate schema definitions of kind '%s'".formatted(kind), e);
+        }
+    }
+
+    default String resolveName(String name, String group, Map<String, ComponentDefinition> components) {
+        if (group == null) {
+            return name;
+        }
+
+        if (components.containsKey(group)) {
+            return resolveName(group, components.get(group).group(), components);
+        }
+
+        return group;
+    }
+
+    /**
+     * Analyze result contains detailed information about the inspected test code,
+     * such as required modules and used endpoints.
+     */
+    record ScanResult(String name, String[] modules, String[] dependencies, String[] actions,
+                      String[] containers, String[] endpoints, String[] functions, String[] validationMatcher) {
+    }
+
+    /**
+     * Citrus component definition provides information about the component.
+     * Components may be one of test actions, containers, endpoints, functions or validation matcher.
+     */
+    record ComponentDefinition(String kind, String version, String name, String group, String module,
+                               String title, String description, JsonNode propertiesSchema) {
+    }
+}

--- a/tools/jbang/src/main/java/org/citrusframework/jbang/util/DelegatingCodeAnalyzer.java
+++ b/tools/jbang/src/main/java/org/citrusframework/jbang/util/DelegatingCodeAnalyzer.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.jbang.util;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
+
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.util.FileUtils;
+
+/**
+ * Delegates to the proper code analyzer implementation based on the given file extension.
+ */
+public class DelegatingCodeAnalyzer implements CodeAnalyzer {
+
+    @Override
+    public ScanResult scan(String fileName, String code) throws IOException {
+        String ext = FileUtils.getFileExtension(fileName);
+
+        return switch (ext) {
+            case "yaml", "yml" -> new YamlCodeAnalyzer().scan(fileName, code);
+            default -> throw new CitrusRuntimeException("Failed to analyze code for the file type: %s".formatted(ext));
+        };
+    }
+
+    @Override
+    public Set<String> scanModules(String code) {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Set<String> scanDependencies(String code) {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Set<String> scanTestActions(String code, Set<String> modules) {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Set<String> scanTestContainers(String code, Set<String> modules) {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Set<String> scanEndpoints(String code, Set<String> modules) {
+        return Collections.emptySet();
+    }
+}

--- a/tools/jbang/src/main/java/org/citrusframework/jbang/util/YamlCodeAnalyzer.java
+++ b/tools/jbang/src/main/java/org/citrusframework/jbang/util/YamlCodeAnalyzer.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.jbang.util;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.citrusframework.util.StringUtils;
+
+public class YamlCodeAnalyzer implements CodeAnalyzer {
+
+    private static final Pattern DEPS_MODELINE_PATTERN = Pattern.compile("^# deps:\\s+(.+)$", Pattern.MULTILINE);
+    private static final Pattern MODULES_MODELINE_PATTERN = Pattern.compile("^# modules:\\s+(.+)$", Pattern.MULTILINE);
+
+    public static final String MODULE_PREFIX = "citrus-";
+
+    @Override
+    public Set<String> scanModules(String code) {
+        Set<String> items = new HashSet<>();
+
+        Matcher matcher = MODULES_MODELINE_PATTERN.matcher(code);
+        while (matcher.find()) {
+            String modules = matcher.group(1);
+            if (modules.contains(",")) {
+                for (String module : modules.split(",")) {
+                    items.add(module.trim().startsWith(MODULE_PREFIX) ? module.trim() : MODULE_PREFIX + module.trim());
+                }
+            } else {
+                items.add(modules.startsWith(MODULE_PREFIX) ? modules : MODULE_PREFIX + modules);
+            }
+        }
+
+        return items;
+    }
+
+    @Override
+    public Set<String> scanDependencies(String code) {
+        Set<String> items = new HashSet<>();
+
+        Matcher matcher = DEPS_MODELINE_PATTERN.matcher(code);
+        while (matcher.find()) {
+            String dependencies = matcher.group(1);
+            if (dependencies.contains(",")) {
+                for (String dependency : dependencies.split(",")) {
+                    items.add(dependency.trim());
+                }
+            } else {
+                items.add(dependencies.trim());
+            }
+        }
+
+        return items;
+    }
+
+    @Override
+    public Set<String> scanTestActions(String code, Set<String> modules) {
+        Map<String, ComponentDefinition> components = getKnownTestActions();
+
+        Set<String> items = new HashSet<>();
+        Set<Map.Entry<String, ComponentDefinition>> testGroups = components.entrySet()
+                .stream()
+                .filter(entry -> "testAction".equals(entry.getValue().kind()))
+                .collect(Collectors.toSet());
+        for (Map.Entry<String, ComponentDefinition> entry : testGroups) {
+            String[] tokens = entry.getKey().split("-");
+
+            boolean allMatch = true;
+            for (int i = 0; i < tokens.length && allMatch; i++) {
+                if (i == 0) {
+                    allMatch = code.contains("- %s:".formatted(tokens[i]));
+                } else {
+                    allMatch = code.contains("%s:".formatted(tokens[i]));
+                }
+            }
+
+            if (allMatch) {
+                ComponentDefinition component = entry.getValue();
+                items.add(entry.getKey());
+                if (StringUtils.hasText(component.module())) {
+                    modules.add(component.module());
+                } else if (component.group() != null) {
+                    ComponentDefinition parentComponent = components.get(component.group());
+                    if (parentComponent != null && parentComponent.module() != null) {
+                        modules.add(parentComponent.module());
+                    }
+                }
+
+                if (entry.getKey().contains("-jbang-")) {
+                    // add jbang connector as it often is a provided scope dependency
+                    modules.add("citrus-jbang-connector");
+                }
+            }
+        }
+
+        return items;
+    }
+
+    @Override
+    public Set<String> scanTestContainers(String code, Set<String> modules) {
+        Map<String, ComponentDefinition> actions = getKnownTestActions();
+        Map<String, ComponentDefinition> components = getKnownTestContainers();
+
+        Set<String> items = new HashSet<>();
+        for (Map.Entry<String, ComponentDefinition> entry : components.entrySet()) {
+            ComponentDefinition component = components.get(entry.getKey());
+            String name = resolveName(entry.getKey(), component.group(), actions);
+
+            if (code.contains("- %s:".formatted(name))) {
+                items.add(name);
+                if (StringUtils.hasText(component.module())) {
+                    modules.add(component.module());
+                }
+            }
+        }
+
+        return items;
+    }
+
+    @Override
+    public Set<String> scanEndpoints(String code, Set<String> modules) {
+        Map<String, ComponentDefinition> components = getKnownEndpoints();
+
+        Set<String> items = new HashSet<>();
+
+        if (code.contains("endpoints:") && code.indexOf("endpoints:") < code.indexOf("actions:")) {
+            String endpointDefs = code.substring(code.indexOf("endpoints:"), code.indexOf("actions:"));
+            for (Map.Entry<String, ComponentDefinition> entry : components.entrySet()) {
+                ComponentDefinition component = components.get(entry.getKey());
+                String name = Optional.ofNullable(component.group()).orElse(entry.getKey());
+
+                if (endpointDefs.contains("- %s:".formatted(name))) {
+                    items.add(name);
+                    if (StringUtils.hasText(component.module())) {
+                        modules.add(component.module());
+                    }
+                }
+            }
+        }
+
+        for (Map.Entry<String, ComponentDefinition> entry : components.entrySet()) {
+            ComponentDefinition component = components.get(entry.getKey());
+            String name = Optional.ofNullable(component.group()).orElse(entry.getKey());
+
+            if (code.contains("endpoint: %s".formatted(name))) {
+                items.add(name);
+                if (StringUtils.hasText(component.module())) {
+                    modules.add(component.module());
+                }
+            }
+        }
+
+        return items;
+    }
+}

--- a/tools/jbang/src/test/java/org/citrusframework/jbang/util/YamlCodeAnalyzerTest.java
+++ b/tools/jbang/src/test/java/org/citrusframework/jbang/util/YamlCodeAnalyzerTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.jbang.util;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.citrusframework.spi.Resources;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class YamlCodeAnalyzerTest {
+
+    @Test
+    public void shouldListComponents() throws IOException {
+        YamlCodeAnalyzer analyzer = new YamlCodeAnalyzer();
+        CodeAnalyzer.ScanResult scanResult = analyzer.scan(Resources.create("sample.citrus.it.yaml"));
+
+        Assert.assertEquals(scanResult.name(), "sample.citrus.it.yaml");
+
+        Assert.assertEquals(scanResult.modules().length, 3L);
+        String[] foundModules = Arrays.stream(scanResult.modules()).sorted().toArray(String[]::new);
+        Assert.assertEquals(foundModules[0], "citrus-base");
+        Assert.assertEquals(foundModules[1], "citrus-camel");
+        Assert.assertEquals(foundModules[2], "citrus-testcontainers");
+
+        Assert.assertEquals(scanResult.dependencies().length, 1L);
+        String[] foundDeps = Arrays.stream(scanResult.dependencies()).sorted().toArray(String[]::new);
+        Assert.assertEquals(foundDeps[0], "org.apache.camel:camel-aws2-s3:4.18.0");
+
+        Assert.assertEquals(scanResult.actions().length, 3L);
+        String[] foundActions = Arrays.stream(scanResult.actions()).sorted().toArray(String[]::new);
+        Assert.assertEquals(foundActions[0], "print");
+        Assert.assertEquals(foundActions[1], "receive");
+        Assert.assertEquals(foundActions[2], "send");
+
+        Assert.assertEquals(scanResult.containers().length, 1L);
+        Assert.assertEquals(scanResult.containers()[0], "iterate");
+
+        Assert.assertEquals(scanResult.endpoints().length, 3L);
+        String[] foundEndpoints = Arrays.stream(scanResult.endpoints()).sorted().toArray(String[]::new);
+        Assert.assertEquals(foundEndpoints[0], "http");
+        Assert.assertEquals(foundEndpoints[1], "jms");
+        Assert.assertEquals(foundEndpoints[2], "kafka");
+
+        Assert.assertEquals(scanResult.functions().length, 1L);
+        Assert.assertEquals(scanResult.functions()[0], "citrus:randomNumber");
+
+        Assert.assertEquals(scanResult.validationMatcher().length, 2L);
+        String[] foundValidationMatcher = Arrays.stream(scanResult.validationMatcher()).sorted().toArray(String[]::new);
+        Assert.assertEquals(foundValidationMatcher[0], "ignore");
+        Assert.assertEquals(foundValidationMatcher[1], "isNumber");
+    }
+
+}

--- a/tools/jbang/src/test/resources/sample.citrus.it.yaml
+++ b/tools/jbang/src/test/resources/sample.citrus.it.yaml
@@ -1,0 +1,35 @@
+# modules: citrus-camel,citrus-testcontainers
+# deps: org.apache.camel:camel-aws2-s3:4.18.0
+name: my-test
+variables:
+  - name: foo
+    value: bar
+  - name: id
+    value: citrus:randomNumber(4)
+endpoints:
+  - jms:
+      asynchronous:
+        queueName: my-queue
+actions:
+  - print:
+      message: Citrus rocks!
+  - send:
+      endpoint: http://localhost:8080/test
+      message:
+        body:
+          data: Howdy
+  - send:
+      endpoint: kafka:my-topic
+      message:
+        body:
+          data: Hello ${id}
+  - receive:
+      endpoint: kafka:my-topic
+      message:
+        body:
+          data: @ignore@ @isNumber()@
+  - iterate:
+      condition: i < 10
+      actions:
+        - print:
+            message: ${i}

--- a/tools/schema-generator/pom.xml
+++ b/tools/schema-generator/pom.xml
@@ -140,29 +140,4 @@
       <version>${project.version}</version>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>generate-schema</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>java</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <mainClass>org.citrusframework.dsl.schema.generator.CitrusSchemaGenerator</mainClass>
-          <arguments>
-            <argument>${project.build.directory}/generated-resources/citrus-catalog</argument>
-            <argument>${project.version}</argument>
-          </arguments>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/tools/schema-generator/src/main/java/org/citrusframework/dsl/schema/Catalog.java
+++ b/tools/schema-generator/src/main/java/org/citrusframework/dsl/schema/Catalog.java
@@ -35,6 +35,7 @@ import org.citrusframework.validation.matcher.DefaultValidationMatcherLibrary;
 import org.citrusframework.validation.matcher.ParameterizedValidationMatcher;
 import org.citrusframework.validation.matcher.ValidationMatcher;
 import org.citrusframework.yaml.SchemaProperty;
+import org.citrusframework.yaml.SchemaType;
 
 import static org.citrusframework.yaml.SchemaProperty.Kind.ACTION;
 import static org.citrusframework.yaml.SchemaProperty.Kind.CONTAINER;
@@ -71,6 +72,7 @@ public class Catalog {
                             CitrusVersion.version(),
                             entry.getKey(),
                             item.schema.group(),
+                            item.schema.module(),
                             Optional.ofNullable(item.schema.title())
                                     .filter(title -> !title.isEmpty())
                                     .orElse(StringUtils.convertFirstCharToUpperCase(item.name)),
@@ -95,6 +97,7 @@ public class Catalog {
                             CitrusVersion.version(),
                             entry.getKey(),
                             item.schema.group(),
+                            item.schema.module(),
                             Optional.ofNullable(item.schema.title())
                                     .filter(title -> !title.isEmpty())
                                     .orElse(StringUtils.convertFirstCharToUpperCase(item.name)),
@@ -122,11 +125,16 @@ public class Catalog {
             String[] tokens = builder.getKey().split("\\.", 2);
             String group = tokens[0];
             String name = tokens[1];
+
+            SchemaType schemaType = builder.getValue().getClass().getAnnotation(SchemaType.class);
+            String module = Optional.ofNullable(schemaType).map(SchemaType::module).orElse("citrus-base");
+
             catalog.put(builder.getKey().replaceAll("\\.", "-"),
                     new CatalogEntry(SchemaProperty.Kind.ENDPOINT.getCatalogKind(),
                             CitrusVersion.version(),
                             "%s-%s".formatted(group, name),
                             group,
+                            module,
                             "%s%s".formatted(StringUtils.convertFirstCharToUpperCase(group), StringUtils.convertFirstCharToUpperCase(name)),
                             null,
                             jsonSchema));
@@ -146,11 +154,16 @@ public class Catalog {
             } else {
                 jsonSchema = CitrusSchemaGenerator.generateSchema(function.getValue().getClass(), Option.INLINE_ALL_SCHEMAS);
             }
+
+            SchemaType schemaType = function.getValue().getClass().getAnnotation(SchemaType.class);
+            String module = Optional.ofNullable(schemaType).map(SchemaType::module).orElse("citrus-base");
+
             catalog.put(function.getKey(),
                     new CatalogEntry(SchemaProperty.Kind.FUNCTION.getCatalogKind(),
                             CitrusVersion.version(),
                             function.getKey(),
                             "citrus",
+                            module,
                             StringUtils.convertFirstCharToUpperCase(function.getKey()),
                             null,
                             jsonSchema));
@@ -170,11 +183,16 @@ public class Catalog {
             } else {
                 jsonSchema = CitrusSchemaGenerator.generateSchema(matcher.getValue().getClass(), Option.INLINE_ALL_SCHEMAS);
             }
+
+            SchemaType schemaType = matcher.getValue().getClass().getAnnotation(SchemaType.class);
+            String module = Optional.ofNullable(schemaType).map(SchemaType::module).orElse("citrus-base");
+
             catalog.put(matcher.getKey(),
                     new CatalogEntry(SchemaProperty.Kind.VALIDATION_MATCHER.getCatalogKind(),
                             CitrusVersion.version(),
                             matcher.getKey(),
                             "citrus",
+                            module,
                             StringUtils.convertFirstCharToUpperCase(matcher.getKey()),
                             null,
                             jsonSchema));
@@ -194,6 +212,7 @@ public class Catalog {
         String version,
         String name,
         String group,
+        String module,
         String title,
         String description,
         JsonNode propertiesSchema

--- a/tools/schema-generator/src/main/java/org/citrusframework/dsl/schema/Endpoints.java
+++ b/tools/schema-generator/src/main/java/org/citrusframework/dsl/schema/Endpoints.java
@@ -57,48 +57,47 @@ import org.citrusframework.yaml.SchemaType;
 })
 public interface Endpoints {
 
-    @SchemaProperty(description = "Http client and server endpoints")
+    @SchemaProperty(description = "Http client and server endpoints", module = "citrus-http")
     default void setHttp(HttpEndpointBuilder builder) {
     }
 
-    @SchemaProperty(description = "SOAP WebService client and server endpoints")
+    @SchemaProperty(description = "SOAP WebService client and server endpoints", module = "citrus-ws")
     default void setSoap(SoapWebServiceEndpointBuilder builder) {
     }
 
-    @SchemaProperty(description = "WebSocket client and server endpoints")
+    @SchemaProperty(description = "WebSocket client and server endpoints", module = "citrus-websocket")
     default void setWebSocket(WebSocketEndpointBuilder builder) {
     }
 
-    @SchemaProperty(description = "Mail client and server endpoints")
+    @SchemaProperty(description = "Mail client and server endpoints", module = "citrus-mail")
     default void setMail(MailEndpointBuilder builder) {
     }
 
-    @SchemaProperty(description = "Ftp client and server endpoints")
+    @SchemaProperty(description = "Ftp client and server endpoints", module = "citrus-ftp")
     default void setFtp(FtpEndpointBuilder builder) {
     }
 
-    @SchemaProperty(description = "Sftp client and server endpoints")
+    @SchemaProperty(description = "Sftp client and server endpoints", module = "citrus-ftp")
     default void setSftp(SftpEndpointBuilder builder) {
     }
 
-    @SchemaProperty(description = "Scp client and server endpoint")
+    @SchemaProperty(description = "Scp client and server endpoint", module = "citrus-ftp")
     default void setScp(ScpEndpointBuilder builder) {
     }
 
-    @SchemaProperty(
-            description = "Docker client")
+    @SchemaProperty(description = "Docker client", module = "citrus-docker")
     default void setDocker(DockerEndpointBuilder builder) {
     }
 
-    @SchemaProperty(description = "Kubernetes client")
+    @SchemaProperty(description = "Kubernetes client", module = "citrus-kubernetes")
     default void setKubernetes(KubernetesEndpointBuilder builder) {
     }
 
-    @SchemaProperty(title = "JMS", description = "JMS endpoint.")
+    @SchemaProperty(title = "JMS", description = "JMS endpoint", module = "citrus-jms")
     default void setJms(JmsEndpointsBuilder builder) {
     }
 
-    @SchemaProperty(title = "Vert.x", description = "Vert.x endpoint.")
+    @SchemaProperty(title = "Vert.x", description = "Vert.x endpoint.", module = "citrus-vertx")
     default void setVertx(VertxEndpointsBuilder builder) {
     }
 
@@ -110,19 +109,19 @@ public interface Endpoints {
     default void setContext(ContextEndpointsBuilder builder) {
     }
 
-    @SchemaProperty(description = "Kafka endpoint.")
+    @SchemaProperty(description = "Kafka endpoint.", module = "citrus-kafka")
     default void setKafka(KafkaEndpointsBuilder builder) {
     }
 
-    @SchemaProperty(description = "Camel endpoint.")
+    @SchemaProperty(description = "Camel endpoint.", module = "citrus-camel")
     default void setCamel(CamelEndpointsBuilder builder) {
     }
 
-    @SchemaProperty(title = "Spring channel", description = "Spring channel endpoint.")
+    @SchemaProperty(title = "Spring channel", description = "Spring channel endpoint.", module = "citrus-spring-integration")
     default void setChannel(MessageChannelEndpointsBuilder builder) {
     }
 
-    @SchemaProperty(description = "Selenium endpoint.")
+    @SchemaProperty(description = "Selenium endpoint.", module = "citrus-selenium")
     default void setSelenium(SeleniumEndpointBuilder builder) {
     }
 

--- a/tools/schema-generator/src/main/java/org/citrusframework/dsl/schema/TestActions.java
+++ b/tools/schema-generator/src/main/java/org/citrusframework/dsl/schema/TestActions.java
@@ -183,59 +183,59 @@ public class TestActions {
     public void setAsync(Async builder) {
     }
 
-    @SchemaProperty(kind = ACTION, description = "Groovy test action.")
+    @SchemaProperty(kind = ACTION, description = "Groovy test action.", module = "citrus-groovy")
     public void setGroovy(Groovy builder) {
     }
 
-    @SchemaProperty(kind = GROUP, description = "Test actions related to Apache Camel.")
+    @SchemaProperty(kind = GROUP, description = "Test actions related to Apache Camel.", module = "citrus-camel")
     public void setCamel(Camel builder) {
     }
 
-    @SchemaProperty(kind = GROUP, description = "Http related test actions.")
+    @SchemaProperty(kind = GROUP, description = "Http related test actions.", module = "citrus-http")
     public void setHttp(Http builder) {
     }
 
-    @SchemaProperty(kind = GROUP, description = "OpenAPI related test actions.")
+    @SchemaProperty(kind = GROUP, description = "OpenAPI related test actions.", module = "citrus-openapi")
     public void setOpenapi(OpenApi builder) {
     }
 
-    @SchemaProperty(kind = GROUP, description = "SOAP Web Services related test actions.")
+    @SchemaProperty(kind = GROUP, description = "SOAP Web Services related test actions.", module = "citrus-ws")
     public void setSoap(Soap builder) {
     }
 
-    @SchemaProperty(kind = GROUP, description = "Agent service test actions.")
+    @SchemaProperty(kind = GROUP, description = "Agent service test actions.", module = "citrus-agent-connector")
     public void setAgent(Agent builder) {
     }
 
-    @SchemaProperty(kind = GROUP, description = "Kubernetes test actions.")
+    @SchemaProperty(kind = GROUP, description = "Kubernetes test actions.", module = "citrus-kubernetes")
     public void setKubernetes(Kubernetes builder) {
     }
 
-    @SchemaProperty(kind = GROUP, description = "Knative test actions.")
+    @SchemaProperty(kind = GROUP, description = "Knative test actions.", module = "citrus-knative")
     public void setKnative(Knative builder) {
     }
 
-    @SchemaProperty(kind = GROUP, description = "Selenium test actions.")
+    @SchemaProperty(kind = GROUP, description = "Selenium test actions.", module = "citrus-selenium")
     public void setSelenium(Selenium builder) {
     }
 
-    @SchemaProperty(kind = GROUP, description = "Testcontainers test actions.")
+    @SchemaProperty(kind = GROUP, description = "Testcontainers test actions.", module = "citrus-testcontainers")
     public void setTestcontainers(Testcontainers builder) {
     }
 
-    @SchemaProperty(kind = ACTION, description = "SQL test actions.")
+    @SchemaProperty(kind = ACTION, description = "SQL test actions.", module = "citrus-sql")
     public void setSql(Sql builder) {
     }
 
-    @SchemaProperty(kind = ACTION, description = "PLSQL test actions.")
+    @SchemaProperty(kind = ACTION, description = "PLSQL test actions.", module = "citrus-sql")
     public void setPlsql(Plsql builder) {
     }
 
-    @SchemaProperty(kind = ACTION, description = "JBang test actions.")
+    @SchemaProperty(kind = ACTION, description = "JBang test actions.", module = "citrus-jbang-connector")
     public void setJbang(JBang builder) {
     }
 
-    @SchemaProperty(kind = ACTION, description = "Purge JMS queue test action.")
+    @SchemaProperty(kind = ACTION, description = "Purge JMS queue test action.", module = "citrus-jms")
     public void setPurgeQueues(PurgeQueues builder) {
     }
 

--- a/validation/citrus-validation-hamcrest/src/main/java/org/citrusframework/validation/matcher/hamcrest/HamcrestValidationMatcher.java
+++ b/validation/citrus-validation-hamcrest/src/main/java/org/citrusframework/validation/matcher/hamcrest/HamcrestValidationMatcher.java
@@ -42,6 +42,7 @@ import org.citrusframework.validation.matcher.DefaultControlExpressionParser;
 import org.citrusframework.validation.matcher.ParameterizedValidationMatcher;
 import org.citrusframework.variable.VariableUtils;
 import org.citrusframework.yaml.SchemaProperty;
+import org.citrusframework.yaml.SchemaType;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 
@@ -51,6 +52,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
  * @since 2.5
  */
 @SuppressWarnings("unchecked")
+@SchemaType(module = "citrus-validation-hamcrest")
 public class HamcrestValidationMatcher implements ParameterizedValidationMatcher<HamcrestValidationMatcher.Parameters>, ControlExpressionParser {
 
     private final List<String> matchers = Arrays.asList( "equalTo", "equalToIgnoringCase", "equalToIgnoringWhiteSpace", "is", "not", "containsString", "startsWith", "endsWith", "matchesPattern" );

--- a/validation/citrus-validation-xml/src/main/java/org/citrusframework/functions/core/CreateCDataSectionFunction.java
+++ b/validation/citrus-validation-xml/src/main/java/org/citrusframework/functions/core/CreateCDataSectionFunction.java
@@ -19,6 +19,7 @@ package org.citrusframework.functions.core;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.functions.ParameterizedFunction;
 import org.citrusframework.functions.parameter.StringParameter;
+import org.citrusframework.yaml.SchemaType;
 
 /**
  * Adds XML CDATA section tags to parameter value. This is extremely useful when having
@@ -26,6 +27,7 @@ import org.citrusframework.functions.parameter.StringParameter;
  * nested CDATA sections are not allowed. This function adds the CDATA section tags
  * at runtime.
  */
+@SchemaType(module = "citrus-validation-xml")
 public class CreateCDataSectionFunction implements ParameterizedFunction<StringParameter> {
 
     /** CDATA section tags */

--- a/validation/citrus-validation-xml/src/main/java/org/citrusframework/functions/core/EscapeXmlFunction.java
+++ b/validation/citrus-validation-xml/src/main/java/org/citrusframework/functions/core/EscapeXmlFunction.java
@@ -19,12 +19,14 @@ package org.citrusframework.functions.core;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.functions.ParameterizedFunction;
 import org.citrusframework.functions.parameter.StringParameter;
+import org.citrusframework.yaml.SchemaType;
 
 import static org.apache.commons.lang3.StringEscapeUtils.escapeXml;
 
 /**
  * Escapes XML fragment with escaped characters for '<', '>'.
  */
+@SchemaType(module = "citrus-validation-xml")
 public class EscapeXmlFunction implements ParameterizedFunction<StringParameter> {
 
     @Override

--- a/validation/citrus-validation-xml/src/main/java/org/citrusframework/functions/core/XpathFunction.java
+++ b/validation/citrus-validation-xml/src/main/java/org/citrusframework/functions/core/XpathFunction.java
@@ -25,10 +25,12 @@ import org.citrusframework.util.XMLUtils;
 import org.citrusframework.xml.namespace.DefaultNamespaceContext;
 import org.citrusframework.xml.xpath.XPathUtils;
 import org.citrusframework.yaml.SchemaProperty;
+import org.citrusframework.yaml.SchemaType;
 
 /**
  * @since 2.6.2
  */
+@SchemaType(module = "citrus-validation-xml")
 public class XpathFunction implements ParameterizedFunction<XpathFunction.Parameters> {
 
     @Override

--- a/validation/citrus-validation-xml/src/main/java/org/citrusframework/validation/matcher/core/XmlValidationMatcher.java
+++ b/validation/citrus-validation-xml/src/main/java/org/citrusframework/validation/matcher/core/XmlValidationMatcher.java
@@ -27,6 +27,7 @@ import org.citrusframework.validation.MessageValidator;
 import org.citrusframework.validation.context.ValidationContext;
 import org.citrusframework.validation.matcher.StringValidationMatcher;
 import org.citrusframework.validation.xml.XmlMessageValidationContext;
+import org.citrusframework.yaml.SchemaType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,6 +35,7 @@ import org.slf4j.LoggerFactory;
  * Validation matcher receives XML data and validates it against expected XML with full
  * XML validation support (e.g. ignoring elements, namespace support, ...).
  */
+@SchemaType(module = "citrus-validation-xml")
 public class XmlValidationMatcher implements StringValidationMatcher {
 
     /** CDATA section starting and ending in XML */


### PR DESCRIPTION
- Add Citrus module information to schema aggregate component definitions
- Inspect command analyzes a given test source code in order to provide detailed information about the test such as used endpoints as well as required modules and dependencies
- Use inspect analysis to auto resolve Citrus modules and required dependencies when running a test via JBang