### PR TITLE
fix(#1505): Citrus MCP server implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -259,7 +259,8 @@
     <org.openapitools.version>7.17.0</org.openapitools.version>
     <picoli-version>4.7.7</picoli-version>
     <postgresql.version>42.7.10</postgresql.version>
-    <quarkus.platform.version>3.32.1</quarkus.platform.version>
+    <quarkus.platform.version>3.34.1</quarkus.platform.version>
+    <quarkus.mcp-server.version>1.11.0</quarkus.mcp-server.version>
     <saaj.version>3.0.4</saaj.version>
     <selenium.version>4.41.0</selenium.version>
     <slf4j.version>2.0.17</slf4j.version>

--- a/src/manual/tools-mcp-server.adoc
+++ b/src/manual/tools-mcp-server.adoc
@@ -1,0 +1,417 @@
+[[citrus-mcp-server]]
+= Citrus MCP Server
+
+The Citrus MCP Server is a Model Context Protocol (MCP) server implementation that enables Large Language Models (LLMs) and AI assistants to interact with Citrus framework metadata, documentation, and schemas. This tool helps AI-powered development environments understand Citrus components and generate accurate test code.
+
+[[citrus-mcp-server-overview]]
+== Overview
+
+The MCP server exposes Citrus framework capabilities through standardized tools and resources that can be consumed by AI assistants like Claude, GitHub Copilot, and other MCP-compatible clients. It provides programmatic access to:
+
+* Catalog tools
+    ** **Catalog Information**: Query available components such as test actions, endpoints, functions, and validation matchers
+    ** **Component Information**: Query component details with module information and property specifications
+* Schema resources
+    ** **Component Schemas**: Retrieve JSON schemas for Citrus components such as test actions, endpoints, functions with detailed property specifications
+    ** **DSL Schemas**: Get YAML and XML DSL schemas for writing tests
+* Documentation tools
+    ** **Documentation index**: Query all available documentation files with filter criteria
+    ** **Documentation**: Access AsciiDoc documentation for specific Citrus components
+
+This enables AI assistants to provide context-aware suggestions, validate component usage, and generate syntactically correct Citrus tests.
+
+== What is MCP?
+
+The Model Context Protocol (MCP) is an open protocol that enables AI applications to securely connect to external data sources and tools. MCP provides a standardized way for:
+
+* **Tools**: Functions that the AI can call to perform actions or retrieve data
+* **Resources**: Static or dynamic content that can be read by the AI
+* **Prompts**: Reusable prompt templates for common tasks
+
+The Citrus MCP Server implements this protocol using the Quarkus MCP Server framework, providing both STDIO and HTTP/SSE transport mechanisms.
+
+For more information about MCP:
+
+* MCP Specification: https://modelcontextprotocol.io/
+* Quarkus MCP Server: https://docs.quarkiverse.io/quarkus-mcp-server/
+
+[[citrus-mcp-server-install]]
+== Installation
+
+The MCP server is packaged as an uber-JAR that can be run standalone or integrated with AI development tools.
+
+=== Maven Dependency
+
+If you need to add the MCP server module to your project:
+
+[source,xml]
+----
+<dependency>
+  <groupId>org.citrusframework</groupId>
+  <artifactId>citrus-mcp-server</artifactId>
+  <version>${citrus.version}</version>
+</dependency>
+----
+
+=== Integrate with AI assistance tools
+
+You can integrate the Citrus MCP server into AI code assistance tools using a local `.mcp.json` configuration file in your project folder.
+
+[source,json]
+----
+{
+  "mcpServers": {
+    "citrus": {
+      "command": "jbang",
+        "args": [
+          "--quiet",
+          "org.citrusframework:citrus-mcp-server:${citrus.version}:runner"
+        ]
+      }
+  }
+}
+----
+
+NOTE: The very same approach also works with Claude desktop integration where you add this configuration to your `claude_desktop_config.json`.
+
+Running the MCP server with JBang is the most convenient way to do this.
+The --quiet flag prevents JBang’s output from interfering with the MCP protocol.
+
+NOTE: You can also run the server directly without using JBang - then it would be something like `java -jar <FULL PATH>/citrus-mcp-server-${citrus.version}-runner.jar`. JBang might be the simpler approach though because it automatically deals with downloading the JAR file from Maven central.
+
+[source,json]
+----
+{
+  "mcpServers": {
+    "citrus": {
+      "command": "java",
+      "args": [
+        "-jar",
+        "/path/to/citrus-mcp-server-${citrus.version}-runner.jar"
+      ]
+    }
+  }
+}
+----
+
+=== Building from Source
+
+You can build the Citrus MCP server uber-JAR locally with:
+
+[source,bash]
+----
+./mvnw clean package -pl tools/mcp-server
+----
+
+The resulting JAR will be located at `tools/mcp-server/target/citrus-mcp-server-${citrus.version}-runner.jar`.
+
+[[citrus-mcp-server-run]]
+== Running the MCP Server
+
+Any MCP-compatible client can connect to the Citrus MCP Server using either:
+
+* **STDIO transport**: Execute the JAR as a subprocess and communicate via stdin/stdout
+* **HTTP/SSE transport**: Connect to the HTTP endpoint at `/mcp`
+
+=== STDIO Mode (Recommended for AI Assistants)
+
+The server runs in STDIO mode by default, which is the standard transport for MCP clients like Claude Desktop:
+
+.Run with JBang
+[source,bash]
+----
+jbang --quiet org.citrusframework:citrus-mcp-server:${citrus.version}:runner
+----
+
+.Java JAR runner
+[source,bash]
+----
+java -jar citrus-mcp-server-${citrus.version}-runner.jar
+----
+
+=== HTTP/SSE Mode
+
+For web-based integrations, the server can also run with HTTP transport:
+
+.Run with JBang
+[source,bash]
+----
+jbang --quiet \
+      -Dquarkus.http.host-enabled=true \
+      -Dquarkus.http.port=8080 \
+ org.citrusframework:citrus-mcp-server:${citrus.version}:runner
+----
+
+.Java JAR runner
+[source,bash]
+----
+java -Dquarkus.http.host-enabled=true \
+     -Dquarkus.http.port=8080 \
+     -jar citrus-mcp-server-${citrus.version}-runner.jar
+----
+
+The MCP endpoint will be available at `http://localhost:8080/mcp`.
+
+[[citrus-mcp-server-tools]]
+== Tools
+
+The Citrus MCP server provides several tools that AI assistants can call to query Citrus metadata.
+
+[[citrus-mcp-server-tools-catalog]]
+=== Catalog Tools
+
+==== Test actions catalog
+
+Lists available Citrus test actions and containers from the catalog.
+
+**Parameters:**
+* `filter` (optional): Filter actions by name, title, or description (case-insensitive substring match)
+* `group` (optional): Filter by group (e.g., camel, kubernetes, selenium)
+* `version` (optional): Citrus version to query (defaults to the server version)
+
+**Returns:**
+* Version information
+* Count of matching components
+* List of components with name, title, description, group, and module
+
+**Example Response:**
+[source,json]
+----
+{
+  "version": "5.0.0-SNAPSHOT",
+  "count": 3,
+  "components": [
+    {
+      "name": "print",
+      "fullName": "print",
+      "version": "5.0.0-SNAPSHOT",
+      "group": "core",
+      "module": "citrus-base",
+      "title": "Print",
+      "description": "Prints messages to the console",
+      "properties": []
+    }
+  ]
+}
+----
+
+==== Test action details
+
+Gets detailed information for a specific test action, including all properties.
+
+**Parameters:**
+* `name` (required): Test action name (e.g., send, receive, print)
+* `version` (optional): Citrus version to query
+
+**Returns:**
+Detailed component information including:
+* Component metadata (name, version, group, module)
+* Property list with name, description, type, required flag, and default value
+
+==== Test action schema
+
+Retrieves the complete JSON schema for a test action with all property definitions.
+
+**Parameters:**
+* `name` (required): Test action name
+* `version` (optional): Citrus version to query
+
+**Returns:**
+JSON schema string with complete property specifications
+
+==== Endpoint catalog
+
+Lists available Citrus endpoints.
+
+**Parameters:**
+* `filter` (optional): Filter endpoints by name (case-insensitive substring match)
+* `group` (optional): Filter by group (e.g., http, kafka, jms)
+* `version` (optional): Citrus version to query
+
+**Returns:**
+List of endpoint components with metadata and properties
+
+==== Endpoint details
+
+Gets detailed information for a specific endpoint.
+
+**Parameters:**
+* `name` (required): Endpoint name (e.g., kafka, http, file, timer)
+* `version` (optional): Citrus version to query
+
+**Returns:**
+Detailed endpoint information with all properties
+
+==== Endpoint schema
+
+Retrieves the complete JSON schema for an endpoint.
+
+**Parameters:**
+* `name` (required): Endpoint name (e.g., kafka, http, direct)
+* `version` (optional): Citrus version to query
+
+**Returns:**
+JSON schema string for the endpoint
+
+[[citrus-mcp-server-tools-docs]]
+=== Documentation Tools
+
+==== Documentation Index
+
+Lists all available Citrus documentation files.
+
+**Parameters:**
+* `filter` (optional): Filter documentation by file name (case-insensitive substring match)
+* `version` (optional): Citrus version to query
+
+**Returns:**
+List of documentation file names
+
+**Example Response:**
+[source,json]
+----
+[
+  "actions-send.adoc",
+  "actions-receive.adoc",
+  "endpoints-http.adoc",
+  "endpoints-kafka.adoc"
+]
+----
+
+==== Documentation Page
+
+Retrieves documentation content for a specific component.
+
+**Parameters:**
+* `kind` (required): Component type (e.g., action, endpoint, function, validationMatcher)
+* `searchKey` (required): Search key (e.g., name of a test action or endpoint)
+* `version` (optional): Citrus version to query
+
+**Returns:**
+* `fileName`: Name of the documentation file
+* `version`: Citrus version
+* `adoc`: AsciiDoc content
+
+**Example:**
+[source,json]
+----
+{
+  "fileName": "actions-send.adoc",
+  "version": "5.0.0-SNAPSHOT",
+  "adoc": "[[actions-send]]\n= Send Action\n\nThe send action..."
+}
+----
+
+[[citrus-mcp-server-resources]]
+== Resources
+
+Resources provide read-only access to schemas and specifications.
+
+=== YAML DSL Schema
+
+**URI:** `citrus://schema/dsl/yaml`
+
+Provides the JSON schema for the Citrus YAML DSL, enabling schema-aware test authoring.
+
+**MIME Type:** `application/json`
+
+=== XML DSL Schema
+
+**URI:** `citrus://schema/dsl/xml`
+
+Provides the XSD schema for the Citrus XML DSL.
+
+**MIME Type:** `application/xml`
+
+=== Test Action Schemas
+
+**URI Template:** `citrus://schema/action/{name}`
+
+Retrieves the JSON schema for a specific test action.
+
+**Parameters:**
+* `name`: Test action name (e.g., print, send, receive)
+
+**MIME Type:** `application/json`
+
+**Example URI:** `citrus://schema/action/send`
+
+=== Endpoint Schemas
+
+**URI Template:** `citrus://schema/endpoint/{name}`
+
+Retrieves the JSON schema for a specific endpoint.
+
+**Parameters:**
+* `name`: Endpoint name (e.g., kafka, http, direct)
+
+**MIME Type:** `application/json`
+
+**Example URI:** `citrus://schema/endpoint/kafka`
+
+[[citrus-mcp-server-configuration]]
+== Server Configuration
+
+The Citrus MCP server uses Quarkus MCP so the server can be configured using Quarkus application properties.
+
+=== Default Configuration
+
+The default configuration (`application.properties`) includes:
+
+[source,properties]
+----
+quarkus.application.name=citrus-mcp-server
+quarkus.application.version=${citrus.version}
+
+# Disable banner for cleaner stdio output
+quarkus.banner.enabled=false
+
+# Logging configuration
+quarkus.log.console.stderr=true
+quarkus.log.level=WARN
+quarkus.log.category."org.citrusframework".level=INFO
+quarkus.log.category."io.quarkiverse.mcp".level=INFO
+
+# Disable HTTP server for STDIO mode
+quarkus.http.host-enabled=false
+----
+
+=== Custom Configuration
+
+Override properties using system properties or environment variables:
+
+[source,bash]
+----
+java -Dquarkus.log.level=DEBUG \
+     -Dquarkus.http.host-enabled=true \
+     -Dquarkus.http.port=9090 \
+     -jar citrus-mcp-server-${citrus.version}-runner.jar
+----
+
+[[citrus-mcp-server-usecases]]
+== Use Cases
+
+=== AI-Assisted Test Generation
+
+AI assistants can use the MCP server to:
+
+1. **Discover available components**: Query catalog tools to find relevant test actions and endpoints
+2. **Validate syntax**: Retrieve schemas to ensure correct property usage
+3. **Access documentation**: Get detailed documentation for specific components
+4. **Generate code**: Create syntactically correct Citrus tests based on user requirements
+
+=== Schema Validation
+
+Development environments can use the schema resources to:
+
+* Provide autocomplete for YAML/XML test definitions
+* Validate test files against official schemas
+* Show inline documentation for properties
+
+=== Documentation Lookup
+
+Tools can query documentation resources to:
+
+* Display contextual help for components
+* Search documentation by component type and name
+* Provide code examples from documentation

--- a/src/manual/tools.adoc
+++ b/src/manual/tools.adoc
@@ -4,5 +4,6 @@
 In the following sections we have a closer into various tooling available for Citrus.
 
 include::tools-cucumber-steps.adoc[]
+include::tools-mcp-server.adoc[]
 include::tools-restdocs.adoc[]
 include::tools-tracing.adoc[]

--- a/tools/mcp-server/pom.xml
+++ b/tools/mcp-server/pom.xml
@@ -1,0 +1,217 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.citrusframework</groupId>
+    <artifactId>citrus-tools</artifactId>
+    <version>5.0.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>citrus-mcp-server</artifactId>
+  <name>Citrus :: Tools :: MCP Server</name>
+  <description>Citrus MCP Server</description>
+
+  <properties>
+    <!-- Build uber-jar for easy JBang execution -->
+    <quarkus.package.jar.type>uber-jar</quarkus.package.jar.type>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.quarkus.platform</groupId>
+        <artifactId>quarkus-bom</artifactId>
+        <version>${quarkus.platform.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <!-- Quarkus MCP Server with STDIO transport -->
+    <dependency>
+      <groupId>io.quarkiverse.mcp</groupId>
+      <artifactId>quarkus-mcp-server-stdio</artifactId>
+      <version>${quarkus.mcp-server.version}</version>
+    </dependency>
+    <!-- Quarkus MCP Server with HTTP/SSE transport -->
+    <dependency>
+      <groupId>io.quarkiverse.mcp</groupId>
+      <artifactId>quarkus-mcp-server-http</artifactId>
+      <version>${quarkus.mcp-server.version}</version>
+    </dependency>
+
+    <!-- Quarkus core dependencies -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-arc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-jackson</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>tools.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <!-- Citrus dependencies -->
+    <dependency>
+      <groupId>org.citrusframework</groupId>
+      <artifactId>citrus-base</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+      <resource>
+        <directory>${project.build.directory}/generated-resources</directory>
+      </resource>
+    </resources>
+
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>generate-schema</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>java</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <includeProjectDependencies>false</includeProjectDependencies>
+          <includePluginDependencies>true</includePluginDependencies>
+          <executableDependency>
+            <groupId>org.citrusframework</groupId>
+            <artifactId>citrus-schema-generator</artifactId>
+          </executableDependency>
+          <mainClass>org.citrusframework.dsl.schema.generator.CitrusSchemaGenerator</mainClass>
+          <arguments>
+            <argument>${project.build.directory}/generated-resources/citrus-catalog</argument>
+            <argument>${project.version}</argument>
+          </arguments>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.citrusframework</groupId>
+            <artifactId>citrus-schema-generator</artifactId>
+            <version>${project.version}</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+
+      <plugin>
+        <groupId>io.quarkus.platform</groupId>
+        <artifactId>quarkus-maven-plugin</artifactId>
+        <version>${quarkus.platform.version}</version>
+        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <goals>
+              <goal>build</goal>
+              <goal>generate-code</goal>
+              <!-- generate-code-tests removed: tests don't use @QuarkusTest,
+                   and the goal triggers a workspace resolution regression
+                   in Quarkus 3.34+ (quarkusio/quarkus#53285) -->
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- Copy user manual .adoc files into the uber-JAR for runtime search -->
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-user-manual</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/generated-resources/manual</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${project.basedir}/../../src/manual</directory>
+                  <filtering>false</filtering>
+                  <includes>
+                    <include>*.adoc</include>
+                  </includes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- Generate index.txt listing all copied user manual filenames -->
+      <plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>generate-user-manual-index</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <fileset id="doc-files" dir="${project.build.directory}/generated-resources/manual">
+                  <include name="*.adoc"/>
+                </fileset>
+                <pathconvert property="doc-list" refid="doc-files" pathsep="${line.separator}">
+                  <flattenmapper/>
+                </pathconvert>
+                <echo file="${project.build.outputDirectory}/manual/index.txt"
+                      message="${doc-list}"/>
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <parameters>true</parameters>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${maven.surefire.plugin.version}</version>
+        <configuration>
+          <systemPropertyVariables>
+            <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+            <maven.home>${maven.home}</maven.home>
+          </systemPropertyVariables>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.surefire</groupId>
+            <artifactId>surefire-junit-platform</artifactId>
+            <version>${maven.surefire.plugin.version}</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/tools/mcp-server/src/main/java/org/citrusframework/mcp/CatalogService.java
+++ b/tools/mcp-server/src/main/java/org/citrusframework/mcp/CatalogService.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.citrusframework.mcp;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import org.citrusframework.CitrusVersion;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.util.ClassLoaderHelper;
+import org.citrusframework.util.FileUtils;
+import org.citrusframework.util.StringUtils;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+
+/**
+ * Shared service for loading and caching Citrus catalogs.
+ * <p>
+ * Catalogs are cached by {@code (citrusVersion, kind)} tuple. The default catalog (no version
+ * parameters) is created once at startup.
+ */
+@ApplicationScoped
+public class CatalogService {
+
+    private final ConcurrentMap<CatalogKey, Map<String, ComponentDefinition>> cache = new ConcurrentHashMap<>();
+    private final ConcurrentMap<CatalogKey, String> schemas = new ConcurrentHashMap<>();
+
+    /**
+     * Default constructor automatically loads the catalog for this current version.
+     */
+    CatalogService() {
+        loadCatalog(CitrusVersion.version());
+    }
+
+    /**
+     * Load a catalog for the given version. Results are cached by the {@code (citrusVersion, kind)} tuple so that repeated calls with the same parameters do not trigger
+     * redundant Maven downloads.
+     *
+     * @param  version the Citrus version to query, or null for the default
+     */
+    public void loadCatalog(String version) {
+        CatalogIndex index = loadCatalogIndex(version);
+
+        for (Catalog catalog : index.catalogs.values()) {
+            CatalogKey key = new CatalogKey(catalog.name(), catalog.version());
+            if (!cache.containsKey(key)) {
+                cache.put(key, loadComponentDefinitions(catalog));
+            }
+        }
+
+        for (Catalog catalog : index.schemas.values()) {
+            CatalogKey key = new CatalogKey(catalog.name(), catalog.version());
+            if (!schemas.containsKey(key)) {
+                schemas.put(key, loadSchema(catalog));
+            }
+        }
+    }
+
+    public Map<String, ComponentDefinition> getTestActions() {
+        return cache.get(new CatalogKey("actions", getVersion()));
+    }
+
+    public Map<String, ComponentDefinition> getTestContainers() {
+        return cache.get(new CatalogKey("containers", getVersion()));
+    }
+
+    public Map<String, ComponentDefinition> getEndpoints() {
+        return cache.get(new CatalogKey("endpoints", getVersion()));
+    }
+
+    public Map<String, ComponentDefinition> getFunctions() {
+        return cache.get(new CatalogKey("functions", getVersion()));
+    }
+
+    public Map<String, ComponentDefinition> getValidationMatcher() {
+        return cache.get(new CatalogKey("validationMatcher", getVersion()));
+    }
+
+    public String getSchema(String name) {
+        return schemas.get(new CatalogKey(name, getVersion()));
+    }
+
+    public String getVersion() {
+        if (StringUtils.hasText(CitrusVersion.version())) {
+            return CitrusVersion.version();
+        } else {
+            return loadCatalogIndex("").version();
+        }
+    }
+
+    private CatalogIndex loadCatalogIndex(String version) {
+        if (StringUtils.hasText(version)) {
+            return JsonSupport.json().readValue(ClassLoaderHelper.getClassLoader()
+                    .getResourceAsStream("citrus-catalog/citrus/%s/index.json".formatted(version)), CatalogIndex.class);
+        } else {
+            return JsonSupport.json().readValue(ClassLoaderHelper.getClassLoader()
+                    .getResourceAsStream("citrus-catalog/citrus/index.json"), CatalogIndex.class);
+        }
+    }
+
+    /**
+     * Loads component definitions for this catalog.
+     */
+    private String loadSchema(Catalog catalog) {
+        try {
+            return FileUtils.readToString(ClassLoaderHelper.getClassLoader().getResourceAsStream("citrus-catalog/citrus/%s/%s".formatted(catalog.version(), catalog.file())))
+                    .replaceAll("\\r?\\n\\s*", "");
+        } catch (IOException e) {
+            throw new CitrusRuntimeException("Failed to read schema '%s'".formatted(catalog.name()), e);
+        }
+    }
+
+    /**
+     * Loads component definitions for this catalog.
+     */
+    private Map<String, ComponentDefinition> loadComponentDefinitions(Catalog catalog) {
+        return loadComponentDefinitions(catalog.name(), catalog.version(), catalog.file());
+    }
+
+    private Map<String, ComponentDefinition> loadComponentDefinitions(String kind, String version, String file) {
+        try {
+            Map<String, ComponentDefinition> components = new HashMap<>();
+            JsonNode raw = JsonSupport.json().readTree(ClassLoaderHelper.getClassLoader().getResourceAsStream("citrus-catalog/citrus/%s/%s".formatted(version, file)));
+            raw.propertyNames().forEach(
+                    name -> components.put(name, JsonSupport.json().convertValue(raw.get(name), ComponentDefinition.class)));
+            return components;
+        } catch (JacksonException e) {
+            throw new CitrusRuntimeException("Failed to read component aggregate schema definitions of kind '%s'".formatted(kind), e);
+        }
+    }
+
+    /**
+     * Extracts the pure test action name and removes a potential group prefix.
+     */
+    public String resolveName(String name, String group) {
+        if (group == null) {
+            return name;
+        }
+
+        if (name.startsWith(group + "-")) {
+            return name.substring(group.length() + 1);
+        }
+
+        return name;
+    }
+
+    /**
+     * Citrus catalog holds one to many component definition entries in given file path.
+     */
+    private record CatalogIndex(String name, String runtime, String version, Map<String, Catalog> catalogs, Map<String, Catalog> schemas) {
+    }
+
+    /**
+     * Citrus catalog holds one to many component definition entries in given file path.
+     */
+    private record Catalog(String name, String description, String version, String file) {
+    }
+
+    /**
+     * A key combines component kind and version.
+     */
+    private record CatalogKey(String kind, String version) {
+    }
+
+    /**
+     * Citrus component definition provides information about the component.
+     * Components may be one of test actions, containers, endpoints, functions or validation matcher.
+     */
+    public record ComponentDefinition(String kind, String version, String name, String group, String module,
+                               String title, String description, JsonNode propertiesSchema) {
+    }
+}

--- a/tools/mcp-server/src/main/java/org/citrusframework/mcp/CatalogTools.java
+++ b/tools/mcp-server/src/main/java/org/citrusframework/mcp/CatalogTools.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.citrusframework.mcp;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolArg;
+import io.quarkiverse.mcp.server.ToolCallException;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.citrusframework.CitrusVersion;
+import tools.jackson.databind.JsonNode;
+
+/**
+ * MCP Tools for querying the Citrus catalog and its component definitions using Quarkus MCP Server.
+ */
+@ApplicationScoped
+public class CatalogTools {
+
+    @Inject
+    CatalogService catalogService;
+
+    /**
+     * Tool to list available Citrus test actions. This includes test actions and containers.
+     */
+    @Tool(description = "List available Citrus test actions from the catalog. " +
+                        "Returns test action name, description, and group information. " +
+                        "Use filter to search by name, group to filter by group.")
+    public ComponentListResult citrus_catalog_actions(
+            @ToolArg(required = false, description = "Filter actions by name (case-insensitive substring match)") String filter,
+            @ToolArg(required = false, description = "Filter by group (e.g., camel, kubernetes, selenium)") String group,
+            @ToolArg(required = false, description = "Citrus version to query. If not specified, uses the default catalog version.") String version) {
+
+        try {
+            String citrusVersion;
+            if (version != null && !version.isBlank()) {
+                citrusVersion = version;
+            } else {
+                citrusVersion = CitrusVersion.version();
+            }
+
+            catalogService.loadCatalog(citrusVersion);
+
+            List<ComponentDetailResult> results = new ArrayList<>();
+             results.addAll(catalogService.getTestActions().values()
+                    .stream()
+                    .filter(def -> def.kind().equals("testAction"))
+                    .filter(def -> matchesFilter(def.name(), def.title(), def.description(), filter))
+                    .filter(def -> matchesGroup(def.group(), group))
+                    .map(this::toComponentDetailResult)
+                    .toList());
+
+            results.addAll(catalogService.getTestContainers().values()
+                    .stream()
+                    .filter(def -> matchesFilter(def.name(), def.title(), def.description(), filter))
+                    .filter(def -> matchesGroup(def.group(), group))
+                    .map(this::toComponentDetailResult)
+                    .toList());
+
+            return new ComponentListResult(citrusVersion, results.size(), results);
+        } catch (ToolCallException e) {
+            throw e;
+        } catch (Throwable e) {
+            throw new ToolCallException("Failed to list actions: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Tool to get detailed information for a specific test action.
+     */
+    @Tool(description = "Get detailed information for a Citrus test action including all properties and some usage examples.")
+    public ComponentDetailResult citrus_catalog_action(
+            @ToolArg(description = "Test action name (e.g., send, receive, print)") String name,
+            @ToolArg(required = false, description = "Citrus version to query. If not specified, uses the default catalog version.") String version) {
+
+        if (name == null || name.isBlank()) {
+            throw new ToolCallException("Test action name is required", null);
+        }
+
+        try {
+            catalogService.loadCatalog(version);
+            CatalogService.ComponentDefinition definition = catalogService.getTestActions().get(name);
+            if (definition == null) {
+                definition = catalogService.getTestContainers().get(name);
+            }
+
+            if (definition == null) {
+                throw new ToolCallException("Test action not found: " + name);
+            }
+
+            return toComponentDetailResult(definition);
+        } catch (ToolCallException e) {
+            throw e;
+        } catch (Throwable ex) {
+            throw new ToolCallException(
+                    "Test action not found: " + name + " (" + ex.getClass().getName() + "): " + ex.getMessage(), null);
+        }
+    }
+
+    /**
+     * Tool to get the Json schema for a specific test action with all defined properties.
+     */
+    @Tool(description = "Get the detailed property Json schema for a Citrus test action.")
+    public String citrus_catalog_action_schema(
+            @ToolArg(description = "Test action name (e.g., kafka, http, file, timer)") String name,
+            @ToolArg(description = "Citrus version to query. If not specified, uses the default catalog version.") String version) {
+
+        if (name == null || name.isBlank()) {
+            throw new ToolCallException("Test action name is required", null);
+        }
+
+        try {
+            catalogService.loadCatalog(version);
+            CatalogService.ComponentDefinition definition = catalogService.getTestActions().get(name);
+            if (definition == null) {
+                definition = catalogService.getTestContainers().get(name);
+            }
+
+            if (definition == null) {
+                throw new ToolCallException("Test action not found: " + name);
+            }
+
+            return JsonSupport.json().writeValueAsString(definition.propertiesSchema());
+        } catch (ToolCallException e) {
+            throw e;
+        } catch (Throwable ex) {
+            throw new ToolCallException(
+                    "Test action not found: " + name + " (" + ex.getClass().getName() + "): " + ex.getMessage(), null);
+        }
+    }
+
+    /**
+     * Tool to list available Citrus endpoints.
+     */
+    @Tool(description = "List available Citrus endpoints from the catalog. " +
+            "Returns endpoint name, description and the endpoint properties specification. " +
+            "Use filter to search by name, group to filter by group.")
+    public ComponentListResult citrus_catalog_endpoints(
+            @ToolArg(required = false, description = "Filter endpoints by name (case-insensitive substring match)") String filter,
+            @ToolArg(required = false, description = "Filter by group (e.g., camel, kubernetes, selenium)") String group,
+            @ToolArg(required = false, description = "Citrus version to query. If not specified, uses the default catalog version.") String version) {
+
+        try {
+            String citrusVersion;
+            if (version != null && !version.isBlank()) {
+                citrusVersion = version;
+            } else {
+                citrusVersion = CitrusVersion.version();
+            }
+
+            catalogService.loadCatalog(citrusVersion);
+
+            List<ComponentDetailResult> results = catalogService.getEndpoints().values()
+                    .stream()
+                    .filter(def -> matchesFilter(def.name(), def.title(), def.description(), filter))
+                    .filter(def -> matchesGroup(def.group(), group))
+                    .map(this::toComponentDetailResult)
+                    .toList();
+
+            return new ComponentListResult(citrusVersion, results.size(), results);
+        } catch (ToolCallException e) {
+            throw e;
+        } catch (Throwable e) {
+            throw new ToolCallException("Failed to list endpoints: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Tool to get detailed information for a specific Citrus endpoint.
+     */
+    @Tool(description = "Get detailed information for a Citrus endpoint including all endpoint properties.")
+    public ComponentDetailResult citrus_catalog_endpoint(
+            @ToolArg(description = "Test endpoint name (e.g., kafka, http, file, timer)") String name,
+            @ToolArg(required = false, description = "Citrus version to query. If not specified, uses the default catalog version.") String version) {
+
+        if (name == null || name.isBlank()) {
+            throw new ToolCallException("Test endpoint name is required", null);
+        }
+
+        try {
+            catalogService.loadCatalog(version);
+            CatalogService.ComponentDefinition definition = catalogService.getEndpoints().get(name);
+
+            if (definition == null && !name.contains("-")) {
+                definition = catalogService.getEndpoints().get(name + "-asynchronous");
+            }
+
+            if (definition == null) {
+                throw new ToolCallException("Test endpoint not found: " + name);
+            }
+
+            return toComponentDetailResult(definition);
+        } catch (ToolCallException e) {
+            throw e;
+        } catch (Throwable ex) {
+            throw new ToolCallException(
+                    "Test endpoint not found: " + name + " (" + ex.getClass().getName() + "): " + ex.getMessage(), null);
+        }
+    }
+
+    /**
+     * Tool to get the Json schema for a specific Citrus endpoint with all defined properties.
+     */
+    @Tool(description = "Get the detailed property Json schema for a Citrus endpoint.")
+    public String citrus_catalog_endpoint_schema(
+            @ToolArg(description = "Endpoint name (e.g., kafka, http, direct)") String name,
+            @ToolArg(description = "Citrus version to query. If not specified, uses the default catalog version.") String version) {
+
+        if (name == null || name.isBlank()) {
+            throw new ToolCallException("Test endpoint name is required", null);
+        }
+
+        try {
+            catalogService.loadCatalog(version);
+            CatalogService.ComponentDefinition definition = catalogService.getEndpoints().get(name);
+
+            if (definition == null && !name.contains("-")) {
+                definition = catalogService.getEndpoints().get(name + "-asynchronous");
+            }
+
+            if (definition == null) {
+                throw new ToolCallException("Test endpoint not found: " + name);
+            }
+
+            return JsonSupport.json().writeValueAsString(definition.propertiesSchema());
+        } catch (ToolCallException e) {
+            throw e;
+        } catch (Throwable ex) {
+            throw new ToolCallException(
+                    "Test endpoint not found: " + name + " (" + ex.getClass().getName() + "): " + ex.getMessage(), null);
+        }
+    }
+
+    private ComponentDetailResult toComponentDetailResult(CatalogService.ComponentDefinition definition) {
+        List<PropertyInfo> properties = new ArrayList<>();
+        if (definition.propertiesSchema() != null) {
+            Optional.ofNullable(definition.propertiesSchema().asObject().get("properties"))
+                    .map(JsonNode::properties)
+                    .orElseGet(Collections::emptySet)
+                    .forEach(property -> properties.add(new PropertyInfo(
+                        property.getKey(),
+                        Optional.ofNullable(property.getValue().get("description"))
+                                .map(JsonNode::stringValue)
+                                .orElse(null),
+                        Optional.ofNullable(property.getValue().get("type")).map(JsonNode::stringValue).orElse(null),
+                        Optional.ofNullable(definition.propertiesSchema().get("required"))
+                                .map(JsonNode::asArray)
+                                .map(array -> array.valueStream()
+                                        .anyMatch(node -> property.getKey().equals(node.stringValue())))
+                                .orElse(false),
+                        Optional.ofNullable(property.getValue().get("defaultValue"))
+                                .map(JsonNode::stringValue)
+                                .orElse(null))));
+        }
+
+        return new ComponentDetailResult(
+                catalogService.resolveName(definition.name(), definition.group()),
+                definition.name(),
+                definition.version(),
+                definition.group(),
+                definition.module(),
+                definition.title(),
+                definition.description(),
+                properties);
+    }
+
+    public record ComponentListResult(String version, int count, List<ComponentDetailResult> components) {
+    }
+
+    public record ComponentDetailResult(String name, String fullName, String version, String group, String module,
+                                        String title, String description, List<PropertyInfo> properties) {
+    }
+
+    public record PropertyInfo(String name, String description, String type, boolean required,
+                             String defaultValue) {
+    }
+
+    // Helper methods
+
+    private boolean matchesFilter(String name, String title, String description, String filter) {
+        if (filter == null || filter.isBlank()) {
+            return true;
+        }
+        String lowerFilter = filter.toLowerCase();
+        return (name != null && name.toLowerCase().contains(lowerFilter))
+                || (title != null && title.toLowerCase().contains(lowerFilter))
+                || (description != null && description.toLowerCase().contains(lowerFilter));
+    }
+
+    private boolean matchesGroup(String group, String groupFilter) {
+        if (groupFilter == null || groupFilter.isBlank()) {
+            return true;
+        }
+        if (group == null) {
+            return false;
+        }
+        return group.toLowerCase().contains(groupFilter.toLowerCase());
+    }
+
+}

--- a/tools/mcp-server/src/main/java/org/citrusframework/mcp/DocsData.java
+++ b/tools/mcp-server/src/main/java/org/citrusframework/mcp/DocsData.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.mcp;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import org.citrusframework.CitrusSettings;
+import org.citrusframework.spi.Resources;
+import org.citrusframework.util.FileUtils;
+
+@ApplicationScoped
+public class DocsData {
+
+    public static final String CITRUS_MANUAL_DOC = "manual";
+
+    /**
+     * Gets all documentation file names.
+     */
+    public List<String> getDocsIndex(String version) throws IOException {
+        String index = FileUtils.readToString(
+                Resources.fromClasspath(CITRUS_MANUAL_DOC + "/index.txt"), StandardCharsets.UTF_8);
+        return Arrays.asList(index.split("\n"));
+    }
+
+    /**
+     * Gets the documentation Ascii doc file content for the given component type and name search.
+     */
+    public DocInfo getDocsPage(String kind, String searchKey, String version) throws IOException {
+        Optional<String> docFile = getDocsIndex(version).stream()
+                .filter(fileName -> fileName.contains(kind))
+                .filter(fileName -> fileName.contains(searchKey))
+                .findFirst();
+
+        if (docFile.isPresent()) {
+            String markdown = FileUtils.readToString(
+                    Resources.fromClasspath(CITRUS_MANUAL_DOC + "/" + docFile.get()));
+            return new DocInfo(docFile.get(), version, markdown);
+        }
+
+        return null;
+    }
+
+    /**
+     * Gets a collection of best practices when writing Citrus tests.
+     */
+    public List<String> getBestPractices() {
+        List<String> bestPractices = new ArrayList<>();
+
+        bestPractices.add("Set Citrus configuration properties in an application.properties file named: " + CitrusSettings.getApplicationPropertiesFile());
+        bestPractices.add("For Java test files use one of the file name pattern: " + CitrusSettings.getJavaTestFileNamePattern());
+        bestPractices.add("For YAML DSL test files use one of the file name pattern: " + CitrusSettings.getYamlTestFileNamePattern());
+        bestPractices.add("For XML DSL test files use one of the file name pattern: " + CitrusSettings.getXmlTestFileNamePattern());
+        bestPractices.add("For Groovy DSL test files use one of the file name pattern: " + CitrusSettings.getGroovyTestFileNamePattern());
+        bestPractices.add("Evaluate the usage of test variables for values that are used multiple times in a test");
+        bestPractices.add("When sending and receiving messages load large message payloads from a file resource");
+
+        return bestPractices;
+    }
+
+    public record DocInfo(String fileName, String version, String adoc) {
+    }
+}

--- a/tools/mcp-server/src/main/java/org/citrusframework/mcp/DocsResources.java
+++ b/tools/mcp-server/src/main/java/org/citrusframework/mcp/DocsResources.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.mcp;
+
+import java.util.stream.Collectors;
+
+import io.quarkiverse.mcp.server.Resource;
+import io.quarkiverse.mcp.server.TextResourceContents;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+/**
+ * MCP Resources exposing Citrus documentation and best practices.
+ */
+@ApplicationScoped
+public class DocsResources {
+
+    @Inject
+    DocsData docsData;
+
+    /**
+     * Resource provides access to Citrus YAML DSL schema.
+     */
+    @Resource(uri = "citrus://docs/best-practices",
+            name = "citrus_docs_best_practices",
+            title = "Citrus Best Practices",
+            description = "Collection of best practices for Writing Citrus tests.",
+            mimeType = "application/json")
+    public TextResourceContents citrus_docs_best_practices() {
+        String uri = "citrus://docs/best-practices";
+        return new TextResourceContents(uri, "[" + docsData.getBestPractices()
+                .stream()
+                .map("\"%s\""::formatted)
+                .collect(Collectors.joining(",")) + "]", "application/json");
+    }
+
+}

--- a/tools/mcp-server/src/main/java/org/citrusframework/mcp/DocsTools.java
+++ b/tools/mcp-server/src/main/java/org/citrusframework/mcp/DocsTools.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.citrusframework.mcp;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolArg;
+import io.quarkiverse.mcp.server.ToolCallException;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.citrusframework.CitrusVersion;
+
+/**
+ * MCP Tools for querying the Citrus documentation using Quarkus MCP Server.
+ */
+@ApplicationScoped
+public class DocsTools {
+
+    @Inject
+    DocsData docsData;
+
+    /**
+     * Tool to list available Citrus test actions. This includes test actions and containers.
+     */
+    @Tool(description = "List available Citrus test actions from the catalog. " +
+                        "Returns test action name, description, and group information. " +
+                        "Use filter to search by name, group to filter by group.")
+    public List<String> citrus_docs_index(
+            @ToolArg(required = false, description = "Filter documentation by given file name filter (case-insensitive substring match)") String filter,
+            @ToolArg(required = false, description = "Citrus version to query. If not specified, uses the default catalog version.") String version) {
+
+        String citrusVersion;
+        if (version != null && !version.isBlank()) {
+            citrusVersion = version;
+        } else {
+            citrusVersion = CitrusVersion.version();
+        }
+
+        try {
+            return docsData.getDocsIndex(citrusVersion).stream()
+                    .filter(fileName -> matchesFilter(fileName, filter))
+                    .collect(Collectors.toList());
+        } catch (Throwable e) {
+            throw new ToolCallException("Failed to get documentation index: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Tool to get the documentation AsciiDoc for a given component kind and a search key.
+     */
+    @Tool(description = "Get documentation AsciiDoc for a given component kind and search key. " +
+            "The kind is the Citrus component type such as action, container, endpoint, function, validationMatcher. " +
+            "The search key may be the name of a Citrus test component.")
+    public DocsData.DocInfo citrus_docs_page(
+            @ToolArg(description = "Test component type (e.g. action, endpoint, function)") String kind,
+            @ToolArg(description = "Search key (e.g., name of a test action or endpoint)") String searchKey,
+            @ToolArg(required = false, description = "Citrus version to query. If not specified, uses the default catalog version.") String version) {
+
+        if (kind == null || kind.isBlank()) {
+            throw new ToolCallException("Component kind is required", null);
+        }
+
+        if (searchKey == null || searchKey.isBlank()) {
+            throw new ToolCallException("Documentation search key is required", null);
+        }
+
+        String citrusVersion;
+        if (version != null && !version.isBlank()) {
+            citrusVersion = version;
+        } else {
+            citrusVersion = CitrusVersion.version();
+        }
+
+        try {
+            DocsData.DocInfo info = docsData.getDocsPage(kind, searchKey, citrusVersion);
+            if (info == null) {
+                throw new ToolCallException("No matching documentation found for kind: %s and search key: %s".formatted(kind, searchKey));
+            }
+
+            return info;
+        } catch (ToolCallException e) {
+            throw e;
+        } catch (Throwable ex) {
+            throw new ToolCallException("No matching documentation found for kind: %s and search key: %s".formatted(kind, searchKey));
+        }
+    }
+
+    // Helper methods
+
+    private boolean matchesFilter(String fileName, String filter) {
+        if (filter == null || filter.isBlank()) {
+            return true;
+        }
+        String lowerFilter = filter.toLowerCase();
+        return fileName != null && fileName.toLowerCase().contains(lowerFilter);
+    }
+
+}

--- a/tools/mcp-server/src/main/java/org/citrusframework/mcp/JsonSupport.java
+++ b/tools/mcp-server/src/main/java/org/citrusframework/mcp/JsonSupport.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.mcp;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import tools.jackson.core.StreamReadFeature;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.cfg.EnumFeature;
+import tools.jackson.databind.json.JsonMapper;
+
+public class JsonSupport {
+
+    private static final ObjectMapper OBJECT_MAPPER;
+
+    static {
+        OBJECT_MAPPER = JsonMapper.builder()
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .enable(EnumFeature.READ_ENUMS_USING_TO_STRING)
+                .enable(EnumFeature.WRITE_ENUMS_USING_TO_STRING)
+                .disable(StreamReadFeature.AUTO_CLOSE_SOURCE)
+                .changeDefaultPropertyInclusion(incl -> incl.withValueInclusion(JsonInclude.Include.NON_EMPTY))
+                .changeDefaultPropertyInclusion(incl -> incl.withContentInclusion(JsonInclude.Include.NON_EMPTY))
+                .build();
+    }
+
+    public static ObjectMapper json() {
+        return OBJECT_MAPPER;
+    }
+}

--- a/tools/mcp-server/src/main/java/org/citrusframework/mcp/PromptDefinitions.java
+++ b/tools/mcp-server/src/main/java/org/citrusframework/mcp/PromptDefinitions.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.citrusframework.mcp;
+
+import java.util.List;
+
+import io.quarkiverse.mcp.server.Prompt;
+import io.quarkiverse.mcp.server.PromptArg;
+import io.quarkiverse.mcp.server.PromptMessage;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * MCP Prompt definitions that provide structured multi-step workflows for LLMs.
+ * <p>
+ * Prompts guide the LLM through orchestrating multiple existing tools in the correct sequence, rather than requiring it
+ * to discover the workflow on its own.
+ */
+@ApplicationScoped
+public class PromptDefinitions {
+
+    /**
+     * Guided workflow for writing a Citrus test in given domain specific language and from given requirements.
+     */
+    @Prompt(name = "citrus_write_test",
+            description = "Guided workflow to write a Citrus test in given domain specific language and from given requirements: "
+                          + "consolidate best practices for writing Citrus tests, analyze requirements, "
+                          + "discover test infrastructure, discover endpoints, discover test actions, "
+                          + "generate a test in given domain specific language, validate it, and present the results.")
+    public List<PromptMessage> citrus_write_test(
+            @PromptArg(name = "requirements",
+                       description = "Natural-language description of what the test should do") String requirements,
+            @PromptArg(name = "language", description = "Domain specific language to use, one of yaml, xml, groovy, feature, Java (default: yaml)",
+                       required = false) String language) {
+
+        String resolvedDsl = language != null && !language.isBlank() ? language : "yaml";
+
+        String instructions = """
+                You are writing a Citrus test using the "%s" domain specific language.
+
+                ## Requirements
+                %s
+
+                ## Workflow
+
+                Follow these steps in order:
+
+                ### Step 1: Use best practices
+                Retrieve best practices using the MCP resource `citrus_docs_best_practices` and follow these rules when writing the test.
+
+                ### Step 2: Identify required infrastructure
+                Analyze the requirements above and identify test infrastructure needed such as databases, message brokers, 3rd party services.
+                If appropriate, use special test actions regarding Testcontainers or Apache Camel JBang infra services to start the infrastructure as part of the test.
+
+                ### Step 3: Identify endpoints
+                Analyze the requirements above and identify the Citrus endpoints needed.
+                Call `citrus_catalog_endpoints` with a relevant filter to find matching endpoints and gather the information given.
+
+                ### Step 4: Identify Test actions
+                Determine which Citrus test actions are needed (e.g., send, receive, print).
+                Call `citrus_catalog_actions` with a relevant filter to find matching test actions.
+
+                ### Step 5: Get endpoint details
+                For each endpoint you selected, call `citrus_catalog_endpoint` with the endpoint name \
+                to get its endpoint property options, required parameters, and URI syntax.
+
+                ### Step 6: Get test action details
+                For each test action you selected, call `citrus_catalog_action` with the action name \
+                to get its property options, required parameters, and usage information.
+
+                ### Step 7: Write the test
+                Using the gathered information, write a complete test definition using the given domain specific language. \
+                Use correct endpoint URI syntax and required options from the documentation.
+
+                ### Step 8: Validate
+                Validate the test to check for syntax errors and unused or undeclared test variables.
+                If available, retrieve the schema via MCP resource `citrus_dsl_schema_%s` and use this schema to check for syntax errors.
+                If validation fails, fix the issues and re-validate.
+
+                ### Step 9: Present result
+                Present the final test along with:
+                - A brief explanation of each endpoint and test action used
+                - Instructions for running the route (e.g., with Citrus JBang)
+                """.formatted(resolvedDsl, requirements, resolvedDsl);
+
+        return List.of(PromptMessage.withUserRole(instructions));
+    }
+
+}

--- a/tools/mcp-server/src/main/java/org/citrusframework/mcp/SchemaResources.java
+++ b/tools/mcp-server/src/main/java/org/citrusframework/mcp/SchemaResources.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.mcp;
+
+import io.quarkiverse.mcp.server.Resource;
+import io.quarkiverse.mcp.server.ResourceTemplate;
+import io.quarkiverse.mcp.server.ResourceTemplateArg;
+import io.quarkiverse.mcp.server.TextResourceContents;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+/**
+ * MCP Resources exposing Citrus schemas for instance the YAML and XML DSL schema and endpoint property schemas.
+ */
+@ApplicationScoped
+public class SchemaResources {
+
+    @Inject
+    CatalogService catalogService;
+
+    /**
+     * Resource provides access to Citrus YAML DSL schema.
+     */
+    @Resource(uri = "citrus://schema/dsl/yaml",
+            name = "citrus_dsl_schema_yaml",
+            title = "Citrus YAML DSL Schema",
+            description = "Retrieves the schema for the Citrus YAML domain specific language.",
+            mimeType = "application/json")
+    public TextResourceContents citrus_yaml_dsl_schema() {
+        String uri = "citrus://schema/dsl/yaml";
+
+        try {
+            String schema = catalogService.getSchema("citrus-yaml");
+            if (schema == null) {
+                return error(uri, "Schema not found: citrus-yaml");
+            }
+
+            return new TextResourceContents(uri, schema, "application/json");
+        } catch (Throwable ex) {
+            return error(uri, ex.getMessage());
+        }
+    }
+
+    /**
+     * Resource provides access to Citrus XML DSL schema.
+     */
+    @Resource(uri = "citrus://schema/dsl/xml",
+            name = "citrus_dsl_schema_xml",
+            title = "Citrus XML DSL Schema",
+            description = "Retrieves the schema for the Citrus XML domain specific language.",
+            mimeType = "application/xml")
+    public TextResourceContents citrus_xml_dsl_schema() {
+        String uri = "citrus://schema/dsl/xml";
+
+        try {
+            String schema = catalogService.getSchema("citrus-xml");
+            if (schema == null) {
+                return error(uri, "Schema not found: citrus-xml");
+            }
+
+            return new TextResourceContents(uri, schema, "application/xml");
+        } catch (Throwable ex) {
+            return error(uri, ex.getMessage());
+        }
+    }
+
+    /**
+     * Resource provides access to Citrus test action schemas.
+     */
+    @ResourceTemplate(uriTemplate = "citrus://schema/action/{name}",
+            name = "citrus_action_schema",
+            title = "Citrus Test Action Schema",
+            description = "Retrieves the Json schema for a specific Citrus test action (e.g., print, send, receive). " +
+                    "The schema includes all available test action properties",
+            mimeType = "application/json")
+    public TextResourceContents citrus_action_schema(@ResourceTemplateArg(name = "name") String name) {
+        String uri = "citrus://schema/action/" + name;
+
+        if (name == null || name.isBlank()) {
+            return error(uri, "Test action name is required");
+        }
+
+        try {
+            CatalogService.ComponentDefinition definition = catalogService.getTestActions().get(name);
+            if (definition == null) {
+                definition = catalogService.getTestContainers().get(name);
+            }
+            if (definition == null) {
+                return error(uri, "Test action not found:" + name);
+            }
+
+            return new TextResourceContents(uri, JsonSupport.json().writeValueAsString(definition.propertiesSchema()), "application/json");
+        } catch (Throwable ex) {
+            return error(uri, ex.getMessage());
+        }
+    }
+
+    /**
+     * Resource provides access to Citrus endpoint schemas.
+     */
+    @ResourceTemplate(uriTemplate = "citrus://schema/endpoint/{name}",
+            name = "citrus_endpoint_schema",
+            title = "Citrus Endpoint Schema",
+            description = "Retrieves the Json schema for a specific Citrus endpoint (e.g., kafka, http, direct). " +
+                    "The schema includes all available endpoint properties",
+            mimeType = "application/json")
+    public TextResourceContents citrus_endpoint_schema(@ResourceTemplateArg(name = "name") String name) {
+        String uri = "citrus://schema/endpoint/" + name;
+
+        if (name == null || name.isBlank()) {
+            return error(uri, "Test endpoint name is required");
+        }
+
+        try {
+            CatalogService.ComponentDefinition definition = catalogService.getEndpoints().get(name);
+            if (definition == null) {
+                return error(uri, "Test endpoint not found:" + name);
+            }
+
+            return new TextResourceContents(uri, JsonSupport.json().writeValueAsString(definition.propertiesSchema()), "application/json");
+        } catch (Throwable ex) {
+            return error(uri, ex.getMessage());
+        }
+    }
+
+    /**
+     * Create a simple Json response that represents an error information.
+     */
+    private TextResourceContents error(String uri, String message) {
+        return new TextResourceContents(uri, "{ \"error\": \"%s\" }".formatted(message), "application/json");
+    }
+}

--- a/tools/mcp-server/src/main/resources/application.properties
+++ b/tools/mcp-server/src/main/resources/application.properties
@@ -1,0 +1,35 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+# Camel MCP Server Configuration
+# This file configures the Quarkus MCP Server for Apache Camel
+
+# Server name and version for MCP protocol
+quarkus.application.name=citrus-mcp-server
+quarkus.application.version=${citrus.version:5.0.0-SNAPSHOT}
+
+# Disable banner for cleaner stdio output
+quarkus.banner.enabled=false
+
+# Logging configuration - stderr only to avoid interfering with stdio transport
+quarkus.log.console.stderr=true
+quarkus.log.level=WARN
+quarkus.log.category."org.citrusframework".level=INFO
+quarkus.log.category."io.quarkiverse.mcp".level=INFO
+
+# Disable HTTP server - use STDIO transport only for CLI integration
+quarkus.http.host-enabled=false
+quarkus.http.cors.enabled=true

--- a/tools/mcp-server/src/test/java/org/citrusframework/mcp/CatalogToolsTest.java
+++ b/tools/mcp-server/src/test/java/org/citrusframework/mcp/CatalogToolsTest.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.citrusframework.mcp;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CatalogToolsTest {
+
+    private CatalogTools createTools() {
+        CatalogService catalogService = new CatalogService();
+
+        CatalogTools tools = new CatalogTools();
+        tools.catalogService = catalogService;
+        return tools;
+    }
+
+    @Test
+    void shouldGetActionDetails() {
+        CatalogTools tools = createTools();
+
+        CatalogTools.ComponentDetailResult result = tools.citrus_catalog_action("print", null);
+
+        assertThat(result).isNotNull();
+        assertThat(result.version()).isNotNull();
+        assertThat(result.name()).isEqualTo("print");
+        assertThat(result.properties().size()).isEqualTo(2);
+        assertThat(result.properties().get(0).name()).isEqualTo("description");
+        assertThat(result.properties().get(0).required()).isFalse();
+        assertThat(result.properties().get(1).name()).isEqualTo("message");
+        assertThat(result.properties().get(1).required()).isTrue();
+    }
+
+    @Test
+    void shouldGetEndpointDetails() {
+        CatalogTools tools = createTools();
+
+        CatalogTools.ComponentDetailResult result = tools.citrus_catalog_endpoint("http-client", null);
+
+        assertThat(result).isNotNull();
+        assertThat(result.version()).isNotNull();
+        assertThat(result.name()).isEqualTo("client");
+        assertThat(result.fullName()).isEqualTo("http-client");
+        assertThat(result.properties().size()).isEqualTo(23);
+    }
+
+    @Test
+    void shouldGetActionSchema() {
+        CatalogTools tools = createTools();
+
+        String result = tools.citrus_catalog_action_schema("print", null);
+
+        assertThat(result).isNotNull();
+        assertThat(result).contains("The message to print.");
+
+        result = tools.citrus_catalog_action_schema("iterate", null);
+
+        assertThat(result).isNotNull();
+        assertThat(result).contains("Sequence of test actions to execute.");
+    }
+
+    @Test
+    void shouldGetEndpointSchema() {
+        CatalogTools tools = createTools();
+
+        String result = tools.citrus_catalog_endpoint_schema("kubernetes-client", null);
+
+        assertThat(result).isNotNull();
+        assertThat(result).contains("Kubernetes client");
+
+        result = tools.citrus_catalog_endpoint_schema("direct-asynchronous", null);
+
+        assertThat(result).isNotNull();
+        assertThat(result).contains("The queue name.");
+    }
+
+    @Test
+    void shouldGetActionsCatalogWithNullArguments() {
+        CatalogTools tools = createTools();
+
+        CatalogTools.ComponentListResult result = tools.citrus_catalog_actions(null, null, null);
+
+        assertThat(result).isNotNull();
+        assertThat(result.version()).isNotNull();
+        assertThat(result.count()).isNotZero();
+        assertThat(result.components().size()).isNotZero();
+    }
+
+    @Test
+    void shouldGetActionsCatalogWithEmptyArguments() {
+        CatalogTools tools = createTools();
+
+        CatalogTools.ComponentListResult result = tools.citrus_catalog_actions("", "", "");
+
+        assertThat(result).isNotNull();
+        assertThat(result.version()).isNotNull();
+        assertThat(result.count()).isNotZero();
+        assertThat(result.components().size()).isNotZero();
+    }
+
+    @Test
+    void shouldGetActionsCatalogWithFilter() {
+        CatalogTools tools = createTools();
+
+        CatalogTools.ComponentListResult result = tools.citrus_catalog_actions("print", null, null);
+
+        assertThat(result).isNotNull();
+        assertThat(result.count()).isEqualTo(1);
+        assertThat(result.components().size()).isEqualTo(1);
+        assertThat(result.components().get(0).properties().size()).isEqualTo(2);
+    }
+
+    @Test
+    void shouldGetActionsCatalogWithGroup() {
+        CatalogTools tools = createTools();
+
+        CatalogTools.ComponentListResult result = tools.citrus_catalog_actions(null, "http", null);
+
+        assertThat(result).isNotNull();
+        assertThat(result.count()).isEqualTo(4);
+    }
+
+    @Test
+    void shouldGetEndpointsCatalogWithNullArguments() {
+        CatalogTools tools = createTools();
+
+        CatalogTools.ComponentListResult result = tools.citrus_catalog_endpoints(null, null, null);
+
+        assertThat(result).isNotNull();
+        assertThat(result.version()).isNotNull();
+        assertThat(result.count()).isNotZero();
+    }
+
+    @Test
+    void shouldGetEndpointsCatalogWithEmptyArguments() {
+        CatalogTools tools = createTools();
+
+        CatalogTools.ComponentListResult result = tools.citrus_catalog_endpoints("", "", "");
+
+        assertThat(result).isNotNull();
+        assertThat(result.version()).isNotNull();
+        assertThat(result.count()).isNotZero();
+    }
+
+    @Test
+    void shouldGetEndpointsCatalogWithFilter() {
+        CatalogTools tools = createTools();
+
+        CatalogTools.ComponentListResult result = tools.citrus_catalog_endpoints("kubernetes-client", null, null);
+
+        assertThat(result).isNotNull();
+        assertThat(result.count()).isEqualTo(1);
+        assertThat(result.components().size()).isEqualTo(1);
+        assertThat(result.components().get(0).properties().size()).isEqualTo(11);
+    }
+
+    @Test
+    void shouldGetEndpointsCatalogWithGroup() {
+        CatalogTools tools = createTools();
+
+        CatalogTools.ComponentListResult result = tools.citrus_catalog_endpoints(null, "http", null);
+
+        assertThat(result).isNotNull();
+        assertThat(result.count()).isEqualTo(2);
+    }
+
+}

--- a/tools/mcp-server/src/test/java/org/citrusframework/mcp/DocsResourcesTest.java
+++ b/tools/mcp-server/src/test/java/org/citrusframework/mcp/DocsResourcesTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.citrusframework.mcp;
+
+import io.quarkiverse.mcp.server.TextResourceContents;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DocsResourcesTest {
+
+    private DocsResources createResources() {
+        DocsData docsData = new DocsData();
+
+        DocsResources tools = new DocsResources();
+        tools.docsData = docsData;
+        return tools;
+    }
+
+    @Test
+    void shouldGetDocsBestPractices() {
+        DocsResources tools = createResources();
+
+        TextResourceContents result = tools.citrus_docs_best_practices();
+
+        assertThat(result).isNotNull();
+        assertThat(result.text()).startsWith("[");
+        assertThat(result.text()).endsWith("]");
+    }
+
+}

--- a/tools/mcp-server/src/test/java/org/citrusframework/mcp/DocsToolsTest.java
+++ b/tools/mcp-server/src/test/java/org/citrusframework/mcp/DocsToolsTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.citrusframework.mcp;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DocsToolsTest {
+
+    private DocsTools createTools() {
+        DocsData docsData = new DocsData();
+
+        DocsTools tools = new DocsTools();
+        tools.docsData = docsData;
+        return tools;
+    }
+
+    @Test
+    void shouldGetDocsIndex() {
+        DocsTools tools = createTools();
+
+        List<String> result = tools.citrus_docs_index(null, null);
+
+        assertThat(result).isNotNull();
+        assertThat(result.size()).isGreaterThan(0);
+        assertThat(result).contains("index.adoc");
+    }
+
+    @Test
+    void shouldGetDocsIndexWithFilter() {
+        DocsTools tools = createTools();
+
+        List<String> result = tools.citrus_docs_index("http", null);
+
+        assertThat(result).isNotNull();
+        assertThat(result.size()).isGreaterThan(0);
+        assertThat(result).contains("endpoint-http.adoc");
+    }
+
+    @Test
+    void shouldGetDocsPage() {
+        DocsTools tools = createTools();
+
+        DocsData.DocInfo result = tools.citrus_docs_page("action", "print", null);
+
+        assertThat(result).isNotNull();
+        assertThat(result.fileName()).isEqualTo("actions-print.adoc");
+        assertThat(result.adoc()).isNotNull();
+
+        result = tools.citrus_docs_page("endpoint", "kafka", null);
+
+        assertThat(result).isNotNull();
+        assertThat(result.fileName()).isEqualTo("endpoint-kafka.adoc");
+        assertThat(result.adoc()).isNotNull();
+    }
+
+}

--- a/tools/mcp-server/src/test/java/org/citrusframework/mcp/PromptDefinitionsTest.java
+++ b/tools/mcp-server/src/test/java/org/citrusframework/mcp/PromptDefinitionsTest.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.citrusframework.mcp;
+
+import java.util.List;
+
+import io.quarkiverse.mcp.server.PromptMessage;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PromptDefinitionsTest {
+
+    private final PromptDefinitions prompts = new PromptDefinitions();
+
+    @Test
+    void buildIntegrationReturnsNonEmptyMessages() {
+        List<PromptMessage> result = prompts.citrus_write_test("Send and receive messages to/from a direct endpoint", "yaml");
+        assertThat(result).isNotEmpty();
+    }
+}

--- a/tools/mcp-server/src/test/java/org/citrusframework/mcp/SchemaResourcesTest.java
+++ b/tools/mcp-server/src/test/java/org/citrusframework/mcp/SchemaResourcesTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.mcp;
+
+import io.quarkiverse.mcp.server.TextResourceContents;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SchemaResourcesTest {
+
+    private SchemaResources createResources() {
+        CatalogService catalogService = new CatalogService();
+
+        SchemaResources resources = new SchemaResources();
+        resources.catalogService = catalogService;
+        return resources;
+    }
+
+    @Test
+    void shouldGetYamlDslSchema() {
+        SchemaResources resources = createResources();
+
+        TextResourceContents result = resources.citrus_yaml_dsl_schema();
+
+        assertThat(result).isNotNull();
+        assertThat(result.uri()).isEqualTo("citrus://schema/dsl/yaml");
+        assertThat(result.text()).startsWith("{\"$schema\" : \"http://json-schema.org/draft-07/schema#\"");
+    }
+
+    @Test
+    void shouldGetXmlIoDslSchema() {
+        SchemaResources resources = createResources();
+
+        TextResourceContents result = resources.citrus_xml_dsl_schema();
+
+        assertThat(result).isNotNull();
+        assertThat(result.uri()).isEqualTo("citrus://schema/dsl/xml");
+        assertThat(result.text()).startsWith("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>");
+    }
+
+    @Test
+    void shouldGetActionSchema() {
+        SchemaResources resources = createResources();
+
+        TextResourceContents result = resources.citrus_action_schema("send");
+
+        assertThat(result).isNotNull();
+        assertThat(result.uri()).isEqualTo("citrus://schema/action/send");
+        assertThat(result.text()).startsWith("{\"$schema\":\"http://json-schema.org/draft-07/schema#\"");
+    }
+
+    @Test
+    void shouldGetEndpointSchema() {
+        SchemaResources resources = createResources();
+
+        TextResourceContents result = resources.citrus_endpoint_schema("kubernetes-client");
+
+        assertThat(result).isNotNull();
+        assertThat(result.uri()).isEqualTo("citrus://schema/endpoint/kubernetes-client");
+        assertThat(result.text()).startsWith("{\"$schema\":\"http://json-schema.org/draft-07/schema#\"");
+    }
+}

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -23,6 +23,7 @@
     <module>agent</module>
     <module>cucumber-steps</module>
     <module>archetypes</module>
+    <module>mcp-server</module>
   </modules>
 
   <dependencyManagement>

--- a/tools/schema-generator/src/main/java/org/citrusframework/dsl/schema/generator/CitrusSchemaGenerator.java
+++ b/tools/schema-generator/src/main/java/org/citrusframework/dsl/schema/generator/CitrusSchemaGenerator.java
@@ -32,7 +32,6 @@ import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
 import com.github.victools.jsonschema.generator.SchemaVersion;
 import com.github.victools.jsonschema.generator.TypeContext;
 import org.citrusframework.agent.CitrusAgentConfiguration;
-import org.citrusframework.agent.connector.yaml.YamlSupport;
 import org.citrusframework.dsl.schema.Catalog;
 import org.citrusframework.dsl.schema.Test;
 import org.citrusframework.message.MessagePayloadUtils;
@@ -81,23 +80,23 @@ public class CitrusSchemaGenerator {
             writeFile(workingDir, "citrus-testcase.xsd", xsdSchema);
             writeFile(versionWorkingDir, "citrus-testcase.xsd", xsdSchema);
 
-            String actionCatalog = MessagePayloadUtils.prettyPrintJson(YamlSupport.json().writeValueAsString(catalog.getTestActionCatalog()));
+            String actionCatalog = MessagePayloadUtils.prettyPrintJson(JsonSupport.json().writeValueAsString(catalog.getTestActionCatalog()));
             writeFile(workingDir, "citrus-catalog-aggregate-test-actions.json", actionCatalog + "\n");
             writeFile(versionWorkingDir, "citrus-catalog-aggregate-test-actions.json", actionCatalog + "\n");
 
-            String containerCatalog = MessagePayloadUtils.prettyPrintJson(YamlSupport.json().writeValueAsString(catalog.getTestContainerCatalog()));
+            String containerCatalog = MessagePayloadUtils.prettyPrintJson(JsonSupport.json().writeValueAsString(catalog.getTestContainerCatalog()));
             writeFile(workingDir, "citrus-catalog-aggregate-test-containers.json", containerCatalog + "\n");
             writeFile(versionWorkingDir, "citrus-catalog-aggregate-test-containers.json", containerCatalog + "\n");
 
-            String endpointCatalog = MessagePayloadUtils.prettyPrintJson(YamlSupport.json().writeValueAsString(catalog.getEndpointCatalog()));
+            String endpointCatalog = MessagePayloadUtils.prettyPrintJson(JsonSupport.json().writeValueAsString(catalog.getEndpointCatalog()));
             writeFile(workingDir, "citrus-catalog-aggregate-endpoints.json", endpointCatalog + "\n");
             writeFile(versionWorkingDir, "citrus-catalog-aggregate-endpoints.json", endpointCatalog + "\n");
 
-            String functionsCatalog = MessagePayloadUtils.prettyPrintJson(YamlSupport.json().writeValueAsString(catalog.getFunctionsCatalog()));
+            String functionsCatalog = MessagePayloadUtils.prettyPrintJson(JsonSupport.json().writeValueAsString(catalog.getFunctionsCatalog()));
             writeFile(workingDir, "citrus-catalog-aggregate-functions.json", functionsCatalog + "\n");
             writeFile(versionWorkingDir, "citrus-catalog-aggregate-functions.json", functionsCatalog + "\n");
 
-            String validationMatcherCatalog = MessagePayloadUtils.prettyPrintJson(YamlSupport.json().writeValueAsString(catalog.getValidationMatcherCatalog()));
+            String validationMatcherCatalog = MessagePayloadUtils.prettyPrintJson(JsonSupport.json().writeValueAsString(catalog.getValidationMatcherCatalog()));
             writeFile(workingDir, "citrus-catalog-aggregate-validation-matcher.json", validationMatcherCatalog + "\n");
             writeFile(versionWorkingDir, "citrus-catalog-aggregate-validation-matcher.json", validationMatcherCatalog + "\n");
         } catch (IOException e) {

--- a/tools/schema-generator/src/main/java/org/citrusframework/dsl/schema/generator/JsonSupport.java
+++ b/tools/schema-generator/src/main/java/org/citrusframework/dsl/schema/generator/JsonSupport.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.dsl.schema.generator;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+
+public class JsonSupport {
+
+    private static final ObjectMapper OBJECT_MAPPER;
+
+    static {
+        OBJECT_MAPPER = JsonMapper.builder()
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING)
+                .enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING)
+                .disable(JsonParser.Feature.AUTO_CLOSE_SOURCE)
+                .enable(MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES)
+                .build()
+                .setDefaultPropertyInclusion(JsonInclude.Value.construct(JsonInclude.Include.NON_EMPTY, JsonInclude.Include.NON_EMPTY));
+    }
+
+    private JsonSupport() {
+        // prevent instantiation of utility class
+    }
+
+    public static ObjectMapper json() {
+        return OBJECT_MAPPER;
+    }
+
+}


### PR DESCRIPTION
- Provide MCP server with Quarkus
- MCP server provides tools and resources that help LLMs to write Citrus tests
- Catalog tools
- Docs tools
- Schema resources
- Prompt definitions