### PR TITLE
fix(#1519): Add typed endpoints schema for XML DSL

### DIFF
--- a/connectors/citrus-docker/src/main/java/org/citrusframework/docker/client/DockerClientBuilder.java
+++ b/connectors/citrus-docker/src/main/java/org/citrusframework/docker/client/DockerClientBuilder.java
@@ -16,6 +16,8 @@
 
 package org.citrusframework.docker.client;
 
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.endpoint.AbstractEndpointBuilder;
 import com.github.dockerjava.core.DefaultDockerClientConfig;
 import org.citrusframework.yaml.SchemaProperty;
@@ -25,6 +27,7 @@ import org.citrusframework.yaml.SchemaType;
  * @since 2.5
  */
 @SchemaType(module = "citrus-docker")
+@XmlType(name = "", propOrder = {})
 public class DockerClientBuilder extends AbstractEndpointBuilder<DockerClient> {
 
     /** Endpoint target */
@@ -51,6 +54,7 @@ public class DockerClientBuilder extends AbstractEndpointBuilder<DockerClient> {
     }
 
     @SchemaProperty(description = "The Docker host engine URL.")
+    @XmlAttribute
     public void setUrl(String url) {
         url(url);
     }
@@ -64,6 +68,7 @@ public class DockerClientBuilder extends AbstractEndpointBuilder<DockerClient> {
     }
 
     @SchemaProperty(description = "The Docker client version.")
+    @XmlAttribute
     public void setVersion(String version) {
         version(version);
     }
@@ -79,6 +84,7 @@ public class DockerClientBuilder extends AbstractEndpointBuilder<DockerClient> {
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "The Docker client username.")
+    @XmlAttribute
     public void setUsername(String username) {
         username(username);
     }
@@ -94,6 +100,7 @@ public class DockerClientBuilder extends AbstractEndpointBuilder<DockerClient> {
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "The Docker client password.")
+    @XmlAttribute
     public void setPassword(String password) {
         password(password);
     }
@@ -110,6 +117,7 @@ public class DockerClientBuilder extends AbstractEndpointBuilder<DockerClient> {
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "The Docker client email."
     )
+    @XmlAttribute
     public void setEmail(String email) {
         email(email);
     }
@@ -123,6 +131,7 @@ public class DockerClientBuilder extends AbstractEndpointBuilder<DockerClient> {
     }
 
     @SchemaProperty(description = "The Docker registry URL.")
+    @XmlAttribute
     public void setRegistry(String url) {
         url(url);
     }
@@ -138,6 +147,7 @@ public class DockerClientBuilder extends AbstractEndpointBuilder<DockerClient> {
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "When enabled the client verifies the Docker host TLS.")
+    @XmlAttribute(name = "verify-tls")
     public void setVerifyTls(boolean verify) {
         verifyTls(verify);
     }
@@ -153,6 +163,7 @@ public class DockerClientBuilder extends AbstractEndpointBuilder<DockerClient> {
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "Sets the path to the client certificate.")
+    @XmlAttribute(name = "cert-path")
     public void setCertPath(String certPath) {
         certPath(certPath);
     }
@@ -165,6 +176,7 @@ public class DockerClientBuilder extends AbstractEndpointBuilder<DockerClient> {
     }
 
     @SchemaProperty(advanced = true, description = "Sets the path to the client configuration file.")
+    @XmlAttribute(name = "config-path")
     public void setConfigPath(String configPath) {
         configPath(configPath);
     }

--- a/connectors/citrus-docker/src/main/java/org/citrusframework/docker/endpoint/builder/DockerEndpointBuilder.java
+++ b/connectors/citrus-docker/src/main/java/org/citrusframework/docker/endpoint/builder/DockerEndpointBuilder.java
@@ -17,6 +17,10 @@
 package org.citrusframework.docker.endpoint.builder;
 
 import jakarta.annotation.Nullable;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.docker.client.DockerClientBuilder;
 import org.citrusframework.endpoint.Endpoint;
 import org.citrusframework.endpoint.EndpointBuilder;
@@ -25,12 +29,17 @@ import org.citrusframework.spi.ReferenceResolver;
 import org.citrusframework.spi.ReferenceResolverAware;
 import org.citrusframework.yaml.SchemaProperty;
 
+@XmlType(name = "", propOrder = {
+        "client"
+})
+@XmlRootElement(name = "docker")
 public class DockerEndpointBuilder implements EndpointBuilder<Endpoint>, ReferenceResolverAware {
 
     private EndpointBuilder<?> delegate;
     private ReferenceResolver referenceResolver;
 
     @SchemaProperty(description = "Sets the Docker client endpoint.")
+    @XmlElement
     public void setClient(DockerClientBuilder client) {
         this.delegate = client;
     }
@@ -54,6 +63,7 @@ public class DockerEndpointBuilder implements EndpointBuilder<Endpoint>, Referen
     }
 
     @Override
+    @XmlTransient
     public void setReferenceResolver(@Nullable ReferenceResolver referenceResolver) {
         this.referenceResolver = referenceResolver;
     }

--- a/connectors/citrus-docker/src/main/java/org/citrusframework/docker/endpoint/builder/package-info.java
+++ b/connectors/citrus-docker/src/main/java/org/citrusframework/docker/endpoint/builder/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@jakarta.xml.bind.annotation.XmlSchema(namespace = "http://citrusframework.org/schema/xml/testcase", elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
+package org.citrusframework.docker.endpoint.builder;

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/client/KubernetesClientBuilder.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/client/KubernetesClientBuilder.java
@@ -17,6 +17,8 @@
 package org.citrusframework.kubernetes.client;
 
 import io.fabric8.kubernetes.client.ConfigBuilder;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.endpoint.AbstractEndpointBuilder;
 import org.citrusframework.kubernetes.message.KubernetesMessageConverter;
 import org.citrusframework.util.StringUtils;
@@ -28,6 +30,7 @@ import tools.jackson.databind.json.JsonMapper;
  * @since 2.7
  */
 @SchemaType(module = "citrus-kubernetes")
+@XmlType(name = "", propOrder = {})
 public class KubernetesClientBuilder extends AbstractEndpointBuilder<KubernetesClient> {
 
     /** Endpoint target */
@@ -72,6 +75,7 @@ public class KubernetesClientBuilder extends AbstractEndpointBuilder<KubernetesC
     }
 
     @SchemaProperty(advanced = true, description = "Sets the reference to the Kubernetes client implementation.")
+    @XmlAttribute
     public void setClient(String client) {
         this.client = client;
     }
@@ -85,6 +89,7 @@ public class KubernetesClientBuilder extends AbstractEndpointBuilder<KubernetesC
     }
 
     @SchemaProperty(advanced = true, description = "Sets the master URL in the client configuration.")
+    @XmlAttribute
     public void setUrl(String url) {
         url(url);
     }
@@ -98,6 +103,7 @@ public class KubernetesClientBuilder extends AbstractEndpointBuilder<KubernetesC
     }
 
     @SchemaProperty(advanced = true, description = "Sets the Kubernetes client version.")
+    @XmlAttribute
     public void setVersion(String version) {
         version(version);
     }
@@ -114,6 +120,7 @@ public class KubernetesClientBuilder extends AbstractEndpointBuilder<KubernetesC
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "Sets the user name used to connect to the Kubernetes cluster."
     )
+    @XmlAttribute
     public void setUsername(String username) {
         username(username);
     }
@@ -130,6 +137,7 @@ public class KubernetesClientBuilder extends AbstractEndpointBuilder<KubernetesC
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "Sets the user password used to connect to the Kubernetes cluster."
     )
+    @XmlAttribute
     public void setPassword(String password) {
         password(password);
     }
@@ -146,6 +154,7 @@ public class KubernetesClientBuilder extends AbstractEndpointBuilder<KubernetesC
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "Sets the OAuth token used to connect to the Kubernetes cluster."
     )
+    @XmlAttribute(name = "oauth-token")
     public void setOAuthToken(String oauthToken) {
         oauthToken(oauthToken);
     }
@@ -159,6 +168,7 @@ public class KubernetesClientBuilder extends AbstractEndpointBuilder<KubernetesC
     }
 
     @SchemaProperty(description = "Sets the namespace on the cluster.")
+    @XmlAttribute
     public void setNamespace(String namespace) {
         namespace(namespace);
     }
@@ -175,6 +185,7 @@ public class KubernetesClientBuilder extends AbstractEndpointBuilder<KubernetesC
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "Sets the client certificate."
     )
+    @XmlAttribute(name = "cert-file")
     public void setCertFile(String certFile) {
         certFile(certFile);
     }
@@ -188,6 +199,7 @@ public class KubernetesClientBuilder extends AbstractEndpointBuilder<KubernetesC
     }
 
     @SchemaProperty(advanced = true, description = "Sets the message converter as a bean reference.")
+    @XmlAttribute(name = "message-converter")
     public void setMessageConverter(String messageConverter) {
         this.messageConverter = messageConverter;
     }
@@ -201,6 +213,7 @@ public class KubernetesClientBuilder extends AbstractEndpointBuilder<KubernetesC
     }
 
     @SchemaProperty(advanced = true, description = "Sets the JSON mapper.")
+    @XmlAttribute(name = "json-mapper")
     public void setJsonMapper(String jsonMapper) {
         this.jsonMapper = jsonMapper;
     }

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/endpoint/builder/KubernetesEndpointBuilder.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/endpoint/builder/KubernetesEndpointBuilder.java
@@ -17,6 +17,10 @@
 package org.citrusframework.kubernetes.endpoint.builder;
 
 import jakarta.annotation.Nullable;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.endpoint.Endpoint;
 import org.citrusframework.endpoint.EndpointBuilder;
 import org.citrusframework.exceptions.CitrusRuntimeException;
@@ -25,12 +29,17 @@ import org.citrusframework.spi.ReferenceResolver;
 import org.citrusframework.spi.ReferenceResolverAware;
 import org.citrusframework.yaml.SchemaProperty;
 
+@XmlType(name = "", propOrder = {
+        "client"
+})
+@XmlRootElement(name = "kubernetes")
 public class KubernetesEndpointBuilder implements EndpointBuilder<Endpoint>, ReferenceResolverAware {
 
     private EndpointBuilder<?> delegate;
     private ReferenceResolver referenceResolver;
 
     @SchemaProperty(description = "Sets the Kubernetes client endpoint.")
+    @XmlElement
     public void setClient(KubernetesClientBuilder client) {
         this.delegate = client;
     }
@@ -54,6 +63,7 @@ public class KubernetesEndpointBuilder implements EndpointBuilder<Endpoint>, Ref
     }
 
     @Override
+    @XmlTransient
     public void setReferenceResolver(@Nullable ReferenceResolver referenceResolver) {
         this.referenceResolver = referenceResolver;
     }

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/endpoint/builder/package-info.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/endpoint/builder/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@jakarta.xml.bind.annotation.XmlSchema(namespace = "http://citrusframework.org/schema/xml/testcase", elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
+package org.citrusframework.kubernetes.endpoint.builder;

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/endpoint/SeleniumBrowserBuilder.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/endpoint/SeleniumBrowserBuilder.java
@@ -17,8 +17,12 @@
 package org.citrusframework.selenium.endpoint;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.endpoint.AbstractEndpointBuilder;
 import org.citrusframework.util.StringUtils;
 import org.citrusframework.yaml.SchemaProperty;
@@ -31,6 +35,7 @@ import org.openqa.selenium.support.events.WebDriverListener;
  * @since 2.7
  */
 @SchemaType(module = "citrus-selenium")
+@XmlType(name = "", propOrder = {})
 public class SeleniumBrowserBuilder extends AbstractEndpointBuilder<SeleniumBrowser> {
 
     /** Endpoint target */
@@ -75,6 +80,7 @@ public class SeleniumBrowserBuilder extends AbstractEndpointBuilder<SeleniumBrow
     }
 
     @SchemaProperty(description = "The Selenium browser type.", defaultValue = "htmlunit")
+    @XmlAttribute
     public void setType(String type) {
         type(type);
     }
@@ -91,6 +97,7 @@ public class SeleniumBrowserBuilder extends AbstractEndpointBuilder<SeleniumBrow
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:firefox" ) },
             description = "The Firefox profile."
     )
+    @XmlAttribute(name = "firefox-profile")
     public void setProfile(String profile) {
         this.firefoxProfile = profile;
     }
@@ -104,6 +111,7 @@ public class SeleniumBrowserBuilder extends AbstractEndpointBuilder<SeleniumBrow
     }
 
     @SchemaProperty(description = "When enabled the browser supports JavaScript.")
+    @XmlAttribute(name = "javascript")
     public void setJavaScript(boolean enabled) {
         javaScript(enabled);
     }
@@ -117,6 +125,7 @@ public class SeleniumBrowserBuilder extends AbstractEndpointBuilder<SeleniumBrow
     }
 
     @SchemaProperty(description = "The remote server URL.")
+    @XmlAttribute(name = "remote-server")
     public void setRemoteServerUrl(String url) {
         remoteServer(url);
     }
@@ -130,6 +139,7 @@ public class SeleniumBrowserBuilder extends AbstractEndpointBuilder<SeleniumBrow
     }
 
     @SchemaProperty(advanced = true, description = "Sets a custom web driver as a bean reference.")
+    @XmlAttribute(name = "web-driver")
     public void setWebDriver(String driver) {
         this.webDriver = driver;
     }
@@ -143,8 +153,14 @@ public class SeleniumBrowserBuilder extends AbstractEndpointBuilder<SeleniumBrow
     }
 
     @SchemaProperty(advanced = true, description = "Sets the list of event listeners.")
+    @XmlTransient
     public void setEventListeners(List<String> listeners) {
         this.eventListeners.addAll(listeners);
+    }
+
+    @XmlAttribute(name = "event-listeners")
+    public void setEventListeners(String listeners) {
+        setEventListeners(Arrays.asList(listeners.split(",")));
     }
 
     /**
@@ -156,6 +172,7 @@ public class SeleniumBrowserBuilder extends AbstractEndpointBuilder<SeleniumBrow
     }
 
     @SchemaProperty(advanced = true, description = "The browser version.")
+    @XmlAttribute
     public void setVersion(String version) {
         version(version);
     }
@@ -169,6 +186,7 @@ public class SeleniumBrowserBuilder extends AbstractEndpointBuilder<SeleniumBrow
     }
 
     @SchemaProperty(description = "The URL to the start page.")
+    @XmlAttribute(name = "start-page")
     public void setStartPage(String url) {
         startPage(url);
     }
@@ -182,6 +200,7 @@ public class SeleniumBrowserBuilder extends AbstractEndpointBuilder<SeleniumBrow
     }
 
     @SchemaProperty(description = "The browser timeout.")
+    @XmlAttribute
     public void setTimeout(long timeout) {
         timeout(timeout);
     }

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/endpoint/SeleniumEndpointBuilder.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/endpoint/SeleniumEndpointBuilder.java
@@ -17,6 +17,9 @@
 package org.citrusframework.selenium.endpoint;
 
 import jakarta.annotation.Nullable;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.endpoint.Endpoint;
 import org.citrusframework.endpoint.EndpointBuilder;
 import org.citrusframework.exceptions.CitrusRuntimeException;
@@ -24,6 +27,9 @@ import org.citrusframework.spi.ReferenceResolver;
 import org.citrusframework.spi.ReferenceResolverAware;
 import org.citrusframework.yaml.SchemaProperty;
 
+@XmlType(name = "", propOrder = {
+        "browser"
+})
 public class SeleniumEndpointBuilder implements EndpointBuilder<Endpoint>, ReferenceResolverAware {
 
     private EndpointBuilder<?> delegate;
@@ -36,6 +42,7 @@ public class SeleniumEndpointBuilder implements EndpointBuilder<Endpoint>, Refer
     }
 
     @SchemaProperty(description = "Sets the Selenium browser endpoint.")
+    @XmlElement
     public void setBrowser(SeleniumBrowserBuilder builder) {
         this.delegate = builder;
     }
@@ -59,6 +66,7 @@ public class SeleniumEndpointBuilder implements EndpointBuilder<Endpoint>, Refer
     }
 
     @Override
+    @XmlTransient
     public void setReferenceResolver(@Nullable ReferenceResolver referenceResolver) {
         this.referenceResolver = referenceResolver;
     }

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/endpoint/package-info.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/endpoint/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@jakarta.xml.bind.annotation.XmlSchema(namespace = "http://citrusframework.org/schema/xml/testcase", elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
+package org.citrusframework.selenium.endpoint;

--- a/core/citrus-base/src/main/java/org/citrusframework/endpoint/AbstractEndpointBuilder.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/endpoint/AbstractEndpointBuilder.java
@@ -16,6 +16,8 @@
 
 package org.citrusframework.endpoint;
 
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlTransient;
 import org.citrusframework.TestActor;
 import org.citrusframework.common.InitializingPhase;
 import org.citrusframework.common.Named;
@@ -40,6 +42,7 @@ public abstract class AbstractEndpointBuilder<T extends Endpoint> implements End
     }
 
     @SchemaProperty(description = "The name of the endpoint")
+    @XmlAttribute
     public void setName(String endpointName) {
         name(endpointName);
     }
@@ -76,6 +79,7 @@ public abstract class AbstractEndpointBuilder<T extends Endpoint> implements End
     }
 
     @Override
+    @XmlTransient
     public void setReferenceResolver(ReferenceResolver referenceResolver) {
         this.referenceResolver = referenceResolver;
     }

--- a/core/citrus-base/src/main/java/org/citrusframework/endpoint/context/ContextEndpointsBuilder.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/endpoint/context/ContextEndpointsBuilder.java
@@ -17,6 +17,10 @@
 package org.citrusframework.endpoint.context;
 
 import jakarta.annotation.Nullable;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.endpoint.Endpoint;
 import org.citrusframework.endpoint.EndpointBuilder;
 import org.citrusframework.exceptions.CitrusRuntimeException;
@@ -24,12 +28,17 @@ import org.citrusframework.spi.ReferenceResolver;
 import org.citrusframework.spi.ReferenceResolverAware;
 import org.citrusframework.yaml.SchemaProperty;
 
+@XmlType(name = "", propOrder = {
+        "message-store"
+})
+@XmlRootElement(name = "context")
 public class ContextEndpointsBuilder implements EndpointBuilder<Endpoint>, ReferenceResolverAware {
 
     private EndpointBuilder<?> delegate;
     private ReferenceResolver referenceResolver;
 
     @SchemaProperty(description = "Sets a message store endpoint .")
+    @XmlElement(name = "message-store")
     public void setMessageStore(MessageStoreEndpointBuilder builder) {
         this.delegate = builder;
     }
@@ -53,6 +62,7 @@ public class ContextEndpointsBuilder implements EndpointBuilder<Endpoint>, Refer
     }
 
     @Override
+    @XmlTransient
     public void setReferenceResolver(@Nullable ReferenceResolver referenceResolver) {
         this.referenceResolver = referenceResolver;
     }

--- a/core/citrus-base/src/main/java/org/citrusframework/endpoint/context/MessageStoreEndpointBuilder.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/endpoint/context/MessageStoreEndpointBuilder.java
@@ -16,9 +16,12 @@
 
 package org.citrusframework.endpoint.context;
 
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.endpoint.AbstractEndpointBuilder;
 import org.citrusframework.yaml.SchemaProperty;
 
+@XmlType(name = "", propOrder = {})
 public class MessageStoreEndpointBuilder extends AbstractEndpointBuilder<MessageStoreEndpoint> {
 
     /** Endpoint target */
@@ -37,7 +40,8 @@ public class MessageStoreEndpointBuilder extends AbstractEndpointBuilder<Message
         return this;
     }
 
-    @SchemaProperty(description = "The message name.")
+    @SchemaProperty(description = "The message name in the context.")
+    @XmlAttribute(name = "message-name")
     public void setMessageName(String messageName) {
         messageName(messageName);
     }
@@ -51,6 +55,7 @@ public class MessageStoreEndpointBuilder extends AbstractEndpointBuilder<Message
     }
 
     @SchemaProperty(description = "The timeout when receiving messages from the message store.")
+    @XmlAttribute
     public void setTimeout(long timeout) {
         timeout(timeout);
     }

--- a/core/citrus-base/src/main/java/org/citrusframework/endpoint/context/package-info.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/endpoint/context/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@jakarta.xml.bind.annotation.XmlSchema(namespace = "http://citrusframework.org/schema/xml/testcase", elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
+package org.citrusframework.endpoint.context;

--- a/core/citrus-base/src/main/java/org/citrusframework/endpoint/direct/DirectEndpointBuilder.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/endpoint/direct/DirectEndpointBuilder.java
@@ -16,6 +16,8 @@
 
 package org.citrusframework.endpoint.direct;
 
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.endpoint.AbstractEndpointBuilder;
 import org.citrusframework.message.DefaultMessageQueue;
 import org.citrusframework.message.MessageQueue;
@@ -23,6 +25,7 @@ import org.citrusframework.util.PropertyUtils;
 import org.citrusframework.util.StringUtils;
 import org.citrusframework.yaml.SchemaProperty;
 
+@XmlType(name = "", propOrder = {})
 public class DirectEndpointBuilder extends AbstractEndpointBuilder<DirectEndpoint> {
 
     /** Endpoint target */
@@ -70,7 +73,13 @@ public class DirectEndpointBuilder extends AbstractEndpointBuilder<DirectEndpoin
     }
 
     @SchemaProperty(description = "The queue name.")
+    @XmlAttribute
     public void setQueue(String queueName) {
+        queue(queueName);
+    }
+
+    @XmlAttribute(name = "queue-name")
+    public void setQueueName(String queueName) {
         queue(queueName);
     }
 
@@ -91,6 +100,7 @@ public class DirectEndpointBuilder extends AbstractEndpointBuilder<DirectEndpoin
     }
 
     @SchemaProperty(description = "When set the queue is automatically created when it does not exist in bean registry.")
+    @XmlAttribute(name = "auto-create-queue")
     public void setAutoCreateQueue(boolean autoCreate) {
         autoCreateQueue(autoCreate);
     }
@@ -104,6 +114,7 @@ public class DirectEndpointBuilder extends AbstractEndpointBuilder<DirectEndpoin
     }
 
     @SchemaProperty(description = "The timeout when receiving messages from the queue.")
+    @XmlAttribute
     public void setTimeout(long timeout) {
         timeout(timeout);
     }

--- a/core/citrus-base/src/main/java/org/citrusframework/endpoint/direct/DirectEndpointsBuilder.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/endpoint/direct/DirectEndpointsBuilder.java
@@ -17,6 +17,10 @@
 package org.citrusframework.endpoint.direct;
 
 import jakarta.annotation.Nullable;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.endpoint.Endpoint;
 import org.citrusframework.endpoint.EndpointBuilder;
 import org.citrusframework.exceptions.CitrusRuntimeException;
@@ -26,17 +30,21 @@ import org.citrusframework.yaml.SchemaProperty;
 import org.citrusframework.yaml.SchemaType;
 
 @SchemaType(oneOf = { "asynchronous", "synchronous" })
+@XmlType(name = "", propOrder = {})
+@XmlRootElement(name = "direct")
 public class DirectEndpointsBuilder implements EndpointBuilder<Endpoint>, ReferenceResolverAware {
 
     private EndpointBuilder<?> delegate;
     private ReferenceResolver referenceResolver;
 
     @SchemaProperty(description = "Sets the synchronous direct endpoint.")
+    @XmlElement
     public void setSynchronous(DirectSyncEndpointBuilder builder) {
         this.delegate = builder;
     }
 
     @SchemaProperty(description = "Sets the direct endpoint.")
+    @XmlElement
     public void setAsynchronous(DirectEndpointBuilder builder) {
         this.delegate = builder;
     }
@@ -60,6 +68,7 @@ public class DirectEndpointsBuilder implements EndpointBuilder<Endpoint>, Refere
     }
 
     @Override
+    @XmlTransient
     public void setReferenceResolver(@Nullable ReferenceResolver referenceResolver) {
         this.referenceResolver = referenceResolver;
     }

--- a/core/citrus-base/src/main/java/org/citrusframework/endpoint/direct/DirectSyncEndpointBuilder.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/endpoint/direct/DirectSyncEndpointBuilder.java
@@ -16,6 +16,8 @@
 
 package org.citrusframework.endpoint.direct;
 
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.endpoint.AbstractEndpointBuilder;
 import org.citrusframework.message.DefaultMessageQueue;
 import org.citrusframework.message.MessageCorrelator;
@@ -24,6 +26,7 @@ import org.citrusframework.util.PropertyUtils;
 import org.citrusframework.util.StringUtils;
 import org.citrusframework.yaml.SchemaProperty;
 
+@XmlType(name = "", propOrder = {})
 public class DirectSyncEndpointBuilder extends AbstractEndpointBuilder<DirectSyncEndpoint> {
 
     /** Endpoint target */
@@ -76,7 +79,13 @@ public class DirectSyncEndpointBuilder extends AbstractEndpointBuilder<DirectSyn
     }
 
     @SchemaProperty(description = "The queue name.")
+    @XmlAttribute
     public void setQueue(String queueName) {
+        queue(queueName);
+    }
+
+    @XmlAttribute(name = "queue-name")
+    public void setQueueName(String queueName) {
         queue(queueName);
     }
 
@@ -97,6 +106,7 @@ public class DirectSyncEndpointBuilder extends AbstractEndpointBuilder<DirectSyn
     }
 
     @SchemaProperty(description = "When set the queue is automatically created when it does not exist in bean registry.")
+    @XmlAttribute(name = "auto-create-queue")
     public void setAutoCreateQueue(boolean autoCreate) {
         autoCreateQueue(autoCreate);
     }
@@ -110,6 +120,7 @@ public class DirectSyncEndpointBuilder extends AbstractEndpointBuilder<DirectSyn
     }
 
     @SchemaProperty(description = "Sets the polling interval when consuming messages.")
+    @XmlAttribute(name = "polling-interval")
     public void setPollingInterval(int pollingInterval) {
         pollingInterval(pollingInterval);
     }
@@ -123,6 +134,7 @@ public class DirectSyncEndpointBuilder extends AbstractEndpointBuilder<DirectSyn
     }
 
     @SchemaProperty(advanced = true, description = "Sets the message correlator.")
+    @XmlAttribute(name = "message-correlator")
     public void setCorrelator(String correlator) {
         this.correlator = correlator;
     }
@@ -136,6 +148,7 @@ public class DirectSyncEndpointBuilder extends AbstractEndpointBuilder<DirectSyn
     }
 
     @SchemaProperty(description = "The timeout when receiving messages from the queue.")
+    @XmlAttribute
     public void setTimeout(long timeout) {
         timeout(timeout);
     }

--- a/core/citrus-base/src/main/java/org/citrusframework/endpoint/direct/package-info.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/endpoint/direct/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@jakarta.xml.bind.annotation.XmlSchema(namespace = "http://citrusframework.org/schema/xml/testcase", elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
+package org.citrusframework.endpoint.direct;

--- a/core/citrus-base/src/main/java/org/citrusframework/server/AbstractServerBuilder.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/server/AbstractServerBuilder.java
@@ -16,6 +16,7 @@
 
 package org.citrusframework.server;
 
+import jakarta.xml.bind.annotation.XmlAttribute;
 import org.citrusframework.endpoint.AbstractEndpointBuilder;
 import org.citrusframework.endpoint.EndpointAdapter;
 import org.citrusframework.util.StringUtils;
@@ -50,6 +51,7 @@ public abstract class AbstractServerBuilder<T extends AbstractServer, B extends 
     }
 
     @SchemaProperty(description = "When enabled the server is automatically started after creation.")
+    @XmlAttribute(name = "auto-start")
     public void setAutoStart(boolean autoStart) {
         autoStart(autoStart);
     }
@@ -63,6 +65,7 @@ public abstract class AbstractServerBuilder<T extends AbstractServer, B extends 
     }
 
     @SchemaProperty(advanced = true, description = "Sets a custom endpoint adapter to handle requests.")
+    @XmlAttribute(name = "endpoint-adapter")
     public void setEndpointAdapter(String endpointAdapter) {
         this.endpointAdapter = endpointAdapter;
     }
@@ -76,6 +79,7 @@ public abstract class AbstractServerBuilder<T extends AbstractServer, B extends 
     }
 
     @SchemaProperty(advanced = true, description = "When enabled the server prints debug logging output.")
+    @XmlAttribute(name = "debug-logging")
     public void setDebugLogging(boolean enabled) {
         debugLogging(enabled);
     }
@@ -93,6 +97,7 @@ public abstract class AbstractServerBuilder<T extends AbstractServer, B extends 
     }
 
     @SchemaProperty(description = "The server timeout.", defaultValue = "5000")
+    @XmlAttribute
     public void setTimeout(long timeout) {
         timeout(timeout);
     }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/endpoint/CamelEndpointBuilder.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/endpoint/CamelEndpointBuilder.java
@@ -16,6 +16,8 @@
 
 package org.citrusframework.camel.endpoint;
 
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.endpoint.EndpointUriBuilder;
 import org.citrusframework.camel.message.CamelMessageConverter;
 import org.citrusframework.endpoint.AbstractEndpointBuilder;
@@ -26,6 +28,7 @@ import org.citrusframework.yaml.SchemaProperty;
 import org.citrusframework.yaml.SchemaType;
 
 @SchemaType(module = "citrus-camel")
+@XmlType(name = "", propOrder = {})
 public class CamelEndpointBuilder extends AbstractEndpointBuilder<CamelEndpoint> {
 
     /** Endpoint target */
@@ -63,6 +66,7 @@ public class CamelEndpointBuilder extends AbstractEndpointBuilder<CamelEndpoint>
     }
 
     @SchemaProperty(description = "The Camel endpoint uri.")
+    @XmlAttribute(name = "endpoint-uri")
     public void setEndpointUri(String endpointUri) {
         endpointUri(endpointUri);
     }
@@ -92,6 +96,7 @@ public class CamelEndpointBuilder extends AbstractEndpointBuilder<CamelEndpoint>
     }
 
     @SchemaProperty(description = "The Camel context to use.")
+    @XmlAttribute(name = "camel-context")
     public void setCamelContext(String camelContext) {
         this.camelContext = camelContext;
     }
@@ -105,6 +110,7 @@ public class CamelEndpointBuilder extends AbstractEndpointBuilder<CamelEndpoint>
     }
 
     @SchemaProperty(advanced = true, description = "Sets the message converter as a bean reference.")
+    @XmlAttribute(name = "message-converter")
     public void setMessageConverter(String messageConverter) {
         this.messageConverter = messageConverter;
     }
@@ -118,6 +124,7 @@ public class CamelEndpointBuilder extends AbstractEndpointBuilder<CamelEndpoint>
     }
 
     @SchemaProperty(description = "The endpoint timeout when waiting for messages.")
+    @XmlAttribute
     public void setTimeout(long timeout) {
         timeout(timeout);
     }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/endpoint/CamelEndpointsBuilder.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/endpoint/CamelEndpointsBuilder.java
@@ -17,6 +17,10 @@
 package org.citrusframework.camel.endpoint;
 
 import jakarta.annotation.Nullable;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.endpoint.Endpoint;
 import org.citrusframework.endpoint.EndpointBuilder;
 import org.citrusframework.exceptions.CitrusRuntimeException;
@@ -26,17 +30,24 @@ import org.citrusframework.yaml.SchemaProperty;
 import org.citrusframework.yaml.SchemaType;
 
 @SchemaType(oneOf = { "asynchronous", "synchronous" }, module = "citrus-camel")
+@XmlType(name = "", propOrder = {
+        "asynchronous",
+        "synchronous"
+})
+@XmlRootElement(name = "camel")
 public class CamelEndpointsBuilder implements EndpointBuilder<Endpoint>, ReferenceResolverAware {
 
     private EndpointBuilder<?> delegate;
     private ReferenceResolver referenceResolver;
 
     @SchemaProperty(description = "Sets the synchronous Camel endpoint.")
+    @XmlElement
     public void setSynchronous(CamelSyncEndpointBuilder builder) {
         this.delegate = builder;
     }
 
     @SchemaProperty(description = "Sets the Camel endpoint.")
+    @XmlElement
     public void setAsynchronous(CamelEndpointBuilder builder) {
         this.delegate = builder;
     }
@@ -60,6 +71,7 @@ public class CamelEndpointsBuilder implements EndpointBuilder<Endpoint>, Referen
     }
 
     @Override
+    @XmlTransient
     public void setReferenceResolver(@Nullable ReferenceResolver referenceResolver) {
         this.referenceResolver = referenceResolver;
     }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/endpoint/CamelSyncEndpointBuilder.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/endpoint/CamelSyncEndpointBuilder.java
@@ -16,6 +16,8 @@
 
 package org.citrusframework.camel.endpoint;
 
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.camel.message.CamelMessageConverter;
 import org.citrusframework.endpoint.AbstractEndpointBuilder;
 import org.citrusframework.message.MessageCorrelator;
@@ -29,6 +31,7 @@ import org.citrusframework.yaml.SchemaType;
  * @since 2.5
  */
 @SchemaType(module = "citrus-camel")
+@XmlType(name = "", propOrder = {})
 public class CamelSyncEndpointBuilder extends AbstractEndpointBuilder<CamelSyncEndpoint> {
 
     /** Endpoint target */
@@ -71,6 +74,7 @@ public class CamelSyncEndpointBuilder extends AbstractEndpointBuilder<CamelSyncE
     }
 
     @SchemaProperty(description = "The Camel endpoint uri.")
+    @XmlAttribute(name = "endpoint-uri")
     public void setEndpointUri(String endpointUri) {
         endpointUri(endpointUri);
     }
@@ -92,6 +96,7 @@ public class CamelSyncEndpointBuilder extends AbstractEndpointBuilder<CamelSyncE
     }
 
     @SchemaProperty(description = "The Camel context to use.")
+    @XmlAttribute(name = "camel-context")
     public void setCamelContext(String camelContext) {
         this.camelContext = camelContext;
     }
@@ -105,6 +110,7 @@ public class CamelSyncEndpointBuilder extends AbstractEndpointBuilder<CamelSyncE
     }
 
     @SchemaProperty(advanced = true, description = "Sets the message converter as a bean reference.")
+    @XmlAttribute(name = "message-converter")
     public void setMessageConverter(String messageConverter) {
         this.messageConverter = messageConverter;
     }
@@ -118,6 +124,7 @@ public class CamelSyncEndpointBuilder extends AbstractEndpointBuilder<CamelSyncE
     }
 
     @SchemaProperty(description = "Sets the polling interval when consuming messages.")
+    @XmlAttribute(name = "polling-interval")
     public void setPollingInterval(int pollingInterval) {
         pollingInterval(pollingInterval);
     }
@@ -131,6 +138,7 @@ public class CamelSyncEndpointBuilder extends AbstractEndpointBuilder<CamelSyncE
     }
 
     @SchemaProperty(advanced = true, description = "Sets the message correlator.")
+    @XmlAttribute(name = "message-correlator")
     public void setCorrelator(String correlator) {
         this.correlator = correlator;
     }
@@ -144,6 +152,7 @@ public class CamelSyncEndpointBuilder extends AbstractEndpointBuilder<CamelSyncE
     }
 
     @SchemaProperty(description = "The endpoint timeout when waiting for messages.")
+    @XmlAttribute
     public void setTimeout(long timeout) {
         timeout(timeout);
     }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/endpoint/package-info.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/endpoint/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@jakarta.xml.bind.annotation.XmlSchema(namespace = "http://citrusframework.org/schema/xml/testcase", elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
+package org.citrusframework.camel.endpoint;

--- a/endpoints/citrus-ftp/src/main/java/org/citrusframework/ftp/client/FtpClientBuilder.java
+++ b/endpoints/citrus-ftp/src/main/java/org/citrusframework/ftp/client/FtpClientBuilder.java
@@ -16,6 +16,8 @@
 
 package org.citrusframework.ftp.client;
 
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.endpoint.AbstractEndpointBuilder;
 import org.citrusframework.message.ErrorHandlingStrategy;
 import org.citrusframework.message.MessageCorrelator;
@@ -27,6 +29,7 @@ import org.citrusframework.yaml.SchemaType;
  * @since 2.5
  */
 @SchemaType(module = "citrus-ftp")
+@XmlType(name = "", propOrder = {})
 public class FtpClientBuilder extends AbstractEndpointBuilder<FtpClient> {
 
     /** Endpoint target */
@@ -59,6 +62,7 @@ public class FtpClientBuilder extends AbstractEndpointBuilder<FtpClient> {
     }
 
     @SchemaProperty(description = "The Ftp server host.")
+    @XmlAttribute
     public void setHost(String host) {
         host(host);
     }
@@ -72,6 +76,7 @@ public class FtpClientBuilder extends AbstractEndpointBuilder<FtpClient> {
     }
 
     @SchemaProperty(description = "The Ftp server port.")
+    @XmlAttribute
     public void setPort(int port) {
         port(port);
     }
@@ -85,6 +90,7 @@ public class FtpClientBuilder extends AbstractEndpointBuilder<FtpClient> {
     }
 
     @SchemaProperty(description = "When enabled the client automatically reads new files.")
+    @XmlAttribute(name = "auto-read-files")
     public void setAutoReadFiles(boolean autoReadFiles) {
         autoReadFiles(autoReadFiles);
     }
@@ -98,6 +104,7 @@ public class FtpClientBuilder extends AbstractEndpointBuilder<FtpClient> {
     }
 
     @SchemaProperty(description = "SEnables the local passive mode.")
+    @XmlAttribute(name = "local-passive-mode")
     public void setLocalPassiveMode(boolean localPassiveMode) {
         localPassiveMode(localPassiveMode);
     }
@@ -114,6 +121,7 @@ public class FtpClientBuilder extends AbstractEndpointBuilder<FtpClient> {
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "Sets the user name."
     )
+    @XmlAttribute
     public void setUsername(String username) {
         username(username);
     }
@@ -130,6 +138,7 @@ public class FtpClientBuilder extends AbstractEndpointBuilder<FtpClient> {
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "Sets the user password."
     )
+    @XmlAttribute
     public void setPassword(String password) {
         password(password);
     }
@@ -143,6 +152,7 @@ public class FtpClientBuilder extends AbstractEndpointBuilder<FtpClient> {
     }
 
     @SchemaProperty(advanced = true, description = "Sets the message correlator.")
+    @XmlAttribute(name = "message-correlator")
     public void setCorrelator(String correlator) {
         this.correlator = correlator;
     }
@@ -159,8 +169,13 @@ public class FtpClientBuilder extends AbstractEndpointBuilder<FtpClient> {
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:errorHandler") },
             description = "Sets the error handling strategy."
     )
-    public void setErrorHandlingStrategy(ErrorHandlingStrategy errorStrategy) {
-        errorHandlingStrategy(errorStrategy);
+    @XmlAttribute(name = "error-handling-strategy")
+    public void setErrorHandlingStrategy(String errorStrategy) {
+        try {
+            errorHandlingStrategy(ErrorHandlingStrategy.fromName(errorStrategy));
+        } catch (IllegalArgumentException e) {
+            errorHandlingStrategy(ErrorHandlingStrategy.valueOf(errorStrategy));
+        }
     }
 
     /**
@@ -172,6 +187,7 @@ public class FtpClientBuilder extends AbstractEndpointBuilder<FtpClient> {
     }
 
     @SchemaProperty(description = "Sets the polling interval when consuming messages.")
+    @XmlAttribute(name = "polling-interval")
     public void setPollingInterval(int pollingInterval) {
         pollingInterval(pollingInterval);
     }
@@ -185,6 +201,7 @@ public class FtpClientBuilder extends AbstractEndpointBuilder<FtpClient> {
     }
 
     @SchemaProperty(description = "The endpoint timeout when waiting for messages.")
+    @XmlAttribute
     public void setTimeout(long timeout) {
         timeout(timeout);
     }

--- a/endpoints/citrus-ftp/src/main/java/org/citrusframework/ftp/client/ScpClientBuilder.java
+++ b/endpoints/citrus-ftp/src/main/java/org/citrusframework/ftp/client/ScpClientBuilder.java
@@ -16,6 +16,8 @@
 
 package org.citrusframework.ftp.client;
 
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.endpoint.AbstractEndpointBuilder;
 import org.citrusframework.message.ErrorHandlingStrategy;
 import org.citrusframework.message.MessageCorrelator;
@@ -27,6 +29,7 @@ import org.citrusframework.yaml.SchemaType;
  * @since 2.7.6
  */
 @SchemaType(module = "citrus-ftp")
+@XmlType(name = "", propOrder = {})
 public class ScpClientBuilder extends AbstractEndpointBuilder<ScpClient> {
 
     /** Endpoint target */
@@ -59,6 +62,7 @@ public class ScpClientBuilder extends AbstractEndpointBuilder<ScpClient> {
     }
 
     @SchemaProperty(advanced = true, description = "Sets the port option.")
+    @XmlAttribute(name = "port-option")
     public void setPortOption(String option) {
         portOption(option);
     }
@@ -72,6 +76,7 @@ public class ScpClientBuilder extends AbstractEndpointBuilder<ScpClient> {
     }
 
     @SchemaProperty(description = "The Ftp server host.")
+    @XmlAttribute
     public void setHost(String host) {
         host(host);
     }
@@ -85,6 +90,7 @@ public class ScpClientBuilder extends AbstractEndpointBuilder<ScpClient> {
     }
 
     @SchemaProperty(description = "The Ftp server port.")
+    @XmlAttribute
     public void setPort(int port) {
         port(port);
     }
@@ -98,6 +104,7 @@ public class ScpClientBuilder extends AbstractEndpointBuilder<ScpClient> {
     }
 
     @SchemaProperty(description = "When enabled the client automatically reads new files.")
+    @XmlAttribute(name = "auto-read-files")
     public void setAutoReadFiles(boolean autoReadFiles) {
         autoReadFiles(autoReadFiles);
     }
@@ -114,6 +121,7 @@ public class ScpClientBuilder extends AbstractEndpointBuilder<ScpClient> {
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "Sets the user name."
     )
+    @XmlAttribute
     public void setUsername(String username) {
         username(username);
     }
@@ -130,6 +138,7 @@ public class ScpClientBuilder extends AbstractEndpointBuilder<ScpClient> {
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "Sets the user password."
     )
+    @XmlAttribute
     public void setPassword(String password) {
         password(password);
     }
@@ -146,6 +155,7 @@ public class ScpClientBuilder extends AbstractEndpointBuilder<ScpClient> {
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "Sets the private key path."
     )
+    @XmlAttribute(name = "private-key-path")
     public void setPrivateKeyPath(String privateKeyPath) {
         privateKeyPath(privateKeyPath);
     }
@@ -162,6 +172,7 @@ public class ScpClientBuilder extends AbstractEndpointBuilder<ScpClient> {
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "Sets the private key password."
     )
+    @XmlAttribute(name = "private-key-password")
     public void setPrivateKeyPassword(String privateKeyPassword) {
         privateKeyPassword(privateKeyPassword);
     }
@@ -178,6 +189,7 @@ public class ScpClientBuilder extends AbstractEndpointBuilder<ScpClient> {
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "Enable strict host checking."
     )
+    @XmlAttribute(name = "strict-host-checking")
     public void setStrictHostChecking(boolean strictHostChecking) {
         strictHostChecking(strictHostChecking);
     }
@@ -194,6 +206,7 @@ public class ScpClientBuilder extends AbstractEndpointBuilder<ScpClient> {
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "List of known hosts."
     )
+    @XmlAttribute(name = "known-hosts")
     public void setKnownHosts(String knownHosts) {
         knownHosts(knownHosts);
     }
@@ -207,6 +220,7 @@ public class ScpClientBuilder extends AbstractEndpointBuilder<ScpClient> {
     }
 
     @SchemaProperty(advanced = true, description = "Sets the message correlator.")
+    @XmlAttribute(name = "message-correlator")
     public void setCorrelator(String correlator) {
         this.correlator = correlator;
     }
@@ -223,8 +237,13 @@ public class ScpClientBuilder extends AbstractEndpointBuilder<ScpClient> {
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:errorHandler") },
             description = "Sets the error handling strategy."
     )
-    public void setErrorHandlingStrategy(ErrorHandlingStrategy errorStrategy) {
-        errorHandlingStrategy(errorStrategy);
+    @XmlAttribute(name = "error-handling-strategy")
+    public void setErrorHandlingStrategy(String errorStrategy) {
+        try {
+            errorHandlingStrategy(ErrorHandlingStrategy.fromName(errorStrategy));
+        } catch (IllegalArgumentException e) {
+            errorHandlingStrategy(ErrorHandlingStrategy.valueOf(errorStrategy));
+        }
     }
 
     /**
@@ -236,6 +255,7 @@ public class ScpClientBuilder extends AbstractEndpointBuilder<ScpClient> {
     }
 
     @SchemaProperty(description = "Sets the polling interval when consuming messages.")
+    @XmlAttribute(name = "polling-interval")
     public void setPollingInterval(int pollingInterval) {
         pollingInterval(pollingInterval);
     }
@@ -249,6 +269,7 @@ public class ScpClientBuilder extends AbstractEndpointBuilder<ScpClient> {
     }
 
     @SchemaProperty(description = "The endpoint timeout when waiting for messages.")
+    @XmlAttribute
     public void setTimeout(long timeout) {
         timeout(timeout);
     }

--- a/endpoints/citrus-ftp/src/main/java/org/citrusframework/ftp/client/SftpClientBuilder.java
+++ b/endpoints/citrus-ftp/src/main/java/org/citrusframework/ftp/client/SftpClientBuilder.java
@@ -16,8 +16,13 @@
 
 package org.citrusframework.ftp.client;
 
+import java.util.Arrays;
 import java.util.Map;
+import java.util.stream.Collectors;
 
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.endpoint.AbstractEndpointBuilder;
 import org.citrusframework.message.ErrorHandlingStrategy;
 import org.citrusframework.message.MessageCorrelator;
@@ -29,6 +34,7 @@ import org.citrusframework.yaml.SchemaType;
  * @since 2.7.5
  */
 @SchemaType(module = "citrus-ftp")
+@XmlType(name = "", propOrder = {})
 public class SftpClientBuilder extends AbstractEndpointBuilder<SftpClient> {
 
     /** Endpoint target */
@@ -61,6 +67,7 @@ public class SftpClientBuilder extends AbstractEndpointBuilder<SftpClient> {
     }
 
     @SchemaProperty(description = "The Ftp server host.")
+    @XmlAttribute
     public void setHost(String host) {
         host(host);
     }
@@ -74,6 +81,7 @@ public class SftpClientBuilder extends AbstractEndpointBuilder<SftpClient> {
     }
 
     @SchemaProperty(description = "The Ftp server port.")
+    @XmlAttribute
     public void setPort(int port) {
         port(port);
     }
@@ -87,6 +95,7 @@ public class SftpClientBuilder extends AbstractEndpointBuilder<SftpClient> {
     }
 
     @SchemaProperty(description = "When enabled the client automatically reads new files.")
+    @XmlAttribute(name = "auto-read-files")
     public void setAutoReadFiles(boolean autoReadFiles) {
         autoReadFiles(autoReadFiles);
     }
@@ -100,6 +109,7 @@ public class SftpClientBuilder extends AbstractEndpointBuilder<SftpClient> {
     }
 
     @SchemaProperty(description = "SEnables the local passive mode.")
+    @XmlAttribute(name = "local-passive-mode")
     public void setLocalPassiveMode(boolean localPassiveMode) {
         localPassiveMode(localPassiveMode);
     }
@@ -116,6 +126,7 @@ public class SftpClientBuilder extends AbstractEndpointBuilder<SftpClient> {
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "Sets the user name."
     )
+    @XmlAttribute
     public void setUsername(String username) {
         username(username);
     }
@@ -132,6 +143,7 @@ public class SftpClientBuilder extends AbstractEndpointBuilder<SftpClient> {
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "Sets the user password."
     )
+    @XmlAttribute
     public void setPassword(String password) {
         password(password);
     }
@@ -148,6 +160,7 @@ public class SftpClientBuilder extends AbstractEndpointBuilder<SftpClient> {
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "Sets the private key path."
     )
+    @XmlAttribute(name = "private-key-path")
     public void setPrivateKeyPath(String privateKeyPath) {
         privateKeyPath(privateKeyPath);
     }
@@ -164,6 +177,7 @@ public class SftpClientBuilder extends AbstractEndpointBuilder<SftpClient> {
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "Sets the private key password."
     )
+    @XmlAttribute(name = "private-key-password")
     public void setPrivateKeyPassword(String privateKeyPassword) {
         privateKeyPassword(privateKeyPassword);
     }
@@ -180,6 +194,7 @@ public class SftpClientBuilder extends AbstractEndpointBuilder<SftpClient> {
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "Enable strict host checking."
     )
+    @XmlAttribute(name = "strict-host-checking")
     public void setStrictHostChecking(boolean strictHostChecking) {
         strictHostChecking(strictHostChecking);
     }
@@ -196,6 +211,7 @@ public class SftpClientBuilder extends AbstractEndpointBuilder<SftpClient> {
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "List of known hosts."
     )
+    @XmlAttribute(name = "known-hosts")
     public void setKnownHosts(String knownHosts) {
         knownHosts(knownHosts);
     }
@@ -212,6 +228,7 @@ public class SftpClientBuilder extends AbstractEndpointBuilder<SftpClient> {
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "Sets the preferred authentication mechanism."
     )
+    @XmlAttribute(name = "preferred-authentications")
     public void setPreferredAuthentications(String preferredAuthentications) {
         preferredAuthentications(preferredAuthentications);
     }
@@ -225,8 +242,18 @@ public class SftpClientBuilder extends AbstractEndpointBuilder<SftpClient> {
     }
 
     @SchemaProperty(description = "The session configuration.")
+    @XmlTransient
     public void setSessionConfigs(Map<String, String> sessionConfigs) {
         sessionConfigs(sessionConfigs);
+    }
+
+    @XmlAttribute(name = "session-configs")
+    public void setSessionConfigs(String sessionConfigs) {
+        setSessionConfigs(Arrays.stream(sessionConfigs.split(","))
+                .map(String::trim)
+                .filter(expression -> expression.contains("="))
+                .map(expression -> expression.split("=", 2))
+                .collect(Collectors.toMap(tokens -> tokens[0].trim(), tokens -> tokens[1].trim())));
     }
 
     /**
@@ -238,6 +265,7 @@ public class SftpClientBuilder extends AbstractEndpointBuilder<SftpClient> {
     }
 
     @SchemaProperty(advanced = true, description = "Sets the message correlator.")
+    @XmlAttribute(name = "message-correlator")
     public void setCorrelator(String correlator) {
         this.correlator = correlator;
     }
@@ -254,8 +282,13 @@ public class SftpClientBuilder extends AbstractEndpointBuilder<SftpClient> {
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:errorHandler") },
             description = "Sets the error handling strategy."
     )
-    public void setErrorHandlingStrategy(ErrorHandlingStrategy errorStrategy) {
-        errorHandlingStrategy(errorStrategy);
+    @XmlAttribute(name = "error-handling-strategy")
+    public void setErrorHandlingStrategy(String errorStrategy) {
+        try {
+            errorHandlingStrategy(ErrorHandlingStrategy.fromName(errorStrategy));
+        } catch (IllegalArgumentException e) {
+            errorHandlingStrategy(ErrorHandlingStrategy.valueOf(errorStrategy));
+        }
     }
 
     /**
@@ -267,6 +300,7 @@ public class SftpClientBuilder extends AbstractEndpointBuilder<SftpClient> {
     }
 
     @SchemaProperty(description = "Sets the polling interval when consuming messages.")
+    @XmlAttribute(name = "polling-interval")
     public void setPollingInterval(int pollingInterval) {
         pollingInterval(pollingInterval);
     }
@@ -280,6 +314,7 @@ public class SftpClientBuilder extends AbstractEndpointBuilder<SftpClient> {
     }
 
     @SchemaProperty(description = "The endpoint timeout when waiting for messages.")
+    @XmlAttribute
     public void setTimeout(long timeout) {
         timeout(timeout);
     }

--- a/endpoints/citrus-ftp/src/main/java/org/citrusframework/ftp/endpoint/builder/FtpEndpointBuilder.java
+++ b/endpoints/citrus-ftp/src/main/java/org/citrusframework/ftp/endpoint/builder/FtpEndpointBuilder.java
@@ -17,6 +17,10 @@
 package org.citrusframework.ftp.endpoint.builder;
 
 import jakarta.annotation.Nullable;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.endpoint.Endpoint;
 import org.citrusframework.endpoint.EndpointBuilder;
 import org.citrusframework.exceptions.CitrusRuntimeException;
@@ -28,17 +32,24 @@ import org.citrusframework.yaml.SchemaProperty;
 import org.citrusframework.yaml.SchemaType;
 
 @SchemaType(oneOf = { "client", "server" }, module = "citrus-ftp")
+@XmlType(name = "", propOrder = {
+        "client",
+        "server"
+})
+@XmlRootElement(name = "ftp")
 public class FtpEndpointBuilder implements EndpointBuilder<Endpoint>, ReferenceResolverAware {
 
     private EndpointBuilder<?> delegate;
     private ReferenceResolver referenceResolver;
 
     @SchemaProperty(description = "Sets the ftp client endpoint.")
+    @XmlElement
     public void setClient(FtpClientBuilder client) {
         this.delegate = client;
     }
 
     @SchemaProperty(description = "Sets the ftp server endpoint.")
+    @XmlElement
     public void setServer(FtpServerBuilder server) {
         this.delegate = server;
     }
@@ -62,6 +73,7 @@ public class FtpEndpointBuilder implements EndpointBuilder<Endpoint>, ReferenceR
     }
 
     @Override
+    @XmlTransient
     public void setReferenceResolver(@Nullable ReferenceResolver referenceResolver) {
         this.referenceResolver = referenceResolver;
     }

--- a/endpoints/citrus-ftp/src/main/java/org/citrusframework/ftp/endpoint/builder/ScpEndpointBuilder.java
+++ b/endpoints/citrus-ftp/src/main/java/org/citrusframework/ftp/endpoint/builder/ScpEndpointBuilder.java
@@ -17,6 +17,10 @@
 package org.citrusframework.ftp.endpoint.builder;
 
 import jakarta.annotation.Nullable;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.endpoint.Endpoint;
 import org.citrusframework.endpoint.EndpointBuilder;
 import org.citrusframework.exceptions.CitrusRuntimeException;
@@ -28,17 +32,24 @@ import org.citrusframework.yaml.SchemaProperty;
 import org.citrusframework.yaml.SchemaType;
 
 @SchemaType(oneOf = { "client", "server" }, module = "citrus-ftp")
+@XmlType(name = "", propOrder = {
+        "client",
+        "server"
+})
+@XmlRootElement(name = "scp")
 public class ScpEndpointBuilder implements EndpointBuilder<Endpoint>, ReferenceResolverAware {
 
     private EndpointBuilder<?> delegate;
     private ReferenceResolver referenceResolver;
 
     @SchemaProperty(description = "Sets the scp client endpoint.")
+    @XmlElement
     public void setClient(ScpClientBuilder client) {
         this.delegate = client;
     }
 
     @SchemaProperty(description = "Sets the sftp server endpoint.")
+    @XmlElement
     public void setServer(SftpServerBuilder server) {
         this.delegate = server;
     }
@@ -62,6 +73,7 @@ public class ScpEndpointBuilder implements EndpointBuilder<Endpoint>, ReferenceR
     }
 
     @Override
+    @XmlTransient
     public void setReferenceResolver(@Nullable ReferenceResolver referenceResolver) {
         this.referenceResolver = referenceResolver;
     }

--- a/endpoints/citrus-ftp/src/main/java/org/citrusframework/ftp/endpoint/builder/SftpEndpointBuilder.java
+++ b/endpoints/citrus-ftp/src/main/java/org/citrusframework/ftp/endpoint/builder/SftpEndpointBuilder.java
@@ -17,6 +17,10 @@
 package org.citrusframework.ftp.endpoint.builder;
 
 import jakarta.annotation.Nullable;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.endpoint.Endpoint;
 import org.citrusframework.endpoint.EndpointBuilder;
 import org.citrusframework.exceptions.CitrusRuntimeException;
@@ -28,17 +32,24 @@ import org.citrusframework.yaml.SchemaProperty;
 import org.citrusframework.yaml.SchemaType;
 
 @SchemaType(oneOf = { "client", "server" }, module = "citrus-ftp")
+@XmlType(name = "", propOrder = {
+        "client",
+        "server"
+})
+@XmlRootElement(name = "sftp")
 public class SftpEndpointBuilder implements EndpointBuilder<Endpoint>, ReferenceResolverAware {
 
     private EndpointBuilder<?> delegate;
     private ReferenceResolver referenceResolver;
 
     @SchemaProperty(description = "Sets the sftp client endpoint.")
+    @XmlElement
     public void setClient(SftpClientBuilder client) {
         this.delegate = client;
     }
 
     @SchemaProperty(description = "Sets the sftp server endpoint.")
+    @XmlElement
     public void setServer(SftpServerBuilder server) {
         this.delegate = server;
     }
@@ -62,6 +73,7 @@ public class SftpEndpointBuilder implements EndpointBuilder<Endpoint>, Reference
     }
 
     @Override
+    @XmlTransient
     public void setReferenceResolver(@Nullable ReferenceResolver referenceResolver) {
         this.referenceResolver = referenceResolver;
     }

--- a/endpoints/citrus-ftp/src/main/java/org/citrusframework/ftp/endpoint/builder/package-info.java
+++ b/endpoints/citrus-ftp/src/main/java/org/citrusframework/ftp/endpoint/builder/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@jakarta.xml.bind.annotation.XmlSchema(namespace = "http://citrusframework.org/schema/xml/testcase", elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
+package org.citrusframework.ftp.endpoint.builder;

--- a/endpoints/citrus-ftp/src/main/java/org/citrusframework/ftp/server/FtpServerBuilder.java
+++ b/endpoints/citrus-ftp/src/main/java/org/citrusframework/ftp/server/FtpServerBuilder.java
@@ -16,6 +16,8 @@
 
 package org.citrusframework.ftp.server;
 
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
 import org.apache.ftpserver.ftplet.UserManager;
 import org.apache.ftpserver.listener.ListenerFactory;
 import org.citrusframework.ftp.message.FtpMarshaller;
@@ -32,6 +34,7 @@ import org.citrusframework.yaml.SchemaType;
  * @since 2.5
  */
 @SchemaType(module = "citrus-ftp")
+@XmlType(name = "", propOrder = {})
 public class FtpServerBuilder extends AbstractServerBuilder<FtpServer, FtpServerBuilder> {
 
     /** Endpoint target */
@@ -84,6 +87,7 @@ public class FtpServerBuilder extends AbstractServerBuilder<FtpServer, FtpServer
     }
 
     @SchemaProperty(description = "The Ftp server port.")
+    @XmlAttribute
     public void setPort(int port) {
         port(port);
     }
@@ -97,6 +101,7 @@ public class FtpServerBuilder extends AbstractServerBuilder<FtpServer, FtpServer
     }
 
     @SchemaProperty(description = "When enabled the server uses automatic connect mode.")
+    @XmlAttribute(name = "auto-connect")
     public void setAutoConnect(boolean autoConnect) {
         autoConnect(autoConnect);
     }
@@ -110,6 +115,7 @@ public class FtpServerBuilder extends AbstractServerBuilder<FtpServer, FtpServer
     }
 
     @SchemaProperty(description = "When enabled the server uses automatic login mode.")
+    @XmlAttribute(name = "auto-login")
     public void setAutoLogin(boolean autoLogin) {
         autoLogin(autoLogin);
     }
@@ -123,6 +129,7 @@ public class FtpServerBuilder extends AbstractServerBuilder<FtpServer, FtpServer
     }
 
     @SchemaProperty(description = "The Ftp server host.")
+    @XmlAttribute
     public void setHost(String host) {
         host(host);
     }
@@ -136,6 +143,7 @@ public class FtpServerBuilder extends AbstractServerBuilder<FtpServer, FtpServer
     }
 
     @SchemaProperty(description = "Sets the allowed user name.")
+    @XmlAttribute
     public void setUser(String user) {
         user(user);
     }
@@ -152,6 +160,7 @@ public class FtpServerBuilder extends AbstractServerBuilder<FtpServer, FtpServer
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "Sets the allowed user password."
     )
+    @XmlAttribute
     public void setPassword(String password) {
         password(password);
     }
@@ -165,6 +174,7 @@ public class FtpServerBuilder extends AbstractServerBuilder<FtpServer, FtpServer
     }
 
     @SchemaProperty(description = "Enables the auto handle commands mode.")
+    @XmlAttribute(name = "auto-handle-commands")
     public void setAutoHandleCommands(String autoHandleCommands) {
         autoHandleCommands(autoHandleCommands);
     }
@@ -178,6 +188,7 @@ public class FtpServerBuilder extends AbstractServerBuilder<FtpServer, FtpServer
     }
 
     @SchemaProperty(description = "When enabled the client automatically reads new files.")
+    @XmlAttribute(name = "auto-read-files")
     public void setAutoReadFiles(boolean autoReadFiles) {
         autoReadFiles(autoReadFiles);
     }
@@ -191,6 +202,7 @@ public class FtpServerBuilder extends AbstractServerBuilder<FtpServer, FtpServer
     }
 
     @SchemaProperty(description = "Enables the local passive mode.")
+    @XmlAttribute(name = "local-passive-mode")
     public void setLocalPassiveMode(boolean localPassiveMode) {
         localPassiveMode(localPassiveMode);
     }
@@ -204,6 +216,7 @@ public class FtpServerBuilder extends AbstractServerBuilder<FtpServer, FtpServer
     }
 
     @SchemaProperty(advanced = true, description = "Sets the Ftp server implementation.")
+    @XmlAttribute
     public void setServer(String server) {
         this.ftpServer = server;
     }
@@ -217,6 +230,7 @@ public class FtpServerBuilder extends AbstractServerBuilder<FtpServer, FtpServer
     }
 
     @SchemaProperty(advanced = true, description = "Sets a custom user manager implementation.")
+    @XmlAttribute(name = "user-manager")
     public void setUserManager(String userManager) {
         this.userManager = userManager;
     }
@@ -230,6 +244,7 @@ public class FtpServerBuilder extends AbstractServerBuilder<FtpServer, FtpServer
     }
 
     @SchemaProperty(advanced = true, description = "Sets a custom listener factory implementation.")
+    @XmlAttribute(name = "listener-factory")
     public void setListenerFactory(String listenerFactory) {
         this.listenerFactory = listenerFactory;
     }
@@ -243,6 +258,7 @@ public class FtpServerBuilder extends AbstractServerBuilder<FtpServer, FtpServer
     }
 
     @SchemaProperty(advanced = true, description = "Loads user manage properties from a file resource.")
+    @XmlAttribute(name = "user-manager-properties")
     public void setUserManagerProperties(String userManagerProperties) {
         userManagerProperties(FileUtils.getFileResource(userManagerProperties));
     }
@@ -256,6 +272,7 @@ public class FtpServerBuilder extends AbstractServerBuilder<FtpServer, FtpServer
     }
 
     @SchemaProperty(advanced = true, description = "Sets a custom Ftp message marshaller.")
+    @XmlAttribute(name = "marshaller")
     public void setMarshaller(String marshaller) {
         this.marshaller = marshaller;
     }
@@ -269,6 +286,7 @@ public class FtpServerBuilder extends AbstractServerBuilder<FtpServer, FtpServer
     }
 
     @SchemaProperty(advanced = true, description = "Sets the message correlator.")
+    @XmlAttribute(name = "message-correlator")
     public void setCorrelator(String correlator) {
         this.correlator = correlator;
     }
@@ -285,7 +303,12 @@ public class FtpServerBuilder extends AbstractServerBuilder<FtpServer, FtpServer
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:errorHandler") },
             description = "Sets the error handling strategy."
     )
-    public void setErrorHandlingStrategy(ErrorHandlingStrategy errorStrategy) {
-        errorHandlingStrategy(errorStrategy);
+    @XmlAttribute(name = "error-handling-strategy")
+    public void setErrorHandlingStrategy(String errorStrategy) {
+        try {
+            errorHandlingStrategy(ErrorHandlingStrategy.fromName(errorStrategy));
+        } catch (IllegalArgumentException e) {
+            errorHandlingStrategy(ErrorHandlingStrategy.valueOf(errorStrategy));
+        }
     }
 }

--- a/endpoints/citrus-ftp/src/main/java/org/citrusframework/ftp/server/SftpServerBuilder.java
+++ b/endpoints/citrus-ftp/src/main/java/org/citrusframework/ftp/server/SftpServerBuilder.java
@@ -16,8 +16,13 @@
 
 package org.citrusframework.ftp.server;
 
+import java.util.Arrays;
 import java.util.Map;
+import java.util.stream.Collectors;
 
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.ftp.client.SftpEndpointConfiguration;
 import org.citrusframework.server.AbstractServerBuilder;
 import org.citrusframework.yaml.SchemaProperty;
@@ -27,6 +32,7 @@ import org.citrusframework.yaml.SchemaType;
  * @since 2.5
  */
 @SchemaType(module = "citrus-ftp")
+@XmlType(name = "", propOrder = {})
 public class SftpServerBuilder extends AbstractServerBuilder<SftpServer, SftpServerBuilder> {
 
     /** Endpoint target */
@@ -46,6 +52,7 @@ public class SftpServerBuilder extends AbstractServerBuilder<SftpServer, SftpSer
     }
 
     @SchemaProperty(description = "The Ftp server port.")
+    @XmlAttribute
     public void setPort(int port) {
         port(port);
     }
@@ -59,6 +66,7 @@ public class SftpServerBuilder extends AbstractServerBuilder<SftpServer, SftpSer
     }
 
     @SchemaProperty(description = "When enabled the server uses automatic connect mode.")
+    @XmlAttribute(name = "auto-connect")
     public void setAutoConnect(boolean autoConnect) {
         autoConnect(autoConnect);
     }
@@ -72,6 +80,7 @@ public class SftpServerBuilder extends AbstractServerBuilder<SftpServer, SftpSer
     }
 
     @SchemaProperty(description = "When enabled the server uses automatic login mode.")
+    @XmlAttribute(name = "auto-login")
     public void setAutoLogin(boolean autoLogin) {
         autoLogin(autoLogin);
     }
@@ -84,7 +93,11 @@ public class SftpServerBuilder extends AbstractServerBuilder<SftpServer, SftpSer
         return this;
     }
 
-    @SchemaProperty(description = "Sets the allowed user name.")
+    @SchemaProperty(
+            metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
+            description = "Sets the allowed user name."
+    )
+    @XmlAttribute
     public void setUser(String user) {
         user(user);
     }
@@ -101,6 +114,7 @@ public class SftpServerBuilder extends AbstractServerBuilder<SftpServer, SftpSer
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "Sets the allowed user password."
     )
+    @XmlAttribute
     public void setPassword(String password) {
         password(password);
     }
@@ -117,6 +131,7 @@ public class SftpServerBuilder extends AbstractServerBuilder<SftpServer, SftpSer
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "Sets the host key certificate path."
     )
+    @XmlAttribute(name = "host-key-path")
     public void setHostKeyPath(String hostKeyPath) {
         hostKeyPath(hostKeyPath);
     }
@@ -130,6 +145,7 @@ public class SftpServerBuilder extends AbstractServerBuilder<SftpServer, SftpSer
     }
 
     @SchemaProperty(description = "Sets the user home path directory.")
+    @XmlAttribute(name = "user-home-path")
     public void setUserHomePath(String userHomePath) {
         userHomePath(userHomePath);
     }
@@ -146,6 +162,7 @@ public class SftpServerBuilder extends AbstractServerBuilder<SftpServer, SftpSer
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "Sets the allowed key certificate path."
     )
+    @XmlAttribute(name = "allowed-key-path")
     public void setAllowedKeyPath(String allowedKeyPath) {
         allowedKeyPath(allowedKeyPath);
     }
@@ -159,6 +176,7 @@ public class SftpServerBuilder extends AbstractServerBuilder<SftpServer, SftpSer
     }
 
     @SchemaProperty(description = "Sets the polling interval when consuming messages.")
+    @XmlAttribute(name = "polling-interval")
     public void setPollingInterval(int pollingInterval) {
         pollingInterval(pollingInterval);
     }
@@ -175,6 +193,7 @@ public class SftpServerBuilder extends AbstractServerBuilder<SftpServer, SftpSer
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "Enable strict host checking."
     )
+    @XmlAttribute(name = "strict-host-checking")
     public void setStrictHostChecking(boolean strictHostChecking) {
         strictHostChecking(strictHostChecking);
     }
@@ -191,6 +210,7 @@ public class SftpServerBuilder extends AbstractServerBuilder<SftpServer, SftpSer
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "List of known hosts."
     )
+    @XmlAttribute(name = "known-hosts")
     public void setKnownHosts(String knownHosts) {
         knownHosts(knownHosts);
     }
@@ -207,6 +227,7 @@ public class SftpServerBuilder extends AbstractServerBuilder<SftpServer, SftpSer
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "Sets the private key certificate path."
     )
+    @XmlAttribute(name = "private-kay-path")
     public void setPrivateKeyPath(String privateKeyPath) {
         privateKeyPath(privateKeyPath);
     }
@@ -223,6 +244,7 @@ public class SftpServerBuilder extends AbstractServerBuilder<SftpServer, SftpSer
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "Sets the private key password."
     )
+    @XmlAttribute(name = "private-key-password")
     public void setPrivateKeyPassword(String privateKeyPassword) {
         privateKeyPassword(privateKeyPassword);
     }
@@ -239,6 +261,7 @@ public class SftpServerBuilder extends AbstractServerBuilder<SftpServer, SftpSer
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "Sets the preferred authentication mechanism."
     )
+    @XmlAttribute(name = "preferred-authentications")
     public void setPreferredAuthentications(String preferredAuthentications) {
         preferredAuthentications(preferredAuthentications);
     }
@@ -252,7 +275,17 @@ public class SftpServerBuilder extends AbstractServerBuilder<SftpServer, SftpSer
     }
 
     @SchemaProperty(description = "The session configuration.")
+    @XmlTransient
     public void setSessionConfigs(Map<String, String> sessionConfigs) {
         sessionConfigs(sessionConfigs);
+    }
+
+    @XmlAttribute(name = "session-configs")
+    public void setSessionConfigs(String sessionConfigs) {
+        setSessionConfigs(Arrays.stream(sessionConfigs.split(","))
+                .map(String::trim)
+                .filter(expression -> expression.contains("="))
+                .map(expression -> expression.split("=", 2))
+                .collect(Collectors.toMap(tokens -> tokens[0].trim(), tokens -> tokens[1].trim())));
     }
 }

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/client/HttpClientBuilder.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/client/HttpClientBuilder.java
@@ -19,6 +19,8 @@ package org.citrusframework.http.client;
 import java.util.ArrayList;
 import java.util.List;
 
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.endpoint.AbstractEndpointBuilder;
 import org.citrusframework.endpoint.resolver.EndpointUriResolver;
 import org.citrusframework.http.message.HttpMessageConverter;
@@ -42,6 +44,7 @@ import org.springframework.web.client.RestTemplate;
  * @since 2.5
  */
 @SchemaType(module = "citrus-http")
+@XmlType(name = "", propOrder = {})
 public class HttpClientBuilder extends AbstractEndpointBuilder<HttpClient> {
 
     /** Endpoint target */
@@ -119,6 +122,7 @@ public class HttpClientBuilder extends AbstractEndpointBuilder<HttpClient> {
     }
 
     @SchemaProperty(description = "Sets the Http client request URL.")
+    @XmlAttribute(name = "request-url")
     public void setRequestUrl(String uri) {
         requestUrl(uri);
     }
@@ -132,6 +136,7 @@ public class HttpClientBuilder extends AbstractEndpointBuilder<HttpClient> {
     }
 
     @SchemaProperty(advanced = true, description = "The reference to a REST template bean.")
+    @XmlAttribute(name = "rest-template")
     public void setRestTemplate(String restTemplate) {
         this.restTemplate = restTemplate;
     }
@@ -145,6 +150,7 @@ public class HttpClientBuilder extends AbstractEndpointBuilder<HttpClient> {
     }
 
     @SchemaProperty(advanced = true, description = "Reference to a request factory.")
+    @XmlAttribute(name = "request-factory")
     public void setRequestFactory(String requestFactory) {
         this.requestFactory = requestFactory;
     }
@@ -158,6 +164,7 @@ public class HttpClientBuilder extends AbstractEndpointBuilder<HttpClient> {
     }
 
     @SchemaProperty(description = "The default request method to use")
+    @XmlAttribute(name = "request-method")
     public void setRequestMethod(RequestMethod requestMethod) {
         requestMethod(requestMethod);
     }
@@ -171,6 +178,7 @@ public class HttpClientBuilder extends AbstractEndpointBuilder<HttpClient> {
     }
 
     @SchemaProperty(advanced = true, description = "Bean reference to a message converter.")
+    @XmlAttribute(name = "message-converter")
     public void setMessageConverter(String messageConverter) {
         this.messageConverter = messageConverter;
     }
@@ -184,6 +192,7 @@ public class HttpClientBuilder extends AbstractEndpointBuilder<HttpClient> {
     }
 
     @SchemaProperty(advanced = true, description = "Sets the message correlator.")
+    @XmlAttribute(name = "message-correlator")
     public void setCorrelator(String correlator) {
         this.correlator = correlator;
     }
@@ -197,6 +206,7 @@ public class HttpClientBuilder extends AbstractEndpointBuilder<HttpClient> {
     }
 
     @SchemaProperty(advanced = true, description = "Sets the endpoint URI resolver.")
+    @XmlAttribute(name = "endpoint-resolver")
     public void setEndpointResolver(String resolver) {
         this.endpointResolver = resolver;
     }
@@ -210,6 +220,7 @@ public class HttpClientBuilder extends AbstractEndpointBuilder<HttpClient> {
     }
 
     @SchemaProperty(advanced = true, description = "The default charset.")
+    @XmlAttribute
     public void setCharset(String charset) {
         charset(charset);
     }
@@ -223,6 +234,7 @@ public class HttpClientBuilder extends AbstractEndpointBuilder<HttpClient> {
     }
 
     @SchemaProperty(advanced = true, description = "When enabled the client adds the default accept header to requests.")
+    @XmlAttribute(name = "default-accept-header")
     public void setDefaultAcceptHeader(boolean flag) {
         defaultAcceptHeader(flag);
     }
@@ -236,6 +248,7 @@ public class HttpClientBuilder extends AbstractEndpointBuilder<HttpClient> {
     }
 
     @SchemaProperty(advanced = true, description = "When enabled the client handles cookies.")
+    @XmlAttribute(name = "handle-cookies")
     public void setHandleCookies(boolean flag) {
         handleCookies(flag);
     }
@@ -249,6 +262,7 @@ public class HttpClientBuilder extends AbstractEndpointBuilder<HttpClient> {
     }
 
     @SchemaProperty(advanced = true, description = "Disables the redirect handling for this client.")
+    @XmlAttribute(name = "disable-redirect-handling")
     public void setDisableRedirectHandling(boolean flag) {
         disableRedirectHandling(flag);
     }
@@ -262,6 +276,7 @@ public class HttpClientBuilder extends AbstractEndpointBuilder<HttpClient> {
     }
 
     @SchemaProperty(advanced = true, description = "Sets the default content type header set for each request.")
+    @XmlAttribute(name = "content-type")
     public void setContentType(String contentType) {
         contentType(contentType);
     }
@@ -275,6 +290,7 @@ public class HttpClientBuilder extends AbstractEndpointBuilder<HttpClient> {
     }
 
     @SchemaProperty(advanced = true, description = "Sets the polling interval when consuming messages.")
+    @XmlAttribute(name = "polling-interval")
     public void setPollingInterval(int pollingInterval) {
         pollingInterval(pollingInterval);
     }
@@ -290,8 +306,13 @@ public class HttpClientBuilder extends AbstractEndpointBuilder<HttpClient> {
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:errorHandling") },
             description = "Sets the error handling strategy.")
-    public void setErrorHandlingStrategy(ErrorHandlingStrategy errorStrategy) {
-        errorHandlingStrategy(errorStrategy);
+    @XmlAttribute(name = "error-handling-strategy")
+    public void setErrorHandlingStrategy(String errorStrategy) {
+        try {
+            errorHandlingStrategy(ErrorHandlingStrategy.fromName(errorStrategy));
+        } catch (IllegalArgumentException e) {
+            errorHandlingStrategy(ErrorHandlingStrategy.valueOf(errorStrategy));
+        }
     }
 
     /**
@@ -306,6 +327,7 @@ public class HttpClientBuilder extends AbstractEndpointBuilder<HttpClient> {
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:errorHandling") },
             description = "Sets a custom error handler."
     )
+    @XmlAttribute(name = "error-handler")
     public void setErrorHandler(String errorHandler) {
         this.errorHandler = errorHandler;
     }
@@ -321,6 +343,7 @@ public class HttpClientBuilder extends AbstractEndpointBuilder<HttpClient> {
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:intercept") },
             description = "Sets the list of client interceptor bean references.")
+    @XmlAttribute
     public void setInterceptors(List<String> interceptors) {
         this.interceptors.addAll(interceptors);
     }
@@ -334,6 +357,7 @@ public class HttpClientBuilder extends AbstractEndpointBuilder<HttpClient> {
     }
 
     @SchemaProperty(advanced = true, description = "Sets the list of binary media types.")
+    @XmlAttribute(name = "binary-media-types")
     public void setBinaryMediaTypes(List<String> binaryMediaTypes) {
         binaryMediaTypes(binaryMediaTypes.stream().map(MediaType::valueOf).toList());
     }
@@ -349,6 +373,7 @@ public class HttpClientBuilder extends AbstractEndpointBuilder<HttpClient> {
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:intercept") },
             description = "Sets a client interceptor.")
+    @XmlAttribute
     public void setInterceptor(String interceptor) {
         this.interceptors.add(interceptor);
     }
@@ -362,6 +387,7 @@ public class HttpClientBuilder extends AbstractEndpointBuilder<HttpClient> {
     }
 
     @SchemaProperty(advanced = true, description = "Sets a custom header mapper bean reference.")
+    @XmlAttribute(name = "header-mapper")
     public void setHeaderMapper(String headerMapper) {
         this.headerMapper = headerMapper;
     }
@@ -375,6 +401,7 @@ public class HttpClientBuilder extends AbstractEndpointBuilder<HttpClient> {
     }
 
     @SchemaProperty(description = "The Http request timeout while waiting for a response", defaultValue = "5000")
+    @XmlAttribute
     public void setTimeout(long timeout) {
         timeout(timeout);
     }
@@ -390,6 +417,7 @@ public class HttpClientBuilder extends AbstractEndpointBuilder<HttpClient> {
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "Use given authentication mechanism.")
+    @XmlAttribute
     public void setAuthentication(String authentication) {
         this.authentication = authentication;
     }
@@ -407,6 +435,7 @@ public class HttpClientBuilder extends AbstractEndpointBuilder<HttpClient> {
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "Secure the connection with given security mechanism.")
+    @XmlAttribute(name = "secured-connection")
     public void setSecuredConnection(String connection) {
         this.securedConnection = connection;
     }

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/endpoint/builder/HttpEndpointBuilder.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/endpoint/builder/HttpEndpointBuilder.java
@@ -17,6 +17,10 @@
 package org.citrusframework.http.endpoint.builder;
 
 import jakarta.annotation.Nullable;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.endpoint.Endpoint;
 import org.citrusframework.endpoint.EndpointBuilder;
 import org.citrusframework.exceptions.CitrusRuntimeException;
@@ -31,17 +35,24 @@ import org.citrusframework.yaml.SchemaType;
  * Endpoint builder delegates to either client od server endpoint builder.
  */
 @SchemaType(oneOf = { "client", "server" }, module = "citrus-http")
+@XmlType(name = "", propOrder = {
+        "client",
+        "server"
+})
+@XmlRootElement(name = "http")
 public class HttpEndpointBuilder implements EndpointBuilder<Endpoint>, ReferenceResolverAware {
 
     private EndpointBuilder<?> delegate;
     private ReferenceResolver referenceResolver;
 
     @SchemaProperty(description = "Sets the Http client endpoint.")
+    @XmlElement
     public void setClient(HttpClientBuilder client) {
         this.delegate = client;
     }
 
     @SchemaProperty(description = "Sets the Http server endpoint.")
+    @XmlElement
     public void setServer(HttpServerBuilder server) {
         this.delegate = server;
     }
@@ -65,6 +76,7 @@ public class HttpEndpointBuilder implements EndpointBuilder<Endpoint>, Reference
     }
 
     @Override
+    @XmlTransient
     public void setReferenceResolver(@Nullable ReferenceResolver referenceResolver) {
         this.referenceResolver = referenceResolver;
     }

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/endpoint/builder/package-info.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/endpoint/builder/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@jakarta.xml.bind.annotation.XmlSchema(namespace = "http://citrusframework.org/schema/xml/testcase", elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
+package org.citrusframework.http.endpoint.builder;

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/server/AbstractHttpServerBuilder.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/server/AbstractHttpServerBuilder.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import jakarta.servlet.Filter;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlTransient;
 import org.citrusframework.http.message.HttpMessageConverter;
 import org.citrusframework.http.security.HttpAuthentication;
 import org.citrusframework.http.security.HttpSecureConnection;
@@ -121,6 +123,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
     }
 
     @SchemaProperty(description = "The Http server port.")
+    @XmlAttribute
     public void setPort(int port) {
         port(port);
     }
@@ -136,6 +139,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "The secured port.")
+    @XmlAttribute(name = "secure-port")
     public void setSecurePort(int port) {
         securePort(port);
     }
@@ -149,6 +153,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
     }
 
     @SchemaProperty(advanced = true, description = "Sets the Spring context configuration loaded for this Http server.")
+    @XmlAttribute(name = "context-config-location")
     public void setContextConfigLocation(String configLocation) {
         contextConfigLocation(configLocation);
     }
@@ -162,6 +167,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
     }
 
     @SchemaProperty(advanced = true, description = "The server resource base path where resources get loaded from.")
+    @XmlAttribute(name = "resource-base")
     public void setResourceBase(String resourceBase) {
         resourceBase(resourceBase);
     }
@@ -175,6 +181,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
     }
 
     @SchemaProperty(advanced = true, description = "When enabled the server uses the root Spring application context.")
+    @XmlAttribute(name = "root-parent-context")
     public void setRootParentContext(boolean rootParentContext) {
         rootParentContext(rootParentContext);
     }
@@ -190,6 +197,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:filter") },
             description = "When enabled the server uses the default set of Http servlet filters.")
+    @XmlAttribute(name = "use-default-filters")
     public void setUseDefaultFilters(boolean useDefaultFilters) {
         useDefaultFilters(useDefaultFilters);
     }
@@ -205,8 +213,14 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:servlet") },
             description = "Sets a list of connectors for this server.")
+    @XmlTransient
     public void setConnectors(List<String> connectors) {
         this.connectors.addAll(connectors);
+    }
+
+    @XmlAttribute
+    public void setConnectors(String connectors) {
+        setConnectors(Arrays.asList(connectors.split(",")));
     }
 
     /**
@@ -220,6 +234,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:servlet") },
             description = "Add a connector to this server.")
+    @XmlAttribute
     public void setConnector(String connector) {
         this.connectors.add(connector);
     }
@@ -235,8 +250,18 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:filter") },
             description = "Map of Http filters used on this server.")
+    @XmlTransient
     public void setFilters(Map<String, String> filters) {
         this.filters.putAll(filters);
+    }
+
+    @XmlAttribute
+    public void setFilters(String filters) {
+        setFilters(Arrays.stream(filters.split(","))
+                .map(String::trim)
+                .filter(expression -> expression.contains("="))
+                .map(expression -> expression.split("=", 2))
+                .collect(Collectors.toMap(tokens -> tokens[0].trim(), tokens -> tokens[1].trim())));
     }
 
     /**
@@ -250,8 +275,18 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:filter") },
             description = "Filter mapping used on this server.")
+    @XmlTransient
     public void setFilterMappings(Map<String, String> filterMappings) {
         filterMappings(filterMappings);
+    }
+
+    @XmlAttribute
+    public void setFilterMappings(String filterMappings) {
+        setFilterMappings(Arrays.stream(filterMappings.split(","))
+                .map(String::trim)
+                .filter(expression -> expression.contains("="))
+                .map(expression -> expression.split("=", 2))
+                .collect(Collectors.toMap(tokens -> tokens[0].trim(), tokens -> tokens[1].trim())));
     }
 
     /**
@@ -263,8 +298,14 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
     }
 
     @SchemaProperty(advanced = true, description = "List of supported media types on this server.")
+    @XmlTransient
     public void setBinaryMediaTypes(List<String> binaryMediaTypes) {
         binaryMediaTypes(binaryMediaTypes.stream().map(MediaType::valueOf).toList());
+    }
+
+    @XmlAttribute(name = "binary-media-types")
+    public void setBinaryMediaTypes(String binaryMediaTypes) {
+        setBinaryMediaTypes(Arrays.asList(binaryMediaTypes.split(",")));
     }
 
     /**
@@ -278,6 +319,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:servlet") },
             description = "Sets the servlet name.")
+    @XmlAttribute(name = "servlet-name")
     public void setServletName(String servletName) {
         servletName(servletName);
     }
@@ -293,6 +335,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:servlet") },
             description = "Sets the servlet mapping path.")
+    @XmlAttribute(name = "servlet-mapping-path")
     public void setServletMappingPath(String servletMappingPath) {
         servletMappingPath(servletMappingPath);
     }
@@ -308,6 +351,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:servlet") },
             description = "Sets the context path on this server.")
+    @XmlAttribute(name = "context-path")
     public void setContextPath(String contextPath) {
         contextPath(contextPath);
     }
@@ -323,7 +367,8 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:servlet") },
             description = "Sets a custom servlet handler as a bean reference.")
-    public void serServletHandler(String servletHandler) {
+    @XmlAttribute(name = "servlet-handler")
+    public void setServletHandler(String servletHandler) {
         this.servletHandler = servletHandler;
     }
 
@@ -338,6 +383,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "Sets the security handler as a bean reference.")
+    @XmlAttribute(name = "security-handler")
     public void setSecurityHandler(String securityHandler) {
         this.securityHandler = securityHandler;
     }
@@ -351,6 +397,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
     }
 
     @SchemaProperty(advanced = true, description = "Sets the Http message converter bean reference.")
+    @XmlAttribute(name = "message-converter")
     public void setMessageConverter(String messageConverter) {
         this.messageConverter = messageConverter;
     }
@@ -364,6 +411,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
     }
 
     @SchemaProperty(advanced = true, description = "When enabled the server handles attribute headers.")
+    @XmlAttribute(name = "handle-attribute-headers")
     public void setHandleAttributeHeaders(boolean flag) {
         handleAttributeHeaders(flag);
     }
@@ -377,6 +425,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
     }
 
     @SchemaProperty(advanced = true, description = "When enabled the server handles cookies.")
+    @XmlAttribute(name = "handle-cookies")
     public void setHandleCookies(boolean flag) {
         handleCookies(flag);
     }
@@ -390,6 +439,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
     }
 
     @SchemaProperty(advanced = true, description = "When enabled the server removes semicolon path content from headers.")
+    @XmlAttribute(name = "remove-semicolon-path-content")
     public void setRemoveSemicolonPathContent(boolean removeSemicolonPathContent) {
         removeSemicolonPathContent(removeSemicolonPathContent);
     }
@@ -403,6 +453,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
     }
 
     @SchemaProperty(advanced = true, description = "Sets the default status returned by the server.")
+    @XmlAttribute(name = "default-status")
     public void setDefaultStatus(HttpStatus status) {
         defaultStatus(status);
     }
@@ -416,6 +467,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
     }
 
     @SchemaProperty(advanced = true, description = "Sets the response cache size.")
+    @XmlAttribute(name = "response-cache-size")
     public void setResponseCacheSize(int size) {
         responseCacheSize(size);
     }
@@ -431,8 +483,14 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:intercept") },
             description = "Sets the list of handler interceptor bean references.")
+    @XmlTransient
     public void setInterceptors(List<String> interceptors) {
         this.interceptors.addAll(interceptors);
+    }
+
+    @XmlAttribute
+    public void setInterceptors(String interceptors) {
+        setInterceptors(Arrays.asList(interceptors.split(",")));
     }
 
     /**
@@ -446,6 +504,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:intercept") },
             description = "Sets a handler interceptor.")
+    @XmlAttribute
     public void setInterceptor(String interceptor) {
         this.interceptors.add(interceptor);
     }
@@ -457,6 +516,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
     }
 
     @SchemaProperty(description = "Sets the server timeout while waiting for incoming requests.", defaultValue = "5000")
+    @XmlAttribute
     public void setTimeout(long timeout) {
         timeout(timeout);
     }
@@ -474,6 +534,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "Use given authentication mechanism for all request paths.")
+    @XmlAttribute
     public void setAuthentication(String authentication) {
         this.authentication = authentication;
     }
@@ -491,6 +552,7 @@ public class AbstractHttpServerBuilder<T extends HttpServer, B extends AbstractH
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "Secure the connections on given secured port with given security mechanism.")
+    @XmlAttribute(name = "secured-connection")
     public void setSecuredConnection(String connection) {
         this.securedConnection = connection;
     }

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/server/HttpServerBuilder.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/server/HttpServerBuilder.java
@@ -16,12 +16,14 @@
 
 package org.citrusframework.http.server;
 
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.yaml.SchemaType;
 
 /**
  * @since 2.5
  */
 @SchemaType(module = "citrus-http")
+@XmlType(name = "", propOrder = {})
 public class HttpServerBuilder extends AbstractHttpServerBuilder<HttpServer, HttpServerBuilder> {
 
     public HttpServerBuilder() {

--- a/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/endpoint/JmsEndpointBuilder.java
+++ b/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/endpoint/JmsEndpointBuilder.java
@@ -18,7 +18,8 @@ package org.citrusframework.jms.endpoint;
 
 import jakarta.jms.ConnectionFactory;
 import jakarta.jms.Destination;
-
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.endpoint.AbstractEndpointBuilder;
 import org.citrusframework.endpoint.resolver.EndpointUriResolver;
 import org.citrusframework.jms.message.JmsMessageConverter;
@@ -32,6 +33,7 @@ import org.springframework.jms.support.destination.DestinationResolver;
  * @since 2.5
  */
 @SchemaType(module = "citrus-jms")
+@XmlType(name = "", propOrder = {})
 public class JmsEndpointBuilder extends AbstractEndpointBuilder<JmsEndpoint> {
 
     /** Endpoint target */
@@ -84,6 +86,7 @@ public class JmsEndpointBuilder extends AbstractEndpointBuilder<JmsEndpoint> {
     }
 
     @SchemaProperty(description = "The JMS destination name.")
+    @XmlAttribute
     public void setDestination(String destinationName) {
         destination(destinationName);
     }
@@ -105,6 +108,7 @@ public class JmsEndpointBuilder extends AbstractEndpointBuilder<JmsEndpoint> {
     }
 
     @SchemaProperty(description = "The JMS connection factory.")
+    @XmlAttribute(name = "connection-factory")
     public void setConnectionFactory(String connectionFactory) {
         this.connectionFactory = connectionFactory;
     }
@@ -118,6 +122,7 @@ public class JmsEndpointBuilder extends AbstractEndpointBuilder<JmsEndpoint> {
     }
 
     @SchemaProperty(advanced = true, description = "Sets the JMS template.")
+    @XmlAttribute(name = "jms-template")
     public void setJmsTemplate(String jmsTemplate) {
         this.jmsTemplate = jmsTemplate;
     }
@@ -131,6 +136,7 @@ public class JmsEndpointBuilder extends AbstractEndpointBuilder<JmsEndpoint> {
     }
 
     @SchemaProperty(advanced = true, description = "Sets the message converter bean reference.")
+    @XmlAttribute(name = "message-converter")
     public  void setMessageConverter(String messageConverter) {
         this.messageConverter = messageConverter;
     }
@@ -144,6 +150,7 @@ public class JmsEndpointBuilder extends AbstractEndpointBuilder<JmsEndpoint> {
     }
 
     @SchemaProperty(advanced = true, description = "Sets the destination resolver.")
+    @XmlAttribute(name = "destination-resolver")
     public void setDestinationResolver(String resolver) {
         this.destinationResolver = resolver;
     }
@@ -157,6 +164,7 @@ public class JmsEndpointBuilder extends AbstractEndpointBuilder<JmsEndpoint> {
     }
 
     @SchemaProperty(advanced = true, description = "Sets the destination name resolver.")
+    @XmlAttribute(name = "destination-name-resolver")
     public void setDestinationNameResolver(String resolver) {
         this.destinationNameResolver = resolver;
     }
@@ -172,6 +180,7 @@ public class JmsEndpointBuilder extends AbstractEndpointBuilder<JmsEndpoint> {
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:publishSubscribe") },
             description = "When enabled the endpoint uses publish/subscribe mode.")
+    @XmlAttribute(name = "pub-sub-domain")
     public void setPubSubDomain(boolean pubSubDomain) {
         pubSubDomain(pubSubDomain);
     }
@@ -187,6 +196,7 @@ public class JmsEndpointBuilder extends AbstractEndpointBuilder<JmsEndpoint> {
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:publishSubscribe") },
             description = "When enabled the JMS consumer is started right after the endpoint is created.")
+    @XmlAttribute(name = "auto-start")
     public void setAutoStart(boolean autoStart) {
         autoStart(autoStart);
     }
@@ -202,6 +212,7 @@ public class JmsEndpointBuilder extends AbstractEndpointBuilder<JmsEndpoint> {
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:publishSubscribe") },
             description = "Enables/disables durable subscription mode.")
+    @XmlAttribute(name = "durable-subscription")
     public void setDurableSubscription(boolean durableSubscription) {
         durableSubscription(durableSubscription);
     }
@@ -217,6 +228,7 @@ public class JmsEndpointBuilder extends AbstractEndpointBuilder<JmsEndpoint> {
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:publishSubscribe") },
             description = "Sets the durable subscriber name.")
+    @XmlAttribute(name = "durable-subscriber-name")
     public void setDurableSubscriberName(String durableSubscriberName) {
         durableSubscriberName(durableSubscriberName);
     }
@@ -230,6 +242,7 @@ public class JmsEndpointBuilder extends AbstractEndpointBuilder<JmsEndpoint> {
     }
 
     @SchemaProperty(advanced = true, description = "When enabled the endpoint uses object messages.")
+    @XmlAttribute(name = "use-object-messages")
     public void setUseObjectMessages(boolean useObjectMessages) {
         useObjectMessages(useObjectMessages);
     }
@@ -243,6 +256,7 @@ public class JmsEndpointBuilder extends AbstractEndpointBuilder<JmsEndpoint> {
     }
 
     @SchemaProperty(advanced = true, description = "Filter internal headers.")
+    @XmlAttribute(name = "filter-internal-headers")
     public void setFilterInternalHeaders(boolean filterInternalHeaders) {
         filterInternalHeaders(filterInternalHeaders);
     }
@@ -256,6 +270,7 @@ public class JmsEndpointBuilder extends AbstractEndpointBuilder<JmsEndpoint> {
     }
 
     @SchemaProperty(description = "Sets the receive timeout when the consumer waits for messages to arrive.", defaultValue = "5000")
+    @XmlAttribute
     public void setTimeout(long timeout) {
         timeout(timeout);
     }

--- a/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/endpoint/JmsEndpointsBuilder.java
+++ b/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/endpoint/JmsEndpointsBuilder.java
@@ -17,6 +17,10 @@
 package org.citrusframework.jms.endpoint;
 
 import jakarta.annotation.Nullable;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.endpoint.Endpoint;
 import org.citrusframework.endpoint.EndpointBuilder;
 import org.citrusframework.exceptions.CitrusRuntimeException;
@@ -26,17 +30,24 @@ import org.citrusframework.yaml.SchemaProperty;
 import org.citrusframework.yaml.SchemaType;
 
 @SchemaType(oneOf = { "asynchronous", "synchronous" }, module = "citrus-jms")
+@XmlType(name = "", propOrder = {
+        "asynchronous",
+        "synchronous"
+})
+@XmlRootElement(name = "jms")
 public class JmsEndpointsBuilder implements EndpointBuilder<Endpoint>, ReferenceResolverAware {
 
     private EndpointBuilder<?> delegate;
     private ReferenceResolver referenceResolver;
 
     @SchemaProperty(description = "Sets the synchronous Jms endpoint.")
+    @XmlElement
     public void setSynchronous(JmsSyncEndpointBuilder builder) {
         this.delegate = builder;
     }
 
     @SchemaProperty(description = "Sets the Jms endpoint.")
+    @XmlElement
     public void setAsynchronous(JmsEndpointBuilder builder) {
         this.delegate = builder;
     }
@@ -60,6 +71,7 @@ public class JmsEndpointsBuilder implements EndpointBuilder<Endpoint>, Reference
     }
 
     @Override
+    @XmlTransient
     public void setReferenceResolver(@Nullable ReferenceResolver referenceResolver) {
         this.referenceResolver = referenceResolver;
     }

--- a/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/endpoint/JmsSyncEndpointBuilder.java
+++ b/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/endpoint/JmsSyncEndpointBuilder.java
@@ -18,6 +18,8 @@ package org.citrusframework.jms.endpoint;
 
 import jakarta.jms.ConnectionFactory;
 import jakarta.jms.Destination;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.endpoint.AbstractEndpointBuilder;
 import org.citrusframework.endpoint.resolver.EndpointUriResolver;
 import org.citrusframework.jms.message.JmsMessageConverter;
@@ -32,6 +34,7 @@ import org.springframework.jms.support.destination.DestinationResolver;
  * @since 2.5
  */
 @SchemaType(module = "citrus-jms")
+@XmlType(name = "", propOrder = {})
 public class JmsSyncEndpointBuilder extends AbstractEndpointBuilder<JmsSyncEndpoint> {
 
     /** Endpoint target */
@@ -89,6 +92,7 @@ public class JmsSyncEndpointBuilder extends AbstractEndpointBuilder<JmsSyncEndpo
     }
 
     @SchemaProperty(description = "The JMS destination name.")
+    @XmlAttribute
     public void setDestination(String destinationName) {
         destination(destinationName);
     }
@@ -110,6 +114,7 @@ public class JmsSyncEndpointBuilder extends AbstractEndpointBuilder<JmsSyncEndpo
     }
 
     @SchemaProperty(description = "Sets the reply destination name.")
+    @XmlAttribute(name = "reply-destination")
     public void setReplyDestination(String replyDestination) {
         replyDestination(replyDestination);
     }
@@ -131,6 +136,7 @@ public class JmsSyncEndpointBuilder extends AbstractEndpointBuilder<JmsSyncEndpo
     }
 
     @SchemaProperty(description = "The JMS connection factory.")
+    @XmlAttribute(name = "connection-factory")
     public void setConnectionFactory(String connectionFactory) {
         this.connectionFactory = connectionFactory;
     }
@@ -144,6 +150,7 @@ public class JmsSyncEndpointBuilder extends AbstractEndpointBuilder<JmsSyncEndpo
     }
 
     @SchemaProperty(advanced = true, description = "Sets the JMS template.")
+    @XmlAttribute(name = "jms-template")
     public void setJmsTemplate(String jmsTemplate) {
         this.jmsTemplate = jmsTemplate;
     }
@@ -157,6 +164,7 @@ public class JmsSyncEndpointBuilder extends AbstractEndpointBuilder<JmsSyncEndpo
     }
 
     @SchemaProperty(advanced = true, description = "Sets the message converter bean reference.")
+    @XmlAttribute(name = "message-converter")
     public void setMessageConverter(String messageConverter) {
         this.messageConverter = messageConverter;
     }
@@ -170,6 +178,7 @@ public class JmsSyncEndpointBuilder extends AbstractEndpointBuilder<JmsSyncEndpo
     }
 
     @SchemaProperty(advanced = true, description = "Sets the destination resolver.")
+    @XmlAttribute(name = "destination-resolver")
     public void setDestinationResolver(String resolver) {
         this.destinationResolver = resolver;
     }
@@ -183,6 +192,7 @@ public class JmsSyncEndpointBuilder extends AbstractEndpointBuilder<JmsSyncEndpo
     }
 
     @SchemaProperty(advanced = true, description = "Sets the destination name resolver.")
+    @XmlAttribute(name = "destination-name-resolver")
     public void setDestinationNameResolver(String resolver) {
         this.destinationNameResolver = resolver;
     }
@@ -196,6 +206,7 @@ public class JmsSyncEndpointBuilder extends AbstractEndpointBuilder<JmsSyncEndpo
     }
 
     @SchemaProperty(advanced = true, description = "When enabled the endpoint uses publish/subscribe mode.")
+    @XmlAttribute(name = "pub-sub-domain")
     public void setPubSubDomain(boolean pubSubDomain) {
         pubSubDomain(pubSubDomain);
     }
@@ -209,6 +220,7 @@ public class JmsSyncEndpointBuilder extends AbstractEndpointBuilder<JmsSyncEndpo
     }
 
     @SchemaProperty(advanced = true, description = "When enabled the endpoint uses object messages.")
+    @XmlAttribute(name = "use-object-messages")
     public void setUseObjectMessages(boolean useObjectMessages) {
         useObjectMessages(useObjectMessages);
     }
@@ -224,6 +236,7 @@ public class JmsSyncEndpointBuilder extends AbstractEndpointBuilder<JmsSyncEndpo
     @SchemaProperty(
             advanced = true,
             description = "When enabled the endpoint removes all internal headers before sending a message.")
+    @XmlAttribute(name = "filter-internal-headers")
     public void setFilterInternalHeaders(boolean filterInternalHeaders) {
         filterInternalHeaders(filterInternalHeaders);
     }
@@ -237,6 +250,7 @@ public class JmsSyncEndpointBuilder extends AbstractEndpointBuilder<JmsSyncEndpo
     }
 
     @SchemaProperty(advanced = true, description = "Sets the polling interval.")
+    @XmlAttribute(name = "polling-interval")
     public void setPollingInterval(int pollingInterval) {
         pollingInterval(pollingInterval);
     }
@@ -250,6 +264,7 @@ public class JmsSyncEndpointBuilder extends AbstractEndpointBuilder<JmsSyncEndpo
     }
 
     @SchemaProperty(advanced = true, description = "Sets the message correlator.")
+    @XmlAttribute(name = "message-correlator")
     public void setCorrelator(String correlator) {
         this.correlator = correlator;
     }
@@ -263,6 +278,7 @@ public class JmsSyncEndpointBuilder extends AbstractEndpointBuilder<JmsSyncEndpo
     }
 
     @SchemaProperty(description = "Sets the receive timeout when the consumer waits for messages to arrive.")
+    @XmlAttribute
     public void setTimeout(long timeout) {
         timeout(timeout);
     }

--- a/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/endpoint/package-info.java
+++ b/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/endpoint/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@jakarta.xml.bind.annotation.XmlSchema(namespace = "http://citrusframework.org/schema/xml/testcase", elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
+package org.citrusframework.jms.endpoint;

--- a/endpoints/citrus-jms/src/test/resources/org/citrusframework/jms/xml/purge-queues.citrus.it.xml
+++ b/endpoints/citrus-jms/src/test/resources/org/citrusframework/jms/xml/purge-queues.citrus.it.xml
@@ -18,6 +18,13 @@
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="http://citrusframework.org/schema/xml/testcase http://citrusframework.org/schema/xml/testcase/citrus-testcase.xsd">
   <description>Sample test in XML</description>
+  <endpoints>
+    <jms>
+      <asynchronous name="foo"
+                    destination="foo-queue"
+                    connection-factory="myConnectionFactory"/>
+    </jms>
+  </endpoints>
   <actions>
     <purge-jms-queues>
       <queue name="JMS.Queue.1"/>

--- a/endpoints/citrus-jms/src/test/resources/org/citrusframework/jms/yaml/purge-queues.citrus.it.yaml
+++ b/endpoints/citrus-jms/src/test/resources/org/citrusframework/jms/yaml/purge-queues.citrus.it.yaml
@@ -1,6 +1,12 @@
 name: "PurgeQueuesTest"
 author: "Christoph"
 status: "FINAL"
+endpoints:
+  - jms:
+      asynchronous:
+        name: foo
+        destination: fooQueue
+        connectionFactory: myConnectionFactory
 actions:
   - purgeQueues:
       queue: "JMS.Queue.1"

--- a/endpoints/citrus-jmx/src/main/java/org/citrusframework/jmx/client/JmxClientBuilder.java
+++ b/endpoints/citrus-jmx/src/main/java/org/citrusframework/jmx/client/JmxClientBuilder.java
@@ -18,19 +18,47 @@ package org.citrusframework.jmx.client;
 
 import javax.management.NotificationFilter;
 
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.endpoint.AbstractEndpointBuilder;
 import org.citrusframework.jmx.message.JmxMessageConverter;
 import org.citrusframework.message.MessageCorrelator;
+import org.citrusframework.util.StringUtils;
+import org.citrusframework.yaml.SchemaProperty;
 import org.citrusframework.yaml.SchemaType;
 
 /**
  * @since 2.5
  */
 @SchemaType(module = "citrus-jmx")
+@XmlType(name = "", propOrder = {})
 public class JmxClientBuilder extends AbstractEndpointBuilder<JmxClient> {
 
     /** Endpoint target */
-    private JmxClient endpoint = new JmxClient();
+    private final JmxClient endpoint = new JmxClient();
+
+    private String notificationFilter;
+    private String messageConverter;
+    private String correlator;
+
+    @Override
+    public JmxClient build() {
+        if (referenceResolver != null) {
+            if (StringUtils.hasText(messageConverter)) {
+                messageConverter(referenceResolver.resolve(messageConverter, JmxMessageConverter.class));
+            }
+
+            if (StringUtils.hasText(correlator)) {
+                correlator(referenceResolver.resolve(correlator, MessageCorrelator.class));
+            }
+
+            if (StringUtils.hasText(notificationFilter)) {
+                notificationFilter(referenceResolver.resolve(notificationFilter, NotificationFilter.class));
+            }
+        }
+
+        return super.build();
+    }
 
     @Override
     protected JmxClient getEndpoint() {
@@ -39,101 +67,141 @@ public class JmxClientBuilder extends AbstractEndpointBuilder<JmxClient> {
 
     /**
      * Sets the serverUrl property.
-     * @param serverUrl
-     * @return
      */
     public JmxClientBuilder serverUrl(String serverUrl) {
         endpoint.getEndpointConfiguration().setServerUrl(serverUrl);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the serverUrl property.")
+    @XmlAttribute(name = "server-url")
+    public void setServerUrl(String serverUrl) {
+        serverUrl(serverUrl);
+    }
+
     /**
      * Sets the username property.
-     * @param username
-     * @return
      */
     public JmxClientBuilder username(String username) {
         endpoint.getEndpointConfiguration().setUsername(username);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the username property.")
+    @XmlAttribute
+    public void setUsername(String username) {
+        username(username);
+    }
+
     /**
      * Sets the password property.
-     * @param password
-     * @return
      */
     public JmxClientBuilder password(String password) {
         endpoint.getEndpointConfiguration().setPassword(password);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the password property.")
+    @XmlAttribute
+    public void setPassword(String password) {
+        password(password);
+    }
+
     /**
      * Sets the reconnectDelay property.
-     * @param reconnectDelay
-     * @return
      */
     public JmxClientBuilder reconnectDelay(long reconnectDelay) {
         endpoint.getEndpointConfiguration().setDelayOnReconnect(reconnectDelay);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the reconnectDelay property.")
+    @XmlAttribute(name = "reconnect-delay")
+    public void setReconnectDelay(long reconnectDelay) {
+        reconnectDelay(reconnectDelay);
+    }
+
     /**
      * Sets the autoReconnect property.
-     * @param autoReconnect
-     * @return
      */
     public JmxClientBuilder autoReconnect(boolean autoReconnect) {
         endpoint.getEndpointConfiguration().setAutoReconnect(autoReconnect);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the autoReconnect property.")
+    @XmlAttribute(name = "auto-connect")
+    public void setAutoReconnect(boolean autoReconnect) {
+        autoReconnect(autoReconnect);
+    }
+
     /**
      * Sets the notification filter.
-     * @param notificationFilter
-     * @return
      */
     public JmxClientBuilder notificationFilter(NotificationFilter notificationFilter) {
         endpoint.getEndpointConfiguration().setNotificationFilter(notificationFilter);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the notification filter.")
+    @XmlAttribute(name = "notification-filter")
+    public void setNotificationFilter(String notificationFilter) {
+        this.notificationFilter = notificationFilter;
+    }
+
     /**
      * Sets the message converter.
-     * @param messageConverter
-     * @return
      */
     public JmxClientBuilder messageConverter(JmxMessageConverter messageConverter) {
         endpoint.getEndpointConfiguration().setMessageConverter(messageConverter);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the message converter.")
+    @XmlAttribute(name = "message-converter")
+    public void setMessageConverter(String messageConverter) {
+        this.messageConverter = messageConverter;
+    }
+
     /**
      * Sets the message correlator.
-     * @param correlator
-     * @return
      */
     public JmxClientBuilder correlator(MessageCorrelator correlator) {
         endpoint.getEndpointConfiguration().setCorrelator(correlator);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the message correlator.")
+    @XmlAttribute(name = "message-correlator")
+    public void setCorrelator(String correlator) {
+        this.correlator = correlator;
+    }
+
     /**
      * Sets the polling interval.
-     * @param pollingInterval
-     * @return
      */
     public JmxClientBuilder pollingInterval(int pollingInterval) {
         endpoint.getEndpointConfiguration().setPollingInterval(pollingInterval);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the polling interval.")
+    @XmlAttribute(name = "polling-interval")
+    public void setPollingInterval(int pollingInterval) {
+        pollingInterval(pollingInterval);
+    }
+
     /**
      * Sets the default timeout.
-     * @param timeout
-     * @return
      */
     public JmxClientBuilder timeout(long timeout) {
         endpoint.getEndpointConfiguration().setTimeout(timeout);
         return this;
+    }
+
+    @SchemaProperty(description = "Sets the default timeout.")
+    @XmlAttribute
+    public void setTimeout(long timeout) {
+        timeout(timeout);
     }
 }

--- a/endpoints/citrus-jmx/src/main/java/org/citrusframework/jmx/endpoint/builder/JmxEndpointBuilder.java
+++ b/endpoints/citrus-jmx/src/main/java/org/citrusframework/jmx/endpoint/builder/JmxEndpointBuilder.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.jmx.endpoint.builder;
+
+import jakarta.annotation.Nullable;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
+import org.citrusframework.endpoint.Endpoint;
+import org.citrusframework.endpoint.EndpointBuilder;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.jmx.client.JmxClientBuilder;
+import org.citrusframework.jmx.server.JmxServerBuilder;
+import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.spi.ReferenceResolverAware;
+import org.citrusframework.yaml.SchemaProperty;
+import org.citrusframework.yaml.SchemaType;
+
+/**
+ * Endpoint builder delegates to either client od server endpoint builder.
+ */
+@SchemaType(oneOf = { "client", "server" }, module = "citrus-jmx")
+@XmlType(name = "", propOrder = {
+        "client",
+        "server"
+})
+@XmlRootElement(name = "jmx")
+public class JmxEndpointBuilder implements EndpointBuilder<Endpoint>, ReferenceResolverAware {
+
+    private EndpointBuilder<?> delegate;
+    private ReferenceResolver referenceResolver;
+
+    @SchemaProperty(description = "Sets the Jmx client endpoint.")
+    @XmlElement
+    public void setClient(JmxClientBuilder client) {
+        this.delegate = client;
+    }
+
+    @SchemaProperty(description = "Sets the Jmx server endpoint.")
+    @XmlElement
+    public void setServer(JmxServerBuilder server) {
+        this.delegate = server;
+    }
+
+    @Override
+    public Endpoint build() {
+        if (delegate == null) {
+            throw new CitrusRuntimeException("Client/server endpoint builder has not been initialized");
+        }
+
+        if (referenceResolver != null && delegate instanceof ReferenceResolverAware resolverAware) {
+            resolverAware.setReferenceResolver(referenceResolver);
+        }
+
+        return delegate.build();
+    }
+
+    @Override
+    public boolean supports(Class<?> endpointType) {
+        return delegate.supports(endpointType);
+    }
+
+    @Override
+    @XmlTransient
+    public void setReferenceResolver(@Nullable ReferenceResolver referenceResolver) {
+        this.referenceResolver = referenceResolver;
+    }
+}

--- a/endpoints/citrus-jmx/src/main/java/org/citrusframework/jmx/endpoint/builder/package-info.java
+++ b/endpoints/citrus-jmx/src/main/java/org/citrusframework/jmx/endpoint/builder/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@jakarta.xml.bind.annotation.XmlSchema(namespace = "http://citrusframework.org/schema/xml/testcase", elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
+package org.citrusframework.jmx.endpoint.builder;

--- a/endpoints/citrus-jmx/src/main/java/org/citrusframework/jmx/model/ManagedBeanDefinition.java
+++ b/endpoints/citrus-jmx/src/main/java/org/citrusframework/jmx/model/ManagedBeanDefinition.java
@@ -53,8 +53,6 @@ public class ManagedBeanDefinition {
     /**
      * Constructs proper object name either from given domain and name property or
      * by evaluating the mbean type class information.
-     *
-     * @return
      */
     public ObjectName createObjectName() {
         try {

--- a/endpoints/citrus-jmx/src/main/java/org/citrusframework/jmx/server/JmxServerBuilder.java
+++ b/endpoints/citrus-jmx/src/main/java/org/citrusframework/jmx/server/JmxServerBuilder.java
@@ -16,27 +16,79 @@
 
 package org.citrusframework.jmx.server;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
 import javax.management.NotificationFilter;
 
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.jmx.message.JmxMessageConverter;
 import org.citrusframework.jmx.model.JmxMarshaller;
 import org.citrusframework.jmx.model.ManagedBeanDefinition;
 import org.citrusframework.message.MessageCorrelator;
 import org.citrusframework.server.AbstractServerBuilder;
+import org.citrusframework.util.StringUtils;
+import org.citrusframework.yaml.SchemaProperty;
 import org.citrusframework.yaml.SchemaType;
 
 /**
  * @since 2.5
  */
 @SchemaType(module = "citrus-jmx")
+@XmlType(name = "", propOrder = {})
 public class JmxServerBuilder extends AbstractServerBuilder<JmxServer, JmxServerBuilder> {
 
     /** Endpoint target */
     private final JmxServer endpoint = new JmxServer();
+
+    private String notificationFilter;
+    private String messageConverter;
+    private String correlator;
+    private String marshaller;
+    private String notificationHandback;
+    private String mbeans;
+
+    @Override
+    public JmxServer build() {
+        if (referenceResolver != null) {
+            if (StringUtils.hasText(messageConverter)) {
+                messageConverter(referenceResolver.resolve(messageConverter, JmxMessageConverter.class));
+            }
+
+            if (StringUtils.hasText(correlator)) {
+                correlator(referenceResolver.resolve(correlator, MessageCorrelator.class));
+            }
+
+            if (StringUtils.hasText(marshaller)) {
+                marshaller(referenceResolver.resolve(marshaller, JmxMarshaller.class));
+            }
+
+            if (StringUtils.hasText(notificationHandback)) {
+                notificationHandback(referenceResolver.resolve(notificationHandback, Object.class));
+            }
+
+            if (StringUtils.hasText(notificationFilter)) {
+                notificationFilter(referenceResolver.resolve(notificationFilter, NotificationFilter.class));
+            }
+
+            if (StringUtils.hasText(mbeans)) {
+                Object mbeansObject = referenceResolver.resolve(mbeans, Object.class);
+                if (mbeansObject instanceof List mbeansList) {
+                    mbeans(mbeansList);
+                } else if (mbeansObject instanceof ManagedBeanDefinition managedBeanDefinition) {
+                    mbeans(Collections.singletonList(managedBeanDefinition));
+                }
+            }
+        }
+
+        return super.build();
+    }
 
     @Override
     protected JmxServer getEndpoint() {
@@ -45,158 +97,225 @@ public class JmxServerBuilder extends AbstractServerBuilder<JmxServer, JmxServer
 
     /**
      * Sets the serverUrl property.
-     * @param serverUrl
-     * @return
      */
     public JmxServerBuilder serverUrl(String serverUrl) {
         endpoint.getEndpointConfiguration().setServerUrl(serverUrl);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the serverUrl property.")
+    @XmlAttribute(name = "server-url")
+    public void setServerUrl(String serverUrl) {
+        serverUrl(serverUrl);
+    }
+
     /**
      * Sets the host property.
-     * @param host
-     * @return
      */
     public JmxServerBuilder host(String host) {
         endpoint.getEndpointConfiguration().setHost(host);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the host property.", defaultValue = "localhost")
+    @XmlAttribute
+    public void setHost(String host) {
+        host(host);
+    }
+
     /**
      * Sets the port property.
-     * @param port
-     * @return
      */
     public JmxServerBuilder port(int port) {
         endpoint.getEndpointConfiguration().setPort(port);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the port property.")
+    @XmlAttribute
+    public void setPort(int port) {
+        port(port);
+    }
+
     /**
      * Sets the user property.
-     * @param user
-     * @return
      */
     public JmxServerBuilder username(String user) {
         endpoint.getEndpointConfiguration().setUsername(user);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the username property.")
+    @XmlAttribute
+    public void setUsername(String user) {
+        username(user);
+    }
+
     /**
      * Sets the password property.
-     * @param password
-     * @return
      */
     public JmxServerBuilder password(String password) {
         endpoint.getEndpointConfiguration().setPassword(password);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the user password property.")
+    @XmlAttribute
+    public void setPassword(String password) {
+        password(password);
+    }
+
     /**
      * Sets the autoReconnect property.
-     * @param autoReconnect
-     * @return
      */
     public JmxServerBuilder autoReconnect(boolean autoReconnect) {
         endpoint.getEndpointConfiguration().setAutoReconnect(autoReconnect);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the auto reconnect property.")
+    @XmlAttribute(name = "auto-reconnect")
+    public void setAutoReconnect(boolean autoReconnect) {
+        autoReconnect(autoReconnect);
+    }
+
     /**
      * Sets the delayOnReconnect property.
-     * @param delayOnReconnect
-     * @return
      */
     public JmxServerBuilder delayOnReconnect(long delayOnReconnect) {
         endpoint.getEndpointConfiguration().setDelayOnReconnect(delayOnReconnect);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the delay on reconnect property.")
+    @XmlAttribute(name = "delay-on-reconnect")
+    public void setDelayOnReconnect(long delayOnReconnect) {
+        delayOnReconnect(delayOnReconnect);
+    }
+
     /**
      * Sets the notificationFilter property.
-     * @param notificationFilter
-     * @return
      */
     public JmxServerBuilder notificationFilter(NotificationFilter notificationFilter) {
         endpoint.getEndpointConfiguration().setNotificationFilter(notificationFilter);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the notification filter as a bean reference.")
+    @XmlAttribute(name = "notification-filter")
+    public void setNotificationFilter(String notificationFilter) {
+        this.notificationFilter = notificationFilter;
+    }
+
     /**
      * Sets the notificationHandback property.
-     * @param notificationHandback
-     * @return
      */
     public JmxServerBuilder notificationHandback(Object notificationHandback) {
         endpoint.getEndpointConfiguration().setNotificationHandback(notificationHandback);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the notification handback.")
+    @XmlAttribute(name = "notification-handback")
+    public void setNotificationHandback(String notificationHandback) {
+        this.notificationHandback = notificationHandback;
+    }
+
     /**
      * Sets the marshaller property.
-     * @param marshaller
-     * @return
      */
     public JmxServerBuilder marshaller(JmxMarshaller marshaller) {
         endpoint.getEndpointConfiguration().setMarshaller(marshaller);
         return this;
     }
 
+    @SchemaProperty
+    @XmlAttribute
+    public void setMarshaller(String marshaller) {
+        this.marshaller = marshaller;
+    }
+
     /**
      * Sets the correlator property.
-     * @param correlator
-     * @return
      */
     public JmxServerBuilder correlator(MessageCorrelator correlator) {
         endpoint.getEndpointConfiguration().setCorrelator(correlator);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the message correlator.")
+    @XmlAttribute(name = "message-correlator")
+    public void setCorrelator(String correlator) {
+        this.correlator = correlator;
+    }
+
     /**
      * Sets the binding property.
-     * @param binding
-     * @return
      */
     public JmxServerBuilder binding(String binding) {
         endpoint.getEndpointConfiguration().setBinding(binding);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the binding property.")
+    @XmlAttribute
+    public void setBinding(String binding) {
+        binding(binding);
+    }
+
     /**
      * Sets the protocol property.
-     * @param protocol
-     * @return
      */
     public JmxServerBuilder protocol(String protocol) {
         endpoint.getEndpointConfiguration().setProtocol(protocol);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the protocol.", defaultValue = "rmi")
+    @XmlAttribute
+    public void setProtocol(String protocol) {
+        protocol(protocol);
+    }
+
     /**
      * Sets the createRegistry property.
-     * @param createRegistry
-     * @return
      */
     public JmxServerBuilder createRegistry(boolean createRegistry) {
         endpoint.setCreateRegistry(createRegistry);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the create registry property.")
+    @XmlAttribute(name = "create-registry")
+    public void setCreateRegistry(boolean createRegistry) {
+        createRegistry(createRegistry);
+    }
+
     /**
      * Sets the environment properties.
-     * @param environmentProperties
-     * @return
      */
     public JmxServerBuilder environmentProperties(Map<String, Object> environmentProperties) {
         endpoint.getEndpointConfiguration().setEnvironmentProperties(environmentProperties);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the environment properties.")
+    @XmlTransient
+    public void setEnvironmentProperties(Map<String, Object> environmentProperties) {
+        environmentProperties(environmentProperties);
+    }
+
+    @XmlAttribute(name = "environment-properties")
+    public void setEnvironmentProperties(String environmentProperties) {
+        environmentProperties(Arrays.stream(environmentProperties.split(","))
+                .map(String::trim)
+                .filter(expression -> expression.contains("="))
+                .map(expression -> expression.split("=", 2))
+                .collect(Collectors.toMap(tokens -> tokens[0].trim(), tokens -> tokens[1].trim())));
+    }
+
     /**
      * Sets the environment properties.
-     * @param environmentProperties
-     * @return
      */
     public JmxServerBuilder environmentProperties(Properties environmentProperties) {
         HashMap<String, Object> properties = new HashMap<>(environmentProperties.size());
@@ -210,21 +329,29 @@ public class JmxServerBuilder extends AbstractServerBuilder<JmxServer, JmxServer
 
     /**
      * Sets the Mbean definitions property.
-     * @param mbeans
-     * @return
      */
     public JmxServerBuilder mbeans(List<ManagedBeanDefinition> mbeans) {
         endpoint.setMbeans(mbeans);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the Mbean definitions as bean references")
+    @XmlAttribute
+    public void setMbeans(String mbeans) {
+        this.mbeans = mbeans;
+    }
+
     /**
      * Sets the message converter.
-     * @param messageConverter
-     * @return
      */
     public JmxServerBuilder messageConverter(JmxMessageConverter messageConverter) {
         endpoint.getEndpointConfiguration().setMessageConverter(messageConverter);
         return this;
+    }
+
+    @SchemaProperty(description = "Sets the message converter.")
+    @XmlAttribute(name = "message-converter")
+    public void setMessageConverter(String messageConverter) {
+        this.messageConverter = messageConverter;
     }
 }

--- a/endpoints/citrus-jmx/src/main/resources/META-INF/citrus/endpoint/builder/jmx
+++ b/endpoints/citrus-jmx/src/main/resources/META-INF/citrus/endpoint/builder/jmx
@@ -1,2 +1,3 @@
+type=org.citrusframework.jmx.endpoint.builder.JmxEndpointBuilder
 client=org.citrusframework.jmx.client.JmxClientBuilder
 server=org.citrusframework.jmx.server.JmxServerBuilder

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaEndpointBuilder.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaEndpointBuilder.java
@@ -16,8 +16,13 @@
 
 package org.citrusframework.kafka.endpoint;
 
+import java.util.Arrays;
 import java.util.Map;
+import java.util.stream.Collectors;
 
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serializer;
 import org.citrusframework.endpoint.AbstractEndpointBuilder;
@@ -33,6 +38,7 @@ import org.citrusframework.yaml.SchemaType;
  * @since 2.8
  */
 @SchemaType(module = "citrus-kafka")
+@XmlType(name = "", propOrder = {})
 public class KafkaEndpointBuilder extends AbstractEndpointBuilder<KafkaEndpoint> {
 
     /** Endpoint target */
@@ -70,6 +76,7 @@ public class KafkaEndpointBuilder extends AbstractEndpointBuilder<KafkaEndpoint>
     }
 
     @SchemaProperty(description = "Sets the Kafka bootstrap server.")
+    @XmlAttribute
     public void setServer(String server) {
         server(server);
     }
@@ -83,6 +90,7 @@ public class KafkaEndpointBuilder extends AbstractEndpointBuilder<KafkaEndpoint>
     }
 
     @SchemaProperty(description = "Sets the Kafka topic.")
+    @XmlAttribute
     public void setTopic(String topic) {
         topic(topic);
     }
@@ -96,6 +104,7 @@ public class KafkaEndpointBuilder extends AbstractEndpointBuilder<KafkaEndpoint>
     }
 
     @SchemaProperty(description = "Sets the Kafka topic partition.")
+    @XmlAttribute
     public void setPartition(int partition) {
         partition(partition);
     }
@@ -111,8 +120,25 @@ public class KafkaEndpointBuilder extends AbstractEndpointBuilder<KafkaEndpoint>
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:consume") },
             description = "Sets auto commit handling for this endpoint.")
+    @XmlAttribute(name = "auto-commit")
     public void setAutoCommit(boolean autoCommit) {
         autoCommit(autoCommit);
+    }
+
+    /**
+     * Sets the thread safe consumer property.
+     */
+    public KafkaEndpointBuilder useThreadSafeConsumer(boolean enabled) {
+        endpoint.getEndpointConfiguration().setUseThreadSafeConsumer(enabled);
+        return this;
+    }
+
+    @SchemaProperty(
+            metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:consume") },
+            description = "Sets thread safe consumer option for this endpoint.")
+    @XmlAttribute(name = "use-thread-safe-consumer")
+    public void setUseThreadSafeConsumer(boolean enabled) {
+        useThreadSafeConsumer(enabled);
     }
 
     /**
@@ -126,6 +152,7 @@ public class KafkaEndpointBuilder extends AbstractEndpointBuilder<KafkaEndpoint>
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:consume") },
             description = "Sets the auto commit interval.")
+    @XmlAttribute(name = "auto-commit-interval")
     public void setAutoCommitInterval(int autoCommitInterval) {
         autoCommitInterval(autoCommitInterval);
     }
@@ -141,6 +168,7 @@ public class KafkaEndpointBuilder extends AbstractEndpointBuilder<KafkaEndpoint>
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:consume") },
             description = "Sets the offset reset.")
+    @XmlAttribute(name = "offset-reset")
     public void setOffsetReset(String offsetReset) {
         offsetReset(offsetReset);
     }
@@ -156,6 +184,7 @@ public class KafkaEndpointBuilder extends AbstractEndpointBuilder<KafkaEndpoint>
     @SchemaProperty(
             advanced = true,
             description = "Sets the client id used to connect to the Kafka server.")
+    @XmlAttribute(name = "client-id")
     public void setClientId(String clientId) {
         clientId(clientId);
     }
@@ -171,6 +200,7 @@ public class KafkaEndpointBuilder extends AbstractEndpointBuilder<KafkaEndpoint>
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:consume") },
             description = "Sets the consumer group used by the endpoint.")
+    @XmlAttribute(name = "consumer-group")
     public void setConsumerGroup(String group) {
         consumerGroup(group);
     }
@@ -184,6 +214,7 @@ public class KafkaEndpointBuilder extends AbstractEndpointBuilder<KafkaEndpoint>
     }
 
     @SchemaProperty(advanced = true, description = "Sets the message converter as a bean reference.")
+    @XmlAttribute(name = "message-converter")
     public void setMessageConverter(String messageConverter) {
         this.messageConverter = messageConverter;
     }
@@ -197,6 +228,7 @@ public class KafkaEndpointBuilder extends AbstractEndpointBuilder<KafkaEndpoint>
     }
 
     @SchemaProperty(advanced = true, description = "Sets the Kafka header mapper.")
+    @XmlAttribute(name = "header-mapper")
     public void setHeaderMapper(String headerMapper) {
         this.headerMapper = headerMapper;
     }
@@ -212,6 +244,7 @@ public class KafkaEndpointBuilder extends AbstractEndpointBuilder<KafkaEndpoint>
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:serialize") },
             description = "Sets the fully qualified key serializer type class name.")
+    @XmlAttribute(name = "key-serializer")
     public void setKeySerializer(String serializerType) {
         try {
             keySerializer((Class<? extends Serializer>) Class.forName(serializerType, true, ClassLoaderHelper.getClassLoader()));
@@ -231,6 +264,7 @@ public class KafkaEndpointBuilder extends AbstractEndpointBuilder<KafkaEndpoint>
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:serialize") },
             description = "Sets the fully qualified value serializer type class name.")
+    @XmlAttribute(name = "value-serializer")
     public void setValueSerializer(String serializerType) {
         try {
             valueSerializer((Class<? extends Serializer>) Class.forName(serializerType, true, ClassLoaderHelper.getClassLoader()));
@@ -250,6 +284,7 @@ public class KafkaEndpointBuilder extends AbstractEndpointBuilder<KafkaEndpoint>
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:deserialize") },
             description = "Sets the fully qualified key deserializer type class name.")
+    @XmlAttribute(name = "key-deserializer")
     public void setKeyDeserializer(String serializerType) {
         try {
             keyDeserializer((Class<? extends Deserializer>) Class.forName(serializerType, true, ClassLoaderHelper.getClassLoader()));
@@ -269,6 +304,7 @@ public class KafkaEndpointBuilder extends AbstractEndpointBuilder<KafkaEndpoint>
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:deserialize") },
             description = "Sets the fully qualified value deserializer type class name.")
+    @XmlAttribute(name = "value-deserializer")
     public void setValueDeserializer(String serializerType) {
         try {
             valueDeserializer((Class<? extends Deserializer>) Class.forName(serializerType, true, ClassLoaderHelper.getClassLoader()));
@@ -288,8 +324,18 @@ public class KafkaEndpointBuilder extends AbstractEndpointBuilder<KafkaEndpoint>
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:produce") },
             description = "Sets the Kafka producer properties.")
+    @XmlTransient
     public void setProducerProperties(Map<String, Object> producerProperties) {
         producerProperties(producerProperties);
+    }
+
+    @XmlAttribute(name = "producer-properties")
+    public void setProducerProperties(String producerProperties) {
+        setProducerProperties(Arrays.stream(producerProperties.split(","))
+                .map(String::trim)
+                .filter(expression -> expression.contains("="))
+                .map(expression -> expression.split("=", 2))
+                .collect(Collectors.toMap(tokens -> tokens[0].trim(), tokens -> tokens[1].trim())));
     }
 
     /**
@@ -303,8 +349,18 @@ public class KafkaEndpointBuilder extends AbstractEndpointBuilder<KafkaEndpoint>
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:consume") },
             description = "Sets the Kafka consumer properties.")
+    @XmlTransient
     public void setConsumerProperties(Map<String, Object> consumerProperties) {
         consumerProperties(consumerProperties);
+    }
+
+    @XmlAttribute(name = "consumer-properties")
+    public void setConsumerProperties(String consumerProperties) {
+        setProducerProperties(Arrays.stream(consumerProperties.split(","))
+                .map(String::trim)
+                .filter(expression -> expression.contains("="))
+                .map(expression -> expression.split("=", 2))
+                .collect(Collectors.toMap(tokens -> tokens[0].trim(), tokens -> tokens[1].trim())));
     }
 
     /**
@@ -318,6 +374,7 @@ public class KafkaEndpointBuilder extends AbstractEndpointBuilder<KafkaEndpoint>
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:consume") },
             description = "Sets the Kafka consumer timeout.")
+    @XmlAttribute
     public void setTimeout(long timeout) {
         timeout(timeout);
     }

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/builder/KafkaEndpointsBuilder.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/builder/KafkaEndpointsBuilder.java
@@ -17,6 +17,10 @@
 package org.citrusframework.kafka.endpoint.builder;
 
 import jakarta.annotation.Nullable;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.endpoint.Endpoint;
 import org.citrusframework.endpoint.EndpointBuilder;
 import org.citrusframework.exceptions.CitrusRuntimeException;
@@ -27,17 +31,24 @@ import org.citrusframework.yaml.SchemaProperty;
 import org.citrusframework.yaml.SchemaType;
 
 @SchemaType(oneOf = { "asynchronous", "synchronous" }, module = "citrus-kafka")
+@XmlType(name = "", propOrder = {
+        "asynchronous",
+        "synchronous"
+})
+@XmlRootElement(name = "kafka")
 public class KafkaEndpointsBuilder implements EndpointBuilder<Endpoint>, ReferenceResolverAware {
 
     private EndpointBuilder<?> delegate;
     private ReferenceResolver referenceResolver;
 
     @SchemaProperty(description = "Sets the synchronous Kafka endpoint.")
+    @XmlElement
     public void setSynchronous(KafkaEndpointBuilder builder) {
         this.delegate = builder;
     }
 
     @SchemaProperty(description = "Sets the Kafka endpoint.")
+    @XmlElement
     public void setAsynchronous(KafkaEndpointBuilder builder) {
         this.delegate = builder;
     }
@@ -61,6 +72,7 @@ public class KafkaEndpointsBuilder implements EndpointBuilder<Endpoint>, Referen
     }
 
     @Override
+    @XmlTransient
     public void setReferenceResolver(@Nullable ReferenceResolver referenceResolver) {
         this.referenceResolver = referenceResolver;
     }

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/builder/package-info.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/builder/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@jakarta.xml.bind.annotation.XmlSchema(namespace = "http://citrusframework.org/schema/xml/testcase", elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
+package org.citrusframework.kafka.endpoint.builder;

--- a/endpoints/citrus-mail/src/main/java/org/citrusframework/mail/client/MailClientBuilder.java
+++ b/endpoints/citrus-mail/src/main/java/org/citrusframework/mail/client/MailClientBuilder.java
@@ -16,9 +16,14 @@
 
 package org.citrusframework.mail.client;
 
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.endpoint.AbstractEndpointBuilder;
 import org.citrusframework.mail.message.MailMessageConverter;
 import org.citrusframework.mail.model.MailMarshaller;
@@ -30,6 +35,7 @@ import org.citrusframework.yaml.SchemaType;
  * @since 2.5
  */
 @SchemaType(module = "citrus-mail")
+@XmlType(name = "", propOrder = {})
 public class MailClientBuilder extends AbstractEndpointBuilder<MailClient> {
 
     /** Endpoint target */
@@ -66,6 +72,7 @@ public class MailClientBuilder extends AbstractEndpointBuilder<MailClient> {
     }
 
     @SchemaProperty(description = "The mail server host to connect to.")
+    @XmlAttribute
     public void setHost(String host) {
         host(host);
     }
@@ -79,6 +86,7 @@ public class MailClientBuilder extends AbstractEndpointBuilder<MailClient> {
     }
 
     @SchemaProperty(description = "The mail server port.")
+    @XmlAttribute
     public void setPort(int port) {
         port(port);
     }
@@ -92,6 +100,7 @@ public class MailClientBuilder extends AbstractEndpointBuilder<MailClient> {
     }
 
     @SchemaProperty(description = "The mail protocol.")
+    @XmlAttribute
     public void setProtocol(String protocol) {
         protocol(protocol);
     }
@@ -108,6 +117,7 @@ public class MailClientBuilder extends AbstractEndpointBuilder<MailClient> {
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "The client user name."
     )
+    @XmlAttribute
     public void setUsername(String username) {
         username(username);
     }
@@ -124,6 +134,7 @@ public class MailClientBuilder extends AbstractEndpointBuilder<MailClient> {
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "The client user password."
     )
+    @XmlAttribute
     public void setPassword(String password) {
         password(password);
     }
@@ -137,10 +148,20 @@ public class MailClientBuilder extends AbstractEndpointBuilder<MailClient> {
     }
 
     @SchemaProperty(advanced = true, description = "Custom properties passed to the java mail implementation.")
+    @XmlTransient
     public void setJavaMailProperties(Map<String, Object> javaMailProperties) {
         Properties props = new Properties();
         props.putAll(javaMailProperties);
         javaMailProperties(props);
+    }
+
+    @XmlAttribute(name = "mail-properties")
+    public void setJavaMailProperties(String javaMailProperties) {
+        setJavaMailProperties(Arrays.stream(javaMailProperties.split(","))
+                .map(String::trim)
+                .filter(expression -> expression.contains("="))
+                .map(expression -> expression.split("=", 2))
+                .collect(Collectors.toMap(tokens -> tokens[0].trim(), tokens -> tokens[1].trim())));
     }
 
     /**
@@ -152,6 +173,7 @@ public class MailClientBuilder extends AbstractEndpointBuilder<MailClient> {
     }
 
     @SchemaProperty(advanced = true, description = "Sets a custom mail message marshaller.")
+    @XmlAttribute
     public void setMarshaller(String marshaller) {
         this.marshaller = marshaller;
     }
@@ -165,6 +187,7 @@ public class MailClientBuilder extends AbstractEndpointBuilder<MailClient> {
     }
 
     @SchemaProperty(advanced = true, description = "Sets custom message converter.")
+    @XmlAttribute(name = "message-converter")
     public void setMessageConverter(String messageConverter) {
         this.messageConverter = messageConverter;
     }
@@ -178,6 +201,7 @@ public class MailClientBuilder extends AbstractEndpointBuilder<MailClient> {
     }
 
     @SchemaProperty(description = "Mail client timeout when waiting for a response.")
+    @XmlAttribute
     public void setTimeout(long timeout) {
         timeout(timeout);
     }

--- a/endpoints/citrus-mail/src/main/java/org/citrusframework/mail/endpoint/builder/MailEndpointBuilder.java
+++ b/endpoints/citrus-mail/src/main/java/org/citrusframework/mail/endpoint/builder/MailEndpointBuilder.java
@@ -17,6 +17,10 @@
 package org.citrusframework.mail.endpoint.builder;
 
 import jakarta.annotation.Nullable;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.endpoint.Endpoint;
 import org.citrusframework.endpoint.EndpointBuilder;
 import org.citrusframework.exceptions.CitrusRuntimeException;
@@ -28,17 +32,24 @@ import org.citrusframework.yaml.SchemaProperty;
 import org.citrusframework.yaml.SchemaType;
 
 @SchemaType(oneOf = { "client", "server" }, module = "citrus-mail")
+@XmlType(name = "", propOrder = {
+        "client",
+        "server"
+})
+@XmlRootElement(name = "mail")
 public class MailEndpointBuilder implements EndpointBuilder<Endpoint>, ReferenceResolverAware {
 
     private EndpointBuilder<?> delegate;
     private ReferenceResolver referenceResolver;
 
     @SchemaProperty(description = "Sets the mail client endpoint.")
+    @XmlElement
     public void setClient(MailClientBuilder client) {
         this.delegate = client;
     }
 
     @SchemaProperty(description = "Sets the mail server endpoint.")
+    @XmlElement
     public void setServer(MailServerBuilder server) {
         this.delegate = server;
     }
@@ -62,6 +73,7 @@ public class MailEndpointBuilder implements EndpointBuilder<Endpoint>, Reference
     }
 
     @Override
+    @XmlTransient
     public void setReferenceResolver(@Nullable ReferenceResolver referenceResolver) {
         this.referenceResolver = referenceResolver;
     }

--- a/endpoints/citrus-mail/src/main/java/org/citrusframework/mail/endpoint/builder/package-info.java
+++ b/endpoints/citrus-mail/src/main/java/org/citrusframework/mail/endpoint/builder/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@jakarta.xml.bind.annotation.XmlSchema(namespace = "http://citrusframework.org/schema/xml/testcase", elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
+package org.citrusframework.mail.endpoint.builder;

--- a/endpoints/citrus-mail/src/main/java/org/citrusframework/mail/server/MailServerBuilder.java
+++ b/endpoints/citrus-mail/src/main/java/org/citrusframework/mail/server/MailServerBuilder.java
@@ -20,8 +20,12 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 import com.icegreen.greenmail.util.GreenMail;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.mail.message.MailMessageConverter;
 import org.citrusframework.mail.model.MailMarshaller;
 import org.citrusframework.server.AbstractServerBuilder;
@@ -33,6 +37,7 @@ import org.citrusframework.yaml.SchemaType;
  * @since 2.5
  */
 @SchemaType(module = "citrus-mail")
+@XmlType(name = "", propOrder = {})
 public class MailServerBuilder extends AbstractServerBuilder<MailServer, MailServerBuilder> {
 
     /** Endpoint target */
@@ -74,6 +79,7 @@ public class MailServerBuilder extends AbstractServerBuilder<MailServer, MailSer
     }
 
     @SchemaProperty(description = "The mail server port.")
+    @XmlAttribute
     public void setPort(int port) {
         port(port);
     }
@@ -87,6 +93,7 @@ public class MailServerBuilder extends AbstractServerBuilder<MailServer, MailSer
     }
 
     @SchemaProperty(advanced = true, description = "Sets a custom mail message marshaller.")
+    @XmlAttribute
     public void setMarshaller(String marshaller) {
         this.marshaller = marshaller;
     }
@@ -100,10 +107,20 @@ public class MailServerBuilder extends AbstractServerBuilder<MailServer, MailSer
     }
 
     @SchemaProperty(advanced = true, description = "Custom properties passed to the java mail implementation.")
+    @XmlTransient
     public void setJavaMailProperties(Map<String, Object> javaMailProperties) {
         Properties props = new Properties();
         props.putAll(javaMailProperties);
         javaMailProperties(props);
+    }
+
+    @XmlAttribute(name = "mail-properties")
+    public void setJavaMailProperties(String javaMailProperties) {
+        setJavaMailProperties(Arrays.stream(javaMailProperties.split(","))
+                .map(String::trim)
+                .filter(expression -> expression.contains("="))
+                .map(expression -> expression.split("=", 2))
+                .collect(Collectors.toMap(tokens -> tokens[0].trim(), tokens -> tokens[1].trim())));
     }
 
     /**
@@ -118,6 +135,7 @@ public class MailServerBuilder extends AbstractServerBuilder<MailServer, MailSer
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "When enabled users must authenticate with the server."
     )
+    @XmlAttribute(name = "auth-required")
     public void setAuthRequired(boolean authRequired) {
         authRequired(authRequired);
     }
@@ -134,6 +152,7 @@ public class MailServerBuilder extends AbstractServerBuilder<MailServer, MailSer
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "When enabled server will auto accept client connections."
     )
+    @XmlAttribute(name = "auto-accept")
     public void setAutoAccept(boolean autoAccept) {
         autoAccept(autoAccept);
     }
@@ -147,6 +166,7 @@ public class MailServerBuilder extends AbstractServerBuilder<MailServer, MailSer
     }
 
     @SchemaProperty(advanced = true, description = "When enabled the server splits multipart messages into individual parts.")
+    @XmlAttribute(name = "split-multipart")
     public void setSplitMultipart(boolean splitMultipart) {
         splitMultipart(splitMultipart);
     }
@@ -160,6 +180,7 @@ public class MailServerBuilder extends AbstractServerBuilder<MailServer, MailSer
     }
 
     @SchemaProperty(advanced = true, description = "Sets the SMTP implementation.")
+    @XmlAttribute
     public void setSmtp(String smtpServer) {
         this.smtpServer = smtpServer;
     }
@@ -173,6 +194,7 @@ public class MailServerBuilder extends AbstractServerBuilder<MailServer, MailSer
     }
 
     @SchemaProperty(advanced = true, description = "Sets custom message converter.")
+    @XmlAttribute(name = "message-converter")
     public void setMessageConverter(String messageConverter) {
         this.messageConverter = messageConverter;
     }
@@ -189,8 +211,14 @@ public class MailServerBuilder extends AbstractServerBuilder<MailServer, MailSer
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "Sets a list of known users that will be accepted when establishing a connection."
     )
+    @XmlTransient
     public void setKnownUsers(List<String> users) {
         knownUsers(users);
+    }
+
+    @XmlAttribute(name = "known-users")
+    public void setKnownUsers(String users) {
+        setKnownUsers(Arrays.asList(users.split(",")));
     }
 
     /**

--- a/endpoints/citrus-rmi/src/main/java/org/citrusframework/rmi/client/RmiClientBuilder.java
+++ b/endpoints/citrus-rmi/src/main/java/org/citrusframework/rmi/client/RmiClientBuilder.java
@@ -16,19 +16,42 @@
 
 package org.citrusframework.rmi.client;
 
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.endpoint.AbstractEndpointBuilder;
 import org.citrusframework.message.MessageCorrelator;
 import org.citrusframework.rmi.message.RmiMessageConverter;
+import org.citrusframework.util.StringUtils;
+import org.citrusframework.yaml.SchemaProperty;
 import org.citrusframework.yaml.SchemaType;
 
 /**
  * @since 2.5
  */
 @SchemaType(module = "citrus-rmi")
+@XmlType(name = "", propOrder = {})
 public class RmiClientBuilder extends AbstractEndpointBuilder<RmiClient> {
 
     /** Endpoint target */
-    private RmiClient endpoint = new RmiClient();
+    private final RmiClient endpoint = new RmiClient();
+
+    private String messageConverter;
+    private String correlator;
+
+    @Override
+    public RmiClient build() {
+        if (referenceResolver != null) {
+            if (StringUtils.hasText(messageConverter)) {
+                messageConverter(referenceResolver.resolve(messageConverter, RmiMessageConverter.class));
+            }
+
+            if (StringUtils.hasText(correlator)) {
+                correlator(referenceResolver.resolve(correlator, MessageCorrelator.class));
+            }
+        }
+
+        return super.build();
+    }
 
     @Override
     protected RmiClient getEndpoint() {
@@ -37,91 +60,127 @@ public class RmiClientBuilder extends AbstractEndpointBuilder<RmiClient> {
 
     /**
      * Sets the serverUrl property.
-     * @param serverUrl
-     * @return
      */
     public RmiClientBuilder serverUrl(String serverUrl) {
         endpoint.getEndpointConfiguration().setServerUrl(serverUrl);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the server url.")
+    @XmlAttribute(name = "server-url")
+    public void setServerUrl(String serverUrl) {
+        serverUrl(serverUrl);
+    }
+
     /**
      * Sets the host property.
-     * @param host
-     * @return
      */
     public RmiClientBuilder host(String host) {
         endpoint.getEndpointConfiguration().setHost(host);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the server host.")
+    @XmlAttribute
+    public void setHost(String host) {
+        host(host);
+    }
+
     /**
      * Sets the port property.
-     * @param port
-     * @return
      */
     public RmiClientBuilder port(int port) {
         endpoint.getEndpointConfiguration().setPort(port);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the server port.")
+    @XmlAttribute
+    public void setPort(int port) {
+        port(port);
+    }
+
     /**
      * Sets the binding property.
-     * @param binding
-     * @return
      */
     public RmiClientBuilder binding(String binding) {
         endpoint.getEndpointConfiguration().setBinding(binding);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the binding.")
+    @XmlAttribute
+    public void setBinding(String binding) {
+        binding(binding);
+    }
+
     /**
      * Sets the method property.
-     * @param method
-     * @return
      */
     public RmiClientBuilder method(String method) {
         endpoint.getEndpointConfiguration().setMethod(method);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the method.")
+    @XmlAttribute
+    public void setMethod(String method) {
+        method(method);
+    }
+
     /**
      * Sets the message converter.
-     * @param messageConverter
-     * @return
      */
     public RmiClientBuilder messageConverter(RmiMessageConverter messageConverter) {
         endpoint.getEndpointConfiguration().setMessageConverter(messageConverter);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the message converter.")
+    @XmlAttribute(name = "message-converter")
+    public void setMessageConverter(String messageConverter) {
+        this.messageConverter = messageConverter;
+    }
+
     /**
      * Sets the message correlator.
-     * @param correlator
-     * @return
      */
     public RmiClientBuilder correlator(MessageCorrelator correlator) {
         endpoint.getEndpointConfiguration().setCorrelator(correlator);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the message correlator.")
+    @XmlAttribute(name = "message-correlator")
+    public void setCorrelator(String correlator) {
+        this.correlator = correlator;
+    }
+
     /**
      * Sets the polling interval.
-     * @param pollingInterval
-     * @return
      */
     public RmiClientBuilder pollingInterval(int pollingInterval) {
         endpoint.getEndpointConfiguration().setPollingInterval(pollingInterval);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the polling interval.")
+    @XmlAttribute(name = "polling-interval")
+    public void setPollingInterval(int pollingInterval) {
+        pollingInterval(pollingInterval);
+    }
+
     /**
      * Sets the default timeout.
-     * @param timeout
-     * @return
      */
     public RmiClientBuilder timeout(long timeout) {
         endpoint.getEndpointConfiguration().setTimeout(timeout);
         return this;
+    }
+
+    @SchemaProperty(description = "Sets the default timeout.")
+    @XmlAttribute
+    public void setTimeout(long timeout) {
+        timeout(timeout);
     }
 }

--- a/endpoints/citrus-rmi/src/main/java/org/citrusframework/rmi/endpoint/builder/RmiEndpointBuilder.java
+++ b/endpoints/citrus-rmi/src/main/java/org/citrusframework/rmi/endpoint/builder/RmiEndpointBuilder.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.rmi.endpoint.builder;
+
+import jakarta.annotation.Nullable;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
+import org.citrusframework.endpoint.Endpoint;
+import org.citrusframework.endpoint.EndpointBuilder;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.spi.ReferenceResolverAware;
+import org.citrusframework.rmi.client.RmiClientBuilder;
+import org.citrusframework.rmi.server.RmiServerBuilder;
+import org.citrusframework.yaml.SchemaProperty;
+import org.citrusframework.yaml.SchemaType;
+
+/**
+ * Endpoint builder delegates to either client od server endpoint builder.
+ */
+@SchemaType(oneOf = { "client", "server" }, module = "citrus-rmi")
+@XmlType(name = "", propOrder = {
+        "client",
+        "server"
+})
+@XmlRootElement(name = "rmi")
+public class RmiEndpointBuilder implements EndpointBuilder<Endpoint>, ReferenceResolverAware {
+
+    private EndpointBuilder<?> delegate;
+    private ReferenceResolver referenceResolver;
+
+    @SchemaProperty(description = "Sets the Rmi client endpoint.")
+    @XmlElement
+    public void setClient(RmiClientBuilder client) {
+        this.delegate = client;
+    }
+
+    @SchemaProperty(description = "Sets the Rmi server endpoint.")
+    @XmlElement
+    public void setServer(RmiServerBuilder server) {
+        this.delegate = server;
+    }
+
+    @Override
+    public Endpoint build() {
+        if (delegate == null) {
+            throw new CitrusRuntimeException("Client/server endpoint builder has not been initialized");
+        }
+
+        if (referenceResolver != null && delegate instanceof ReferenceResolverAware resolverAware) {
+            resolverAware.setReferenceResolver(referenceResolver);
+        }
+
+        return delegate.build();
+    }
+
+    @Override
+    public boolean supports(Class<?> endpointType) {
+        return delegate.supports(endpointType);
+    }
+
+    @Override
+    @XmlTransient
+    public void setReferenceResolver(@Nullable ReferenceResolver referenceResolver) {
+        this.referenceResolver = referenceResolver;
+    }
+}

--- a/endpoints/citrus-rmi/src/main/java/org/citrusframework/rmi/endpoint/builder/package-info.java
+++ b/endpoints/citrus-rmi/src/main/java/org/citrusframework/rmi/endpoint/builder/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@jakarta.xml.bind.annotation.XmlSchema(namespace = "http://citrusframework.org/schema/xml/testcase", elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
+package org.citrusframework.rmi.endpoint.builder;

--- a/endpoints/citrus-rmi/src/main/java/org/citrusframework/rmi/server/RmiServerBuilder.java
+++ b/endpoints/citrus-rmi/src/main/java/org/citrusframework/rmi/server/RmiServerBuilder.java
@@ -18,24 +18,60 @@ package org.citrusframework.rmi.server;
 
 import java.rmi.Remote;
 import java.rmi.registry.Registry;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
+import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.message.MessageCorrelator;
 import org.citrusframework.rmi.endpoint.RmiEndpointUtils;
 import org.citrusframework.rmi.message.RmiMessageConverter;
 import org.citrusframework.rmi.model.RmiMarshaller;
 import org.citrusframework.server.AbstractServerBuilder;
+import org.citrusframework.util.ClassLoaderHelper;
+import org.citrusframework.util.StringUtils;
+import org.citrusframework.yaml.SchemaProperty;
 import org.citrusframework.yaml.SchemaType;
 
 /**
  * @since 2.5
  */
 @SchemaType(module = "citrus-rmi")
+@XmlType(name = "", propOrder = {})
 public class RmiServerBuilder  extends AbstractServerBuilder<RmiServer, RmiServerBuilder> {
 
     /** Endpoint target */
     private final RmiServer endpoint = new RmiServer();
+
+    private String messageConverter;
+    private String correlator;
+    private String registry;
+    private String marshaller;
+
+    @Override
+    public RmiServer build() {
+        if (referenceResolver != null) {
+            if (StringUtils.hasText(messageConverter)) {
+                messageConverter(referenceResolver.resolve(messageConverter, RmiMessageConverter.class));
+            }
+
+            if (StringUtils.hasText(correlator)) {
+                correlator(referenceResolver.resolve(correlator, MessageCorrelator.class));
+            }
+
+            if (StringUtils.hasText(registry)) {
+                registry(referenceResolver.resolve(registry, Registry.class));
+            }
+
+            if (StringUtils.hasText(marshaller)) {
+                marshaller(referenceResolver.resolve(marshaller, RmiMarshaller.class));
+            }
+        }
+
+        return super.build();
+    }
 
     @Override
     protected RmiServer getEndpoint() {
@@ -44,8 +80,6 @@ public class RmiServerBuilder  extends AbstractServerBuilder<RmiServer, RmiServe
 
     /**
      * Sets the serverUrl property.
-     * @param serverUrl
-     * @return
      */
     public RmiServerBuilder serverUrl(String serverUrl) {
         endpoint.getEndpointConfiguration().setServerUrl(serverUrl);
@@ -56,80 +90,129 @@ public class RmiServerBuilder  extends AbstractServerBuilder<RmiServer, RmiServe
         return this;
     }
 
+    @SchemaProperty
+    @XmlAttribute
+    public void setServerUrl(String serverUrl) {
+        serverUrl(serverUrl);
+    }
+
     /**
      * Sets the host property.
-     * @param host
-     * @return
      */
     public RmiServerBuilder host(String host) {
         endpoint.getEndpointConfiguration().setHost(host);
         return this;
     }
 
+    @SchemaProperty
+    @XmlAttribute
+    public void setHost(String host) {
+        host(host);
+    }
+
     /**
      * Sets the port property.
-     * @param port
-     * @return
      */
     public RmiServerBuilder port(int port) {
         endpoint.getEndpointConfiguration().setPort(port);
         return this;
     }
 
+    @SchemaProperty
+    @XmlAttribute
+    public void setPort(int port) {
+        port(port);
+    }
+
     /**
      * Sets the registry property.
-     * @param registry
-     * @return
      */
     public RmiServerBuilder registry(Registry registry) {
         endpoint.getEndpointConfiguration().setRegistry(registry);
         return this;
     }
 
+    @SchemaProperty
+    @XmlAttribute
+    public void setRegistry(String registry) {
+        this.registry = registry;
+    }
+
     /**
      * Sets the binding property.
-     * @param binding
-     * @return
      */
     public RmiServerBuilder binding(String binding) {
         endpoint.getEndpointConfiguration().setBinding(binding);
         return this;
     }
 
+    @SchemaProperty
+    @XmlAttribute
+    public void setBinding(String binding) {
+        binding(binding);
+    }
+
     /**
      * Sets the method property.
-     * @param method
-     * @return
      */
     public RmiServerBuilder method(String method) {
         endpoint.getEndpointConfiguration().setMethod(method);
         return this;
     }
 
+    @SchemaProperty
+    @XmlAttribute
+    public void setMethod(String method) {
+        method(method);
+    }
+
     /**
      * Sets the createRegistry property.
-     * @param createRegistry
-     * @return
      */
     public RmiServerBuilder createRegistry(boolean createRegistry) {
         endpoint.setCreateRegistry(createRegistry);
         return this;
     }
 
+    @SchemaProperty
+    @XmlAttribute
+    public void setCreateRegistry(boolean createRegistry) {
+        createRegistry(createRegistry);
+    }
+
     /**
      * Sets the remote interfaces property.
-     * @param remoteInterfaces
-     * @return
      */
     public RmiServerBuilder remoteInterfaces(Class<? extends Remote> ... remoteInterfaces) {
         endpoint.setRemoteInterfaces(Arrays.asList(remoteInterfaces));
         return this;
     }
 
+    @SchemaProperty(description = "List of remote interfaces as fully qualified class name.")
+    public void setRemoteInterfaces(List<String> remoteInterfaces) {
+        List<Class<? extends Remote>> interfaces = new ArrayList<>();
+
+        for (String interfaceName : remoteInterfaces) {
+            try {
+                Class<?> maybeRemote = Class.forName(interfaceName, false, ClassLoaderHelper.getClassLoader());
+                if (Remote.class.isAssignableFrom(maybeRemote)) {
+                    interfaces.add((Class<? extends Remote>) maybeRemote);
+                }
+            } catch (ClassNotFoundException e) {
+                throw new CitrusRuntimeException(String.format("Failed to load remote interface '%s'", interfaceName), e);
+            }
+        }
+
+        remoteInterfaces(interfaces);
+    }
+
+    @XmlAttribute(name = "remote-interfaces")
+    public void setRemoteInterfaces(String remoteInterfaces) {
+        setRemoteInterfaces(Arrays.asList(remoteInterfaces.split(",")));
+    }
+
     /**
      * Sets the remote interfaces property.
-     * @param remoteInterfaces
-     * @return
      */
     public RmiServerBuilder remoteInterfaces(List<Class<? extends Remote>> remoteInterfaces) {
         endpoint.setRemoteInterfaces(remoteInterfaces);
@@ -138,41 +221,57 @@ public class RmiServerBuilder  extends AbstractServerBuilder<RmiServer, RmiServe
 
     /**
      * Sets the marshaller.
-     * @param marshaller
-     * @return
      */
     public RmiServerBuilder marshaller(RmiMarshaller marshaller) {
         endpoint.getEndpointConfiguration().setMarshaller(marshaller);
         return this;
     }
 
+    @SchemaProperty
+    @XmlAttribute
+    public void setMarshaller(String marshaller) {
+        this.marshaller = marshaller;
+    }
+
     /**
      * Sets the message converter.
-     * @param messageConverter
-     * @return
      */
     public RmiServerBuilder messageConverter(RmiMessageConverter messageConverter) {
         endpoint.getEndpointConfiguration().setMessageConverter(messageConverter);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the message converter.")
+    @XmlAttribute(name = "message-converter")
+    public void setMessageConverter(String messageConverter) {
+        this.messageConverter = messageConverter;
+    }
+
     /**
      * Sets the message correlator.
-     * @param correlator
-     * @return
      */
     public RmiServerBuilder correlator(MessageCorrelator correlator) {
         endpoint.getEndpointConfiguration().setCorrelator(correlator);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the message correlator.")
+    @XmlAttribute(name = "message-correlator")
+    public void setCorrelator(String correlator) {
+        this.correlator = correlator;
+    }
+
     /**
      * Sets the polling interval.
-     * @param pollingInterval
-     * @return
      */
     public RmiServerBuilder pollingInterval(int pollingInterval) {
         endpoint.getEndpointConfiguration().setPollingInterval(pollingInterval);
         return this;
+    }
+
+    @SchemaProperty(description = "Sets the polling interval.")
+    @XmlAttribute(name = "polling-interval")
+    public void setPollingInterval(int pollingInterval) {
+        pollingInterval(pollingInterval);
     }
 }

--- a/endpoints/citrus-rmi/src/main/resources/META-INF/citrus/endpoint/builder/rmi
+++ b/endpoints/citrus-rmi/src/main/resources/META-INF/citrus/endpoint/builder/rmi
@@ -1,2 +1,3 @@
+type=org.citrusframework.rmi.endpoint.builder.RmiEndpointBuilder
 client=org.citrusframework.rmi.client.RmiClientBuilder
 server=org.citrusframework.rmi.server.RmiServerBuilder

--- a/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/channel/ChannelEndpointBuilder.java
+++ b/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/channel/ChannelEndpointBuilder.java
@@ -16,6 +16,8 @@
 
 package org.citrusframework.channel;
 
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.endpoint.AbstractEndpointBuilder;
 import org.citrusframework.util.StringUtils;
 import org.citrusframework.yaml.SchemaProperty;
@@ -28,6 +30,7 @@ import org.springframework.messaging.core.DestinationResolver;
  * @since 2.7.6
  */
 @SchemaType(module = "citrus-spring-integration")
+@XmlType(name = "", propOrder = {})
 public class ChannelEndpointBuilder extends AbstractEndpointBuilder<ChannelEndpoint> {
 
     /** Endpoint target */
@@ -70,7 +73,13 @@ public class ChannelEndpointBuilder extends AbstractEndpointBuilder<ChannelEndpo
     }
 
     @SchemaProperty(description = "The Spring message channel name.")
+    @XmlAttribute
     public void setChannel(String channelName) {
+        channel(channelName);
+    }
+
+    @XmlAttribute(name = "channel-name")
+    public void setChannelName(String channelName) {
         channel(channelName);
     }
 
@@ -91,6 +100,7 @@ public class ChannelEndpointBuilder extends AbstractEndpointBuilder<ChannelEndpo
     }
 
     @SchemaProperty(advanced = true, description = "Sets a custom messaging template.")
+    @XmlAttribute(name = "messaging-template")
     public void setMessagingTemplate(String messagingTemplate) {
         this.messagingTemplate = messagingTemplate;
     }
@@ -104,6 +114,7 @@ public class ChannelEndpointBuilder extends AbstractEndpointBuilder<ChannelEndpo
     }
 
     @SchemaProperty(advanced = true, description = "Sets the message converter as a bean reference.")
+    @XmlAttribute(name = "message-converter")
     public void setMessageConverter(String messageConverter) {
         this.messageConverter = messageConverter;
     }
@@ -117,6 +128,7 @@ public class ChannelEndpointBuilder extends AbstractEndpointBuilder<ChannelEndpo
     }
 
     @SchemaProperty(advanced = true, description = "The channel destination resolver.")
+    @XmlAttribute(name = "channel-resolver")
     public void setChannelResolver(String resolver) {
         this.channelResolver = resolver;
     }
@@ -130,6 +142,7 @@ public class ChannelEndpointBuilder extends AbstractEndpointBuilder<ChannelEndpo
     }
 
     @SchemaProperty(advanced = true, description = "When enabled the endpoint uses object messages.")
+    @XmlAttribute(name = "use-object-messages")
     public void setUseObjectMessages(boolean useObjectMessages) {
         useObjectMessages(useObjectMessages);
     }
@@ -145,6 +158,7 @@ public class ChannelEndpointBuilder extends AbstractEndpointBuilder<ChannelEndpo
     @SchemaProperty(
             advanced = true,
             description = "When enabled the endpoint removes all internal headers before sending a message.")
+    @XmlAttribute(name = "filter-internal-headers")
     public void setFilterInternalHeaders(boolean filterInternalHeaders) {
         filterInternalHeaders(filterInternalHeaders);
     }
@@ -158,6 +172,7 @@ public class ChannelEndpointBuilder extends AbstractEndpointBuilder<ChannelEndpo
     }
 
     @SchemaProperty(description = "Sets the receive timeout when waiting for messages.", defaultValue = "5000")
+    @XmlAttribute
     public void setTimeout(long timeout) {
         timeout(timeout);
     }

--- a/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/channel/ChannelSyncEndpointBuilder.java
+++ b/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/channel/ChannelSyncEndpointBuilder.java
@@ -16,6 +16,8 @@
 
 package org.citrusframework.channel;
 
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.endpoint.AbstractEndpointBuilder;
 import org.citrusframework.message.MessageCorrelator;
 import org.citrusframework.util.StringUtils;
@@ -29,6 +31,7 @@ import org.springframework.messaging.core.DestinationResolver;
  * @since 2.7.6
  */
 @SchemaType(module = "citrus-spring-integration")
+@XmlType(name = "", propOrder = {})
 public class ChannelSyncEndpointBuilder extends AbstractEndpointBuilder<ChannelSyncEndpoint> {
 
     /** Endpoint target */
@@ -76,7 +79,13 @@ public class ChannelSyncEndpointBuilder extends AbstractEndpointBuilder<ChannelS
     }
 
     @SchemaProperty(description = "The Spring message channel name.")
+    @XmlAttribute
     public void setChannel(String channelName) {
+        channel(channelName);
+    }
+
+    @XmlAttribute(name = "channel-name")
+    public void setChannelName(String channelName) {
         channel(channelName);
     }
 
@@ -97,6 +106,7 @@ public class ChannelSyncEndpointBuilder extends AbstractEndpointBuilder<ChannelS
     }
 
     @SchemaProperty(advanced = true, description = "Sets a custom messaging template.")
+    @XmlAttribute(name = "messaging-template")
     public void setMessagingTemplate(String messagingTemplate) {
         this.messagingTemplate = messagingTemplate;
     }
@@ -110,6 +120,7 @@ public class ChannelSyncEndpointBuilder extends AbstractEndpointBuilder<ChannelS
     }
 
     @SchemaProperty(advanced = true, description = "Sets the message converter as a bean reference.")
+    @XmlAttribute(name = "message-converter")
     public void setMessageConverter(String messageConverter) {
         this.messageConverter = messageConverter;
     }
@@ -123,6 +134,7 @@ public class ChannelSyncEndpointBuilder extends AbstractEndpointBuilder<ChannelS
     }
 
     @SchemaProperty(advanced = true, description = "The channel destination resolver.")
+    @XmlAttribute(name = "channel-resolver")
     public void setChannelResolver(String resolver) {
         this.channelResolver = resolver;
     }
@@ -136,6 +148,7 @@ public class ChannelSyncEndpointBuilder extends AbstractEndpointBuilder<ChannelS
     }
 
     @SchemaProperty(advanced = true, description = "When enabled the endpoint uses object messages.")
+    @XmlAttribute(name = "use-object-messages")
     public void setUseObjectMessages(boolean useObjectMessages) {
         useObjectMessages(useObjectMessages);
     }
@@ -151,6 +164,7 @@ public class ChannelSyncEndpointBuilder extends AbstractEndpointBuilder<ChannelS
     @SchemaProperty(
             advanced = true,
             description = "When enabled the endpoint removes all internal headers before sending a message.")
+    @XmlAttribute(name = "filter-internal-headers")
     public void setFilterInternalHeaders(boolean filterInternalHeaders) {
         filterInternalHeaders(filterInternalHeaders);
     }
@@ -164,6 +178,7 @@ public class ChannelSyncEndpointBuilder extends AbstractEndpointBuilder<ChannelS
     }
 
     @SchemaProperty(advanced = true, description = "Sets the polling interval.")
+    @XmlAttribute(name = "polling-interval")
     public void setPollingInterval(int pollingInterval) {
         pollingInterval(pollingInterval);
     }
@@ -177,6 +192,7 @@ public class ChannelSyncEndpointBuilder extends AbstractEndpointBuilder<ChannelS
     }
 
     @SchemaProperty(advanced = true, description = "Sets the message correlator.")
+    @XmlAttribute(name = "message-correlator")
     public void setCorrelator(String correlator) {
         this.correlator = correlator;
     }
@@ -190,6 +206,7 @@ public class ChannelSyncEndpointBuilder extends AbstractEndpointBuilder<ChannelS
     }
 
     @SchemaProperty(description = "Sets the receive timeout when waiting for messages.", defaultValue = "5000")
+    @XmlAttribute
     public void setTimeout(long timeout) {
         timeout(timeout);
     }

--- a/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/channel/endpoint/builder/MessageChannelEndpointsBuilder.java
+++ b/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/channel/endpoint/builder/MessageChannelEndpointsBuilder.java
@@ -17,6 +17,10 @@
 package org.citrusframework.channel.endpoint.builder;
 
 import jakarta.annotation.Nullable;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.channel.ChannelEndpointBuilder;
 import org.citrusframework.channel.ChannelSyncEndpointBuilder;
 import org.citrusframework.endpoint.Endpoint;
@@ -28,17 +32,24 @@ import org.citrusframework.yaml.SchemaProperty;
 import org.citrusframework.yaml.SchemaType;
 
 @SchemaType(oneOf = { "asynchronous", "synchronous" }, module = "citrus-spring-integration")
+@XmlType(name = "", propOrder = {
+        "asynchronous",
+        "synchronous"
+})
+@XmlRootElement(name = "channel")
 public class MessageChannelEndpointsBuilder implements EndpointBuilder<Endpoint>, ReferenceResolverAware {
 
     private EndpointBuilder<?> delegate;
     private ReferenceResolver referenceResolver;
 
     @SchemaProperty(description = "Sets the synchronous Spring message channel endpoint.")
+    @XmlElement
     public void setSynchronous(ChannelSyncEndpointBuilder builder) {
         this.delegate = builder;
     }
 
     @SchemaProperty(description = "Sets the Spring message channel endpoint.")
+    @XmlElement
     public void setAsynchronous(ChannelEndpointBuilder builder) {
         this.delegate = builder;
     }
@@ -62,6 +73,7 @@ public class MessageChannelEndpointsBuilder implements EndpointBuilder<Endpoint>
     }
 
     @Override
+    @XmlTransient
     public void setReferenceResolver(@Nullable ReferenceResolver referenceResolver) {
         this.referenceResolver = referenceResolver;
     }

--- a/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/channel/endpoint/builder/package-info.java
+++ b/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/channel/endpoint/builder/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@jakarta.xml.bind.annotation.XmlSchema(namespace = "http://citrusframework.org/schema/xml/testcase", elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
+package org.citrusframework.channel.endpoint.builder;

--- a/endpoints/citrus-ssh/src/main/java/org/citrusframework/ssh/client/SshClientBuilder.java
+++ b/endpoints/citrus-ssh/src/main/java/org/citrusframework/ssh/client/SshClientBuilder.java
@@ -16,19 +16,42 @@
 
 package org.citrusframework.ssh.client;
 
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.endpoint.AbstractEndpointBuilder;
 import org.citrusframework.message.MessageCorrelator;
 import org.citrusframework.ssh.message.SshMessageConverter;
+import org.citrusframework.util.StringUtils;
+import org.citrusframework.yaml.SchemaProperty;
 import org.citrusframework.yaml.SchemaType;
 
 /**
  * @since 2.5
  */
 @SchemaType(module = "citrus-ssh")
+@XmlType(name = "", propOrder = {})
 public class SshClientBuilder extends AbstractEndpointBuilder<SshClient> {
 
     /** Endpoint target */
-    private SshClient endpoint = new SshClient();
+    private final SshClient endpoint = new SshClient();
+
+    private String messageConverter;
+    private String correlator;
+
+    @Override
+    public SshClient build() {
+        if (referenceResolver != null) {
+            if (StringUtils.hasText(messageConverter)) {
+                messageConverter(referenceResolver.resolve(messageConverter, SshMessageConverter.class));
+            }
+
+            if (StringUtils.hasText(correlator)) {
+                correlator(referenceResolver.resolve(correlator, MessageCorrelator.class));
+            }
+        }
+
+        return super.build();
+    }
 
     @Override
     protected SshClient getEndpoint() {
@@ -37,141 +60,197 @@ public class SshClientBuilder extends AbstractEndpointBuilder<SshClient> {
 
     /**
      * Sets the host property.
-     * @param host
-     * @return
      */
     public SshClientBuilder host(String host) {
         endpoint.getEndpointConfiguration().setHost(host);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the host.")
+    @XmlAttribute
+    public void setHost(String host) {
+        host(host);
+    }
+
     /**
      * Sets the port property.
-     * @param port
-     * @return
      */
     public SshClientBuilder port(int port) {
         endpoint.getEndpointConfiguration().setPort(port);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the port.")
+    @XmlAttribute
+    public void setPort(int port) {
+        port(port);
+    }
+
     /**
      * Sets the user property.
-     * @param user
-     * @return
      */
     public SshClientBuilder user(String user) {
         endpoint.getEndpointConfiguration().setUser(user);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the username.")
+    @XmlAttribute
+    public void setUser(String user) {
+        user(user);
+    }
+
     /**
      * Sets the client password.
-     * @param password
-     * @return
      */
     public SshClientBuilder password(String password) {
         endpoint.getEndpointConfiguration().setPassword(password);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the password.")
+    @XmlAttribute
+    public void setPassword(String password) {
+        password(password);
+    }
+
     /**
      * Sets the privateKeyPath property.
-     * @param privateKeyPath
-     * @return
      */
     public SshClientBuilder privateKeyPath(String privateKeyPath) {
         endpoint.getEndpointConfiguration().setPrivateKeyPath(privateKeyPath);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the private key path.")
+    @XmlAttribute(name = "privet-key-path")
+    public void setPrivateKeyPath(String privateKeyPath) {
+        privateKeyPath(privateKeyPath);
+    }
+
     /**
      * Sets the privateKeyPassword property.
-     * @param privateKeyPassword
-     * @return
      */
     public SshClientBuilder privateKeyPassword(String privateKeyPassword) {
         endpoint.getEndpointConfiguration().setPrivateKeyPassword(privateKeyPassword);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the private key password.")
+    @XmlAttribute(name = "private-kay-password")
+    public void setPrivateKeyPassword(String privateKeyPassword) {
+        privateKeyPassword(privateKeyPassword);
+    }
+
     /**
      * Sets the strictHostChecking property.
-     * @param strictHostChecking
-     * @return
      */
     public SshClientBuilder strictHostChecking(boolean strictHostChecking) {
         endpoint.getEndpointConfiguration().setStrictHostChecking(strictHostChecking);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the strict host checking.")
+    @XmlAttribute(name = "strict-host-checking")
+    public void setStrictHostChecking(boolean strictHostChecking) {
+        strictHostChecking(strictHostChecking);
+    }
+
     /**
      * Sets the knownHosts property.
-     * @param knownHosts
-     * @return
      */
     public SshClientBuilder knownHosts(String knownHosts) {
         endpoint.getEndpointConfiguration().setKnownHosts(knownHosts);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the known hosts.")
+    @XmlAttribute(name = "known-hosts")
+    public void setKnownHosts(String knownHosts) {
+        knownHosts(knownHosts);
+    }
+
     /**
      * Sets the commandTimeout property.
-     * @param commandTimeout
-     * @return
      */
     public SshClientBuilder commandTimeout(long commandTimeout) {
         endpoint.getEndpointConfiguration().setCommandTimeout(commandTimeout);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the command timeout.")
+    @XmlAttribute(name = "command-timeout")
+    public void setCommandTimeout(long commandTimeout) {
+        commandTimeout(commandTimeout);
+    }
+
     /**
      * Sets the connectionTimeout property.
-     * @param connectionTimeout
-     * @return
      */
     public SshClientBuilder connectionTimeout(int connectionTimeout) {
         endpoint.getEndpointConfiguration().setConnectionTimeout(connectionTimeout);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the connection timeout.")
+    @XmlAttribute(name = "connection-timeout")
+    public void setConnectionTimeout(int connectionTimeout) {
+        connectionTimeout(connectionTimeout);
+    }
+
     /**
      * Sets the message converter.
-     * @param messageConverter
-     * @return
      */
     public SshClientBuilder messageConverter(SshMessageConverter messageConverter) {
         endpoint.getEndpointConfiguration().setMessageConverter(messageConverter);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the message converter.")
+    @XmlAttribute(name = "message-converter")
+    public void setMessageConverter(String messageConverter) {
+        this.messageConverter = messageConverter;
+    }
+
     /**
      * Sets the message correlator.
-     * @param correlator
-     * @return
      */
     public SshClientBuilder correlator(MessageCorrelator correlator) {
         endpoint.getEndpointConfiguration().setCorrelator(correlator);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the message correlator.")
+    @XmlAttribute(name = "message-correlator")
+    public void setCorrelator(String correlator) {
+        this.correlator = correlator;
+    }
+
     /**
      * Sets the polling interval.
-     * @param pollingInterval
-     * @return
      */
     public SshClientBuilder pollingInterval(int pollingInterval) {
         endpoint.getEndpointConfiguration().setPollingInterval(pollingInterval);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the polling interval.")
+    @XmlAttribute(name = "polling-interval")
+    public void setPollingInterval(int pollingInterval) {
+        pollingInterval(pollingInterval);
+    }
+
     /**
      * Sets the default timeout.
-     * @param timeout
-     * @return
      */
     public SshClientBuilder timeout(long timeout) {
         endpoint.getEndpointConfiguration().setTimeout(timeout);
         return this;
+    }
+
+    @SchemaProperty(description = "Sets the default timeout.")
+    @XmlAttribute
+    public void setTimeout(long timeout) {
+        timeout(timeout);
     }
 }

--- a/endpoints/citrus-ssh/src/main/java/org/citrusframework/ssh/endpoint/builder/SshEndpointBuilder.java
+++ b/endpoints/citrus-ssh/src/main/java/org/citrusframework/ssh/endpoint/builder/SshEndpointBuilder.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.ssh.endpoint.builder;
+
+import jakarta.annotation.Nullable;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
+import org.citrusframework.endpoint.Endpoint;
+import org.citrusframework.endpoint.EndpointBuilder;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.spi.ReferenceResolverAware;
+import org.citrusframework.ssh.client.SshClientBuilder;
+import org.citrusframework.ssh.server.SshServerBuilder;
+import org.citrusframework.yaml.SchemaProperty;
+import org.citrusframework.yaml.SchemaType;
+
+/**
+ * Endpoint builder delegates to either client od server endpoint builder.
+ */
+@SchemaType(oneOf = { "client", "server" }, module = "citrus-ssh")
+@XmlType(name = "", propOrder = {
+        "client",
+        "server"
+})
+@XmlRootElement(name = "ssh")
+public class SshEndpointBuilder implements EndpointBuilder<Endpoint>, ReferenceResolverAware {
+
+    private EndpointBuilder<?> delegate;
+    private ReferenceResolver referenceResolver;
+
+    @SchemaProperty(description = "Sets the Ssh client endpoint.")
+    @XmlElement
+    public void setClient(SshClientBuilder client) {
+        this.delegate = client;
+    }
+
+    @SchemaProperty(description = "Sets the Ssh server endpoint.")
+    @XmlElement
+    public void setServer(SshServerBuilder server) {
+        this.delegate = server;
+    }
+
+    @Override
+    public Endpoint build() {
+        if (delegate == null) {
+            throw new CitrusRuntimeException("Client/server endpoint builder has not been initialized");
+        }
+
+        if (referenceResolver != null && delegate instanceof ReferenceResolverAware resolverAware) {
+            resolverAware.setReferenceResolver(referenceResolver);
+        }
+
+        return delegate.build();
+    }
+
+    @Override
+    public boolean supports(Class<?> endpointType) {
+        return delegate.supports(endpointType);
+    }
+
+    @Override
+    @XmlTransient
+    public void setReferenceResolver(@Nullable ReferenceResolver referenceResolver) {
+        this.referenceResolver = referenceResolver;
+    }
+}

--- a/endpoints/citrus-ssh/src/main/java/org/citrusframework/ssh/endpoint/builder/package-info.java
+++ b/endpoints/citrus-ssh/src/main/java/org/citrusframework/ssh/endpoint/builder/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@jakarta.xml.bind.annotation.XmlSchema(namespace = "http://citrusframework.org/schema/xml/testcase", elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
+package org.citrusframework.ssh.endpoint.builder;

--- a/endpoints/citrus-ssh/src/main/java/org/citrusframework/ssh/server/SshServerBuilder.java
+++ b/endpoints/citrus-ssh/src/main/java/org/citrusframework/ssh/server/SshServerBuilder.java
@@ -16,20 +16,42 @@
 
 package org.citrusframework.ssh.server;
 
-import org.citrusframework.endpoint.EndpointAdapter;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.server.AbstractServerBuilder;
 import org.citrusframework.ssh.message.SshMessageConverter;
 import org.citrusframework.ssh.model.SshMarshaller;
+import org.citrusframework.util.StringUtils;
+import org.citrusframework.yaml.SchemaProperty;
 import org.citrusframework.yaml.SchemaType;
 
 /**
  * @since 2.5
  */
 @SchemaType(module = "citrus-ssh")
+@XmlType(name = "", propOrder = {})
 public class SshServerBuilder extends AbstractServerBuilder<SshServer, SshServerBuilder> {
 
     /** Endpoint target */
     private final SshServer endpoint = new SshServer();
+
+    private String messageConverter;
+    private String marshaller;
+
+    @Override
+    public SshServer build() {
+        if (referenceResolver != null) {
+            if (StringUtils.hasText(messageConverter)) {
+                messageConverter(referenceResolver.resolve(messageConverter, SshMessageConverter.class));
+            }
+
+            if (StringUtils.hasText(marshaller)) {
+                marshaller(referenceResolver.resolve(marshaller, SshMarshaller.class));
+            }
+        }
+
+        return super.build();
+    }
 
     @Override
     protected SshServer getEndpoint() {
@@ -38,121 +60,127 @@ public class SshServerBuilder extends AbstractServerBuilder<SshServer, SshServer
 
     /**
      * Sets the port property.
-     * @param port
-     * @return
      */
     public SshServerBuilder port(int port) {
         endpoint.setPort(port);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the port.")
+    @XmlAttribute
+    public void setPort(int port) {
+        port(port);
+    }
+
     /**
      * Sets the user property.
-     * @param user
-     * @return
      */
     public SshServerBuilder user(String user) {
         endpoint.setUser(user);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the username.")
+    @XmlAttribute
+    public void setUser(String user) {
+        user(user);
+    }
+
     /**
      * Sets the client password.
-     * @param password
-     * @return
      */
     public SshServerBuilder password(String password) {
         endpoint.setPassword(password);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the password.")
+    @XmlAttribute
+    public void setPassword(String password) {
+        password(password);
+    }
+
     /**
      * Sets the hostKeyPath property.
-     * @param hostKeyPath
-     * @return
      */
     public SshServerBuilder hostKeyPath(String hostKeyPath) {
         endpoint.setHostKeyPath(hostKeyPath);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the host key path")
+    @XmlAttribute(name = "host-key-path")
+    public void setHostKeyPath(String hostKeyPath) {
+        hostKeyPath(hostKeyPath);
+    }
+
     /**
      * Sets the userHomePath property.
-     * @param userHomePath
-     * @return
      */
     public SshServerBuilder userHomePath(String userHomePath) {
         endpoint.setUserHomePath(userHomePath);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the user home path")
+    @XmlAttribute(name = "user-home-path")
+    public void setUserHomePath(String userHomePath) {
+        userHomePath(userHomePath);
+    }
+
     /**
      * Sets the allowedKeyPath property.
-     * @param allowedKeyPath
-     * @return
      */
     public SshServerBuilder allowedKeyPath(String allowedKeyPath) {
         endpoint.setAllowedKeyPath(allowedKeyPath);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the allowed key path.")
+    @XmlAttribute(name = "allowed-key-path")
+    public void setAllowedKeyPath(String allowedKeyPath) {
+        allowedKeyPath(allowedKeyPath);
+    }
+
     /**
      * Sets the message converter.
-     * @param messageConverter
-     * @return
      */
     public SshServerBuilder messageConverter(SshMessageConverter messageConverter) {
         endpoint.setMessageConverter(messageConverter);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the message converter.")
+    @XmlAttribute(name = "message-converter")
+    public void setMessageConverter(String messageConverter) {
+        this.messageConverter = messageConverter;
+    }
+
     /**
      * Sets the marshaller.
-     * @param marshaller
-     * @return
      */
     public SshServerBuilder marshaller(SshMarshaller marshaller) {
         endpoint.setMarshaller(marshaller);
         return this;
     }
 
+    @SchemaProperty(description = "Sets the marshaller as a bean reference.")
+    @XmlAttribute
+    public void setMarshaller(String marshaller) {
+        this.marshaller = marshaller;
+    }
+
     /**
      * Sets the polling interval.
-     * @param pollingInterval
-     * @return
      */
     public SshServerBuilder pollingInterval(int pollingInterval) {
         endpoint.getEndpointConfiguration().setPollingInterval(pollingInterval);
         return this;
     }
 
-    /**
-     * Sets the endpoint adapter.
-     * @param endpointAdapter
-     * @return
-     */
-    public SshServerBuilder endpointAdapter(EndpointAdapter endpointAdapter) {
-        endpoint.setEndpointAdapter(endpointAdapter);
-        return this;
-    }
-
-    /**
-     * Sets the debug logging enabled flag.
-     * @param enabled
-     * @return
-     */
-    public SshServerBuilder debugLogging(boolean enabled) {
-        endpoint.setDebugLogging(enabled);
-        return this;
-    }
-
-    /**
-     * Sets the autoStart property.
-     * @param autoStart
-     * @return
-     */
-    public SshServerBuilder autoStart(boolean autoStart) {
-        endpoint.setAutoStart(autoStart);
-        return this;
+    @SchemaProperty(description = "Sets the polling interval.")
+    @XmlAttribute(name = "polling-interval")
+    public void setPollingInterval(int pollingInterval) {
+        pollingInterval(pollingInterval);
     }
 }

--- a/endpoints/citrus-ssh/src/main/resources/META-INF/citrus/endpoint/builder/ssh
+++ b/endpoints/citrus-ssh/src/main/resources/META-INF/citrus/endpoint/builder/ssh
@@ -1,2 +1,3 @@
+type=org.citrusframework.ssh.endpoint.builder.SshEndpointBuilder
 client=org.citrusframework.ssh.client.SshClientBuilder
 server=org.citrusframework.ssh.server.SshServerBuilder

--- a/endpoints/citrus-vertx/src/main/java/org/citrusframework/vertx/endpoint/VertxEndpointBuilder.java
+++ b/endpoints/citrus-vertx/src/main/java/org/citrusframework/vertx/endpoint/VertxEndpointBuilder.java
@@ -16,6 +16,8 @@
 
 package org.citrusframework.vertx.endpoint;
 
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.endpoint.AbstractEndpointBuilder;
 import org.citrusframework.util.StringUtils;
 import org.citrusframework.vertx.factory.VertxInstanceFactory;
@@ -27,6 +29,7 @@ import org.citrusframework.yaml.SchemaType;
  * @since 2.5
  */
 @SchemaType(module = "citrus-vertx")
+@XmlType(name = "", propOrder = {})
 public class VertxEndpointBuilder extends AbstractEndpointBuilder<VertxEndpoint> {
 
     /** Endpoint target */
@@ -64,6 +67,7 @@ public class VertxEndpointBuilder extends AbstractEndpointBuilder<VertxEndpoint>
     }
 
     @SchemaProperty(description = "The Vert.x event bus host.")
+    @XmlAttribute
     public void setHost(String host) {
         host(host);
     }
@@ -77,6 +81,7 @@ public class VertxEndpointBuilder extends AbstractEndpointBuilder<VertxEndpoint>
     }
 
     @SchemaProperty(description = "The Vert.x event bus port.")
+    @XmlAttribute
     public void setPort(int port) {
         port(port);
     }
@@ -90,6 +95,7 @@ public class VertxEndpointBuilder extends AbstractEndpointBuilder<VertxEndpoint>
     }
 
     @SchemaProperty(description = "The event bus address.")
+    @XmlAttribute
     public void setAddress(String address) {
         address(address);
     }
@@ -103,6 +109,7 @@ public class VertxEndpointBuilder extends AbstractEndpointBuilder<VertxEndpoint>
     }
 
     @SchemaProperty(advanced = true, description = "Sets a custom Vert.x factory.")
+    @XmlAttribute(name = "vertx-factory")
     public void setVertxFactory(String vertxFactory) {
         this.vertxFactory = vertxFactory;
     }
@@ -116,6 +123,7 @@ public class VertxEndpointBuilder extends AbstractEndpointBuilder<VertxEndpoint>
     }
 
     @SchemaProperty(advanced = true, description = "Sets the message converter as a bean reference.")
+    @XmlAttribute(name = "message-converter")
     public void setMessageConverter(String messageConverter) {
         this.messageConverter = messageConverter;
     }
@@ -129,6 +137,7 @@ public class VertxEndpointBuilder extends AbstractEndpointBuilder<VertxEndpoint>
     }
 
     @SchemaProperty(advanced = true, description = "When enabled the endpoint uses publish/subscribe mode.")
+    @XmlAttribute(name = "pub-sub-domain")
     public void setPubSubDomain(boolean pubSubDomain) {
         pubSubDomain(pubSubDomain);
     }
@@ -142,6 +151,7 @@ public class VertxEndpointBuilder extends AbstractEndpointBuilder<VertxEndpoint>
     }
 
     @SchemaProperty(description = "Sets the polling interval when consuming messages.")
+    @XmlAttribute(name = "polling-interval")
     public void setPollingInterval(int pollingInterval) {
         pollingInterval(pollingInterval);
     }
@@ -155,6 +165,7 @@ public class VertxEndpointBuilder extends AbstractEndpointBuilder<VertxEndpoint>
     }
 
     @SchemaProperty(description = "The endpoint timeout when waiting for messages.")
+    @XmlAttribute
     public void setTimeout(long timeout) {
         timeout(timeout);
     }

--- a/endpoints/citrus-vertx/src/main/java/org/citrusframework/vertx/endpoint/VertxSyncEndpointBuilder.java
+++ b/endpoints/citrus-vertx/src/main/java/org/citrusframework/vertx/endpoint/VertxSyncEndpointBuilder.java
@@ -16,6 +16,8 @@
 
 package org.citrusframework.vertx.endpoint;
 
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.endpoint.AbstractEndpointBuilder;
 import org.citrusframework.message.MessageCorrelator;
 import org.citrusframework.util.StringUtils;
@@ -28,6 +30,7 @@ import org.citrusframework.yaml.SchemaType;
  * @since 2.5
  */
 @SchemaType(module = "citrus-vertx")
+@XmlType(name = "", propOrder = {})
 public class VertxSyncEndpointBuilder extends AbstractEndpointBuilder<VertxSyncEndpoint> {
 
     /** Endpoint target */
@@ -70,6 +73,7 @@ public class VertxSyncEndpointBuilder extends AbstractEndpointBuilder<VertxSyncE
     }
 
     @SchemaProperty(description = "The Vert.x event bus host.")
+    @XmlAttribute
     public void setHost(String host) {
         host(host);
     }
@@ -83,6 +87,7 @@ public class VertxSyncEndpointBuilder extends AbstractEndpointBuilder<VertxSyncE
     }
 
     @SchemaProperty(description = "The Vert.x event bus port.")
+    @XmlAttribute
     public void setPort(int port) {
         port(port);
     }
@@ -96,6 +101,7 @@ public class VertxSyncEndpointBuilder extends AbstractEndpointBuilder<VertxSyncE
     }
 
     @SchemaProperty(description = "The event bus address.")
+    @XmlAttribute
     public void setAddress(String address) {
         address(address);
     }
@@ -109,6 +115,7 @@ public class VertxSyncEndpointBuilder extends AbstractEndpointBuilder<VertxSyncE
     }
 
     @SchemaProperty(advanced = true, description = "Sets a custom Vert.x factory.")
+    @XmlAttribute(name = "vertx-factory")
     public void setVertxFactory(String vertxFactory) {
         this.vertxFactory = vertxFactory;
     }
@@ -122,6 +129,7 @@ public class VertxSyncEndpointBuilder extends AbstractEndpointBuilder<VertxSyncE
     }
 
     @SchemaProperty(advanced = true, description = "Sets the message converter as a bean reference.")
+    @XmlAttribute(name = "message-converter")
     public void setMessageConverter(String messageConverter) {
         this.messageConverter = messageConverter;
     }
@@ -135,6 +143,7 @@ public class VertxSyncEndpointBuilder extends AbstractEndpointBuilder<VertxSyncE
     }
 
     @SchemaProperty(advanced = true, description = "When enabled the endpoint uses publish/subscribe mode.")
+    @XmlAttribute(name = "pub-sub-domain")
     public void setPubSubDomain(boolean pubSubDomain) {
         pubSubDomain(pubSubDomain);
     }
@@ -148,6 +157,7 @@ public class VertxSyncEndpointBuilder extends AbstractEndpointBuilder<VertxSyncE
     }
 
     @SchemaProperty(description = "Sets the polling interval when consuming messages.")
+    @XmlAttribute(name = "polling-interval")
     public void setPollingInterval(int pollingInterval) {
         pollingInterval(pollingInterval);
     }
@@ -161,6 +171,7 @@ public class VertxSyncEndpointBuilder extends AbstractEndpointBuilder<VertxSyncE
     }
 
     @SchemaProperty(advanced = true, description = "Sets the message correlator.")
+    @XmlAttribute(name = "message-correlator")
     public void setCorrelator(String correlator) {
         this.correlator = correlator;
     }
@@ -174,6 +185,7 @@ public class VertxSyncEndpointBuilder extends AbstractEndpointBuilder<VertxSyncE
     }
 
     @SchemaProperty(description = "The endpoint timeout when waiting for messages.")
+    @XmlAttribute
     public void setTimeout(long timeout) {
         timeout(timeout);
     }

--- a/endpoints/citrus-vertx/src/main/java/org/citrusframework/vertx/endpoint/builder/VertxEndpointsBuilder.java
+++ b/endpoints/citrus-vertx/src/main/java/org/citrusframework/vertx/endpoint/builder/VertxEndpointsBuilder.java
@@ -17,6 +17,10 @@
 package org.citrusframework.vertx.endpoint.builder;
 
 import jakarta.annotation.Nullable;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.endpoint.Endpoint;
 import org.citrusframework.endpoint.EndpointBuilder;
 import org.citrusframework.exceptions.CitrusRuntimeException;
@@ -28,17 +32,24 @@ import org.citrusframework.yaml.SchemaProperty;
 import org.citrusframework.yaml.SchemaType;
 
 @SchemaType(oneOf = { "asynchronous", "synchronous" }, module = "citrus-vertx")
+@XmlType(name = "", propOrder = {
+        "asynchronous",
+        "synchronous"
+})
+@XmlRootElement(name = "vertx")
 public class VertxEndpointsBuilder implements EndpointBuilder<Endpoint>, ReferenceResolverAware {
 
     private EndpointBuilder<?> delegate;
     private ReferenceResolver referenceResolver;
 
     @SchemaProperty(description = "Sets the synchronous Vert.x endpoint.")
+    @XmlElement
     public void setSynchronous(VertxSyncEndpointBuilder builder) {
         this.delegate = builder;
     }
 
     @SchemaProperty(description = "Sets the Vert.x endpoint.")
+    @XmlElement
     public void setAsynchronous(VertxEndpointBuilder builder) {
         this.delegate = builder;
     }
@@ -62,6 +73,7 @@ public class VertxEndpointsBuilder implements EndpointBuilder<Endpoint>, Referen
     }
 
     @Override
+    @XmlTransient
     public void setReferenceResolver(@Nullable ReferenceResolver referenceResolver) {
         this.referenceResolver = referenceResolver;
     }

--- a/endpoints/citrus-vertx/src/main/java/org/citrusframework/vertx/endpoint/builder/package-info.java
+++ b/endpoints/citrus-vertx/src/main/java/org/citrusframework/vertx/endpoint/builder/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@jakarta.xml.bind.annotation.XmlSchema(namespace = "http://citrusframework.org/schema/xml/testcase", elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
+package org.citrusframework.vertx.endpoint.builder;

--- a/endpoints/citrus-websocket/src/main/java/org/citrusframework/websocket/client/WebSocketClient.java
+++ b/endpoints/citrus-websocket/src/main/java/org/citrusframework/websocket/client/WebSocketClient.java
@@ -30,10 +30,13 @@ public class WebSocketClient extends WebSocketEndpoint {
         this(new WebSocketClientEndpointConfiguration());
     }
 
+    @Override
+    public WebSocketClientEndpointConfiguration getEndpointConfiguration() {
+        return (WebSocketClientEndpointConfiguration) super.getEndpointConfiguration();
+    }
+
     /**
      * Default constructor using endpoint configuration.
-     *
-     * @param endpointConfiguration
      */
     public WebSocketClient(WebSocketClientEndpointConfiguration endpointConfiguration) {
         super(endpointConfiguration);

--- a/endpoints/citrus-websocket/src/main/java/org/citrusframework/websocket/client/WebSocketClientBuilder.java
+++ b/endpoints/citrus-websocket/src/main/java/org/citrusframework/websocket/client/WebSocketClientBuilder.java
@@ -16,28 +16,37 @@
 
 package org.citrusframework.websocket.client;
 
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.endpoint.AbstractEndpointBuilder;
 import org.citrusframework.endpoint.resolver.EndpointUriResolver;
 import org.citrusframework.util.StringUtils;
 import org.citrusframework.websocket.message.WebSocketMessageConverter;
 import org.citrusframework.yaml.SchemaProperty;
 import org.citrusframework.yaml.SchemaType;
+import org.springframework.web.socket.WebSocketHttpHeaders;
 
 /**
  * @since 2.5
  */
 @SchemaType(module = "citrus-websocket")
+@XmlType(name = "", propOrder = {})
 public class WebSocketClientBuilder extends AbstractEndpointBuilder<WebSocketClient> {
 
     /** Endpoint target */
     private final WebSocketClient endpoint = new WebSocketClient();
 
+    private String httpHeaders;
     private String messageConverter;
     private String endpointResolver;
 
     @Override
     public WebSocketClient build() {
         if (referenceResolver != null) {
+            if (StringUtils.hasText(httpHeaders)) {
+                httpHeaders(referenceResolver.resolve(httpHeaders, WebSocketHttpHeaders.class));
+            }
+
             if (StringUtils.hasText(messageConverter)) {
                 messageConverter(referenceResolver.resolve(messageConverter, WebSocketMessageConverter.class));
             }
@@ -64,8 +73,23 @@ public class WebSocketClientBuilder extends AbstractEndpointBuilder<WebSocketCli
     }
 
     @SchemaProperty(description = "Sets the client request URL.")
+    @XmlAttribute(name = "request-url")
     public void setRequestUrl(String requestUrl) {
         requestUrl(requestUrl);
+    }
+
+    /**
+     * Sets the Websocket Http headers property.
+     */
+    public WebSocketClientBuilder httpHeaders(WebSocketHttpHeaders headers) {
+        endpoint.getEndpointConfiguration().setWebSocketHttpHeaders(headers);
+        return this;
+    }
+
+    @SchemaProperty(advanced = true, description = "Sets the Websocket Http headers.")
+    @XmlAttribute(name = "http-headers")
+    public void setHttpHeaders(String headers) {
+        this.httpHeaders = headers;
     }
 
     /**
@@ -77,6 +101,7 @@ public class WebSocketClientBuilder extends AbstractEndpointBuilder<WebSocketCli
     }
 
     @SchemaProperty(advanced = true, description = "Bean reference to a message converter.")
+    @XmlAttribute(name = "message-converter")
     public void setMessageConverter(String messageConverter) {
         this.messageConverter = messageConverter;
     }
@@ -90,6 +115,7 @@ public class WebSocketClientBuilder extends AbstractEndpointBuilder<WebSocketCli
     }
 
     @SchemaProperty(advanced = true, description = "Sets the endpoint URI resolver.")
+    @XmlAttribute(name = "endpoint-resolver")
     public void setEndpointResolver(String resolver) {
         this.endpointResolver = resolver;
     }
@@ -103,6 +129,7 @@ public class WebSocketClientBuilder extends AbstractEndpointBuilder<WebSocketCli
     }
 
     @SchemaProperty(advanced = true, description = "Sets the polling interval when consuming messages.")
+    @XmlAttribute(name = "polling-interval")
     public void setPollingInterval(int pollingInterval) {
         pollingInterval(pollingInterval);
     }
@@ -116,6 +143,7 @@ public class WebSocketClientBuilder extends AbstractEndpointBuilder<WebSocketCli
     }
 
     @SchemaProperty(description = "The Http request timeout while waiting for a response", defaultValue = "5000")
+    @XmlAttribute
     public void setTimeout(long timeout) {
         timeout(timeout);
     }

--- a/endpoints/citrus-websocket/src/main/java/org/citrusframework/websocket/endpoint/builder/WebSocketEndpointBuilder.java
+++ b/endpoints/citrus-websocket/src/main/java/org/citrusframework/websocket/endpoint/builder/WebSocketEndpointBuilder.java
@@ -17,6 +17,10 @@
 package org.citrusframework.websocket.endpoint.builder;
 
 import jakarta.annotation.Nullable;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.endpoint.Endpoint;
 import org.citrusframework.endpoint.EndpointBuilder;
 import org.citrusframework.exceptions.CitrusRuntimeException;
@@ -28,17 +32,24 @@ import org.citrusframework.yaml.SchemaProperty;
 import org.citrusframework.yaml.SchemaType;
 
 @SchemaType(oneOf = { "client", "server" }, module = "citrus-websocket")
+@XmlType(name = "", propOrder = {
+        "client",
+        "server"
+})
+@XmlRootElement(name = "websocket")
 public class WebSocketEndpointBuilder implements EndpointBuilder<Endpoint>, ReferenceResolverAware {
 
     private EndpointBuilder<?> delegate;
     private ReferenceResolver referenceResolver;
 
     @SchemaProperty(description = "Sets the WebSocket client endpoint.")
+    @XmlElement
     public void setClient(WebSocketClientBuilder client) {
         this.delegate = client;
     }
 
     @SchemaProperty(description = "Sets the WebSocket server endpoint.")
+    @XmlElement
     public void setServer(WebSocketServerBuilder server) {
         this.delegate = server;
     }
@@ -62,6 +73,7 @@ public class WebSocketEndpointBuilder implements EndpointBuilder<Endpoint>, Refe
     }
 
     @Override
+    @XmlTransient
     public void setReferenceResolver(@Nullable ReferenceResolver referenceResolver) {
         this.referenceResolver = referenceResolver;
     }

--- a/endpoints/citrus-websocket/src/main/java/org/citrusframework/websocket/endpoint/builder/package-info.java
+++ b/endpoints/citrus-websocket/src/main/java/org/citrusframework/websocket/endpoint/builder/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@jakarta.xml.bind.annotation.XmlSchema(namespace = "http://citrusframework.org/schema/xml/testcase", elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
+package org.citrusframework.websocket.endpoint.builder;

--- a/endpoints/citrus-websocket/src/main/java/org/citrusframework/websocket/server/WebSocketServer.java
+++ b/endpoints/citrus-websocket/src/main/java/org/citrusframework/websocket/server/WebSocketServer.java
@@ -16,15 +16,15 @@
 
 package org.citrusframework.websocket.server;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.citrusframework.http.server.HttpServer;
 import org.citrusframework.websocket.endpoint.WebSocketEndpoint;
 import org.citrusframework.websocket.servlet.CitrusWebSocketDispatcherServlet;
 import org.eclipse.jetty.ee11.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee11.websocket.server.config.JettyWebSocketServletContainerInitializer;
 import org.springframework.web.servlet.DispatcherServlet;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * @since 2.3

--- a/endpoints/citrus-websocket/src/main/java/org/citrusframework/websocket/server/WebSocketServerBuilder.java
+++ b/endpoints/citrus-websocket/src/main/java/org/citrusframework/websocket/server/WebSocketServerBuilder.java
@@ -17,8 +17,12 @@
 package org.citrusframework.websocket.server;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.http.server.AbstractHttpServerBuilder;
 import org.citrusframework.websocket.endpoint.WebSocketEndpoint;
 import org.citrusframework.yaml.SchemaProperty;
@@ -28,6 +32,7 @@ import org.citrusframework.yaml.SchemaType;
  * @since 2.5
  */
 @SchemaType(module = "citrus-websocket")
+@XmlType(name = "", propOrder = {})
 public class WebSocketServerBuilder extends AbstractHttpServerBuilder<WebSocketServer, WebSocketServerBuilder> {
 
     private final List<String> webSockets = new ArrayList<>();
@@ -62,7 +67,13 @@ public class WebSocketServerBuilder extends AbstractHttpServerBuilder<WebSocketS
     }
 
     @SchemaProperty(description = "Sets the list of web sockets for this server.")
+    @XmlTransient
     public void setWebSockets(List<String> webSockets) {
         this.webSockets.addAll(webSockets);
+    }
+
+    @XmlAttribute
+    public void setWebSockets(String webSockets) {
+        setWebSockets(Arrays.asList(webSockets.split(",")));
     }
 }

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/client/WebServiceClientBuilder.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/client/WebServiceClientBuilder.java
@@ -17,8 +17,12 @@
 package org.citrusframework.ws.client;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.endpoint.AbstractEndpointBuilder;
 import org.citrusframework.endpoint.resolver.EndpointUriResolver;
 import org.citrusframework.message.ErrorHandlingStrategy;
@@ -36,6 +40,7 @@ import org.springframework.ws.transport.WebServiceMessageSender;
  * @since 2.5
  */
 @SchemaType(module = "citrus-ws")
+@XmlType(name = "", propOrder = {})
 public class WebServiceClientBuilder extends AbstractEndpointBuilder<WebServiceClient> {
 
     /** Endpoint target */
@@ -100,6 +105,7 @@ public class WebServiceClientBuilder extends AbstractEndpointBuilder<WebServiceC
     }
 
     @SchemaProperty(description = "Sets the SOAP Web Service server url.")
+    @XmlAttribute(name = "default-uri")
     public void setDefaultUri(String defaultUri) {
         defaultUri(defaultUri);
     }
@@ -113,6 +119,7 @@ public class WebServiceClientBuilder extends AbstractEndpointBuilder<WebServiceC
     }
 
     @SchemaProperty(advanced = true, description = "Sets a custom message factory.")
+    @XmlAttribute(name = "message-factory")
     public void setMessageFactory(String messageFactory) {
         this.messageFactory = messageFactory;
     }
@@ -126,6 +133,7 @@ public class WebServiceClientBuilder extends AbstractEndpointBuilder<WebServiceC
     }
 
     @SchemaProperty(advanced = true, description = "When enabled the client does not remove the SOAP envelope before processing the message.")
+    @XmlAttribute(name = "keep-soap-envelope")
     public void setKeepSoapEnvelope(boolean flag) {
         keepSoapEnvelope(flag);
     }
@@ -139,6 +147,7 @@ public class WebServiceClientBuilder extends AbstractEndpointBuilder<WebServiceC
     }
 
     @SchemaProperty(advanced = true, description = "Sets custom web service template reference.")
+    @XmlAttribute(name = "web-service-template")
     public void setWebServiceTemplate(String webServiceTemplate) {
         this.webServiceTemplate = webServiceTemplate;
     }
@@ -152,6 +161,7 @@ public class WebServiceClientBuilder extends AbstractEndpointBuilder<WebServiceC
     }
 
     @SchemaProperty(advanced = true, description = "Sets a custom message sender implementation.")
+    @XmlAttribute(name = "message-sender")
     public void setMessageSender(String messageSender) {
         this.messageSender = messageSender;
     }
@@ -165,6 +175,7 @@ public class WebServiceClientBuilder extends AbstractEndpointBuilder<WebServiceC
     }
 
     @SchemaProperty(advanced = true, description = "Sets a custom message converter implementation.")
+    @XmlAttribute(name = "message-converter")
     public void setMessageConverter(String messageConverter) {
         this.messageConverter = messageConverter;
     }
@@ -181,6 +192,7 @@ public class WebServiceClientBuilder extends AbstractEndpointBuilder<WebServiceC
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:intercept") },
             description = "Sets a custom client interceptor."
     )
+    @XmlAttribute
     public void setInterceptor(String interceptor) {
         this.interceptors.add(interceptor);
     }
@@ -196,10 +208,15 @@ public class WebServiceClientBuilder extends AbstractEndpointBuilder<WebServiceC
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:intercept") },
             description = "Sets client interceptors."
     )
+    @XmlTransient
     public void setInterceptors(List<String> interceptors) {
         this.interceptors.addAll(interceptors);
     }
 
+    @XmlAttribute
+    public void setInterceptors(String interceptors) {
+        setInterceptors(Arrays.asList(interceptors.split(",")));
+    }
     /**
      * Sets the message correlator.
      */
@@ -209,6 +226,7 @@ public class WebServiceClientBuilder extends AbstractEndpointBuilder<WebServiceC
     }
 
     @SchemaProperty(advanced = true, description = "Sets the message correlator.")
+    @XmlAttribute(name = "message-correlator")
     public void setCorrelator(String correlator) {
         this.correlator = correlator;
     }
@@ -222,6 +240,7 @@ public class WebServiceClientBuilder extends AbstractEndpointBuilder<WebServiceC
     }
 
     @SchemaProperty(advanced = true, description = "Sets the endpoint resolver.")
+    @XmlAttribute(name = "endpoint-resolver")
     public void setEndpointResolver(String resolver) {
         this.endpointResolver = resolver;
     }
@@ -238,8 +257,13 @@ public class WebServiceClientBuilder extends AbstractEndpointBuilder<WebServiceC
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:errorHandler") },
             description = "Sets the error handling strategy."
     )
-    public void setFaultStrategy(ErrorHandlingStrategy faultStrategy) {
-        faultStrategy(faultStrategy);
+    @XmlAttribute(name = "fault-strategy")
+    public void setFaultStrategy(String faultStrategy) {
+        try {
+            faultStrategy(ErrorHandlingStrategy.fromName(faultStrategy));
+        } catch (IllegalArgumentException e) {
+            faultStrategy(ErrorHandlingStrategy.valueOf(faultStrategy));
+        }
     }
 
     /**
@@ -251,6 +275,7 @@ public class WebServiceClientBuilder extends AbstractEndpointBuilder<WebServiceC
     }
 
     @SchemaProperty(description = "Sets the polling interval when consuming messages.")
+    @XmlAttribute(name = "polling-interval")
     public void setPollingInterval(int pollingInterval) {
         pollingInterval(pollingInterval);
     }
@@ -264,6 +289,7 @@ public class WebServiceClientBuilder extends AbstractEndpointBuilder<WebServiceC
     }
 
     @SchemaProperty(description = "Sets the receive timeout when the client waits for response messages.", defaultValue = "5000")
+    @XmlAttribute
     public void setTimeout(long timeout) {
         timeout(timeout);
     }

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/endpoint/builder/SoapWebServiceEndpointBuilder.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/endpoint/builder/SoapWebServiceEndpointBuilder.java
@@ -17,6 +17,10 @@
 package org.citrusframework.ws.endpoint.builder;
 
 import jakarta.annotation.Nullable;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.endpoint.Endpoint;
 import org.citrusframework.endpoint.EndpointBuilder;
 import org.citrusframework.exceptions.CitrusRuntimeException;
@@ -28,17 +32,24 @@ import org.citrusframework.yaml.SchemaProperty;
 import org.citrusframework.yaml.SchemaType;
 
 @SchemaType(oneOf = { "client", "server" }, module = "citrus-ws")
+@XmlType(name = "", propOrder = {
+        "client",
+        "server"
+})
+@XmlRootElement(name = "soap")
 public class SoapWebServiceEndpointBuilder implements EndpointBuilder<Endpoint>, ReferenceResolverAware {
 
     private EndpointBuilder<?> delegate;
     private ReferenceResolver referenceResolver;
 
     @SchemaProperty(description = "Sets the SOAP WebService client endpoint.")
+    @XmlElement
     public void setClient(WebServiceClientBuilder client) {
         this.delegate = client;
     }
 
     @SchemaProperty(description = "Sets the SOAP WebService server endpoint.")
+    @XmlElement
     public void setServer(WebServiceServerBuilder server) {
         this.delegate = server;
     }
@@ -62,6 +73,7 @@ public class SoapWebServiceEndpointBuilder implements EndpointBuilder<Endpoint>,
     }
 
     @Override
+    @XmlTransient
     public void setReferenceResolver(@Nullable ReferenceResolver referenceResolver) {
         this.referenceResolver = referenceResolver;
     }

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/endpoint/builder/package-info.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/endpoint/builder/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@jakarta.xml.bind.annotation.XmlSchema(namespace = "http://citrusframework.org/schema/xml/testcase", elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
+package org.citrusframework.ws.endpoint.builder;

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/server/WebServiceServerBuilder.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/server/WebServiceServerBuilder.java
@@ -21,6 +21,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.server.AbstractServerBuilder;
 import org.citrusframework.util.StringUtils;
 import org.citrusframework.ws.message.converter.WebServiceMessageConverter;
@@ -35,6 +38,7 @@ import org.springframework.ws.server.EndpointInterceptor;
  * @since 2.5
  */
 @SchemaType(module = "citrus-ws")
+@XmlType(name = "", propOrder = {})
 public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceServer, WebServiceServerBuilder> {
 
     /**
@@ -92,6 +96,7 @@ public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceSer
     }
 
     @SchemaProperty(description = "The SOAP WebService server port.")
+    @XmlAttribute
     public void setPort(int port) {
         port(port);
     }
@@ -105,6 +110,7 @@ public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceSer
     }
 
     @SchemaProperty(advanced = true, description = "Sets the path to the Spring context configuration for this server.")
+    @XmlAttribute(name = "context-config-location")
     public void setContextConfigLocation(String configLocation) {
         contextConfigLocation(configLocation);
     }
@@ -118,6 +124,7 @@ public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceSer
     }
 
     @SchemaProperty(advanced = true, description = "Sets the resource base path where the server reads resources from.")
+    @XmlAttribute(name = "resource-base")
     public void setResourceBase(String resourceBase) {
         resourceBase(resourceBase);
     }
@@ -131,6 +138,7 @@ public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceSer
     }
 
     @SchemaProperty(advanced = true, description = "When enabled the server uses the root Spring application context.")
+    @XmlAttribute(name = "root-parent-context")
     public void setRootParentContext(boolean rootParentContext) {
         rootParentContext(rootParentContext);
     }
@@ -146,8 +154,14 @@ public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceSer
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:servlet") },
             description = "Sets a list of connectors for this server.")
+    @XmlTransient
     public void setConnectors(List<String> connectors) {
         this.connectors.addAll(connectors);
+    }
+
+    @XmlAttribute
+    public void setConnectors(String connectors) {
+        setConnectors(Arrays.asList(connectors.split(",")));
     }
 
     /**
@@ -161,6 +175,7 @@ public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceSer
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:servlet") },
             description = "Add a connector to this server.")
+    @XmlAttribute
     public void setConnector(String connector) {
         this.connectors.add(connector);
     }
@@ -176,6 +191,7 @@ public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceSer
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:servlet") },
             description = "Sets the servlet name.")
+    @XmlAttribute
     public void setServletName(String servletName) {
         servletName(servletName);
     }
@@ -191,6 +207,7 @@ public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceSer
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:servlet") },
             description = "Sets the servlet mapping path.")
+    @XmlAttribute(name = "servlet-mapping-path")
     public void setServletMappingPath(String servletMappingPath) {
         servletMappingPath(servletMappingPath);
     }
@@ -206,6 +223,7 @@ public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceSer
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:servlet") },
             description = "Sets the context path on this server.")
+    @XmlAttribute(name = "context-path")
     public void setContextPath(String contextPath) {
         contextPath(contextPath);
     }
@@ -221,6 +239,7 @@ public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceSer
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:servlet") },
             description = "Sets a custom servlet handler as a bean reference.")
+    @XmlAttribute(name = "servlet-handler")
     public void serServletHandler(String servletHandler) {
         this.servletHandler = servletHandler;
     }
@@ -236,6 +255,7 @@ public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceSer
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
             description = "Sets the security handler as a bean reference.")
+    @XmlAttribute(name = "security-handler")
     public void setSecurityHandler(String securityHandler) {
         this.securityHandler = securityHandler;
     }
@@ -249,6 +269,7 @@ public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceSer
     }
 
     @SchemaProperty(advanced = true, description = "Sets the Http message converter bean reference.")
+    @XmlAttribute(name = "message-converter")
     public void setMessageConverter(String messageConverter) {
         this.messageConverter = messageConverter;
     }
@@ -260,6 +281,7 @@ public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceSer
     }
 
     @SchemaProperty(description = "Sets the server timeout while waiting for incoming requests.", defaultValue = "5000")
+    @XmlAttribute
     public void setTimeout(long timeout) {
         timeout(timeout);
     }
@@ -275,10 +297,15 @@ public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceSer
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:intercept") },
             description = "Sets the list of endpoint interceptor bean references.")
+    @XmlTransient
     public void setInterceptors(List<String> interceptors) {
         this.interceptors.addAll(interceptors);
     }
 
+    @XmlAttribute
+    public void setInterceptors(String interceptors) {
+        setInterceptors(Arrays.asList(interceptors.split(",")));
+    }
     /**
      * Sets the interceptors.
      */
@@ -298,6 +325,7 @@ public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceSer
     @SchemaProperty(
             metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:intercept") },
             description = "Sets a endpoint interceptor.")
+    @XmlAttribute
     public void setInterceptor(String interceptor) {
         this.interceptors.add(interceptor);
     }
@@ -311,6 +339,7 @@ public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceSer
     }
 
     @SchemaProperty(advanced = true, description = "Sets a custom message factory.")
+    @XmlAttribute(name = "message-factory")
     public void setMessageFactory(String messageFactory) {
         messageFactory(messageFactory);
     }
@@ -326,6 +355,7 @@ public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceSer
     @SchemaProperty(
             advanced = true,
             description = "When enabled the server does not remove the SOAP envelope before processing messages.")
+    @XmlAttribute(name = "keep-soap-envelope")
     public void setKeepSoapEnvelope(boolean flag) {
         keepSoapEnvelope(flag);
     }
@@ -339,6 +369,7 @@ public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceSer
     }
 
     @SchemaProperty(advanced = true, description = "When enabled the server handles mime headers.")
+    @XmlAttribute(name = "handle-mime-headers")
     public void setHandleMimeHeaders(boolean handleMimeHeaders) {
         handleMimeHeaders(handleMimeHeaders);
     }
@@ -352,6 +383,7 @@ public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceSer
     }
 
     @SchemaProperty(advanced = true, description = "When enabled the server handles attribute headers.")
+    @XmlAttribute(name = "handle-attribute-headers")
     public void setHandleAttributeHeaders(boolean handleAttributeHeaders) {
         handleAttributeHeaders(handleAttributeHeaders);
     }
@@ -365,6 +397,7 @@ public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceSer
     }
 
     @SchemaProperty(advanced = true, description = "Sets the SOAP header namespace.")
+    @XmlAttribute(name = "soap-header-namespace")
     public void setSoapHeaderNamespace(String namespace) {
         soapHeaderNamespace(namespace);
     }
@@ -378,6 +411,7 @@ public class WebServiceServerBuilder extends AbstractServerBuilder<WebServiceSer
     }
 
     @SchemaProperty(advanced = true, description = "Sets the SOAP header namespace prefix.")
+    @XmlAttribute(name = "soap-header-prefix")
     public void setSoapHeaderPrefix(String prefix) {
         soapHeaderPrefix(prefix);
     }

--- a/runtime/citrus-xml/src/main/java/org/citrusframework/xml/actions/CreateEndpoint.java
+++ b/runtime/citrus-xml/src/main/java/org/citrusframework/xml/actions/CreateEndpoint.java
@@ -18,9 +18,15 @@ package org.citrusframework.xml.actions;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAnyElement;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
@@ -28,6 +34,9 @@ import jakarta.xml.bind.annotation.XmlType;
 import org.citrusframework.CitrusSettings;
 import org.citrusframework.TestActionBuilder;
 import org.citrusframework.actions.CreateEndpointAction;
+import org.citrusframework.endpoint.EndpointBuilder;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.w3c.dom.Node;
 
 @XmlRootElement(name = "create-endpoint")
 public class CreateEndpoint implements TestActionBuilder<CreateEndpointAction> {
@@ -40,6 +49,8 @@ public class CreateEndpoint implements TestActionBuilder<CreateEndpointAction> {
     private boolean autoClose = CitrusSettings.isAutoCloseDynamicEndpoints();
     private boolean autoRemove = CitrusSettings.isAutoRemoveDynamicEndpoints();
     private Properties properties;
+
+    private Object anyEndpoint;
 
     @XmlAttribute
     public void setType(String type) {
@@ -91,6 +102,15 @@ public class CreateEndpoint implements TestActionBuilder<CreateEndpointAction> {
         this.properties = properties;
     }
 
+    public Object getAnyEndpoint() {
+        return anyEndpoint;
+    }
+
+    @XmlAnyElement(lax = true)
+    public void setAnyEndpoint(Object anyEndpoint) {
+        this.anyEndpoint = anyEndpoint;
+    }
+
     @Override
     public CreateEndpointAction build() {
         builder.type(type);
@@ -113,6 +133,30 @@ public class CreateEndpoint implements TestActionBuilder<CreateEndpointAction> {
 
         if (properties != null) {
             properties.getProperties().forEach(p -> builder.property(p.name, p.value));
+        }
+
+        if (anyEndpoint != null) {
+            Object endpoint = anyEndpoint;
+
+            if (anyEndpoint instanceof JAXBElement) {
+                endpoint = ((JAXBElement<?>) anyEndpoint).getValue();
+            }
+
+            if (anyEndpoint instanceof Node node) {
+                Optional<EndpointBuilder<?>> builder = EndpointBuilder.lookup(node.getLocalName());
+                if (builder.isPresent()) {
+                    try {
+                        Unmarshaller unmarshaller = JAXBContext.newInstance(builder.get().getClass()).createUnmarshaller();
+                        endpoint = unmarshaller.unmarshal(node, builder.get().getClass()).getValue();
+                    } catch (JAXBException e) {
+                        throw new CitrusRuntimeException("Failed to create XMLTestLoader instance", e);
+                    }
+                }
+            }
+
+            if (endpoint instanceof EndpointBuilder<?>) {
+                builder.endpoint((EndpointBuilder<?>) endpoint);
+            }
         }
 
         return builder.build();

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-5.0.0-SNAPSHOT.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-5.0.0-SNAPSHOT.xsd
@@ -164,9 +164,1230 @@
 
   <xs:complexType name="TestEndpoints">
     <xs:sequence>
-      <xs:element name="endpoint" minOccurs="0" maxOccurs="unbounded" type="tns:TestEndpoint"/>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="endpoint" type="tns:TestEndpoint"/>
+        <xs:element name="camel" type="tns:CamelEndpoints"/>
+        <xs:element name="channel" type="tns:SpringMessageChannelEndpoints"/>
+        <xs:element name="context" type="tns:ContextEndpoints"/>
+        <xs:element name="direct" type="tns:DirectEndpoints"/>
+        <xs:element name="docker" type="tns:DockerEndpoints"/>
+        <xs:element name="ftp" type="tns:FtpEndpoints"/>
+        <xs:element name="scp" type="tns:ScpEndpoints"/>
+        <xs:element name="sftp" type="tns:SftpEndpoints"/>
+        <xs:element name="http" type="tns:HttpEndpoints"/>
+        <xs:element name="jms" type="tns:JmsEndpoints"/>
+        <xs:element name="jmx" type="tns:JmxEndpoints"/>
+        <xs:element name="kafka" type="tns:KafkaEndpoints"/>
+        <xs:element name="kubernetes" type="tns:KubernetesEndpoints"/>
+        <xs:element name="mail" type="tns:MailEndpoints"/>
+        <xs:element name="rmi" type="tns:RmiEndpoints"/>
+        <xs:element name="selenium" type="tns:SeleniumEndpoints"/>
+        <xs:element name="ssh" type="tns:SshEndpoints"/>
+        <xs:element name="soap" type="tns:SoapWebServiceEndpoints"/>
+        <xs:element name="websocket" type="tns:WebsocketEndpoints"/>
+        <xs:element name="vertx" type="tns:VertxEndpoints"/>
+      </xs:choice>
       <xs:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="CamelEndpoints">
+    <xs:choice>
+      <xs:element name="asynchronous">
+        <xs:annotation>
+          <xs:documentation>Camel endpoint for asynchronous communication</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="camel-context" type="xs:string"/>
+          <xs:attribute name="endpoint-uri" type="xs:string" use="required"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="actor" type="xs:string"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="synchronous">
+        <xs:annotation>
+          <xs:documentation>Camel endpoint for synchronous communication</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="camel-context" type="xs:string"/>
+          <xs:attribute name="endpoint-uri" type="xs:string" use="required"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="message-correlator" type="xs:string"/>
+          <xs:attribute name="polling-interval" type="xs:string"/>
+          <xs:attribute name="actor" type="xs:string"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="ContextEndpoints">
+    <xs:sequence>
+      <xs:element name="message-store">
+        <xs:annotation>
+          <xs:documentation>Endpoint connects to the Citrus context message store.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="message-name" type="xs:string"/>
+          <xs:attribute name="actor" type="xs:string"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="SpringMessageChannelEndpoints">
+    <xs:choice>
+      <xs:element name="asynchronous">
+        <xs:annotation>
+          <xs:documentation>Message channel endpoint able to produce and consume messages on a channel destination.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:complexContent>
+            <xs:restriction base="SpringMessageChannelEndpointType"/>
+          </xs:complexContent>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="synchronous">
+        <xs:annotation>
+          <xs:documentation>Message channel endpoint able to produce and consume messages on a channel destination.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:complexContent>
+            <xs:extension base="SpringMessageChannelEndpointType">
+              <xs:attribute name="polling-interval" type="xs:string"/>
+              <xs:attribute name="message-correlator" type="xs:string"/>
+            </xs:extension>
+          </xs:complexContent>
+        </xs:complexType>
+      </xs:element>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="SpringMessageChannelEndpointType">
+    <xs:annotation>
+      <xs:documentation>Basic channel endpoint properties.</xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="name" type="xs:ID"/>
+    <xs:attribute name="messaging-template" type="xs:string"/>
+    <xs:attribute name="channel" type="xs:string"/>
+    <xs:attribute name="channel-name" type="xs:string"/>
+    <xs:attribute name="channel-resolver" type="xs:string"/>
+    <xs:attribute name="use-object-messages" type="xs:boolean"/>
+    <xs:attribute name="filter-internal-headers" type="xs:boolean" default="true"/>
+    <xs:attribute name="actor" type="xs:string"/>
+    <xs:attribute name="timeout" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="DirectEndpoints">
+    <xs:choice>
+      <xs:element name="asynchronous">
+        <xs:annotation>
+          <xs:documentation>Direct message queue endpoint able to produce and consume messages on a in memory destination.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:complexContent>
+            <xs:restriction base="DirectEndpointType"/>
+          </xs:complexContent>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="synchronous">
+        <xs:annotation>
+          <xs:documentation>Direct message queue endpoint able to produce and consume messages on a in memory destination.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:complexContent>
+            <xs:extension base="DirectEndpointType">
+              <xs:attribute name="polling-interval" type="xs:string"/>
+              <xs:attribute name="message-correlator" type="xs:string"/>
+            </xs:extension>
+          </xs:complexContent>
+        </xs:complexType>
+      </xs:element>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="DirectEndpointType">
+    <xs:annotation>
+      <xs:documentation>Basic direct endpoint properties.</xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="name" type="xs:ID"/>
+    <xs:attribute name="queue" type="xs:string"/>
+    <xs:attribute name="queue-name" type="xs:string"/>
+    <xs:attribute name="actor" type="xs:string"/>
+    <xs:attribute name="timeout" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="DockerEndpoints">
+    <xs:sequence>
+      <xs:element name="client">
+        <xs:annotation>
+          <xs:documentation>Docker Http client component able to execute docker commands such as inspect, start, stop.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="url" type="xs:string"/>
+          <xs:attribute name="version" type="xs:string"/>
+          <xs:attribute name="username" type="xs:string"/>
+          <xs:attribute name="password" type="xs:string"/>
+          <xs:attribute name="email" type="xs:string"/>
+          <xs:attribute name="registry" type="xs:string"/>
+          <xs:attribute name="verify-tls" type="xs:boolean"/>
+          <xs:attribute name="cert-path" type="xs:string"/>
+          <xs:attribute name="config-path" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="FtpEndpoints">
+    <xs:choice>
+      <xs:element name="client">
+        <xs:annotation>
+          <xs:documentation>Ftp client component sends commands to server instance and receives reply messages.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="host" type="xs:string"/>
+          <xs:attribute name="port" type="xs:string"/>
+          <xs:attribute name="username" type="xs:string"/>
+          <xs:attribute name="password" type="xs:string"/>
+          <xs:attribute name="message-correlator" type="xs:string"/>
+          <xs:attribute name="actor" type="xs:string"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+          <xs:attribute name="auto-read-files" type="xs:boolean"/>
+          <xs:attribute name="local-passive-mode" type="xs:boolean"/>
+          <xs:attribute name="polling-interval" type="xs:string"/>
+          <xs:attribute name="error-strategy">
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <xs:enumeration value="throwsException"/>
+                <xs:enumeration value="propagateError"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="server">
+        <xs:annotation>
+          <xs:documentation>Ftp server implementation accepts client connections and receives messages via Ftp transport protocol.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="server" type="xs:string"/>
+          <xs:attribute name="port" type="xs:string"/>
+          <xs:attribute name="auto-start" type="xs:boolean"/>
+          <xs:attribute name="auto-connect" type="xs:boolean"/>
+          <xs:attribute name="auto-login" type="xs:boolean"/>
+          <xs:attribute name="auto-handle-commands" type="xs:string" default="PORT,TYPE"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+          <xs:attribute name="user-manager" type="xs:string"/>
+          <xs:attribute name="user-manager-properties" type="xs:string"/>
+          <xs:attribute name="endpoint-adapter" type="xs:string"/>
+          <xs:attribute name="debug-logging" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="ScpEndpoints">
+    <xs:choice>
+      <xs:element name="client">
+        <xs:annotation>
+          <xs:documentation>Sftp client component sends commands to server instance and receives reply messages.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="host" type="xs:string"/>
+          <xs:attribute name="port" type="xs:string"/>
+          <xs:attribute name="port-option" type="xs:string"/>
+          <xs:attribute name="username" type="xs:string"/>
+          <xs:attribute name="password" type="xs:string"/>
+          <xs:attribute name="private-key-path" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Path to a private key, which can be either a plain file path or an class resource if prefixed with 'classpath:'
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="private-key-password" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Optional password for the private key
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="message-correlator" type="xs:string"/>
+          <xs:attribute name="actor" type="xs:string"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+          <xs:attribute name="polling-interval" type="xs:string"/>
+          <xs:attribute name="error-strategy">
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <xs:enumeration value="throwsException"/>
+                <xs:enumeration value="propagateError"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="server">
+        <xs:annotation>
+          <xs:documentation>SSH server component</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="port" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Port to listen to. Default is 22
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="auto-start" type="xs:boolean">
+            <xs:annotation>
+              <xs:documentation>
+                Whether to start this SSH server automatically. Default is true. If set to false,
+                a test action is responsible for starting/stopping the server
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="auto-connect" type="xs:boolean"/>
+          <xs:attribute name="auto-login" type="xs:boolean"/>
+          <xs:attribute name="host-key-path" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Path to PEM encoded key pair (public and private key) which is used as host key.
+                By default, a standard, fixed keypair is used.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="user-home-path" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Path to user home directory. If not set ${user.dir}/target/{serverName}/home/{user} is used by default.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="user" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                User which is allowed to connect.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="password" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Password for authenticating the user.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="allowed-key-path" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Path to a public key in PEM format. If prefixed with 'classpath:' it is read
+                as a resource.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="endpoint-adapter" type="xs:string"/>
+          <xs:attribute name="interceptors" type="xs:string"/>
+          <xs:attribute name="debug-logging" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="SftpEndpoints">
+    <xs:choice>
+      <xs:element name="client">
+        <xs:annotation>
+          <xs:documentation>Sftp client component sends commands to server instance and receives reply messages.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="host" type="xs:string"/>
+          <xs:attribute name="port" type="xs:string"/>
+          <xs:attribute name="username" type="xs:string"/>
+          <xs:attribute name="password" type="xs:string"/>
+          <xs:attribute name="private-key-path" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Path to a private key, which can be either a plain file path or an class resource if prefixed with 'classpath:'
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="private-key-password" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Optional password for the private key
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="strict-host-checking" type="xs:boolean"/>
+          <xs:attribute name="known-hosts-path" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Path to a known hosts file. If prefixed with 'classpath:' this file is looked up as a resource in the classpath.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="preferred-authentications" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Ordered list of preferred authentications. Client will try to authentication with these methods first.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="session-configs" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Reference to a map of session properties as key-value pairs. Applied on Jsch session on client.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="message-correlator" type="xs:string"/>
+          <xs:attribute name="actor" type="xs:string"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+          <xs:attribute name="auto-read-files" type="xs:boolean"/>
+          <xs:attribute name="local-passive-mode" type="xs:boolean"/>
+          <xs:attribute name="polling-interval" type="xs:string"/>
+          <xs:attribute name="error-strategy">
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <xs:enumeration value="throwsException"/>
+                <xs:enumeration value="propagateError"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="server">
+        <xs:annotation>
+          <xs:documentation>SSH server component</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="port" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Port to listen to. Default is 22
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="auto-start" type="xs:boolean">
+            <xs:annotation>
+              <xs:documentation>
+                Whether to start this SSH server automatically. Default is true. If set to false,
+                a test action is responsible for starting/stopping the server
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="auto-connect" type="xs:boolean"/>
+          <xs:attribute name="auto-login" type="xs:boolean"/>
+          <xs:attribute name="host-key-path" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Path to PEM encoded key pair (public and private key) which is used as host key.
+                By default, a standard, fixed keypair is used.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="user-home-path" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Path to user home directory. If not set ${user.dir}/target/{serverName}/home/{user} is used by default.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="user" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                User which is allowed to connect.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="password" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Password for authenticating the user.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="allowed-key-path" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Path to a public key in PEM format. If prefixed with 'classpath:' it is read
+                as a resource.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="endpoint-adapter" type="xs:string"/>
+          <xs:attribute name="interceptors" type="xs:string"/>
+          <xs:attribute name="debug-logging" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="HttpEndpoints">
+    <xs:choice>
+      <xs:element name="client">
+        <xs:annotation>
+          <xs:documentation>Http client component sends messages to some Http server instance and receives synchronous response message.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="request-url" type="xs:string"/>
+          <xs:attribute name="request-method" type="xs:string"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="message-correlator" type="xs:string"/>
+          <xs:attribute name="endpoint-resolver" type="xs:string"/>
+          <xs:attribute name="request-factory" type="xs:string"/>
+          <xs:attribute name="rest-template" type="xs:string"/>
+          <xs:attribute name="charset" type="xs:string"/>
+          <xs:attribute name="content-type" type="xs:string"/>
+          <xs:attribute name="default-accept-header" type="xs:boolean"/>
+          <xs:attribute name="handle-cookies" type="xs:boolean"/>
+          <xs:attribute name="disable-redirect-handling" type="xs:boolean"/>
+          <xs:attribute name="interceptors" type="xs:string"/>
+          <xs:attribute name="binary-media-types" type="xs:string"/>
+          <xs:attribute name="error-handler" type="xs:string"/>
+          <xs:attribute name="error-handling-strategy">
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <xs:enumeration value="throwsException"/>
+                <xs:enumeration value="propagateError"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="actor" type="xs:string"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+          <xs:attribute name="polling-interval" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="server">
+        <xs:annotation>
+          <xs:documentation>Http server implementation accepts client connections and receives messages via Http transport protocol.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="port" type="xs:string"/>
+          <xs:attribute name="auto-start" type="xs:boolean"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+          <xs:attribute name="context-config-location" type="xs:string"/>
+          <xs:attribute name="resource-base" type="xs:string"/>
+          <xs:attribute name="root-parent-context" type="xs:boolean"/>
+          <xs:attribute name="connector" type="xs:string"/>
+          <xs:attribute name="connectors" type="xs:string"/>
+          <xs:attribute name="filters" type="xs:string"/>
+          <xs:attribute name="filter-mappings" type="xs:string"/>
+          <xs:attribute name="binary-media-types" type="xs:string"/>
+          <xs:attribute name="servlet-name" type="xs:string"/>
+          <xs:attribute name="servlet-mapping-path" type="xs:string"/>
+          <xs:attribute name="context-path" type="xs:string"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="servlet-handler" type="xs:string"/>
+          <xs:attribute name="security-handler" type="xs:string"/>
+          <xs:attribute name="endpoint-adapter" type="xs:string"/>
+          <xs:attribute name="handle-header-attributes" type="xs:boolean"/>
+          <xs:attribute name="handle-cookies" type="xs:boolean"/>
+          <xs:attribute name="default-status-code" type="xs:string"/>
+          <xs:attribute name="response-cache-size" type="xs:integer"/>
+          <xs:attribute name="interceptors" type="xs:string"/>
+          <xs:attribute name="debug-logging" type="xs:boolean"/>
+          <xs:attribute name="actor" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="JmsEndpoints">
+    <xs:choice>
+      <xs:element name="asynchronous">
+        <xs:annotation>
+          <xs:documentation>JMS endpoint able to produce and consume messages on a JMS destination (queue or topic).</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:complexContent>
+            <xs:extension base="tns:JmsEndpointType">
+              <xs:attribute name="auto-start" type="xs:boolean"/>
+              <xs:attribute name="durable-subscription" type="xs:boolean"/>
+              <xs:attribute name="durable-subscriber-name" type="xs:string"/>
+            </xs:extension>
+          </xs:complexContent>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="synchronous">
+        <xs:annotation>
+          <xs:documentation>JMS synchronous endpoint able to produce and consume messages on a synchronous JMS
+            destination with reply message handling.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:complexContent>
+            <xs:extension base="tns:JmsEndpointType">
+              <xs:attribute name="reply-destination" type="xs:string"/>
+              <xs:attribute name="reply-destination-name" type="xs:string"/>
+              <xs:attribute name="message-correlator" type="xs:string"/>
+            </xs:extension>
+          </xs:complexContent>
+        </xs:complexType>
+      </xs:element>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="JmsEndpointType">
+    <xs:annotation>
+      <xs:documentation>Basic JMS endpoint properties.</xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="name" type="xs:ID"/>
+    <xs:attribute name="destination" type="xs:string"/>
+    <xs:attribute name="destination-name" type="xs:string"/>
+    <xs:attribute name="connection-factory" type="xs:string"/>
+    <xs:attribute name="jms-template" type="xs:string"/>
+    <xs:attribute name="message-converter" type="xs:string"/>
+    <xs:attribute name="destination-resolver" type="xs:string"/>
+    <xs:attribute name="destination-name-resolver" type="xs:string"/>
+    <xs:attribute name="pub-sub-domain" type="xs:boolean"/>
+    <xs:attribute name="filter-internal-headers" type="xs:boolean" default="true"/>
+    <xs:attribute name="use-object-messages" type="xs:boolean"/>
+    <xs:attribute name="actor" type="xs:string"/>
+    <xs:attribute name="timeout" type="xs:string"/>
+    <xs:attribute name="polling-interval" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="JmxEndpoints">
+    <xs:choice>
+      <xs:element name="client">
+        <xs:annotation>
+          <xs:documentation>Jmx Http client component able to execute jmx commands such as exec.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="server-url" type="xs:string" default="platform"/>
+          <xs:attribute name="username" type="xs:string"/>
+          <xs:attribute name="password" type="xs:string"/>
+          <xs:attribute name="auto-reconnect" type="xs:string"/>
+          <xs:attribute name="delay-on-reconnect" type="xs:string"/>
+          <xs:attribute name="notification-filter" type="xs:string"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="message-correlator" type="xs:string"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+          <xs:attribute name="polling-interval" type="xs:string"/>
+          <xs:attribute name="actor" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="server">
+        <xs:annotation>
+          <xs:documentation>RMI server implementation registers one service in RMI registry and receives messages via RMI invocation.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="mbeans">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="mbean" minOccurs="1" maxOccurs="unbounded">
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element name="operations" minOccurs="0">
+                          <xs:complexType>
+                            <xs:sequence>
+                              <xs:element name="operation" minOccurs="1" maxOccurs="unbounded">
+                                <xs:complexType>
+                                  <xs:sequence>
+                                    <xs:element name="parameter" minOccurs="0">
+                                      <xs:complexType>
+                                        <xs:sequence>
+                                          <xs:element name ="param" minOccurs="1" maxOccurs="unbounded">
+                                            <xs:complexType>
+                                              <xs:attribute name="type" type="xs:string"/>
+                                            </xs:complexType>
+                                          </xs:element>
+                                        </xs:sequence>
+                                      </xs:complexType>
+                                    </xs:element>
+                                  </xs:sequence>
+                                  <xs:attribute name="name" type="xs:string" use="required"/>
+                                  <xs:attribute name="return-type" type="xs:string"/>
+                                </xs:complexType>
+                              </xs:element>
+                            </xs:sequence>
+                          </xs:complexType>
+                        </xs:element>
+                        <xs:element name="attributes" minOccurs="0">
+                          <xs:complexType>
+                            <xs:sequence>
+                              <xs:element name="attribute" minOccurs="1" maxOccurs="unbounded">
+                                <xs:complexType>
+                                  <xs:attribute name="name" type="xs:string" use="required"/>
+                                  <xs:attribute name="type" type="xs:string" use="required"/>
+                                </xs:complexType>
+                              </xs:element>
+                            </xs:sequence>
+                          </xs:complexType>
+                        </xs:element>
+                      </xs:sequence>
+                      <xs:attribute name="type" type="xs:string"/>
+                      <xs:attribute name="name" type="xs:string"/>
+                      <xs:attribute name="objectDomain" type="xs:string"/>
+                      <xs:attribute name="objectName" type="xs:string"/>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="server-url" type="xs:string"/>
+          <xs:attribute name="host" type="xs:string" default="localhost"/>
+          <xs:attribute name="port" type="xs:string"/>
+          <xs:attribute name="protocol" type="xs:string" default="rmi"/>
+          <xs:attribute name="mbeans" type="xs:string"/>
+          <xs:attribute name="binding" type="xs:string"/>
+          <xs:attribute name="create-registry" type="xs:boolean"/>
+          <xs:attribute name="auto-start" type="xs:boolean"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="environment-properties" type="xs:string"/>
+          <xs:attribute name="debug-logging" type="xs:boolean"/>
+          <xs:attribute name="actor" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="KafkaEndpoints">
+    <xs:choice>
+      <xs:element name="asynchronous">
+        <xs:annotation>
+          <xs:documentation>Kafka endpoint able to produce and consume messages to and from topics on a Kafka message broker.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID"/>
+          <xs:attribute name="client-id" type="xs:string"/>
+          <xs:attribute name="consumer-group" type="xs:string"/>
+          <xs:attribute name="random-consumer-group" type="xs:boolean" default="false"/>
+          <xs:attribute name="auto-commit" type="xs:string"/>
+          <xs:attribute name="auto-commit-interval" type="xs:int"/>
+          <xs:attribute name="server" type="xs:string"/>
+          <xs:attribute name="offset-reset" type="xs:string"/>
+          <xs:attribute name="topic" type="xs:string"/>
+          <xs:attribute name="partition" type="xs:int"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="header-mapper" type="xs:string"/>
+          <xs:attribute name="actor" type="xs:string"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+          <xs:attribute name="key-serializer" type="xs:string"/>
+          <xs:attribute name="key-deserializer" type="xs:string"/>
+          <xs:attribute name="value-serializer" type="xs:string"/>
+          <xs:attribute name="value-deserializer" type="xs:string"/>
+          <xs:attribute name="producer-properties" type="xs:string"/>
+          <xs:attribute name="consumer-properties" type="xs:string"/>
+          <xs:attribute name="use-thread-safe-consumer" type="xs:boolean" default="false"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="synchronous">
+        <xs:annotation>
+          <xs:documentation>Kafka endpoint able to produce and consume messages to and from topics on a Kafka message broker.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID"/>
+          <xs:attribute name="client-id" type="xs:string"/>
+          <xs:attribute name="consumer-group" type="xs:string"/>
+          <xs:attribute name="random-consumer-group" type="xs:boolean" default="false"/>
+          <xs:attribute name="auto-commit" type="xs:string"/>
+          <xs:attribute name="auto-commit-interval" type="xs:int"/>
+          <xs:attribute name="server" type="xs:string"/>
+          <xs:attribute name="offset-reset" type="xs:string"/>
+          <xs:attribute name="topic" type="xs:string"/>
+          <xs:attribute name="partition" type="xs:int"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="header-mapper" type="xs:string"/>
+          <xs:attribute name="actor" type="xs:string"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+          <xs:attribute name="key-serializer" type="xs:string"/>
+          <xs:attribute name="key-deserializer" type="xs:string"/>
+          <xs:attribute name="value-serializer" type="xs:string"/>
+          <xs:attribute name="value-deserializer" type="xs:string"/>
+          <xs:attribute name="producer-properties" type="xs:string"/>
+          <xs:attribute name="consumer-properties" type="xs:string"/>
+          <xs:attribute name="thread-safe-consumer" type="xs:boolean" default="false"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="KubernetesEndpoints">
+    <xs:sequence>
+      <xs:element name="client">
+        <xs:annotation>
+          <xs:documentation>Kubernetes Http client component able to execute kubernetes commands such as inspect, start, stop.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="url" type="xs:string"/>
+          <xs:attribute name="version" type="xs:string"/>
+          <xs:attribute name="username" type="xs:string"/>
+          <xs:attribute name="password" type="xs:string"/>
+          <xs:attribute name="oauth-token" type="xs:string"/>
+          <xs:attribute name="namespace" type="xs:string"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="json-mapper" type="xs:string"/>
+          <xs:attribute name="cert-file" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="MailEndpoints">
+    <xs:choice>
+      <xs:element name="client">
+        <xs:annotation>
+          <xs:documentation>Mail client connects to SMTP server for publishing mail messages to recipients.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="host" type="xs:string" use="required"/>
+          <xs:attribute name="port" type="xs:string" use="required"/>
+          <xs:attribute name="protocol" type="xs:string"/>
+          <xs:attribute name="username" type="xs:string"/>
+          <xs:attribute name="password" type="xs:string"/>
+          <xs:attribute name="mail-properties" type="xs:string"/>
+          <xs:attribute name="actor" type="xs:string"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="marshaller" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="server">
+        <xs:annotation>
+          <xs:documentation>Mail SMTP server component - accepts mail requests and validates mail content</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="port" type="xs:string"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+          <xs:attribute name="endpoint-adapter" type="xs:string"/>
+          <xs:attribute name="auth-required" type="xs:boolean"/>
+          <xs:attribute name="auto-start" type="xs:boolean"/>
+          <xs:attribute name="auto-accept" type="xs:boolean"/>
+          <xs:attribute name="split-multipart" type="xs:boolean"/>
+          <xs:attribute name="mail-properties" type="xs:string"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="known-users" type="xs:string"/>
+          <xs:attribute name="marshaller" type="xs:string"/>
+          <xs:attribute name="debug-logging" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="SshEndpoints">
+    <xs:choice>
+      <xs:element name="client">
+        <xs:annotation>
+          <xs:documentation>Executes an SSH client request to a given server</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="host" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Host to connect to for sending an SSH Exec request. Default is 'localhost'
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="port" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Port to use. Default is 2222
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="private-key-path" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Path to a private key, which can be either a plain file path or an class resource
+                if prefixed with 'classpath:'
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="private-key-password" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Optional password for the private key
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="user" type="xs:string" use="required">
+            <xs:annotation>
+              <xs:documentation>
+                User used for connecting to the SSH server.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="password" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Password used for password based authentication. Might be combined
+                with "private-key-path" in which case both authentication mechanism are tried.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="strict-host-checking" type="xs:boolean">
+            <xs:annotation>
+              <xs:documentation>
+                Whether the host key should be verified by looking it up in a 'known_hosts' file.
+                Default is false.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="known-hosts-path" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Path to a known hosts file. If prefixed with 'classpath:' this file is looked up as
+                a resource in the classpath.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="command-timeout" type="xs:int">
+            <xs:annotation>
+              <xs:documentation>
+                Timeout in milliseconds for how long to wait for the SSH command to complete.
+                Default is 5 minutes.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="connection-timeout" type="xs:int">
+            <xs:annotation>
+              <xs:documentation>
+                Timeout in milliseconds for how long to for a connectiuon to connect.
+                Default is 1 minute.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="actor" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Actor used for switching groups of actions. See the reference documentation
+                for details.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="message-correlator" type="xs:string"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+          <xs:attribute name="polling-interval" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="server">
+        <xs:annotation>
+          <xs:documentation>SSH server component</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="port" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Port to listen to. Default is 22
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="auto-start" type="xs:boolean">
+            <xs:annotation>
+              <xs:documentation>
+                Whether to start this SSH server automatically. Default is true. If set to false,
+                a test action is responsible for starting/stopping the server
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="host-key-path" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Path to PEM encoded key pair (public and private key) which is used as host key.
+                By default, a standard, fixed keypair is used.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="user-home-path" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Path to user home directory. If not set ${user.dir}/target/{serverName}/home/{user} is used by default.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="user" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                User which is allowed to connect.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="password" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Password for authenticating the user.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="allowed-key-path" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Path to a public key in PEM format. If prefixed with 'classpath:' it is read
+                as a resource.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="endpoint-adapter" type="xs:string"/>
+          <xs:attribute name="interceptors" type="xs:string"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="debug-logging" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="RmiEndpoints">
+    <xs:choice>
+      <xs:element name="client">
+        <xs:annotation>
+          <xs:documentation>RMI client component sends messages to some RMI server instance and receives synchronous response message.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="server-url" type="xs:string"/>
+          <xs:attribute name="host" type="xs:string"/>
+          <xs:attribute name="port" type="xs:string"/>
+          <xs:attribute name="binding" type="xs:string"/>
+          <xs:attribute name="method" type="xs:string"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="message-correlator" type="xs:string"/>
+          <xs:attribute name="actor" type="xs:string"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+          <xs:attribute name="polling-interval" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="server">
+        <xs:annotation>
+          <xs:documentation>RMI server implementation registers one service in RMI registry and receives messages via RMI invocation.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="host" type="xs:string"/>
+          <xs:attribute name="port" type="xs:string"/>
+          <xs:attribute name="binding" type="xs:string" use="required"/>
+          <xs:attribute name="interface" type="xs:string" use="required"/>
+          <xs:attribute name="create-registry" type="xs:boolean"/>
+          <xs:attribute name="auto-start" type="xs:boolean"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="debug-logging" type="xs:boolean"/>
+          <xs:attribute name="actor" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="SeleniumEndpoints">
+    <xs:sequence>
+      <xs:element name="browser">
+        <xs:annotation>
+          <xs:documentation>Selenium browser configuration.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="type">
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <xs:enumeration value="custom"/>
+                <xs:enumeration value="htmlunit"/>
+                <xs:enumeration value="firefox"/>
+                <xs:enumeration value="safari"/>
+                <xs:enumeration value="chrome"/>
+                <xs:enumeration value="googlechrome"/>
+                <xs:enumeration value="internet explorer"/>
+                <xs:enumeration value="edge"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="start-page" type="xs:string"/>
+          <xs:attribute name="event-listeners" type="xs:string"/>
+          <xs:attribute name="remote-server" type="xs:string"/>
+          <xs:attribute name="javascript" type="xs:boolean"/>
+          <xs:attribute name="version" type="xs:string"/>
+          <xs:attribute name="web-driver" type="xs:string"/>
+          <xs:attribute name="firefox-profile" type="xs:string"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="SoapWebServiceEndpoints">
+    <xs:choice>
+      <xs:element name="client">
+        <xs:annotation>
+          <xs:documentation>SOAP client component sends SOAP messages to some Http web server instance and receives synchronous SOAP response message.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="request-url" type="xs:string" use="required"/>
+          <xs:attribute name="web-service-template" type="xs:string"/>
+          <xs:attribute name="message-factory" type="xs:string"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="message-sender" type="xs:string"/>
+          <xs:attribute name="message-correlator" type="xs:string"/>
+          <xs:attribute name="interceptor" type="xs:string"/>
+          <xs:attribute name="interceptors" type="xs:string"/>
+          <xs:attribute name="endpoint-resolver" type="xs:string"/>
+          <xs:attribute name="fault-strategy">
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <xs:enumeration value="throwsException"/>
+                <xs:enumeration value="propagateError"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="actor" type="xs:string"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+          <xs:attribute name="polling-interval" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="server">
+        <xs:annotation>
+          <xs:documentation>Http web server implementation accepts client connections and receives WebService messages via SOAP message protocol.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="port" type="xs:string"/>
+          <xs:attribute name="auto-start" type="xs:boolean"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+          <xs:attribute name="context-config-location" type="xs:string"/>
+          <xs:attribute name="resource-base" type="xs:string"/>
+          <xs:attribute name="root-parent-context" type="xs:boolean"/>
+          <xs:attribute name="connector" type="xs:string"/>
+          <xs:attribute name="connectors" type="xs:string"/>
+          <xs:attribute name="servlet-name" type="xs:string"/>
+          <xs:attribute name="servlet-mapping-path" type="xs:string"/>
+          <xs:attribute name="context-path" type="xs:string"/>
+          <xs:attribute name="servlet-handler" type="xs:string"/>
+          <xs:attribute name="security-handler" type="xs:string"/>
+          <xs:attribute name="endpoint-adapter" type="xs:string"/>
+          <xs:attribute name="interceptors" type="xs:string"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="message-factory" type="xs:string"/>
+          <xs:attribute name="handle-mime-headers" type="xs:boolean"/>
+          <xs:attribute name="handle-header-attributes" type="xs:boolean"/>
+          <xs:attribute name="keep-soap-envelope" type="xs:boolean"/>
+          <xs:attribute name="soap-header-namespace" type="xs:string"/>
+          <xs:attribute name="soap-header-prefix" type="xs:string"/>
+          <xs:attribute name="debug-logging" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="WebsocketEndpoints">
+    <xs:choice>
+      <xs:element name="client">
+        <xs:annotation>
+          <xs:documentation>WebSocket client component for sending and receiving asynchronous requests to and from WebSocket server</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="url" type="xs:string"/>
+          <xs:attribute name="http-headers" type="xs:string"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="endpoint-resolver" type="xs:string"/>
+          <xs:attribute name="actor" type="xs:string"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+          <xs:attribute name="polling-interval" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="server">
+        <xs:annotation>
+          <xs:documentation>Http websocket server implementation accepts client connections and receives messages via Http WebSocket transport protocol.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="endpoints" minOccurs="0">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="endpoint" maxOccurs="unbounded">
+                    <xs:complexType>
+                      <xs:attribute name="ref" type="xs:string" use="required" />
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="port" type="xs:string"/>
+          <xs:attribute name="auto-start" type="xs:boolean"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+          <xs:attribute name="context-config-location" type="xs:string"/>
+          <xs:attribute name="resource-base" type="xs:string"/>
+          <xs:attribute name="root-parent-context" type="xs:boolean"/>
+          <xs:attribute name="connector" type="xs:string"/>
+          <xs:attribute name="connectors" type="xs:string"/>
+          <xs:attribute name="servlet-name" type="xs:string"/>
+          <xs:attribute name="servlet-mapping-path" type="xs:string"/>
+          <xs:attribute name="context-path" type="xs:string"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="servlet-handler" type="xs:string"/>
+          <xs:attribute name="security-handler" type="xs:string"/>
+          <xs:attribute name="endpoints" type="xs:string"/>
+          <xs:attribute name="endpoint-adapter" type="xs:string"/>
+          <xs:attribute name="interceptors" type="xs:string"/>
+          <xs:attribute name="debug-logging" type="xs:boolean"/>
+          <xs:attribute name="actor" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="VertxEndpoints">
+    <xs:choice>
+      <xs:element name="asynchronous">
+        <xs:annotation>
+          <xs:documentation>Vert.x endpoint for asynchronous communication</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="host" type="xs:string"/>
+          <xs:attribute name="port" type="xs:string"/>
+          <xs:attribute name="address" type="xs:string" use="required"/>
+          <xs:attribute name="vertx-factory" type="xs:string"/>
+          <xs:attribute name="pub-sub-domain" type="xs:boolean"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="polling-interval" type="xs:string"/>
+          <xs:attribute name="actor" type="xs:string"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="synchronous">
+        <xs:annotation>
+          <xs:documentation>Vert.x endpoint for synchronous communication</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="host" type="xs:string"/>
+          <xs:attribute name="port" type="xs:string"/>
+          <xs:attribute name="address" type="xs:string" use="required"/>
+          <xs:attribute name="message-correlator" type="xs:string"/>
+          <xs:attribute name="vertx-factory" type="xs:string"/>
+          <xs:attribute name="pub-sub-domain" type="xs:boolean"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="polling-interval" type="xs:string"/>
+          <xs:attribute name="actor" type="xs:string"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:choice>
   </xs:complexType>
 
   <xs:complexType name="TestEndpoint">
@@ -403,6 +1624,39 @@
       <xs:element name="description" type="xs:string" minOccurs="0"/>
       <xs:element name="variable" type="tns:VariableType" maxOccurs="unbounded"/>
     </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="CreateEndpoint">
+    <xs:complexContent>
+      <xs:extension base="tns:TestEndpoint">
+        <xs:sequence>
+          <xs:element name="description" type="xs:string" minOccurs="0"/>
+          <xs:choice minOccurs="0">
+            <xs:element name="camel" type="tns:CamelEndpoints"/>
+            <xs:element name="channel" type="tns:SpringMessageChannelEndpoints"/>
+            <xs:element name="context" type="tns:ContextEndpoints"/>
+            <xs:element name="direct" type="tns:DirectEndpoints"/>
+            <xs:element name="docker" type="tns:DockerEndpoints"/>
+            <xs:element name="ftp" type="tns:FtpEndpoints"/>
+            <xs:element name="scp" type="tns:ScpEndpoints"/>
+            <xs:element name="sftp" type="tns:SftpEndpoints"/>
+            <xs:element name="http" type="tns:HttpEndpoints"/>
+            <xs:element name="jms" type="tns:JmsEndpoints"/>
+            <xs:element name="jmx" type="tns:JmxEndpoints"/>
+            <xs:element name="kafka" type="tns:KafkaEndpoints"/>
+            <xs:element name="kubernetes" type="tns:KubernetesEndpoints"/>
+            <xs:element name="mail" type="tns:MailEndpoints"/>
+            <xs:element name="rmi" type="tns:RmiEndpoints"/>
+            <xs:element name="selenium" type="tns:SeleniumEndpoints"/>
+            <xs:element name="ssh" type="tns:SshEndpoints"/>
+            <xs:element name="soap" type="tns:SoapWebServiceEndpoints"/>
+            <xs:element name="websocket" type="tns:WebsocketEndpoints"/>
+            <xs:element name="vertx" type="tns:VertxEndpoints"/>
+          </xs:choice>
+          <xs:any processContents="lax" minOccurs="0"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
   </xs:complexType>
 
   <xs:complexType name="StopTimer">
@@ -732,7 +1986,7 @@
   <xs:element name="catch" type="tns:Catch"/>
   <xs:element name="conditional" type="tns:Conditional"/>
   <xs:element name="create-variables" type="tns:CreateVariables"/>
-  <xs:element name="create-endpoint" type="tns:TestEndpoint"/>
+  <xs:element name="create-endpoint" type="tns:CreateEndpoint"/>
   <xs:element name="delay" type="tns:Delay"/>
   <xs:element name="echo" type="tns:Echo"/>
   <xs:element name="expect-timeout" type="tns:ExpectTimeout"/>

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
@@ -164,9 +164,1230 @@
 
   <xs:complexType name="TestEndpoints">
     <xs:sequence>
-      <xs:element name="endpoint" minOccurs="0" maxOccurs="unbounded" type="tns:TestEndpoint"/>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="endpoint" type="tns:TestEndpoint"/>
+        <xs:element name="camel" type="tns:CamelEndpoints"/>
+        <xs:element name="channel" type="tns:SpringMessageChannelEndpoints"/>
+        <xs:element name="context" type="tns:ContextEndpoints"/>
+        <xs:element name="direct" type="tns:DirectEndpoints"/>
+        <xs:element name="docker" type="tns:DockerEndpoints"/>
+        <xs:element name="ftp" type="tns:FtpEndpoints"/>
+        <xs:element name="scp" type="tns:ScpEndpoints"/>
+        <xs:element name="sftp" type="tns:SftpEndpoints"/>
+        <xs:element name="http" type="tns:HttpEndpoints"/>
+        <xs:element name="jms" type="tns:JmsEndpoints"/>
+        <xs:element name="jmx" type="tns:JmxEndpoints"/>
+        <xs:element name="kafka" type="tns:KafkaEndpoints"/>
+        <xs:element name="kubernetes" type="tns:KubernetesEndpoints"/>
+        <xs:element name="mail" type="tns:MailEndpoints"/>
+        <xs:element name="rmi" type="tns:RmiEndpoints"/>
+        <xs:element name="selenium" type="tns:SeleniumEndpoints"/>
+        <xs:element name="ssh" type="tns:SshEndpoints"/>
+        <xs:element name="soap" type="tns:SoapWebServiceEndpoints"/>
+        <xs:element name="websocket" type="tns:WebsocketEndpoints"/>
+        <xs:element name="vertx" type="tns:VertxEndpoints"/>
+      </xs:choice>
       <xs:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="CamelEndpoints">
+    <xs:choice>
+      <xs:element name="asynchronous">
+        <xs:annotation>
+          <xs:documentation>Camel endpoint for asynchronous communication</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="camel-context" type="xs:string"/>
+          <xs:attribute name="endpoint-uri" type="xs:string" use="required"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="actor" type="xs:string"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="synchronous">
+        <xs:annotation>
+          <xs:documentation>Camel endpoint for synchronous communication</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="camel-context" type="xs:string"/>
+          <xs:attribute name="endpoint-uri" type="xs:string" use="required"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="message-correlator" type="xs:string"/>
+          <xs:attribute name="polling-interval" type="xs:string"/>
+          <xs:attribute name="actor" type="xs:string"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="ContextEndpoints">
+    <xs:sequence>
+      <xs:element name="message-store">
+        <xs:annotation>
+          <xs:documentation>Endpoint connects to the Citrus context message store.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="message-name" type="xs:string"/>
+          <xs:attribute name="actor" type="xs:string"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="SpringMessageChannelEndpoints">
+    <xs:choice>
+      <xs:element name="asynchronous">
+        <xs:annotation>
+          <xs:documentation>Message channel endpoint able to produce and consume messages on a channel destination.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:complexContent>
+            <xs:restriction base="SpringMessageChannelEndpointType"/>
+          </xs:complexContent>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="synchronous">
+        <xs:annotation>
+          <xs:documentation>Message channel endpoint able to produce and consume messages on a channel destination.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:complexContent>
+            <xs:extension base="SpringMessageChannelEndpointType">
+              <xs:attribute name="polling-interval" type="xs:string"/>
+              <xs:attribute name="message-correlator" type="xs:string"/>
+            </xs:extension>
+          </xs:complexContent>
+        </xs:complexType>
+      </xs:element>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="SpringMessageChannelEndpointType">
+    <xs:annotation>
+      <xs:documentation>Basic channel endpoint properties.</xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="name" type="xs:ID"/>
+    <xs:attribute name="messaging-template" type="xs:string"/>
+    <xs:attribute name="channel" type="xs:string"/>
+    <xs:attribute name="channel-name" type="xs:string"/>
+    <xs:attribute name="channel-resolver" type="xs:string"/>
+    <xs:attribute name="use-object-messages" type="xs:boolean"/>
+    <xs:attribute name="filter-internal-headers" type="xs:boolean" default="true"/>
+    <xs:attribute name="actor" type="xs:string"/>
+    <xs:attribute name="timeout" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="DirectEndpoints">
+    <xs:choice>
+      <xs:element name="asynchronous">
+        <xs:annotation>
+          <xs:documentation>Direct message queue endpoint able to produce and consume messages on a in memory destination.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:complexContent>
+            <xs:restriction base="DirectEndpointType"/>
+          </xs:complexContent>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="synchronous">
+        <xs:annotation>
+          <xs:documentation>Direct message queue endpoint able to produce and consume messages on a in memory destination.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:complexContent>
+            <xs:extension base="DirectEndpointType">
+              <xs:attribute name="polling-interval" type="xs:string"/>
+              <xs:attribute name="message-correlator" type="xs:string"/>
+            </xs:extension>
+          </xs:complexContent>
+        </xs:complexType>
+      </xs:element>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="DirectEndpointType">
+    <xs:annotation>
+      <xs:documentation>Basic direct endpoint properties.</xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="name" type="xs:ID"/>
+    <xs:attribute name="queue" type="xs:string"/>
+    <xs:attribute name="queue-name" type="xs:string"/>
+    <xs:attribute name="actor" type="xs:string"/>
+    <xs:attribute name="timeout" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="DockerEndpoints">
+    <xs:sequence>
+      <xs:element name="client">
+        <xs:annotation>
+          <xs:documentation>Docker Http client component able to execute docker commands such as inspect, start, stop.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="url" type="xs:string"/>
+          <xs:attribute name="version" type="xs:string"/>
+          <xs:attribute name="username" type="xs:string"/>
+          <xs:attribute name="password" type="xs:string"/>
+          <xs:attribute name="email" type="xs:string"/>
+          <xs:attribute name="registry" type="xs:string"/>
+          <xs:attribute name="verify-tls" type="xs:boolean"/>
+          <xs:attribute name="cert-path" type="xs:string"/>
+          <xs:attribute name="config-path" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="FtpEndpoints">
+    <xs:choice>
+      <xs:element name="client">
+        <xs:annotation>
+          <xs:documentation>Ftp client component sends commands to server instance and receives reply messages.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="host" type="xs:string"/>
+          <xs:attribute name="port" type="xs:string"/>
+          <xs:attribute name="username" type="xs:string"/>
+          <xs:attribute name="password" type="xs:string"/>
+          <xs:attribute name="message-correlator" type="xs:string"/>
+          <xs:attribute name="actor" type="xs:string"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+          <xs:attribute name="auto-read-files" type="xs:boolean"/>
+          <xs:attribute name="local-passive-mode" type="xs:boolean"/>
+          <xs:attribute name="polling-interval" type="xs:string"/>
+          <xs:attribute name="error-strategy">
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <xs:enumeration value="throwsException"/>
+                <xs:enumeration value="propagateError"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="server">
+        <xs:annotation>
+          <xs:documentation>Ftp server implementation accepts client connections and receives messages via Ftp transport protocol.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="server" type="xs:string"/>
+          <xs:attribute name="port" type="xs:string"/>
+          <xs:attribute name="auto-start" type="xs:boolean"/>
+          <xs:attribute name="auto-connect" type="xs:boolean"/>
+          <xs:attribute name="auto-login" type="xs:boolean"/>
+          <xs:attribute name="auto-handle-commands" type="xs:string" default="PORT,TYPE"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+          <xs:attribute name="user-manager" type="xs:string"/>
+          <xs:attribute name="user-manager-properties" type="xs:string"/>
+          <xs:attribute name="endpoint-adapter" type="xs:string"/>
+          <xs:attribute name="debug-logging" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="ScpEndpoints">
+    <xs:choice>
+      <xs:element name="client">
+        <xs:annotation>
+          <xs:documentation>Sftp client component sends commands to server instance and receives reply messages.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="host" type="xs:string"/>
+          <xs:attribute name="port" type="xs:string"/>
+          <xs:attribute name="port-option" type="xs:string"/>
+          <xs:attribute name="username" type="xs:string"/>
+          <xs:attribute name="password" type="xs:string"/>
+          <xs:attribute name="private-key-path" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Path to a private key, which can be either a plain file path or an class resource if prefixed with 'classpath:'
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="private-key-password" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Optional password for the private key
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="message-correlator" type="xs:string"/>
+          <xs:attribute name="actor" type="xs:string"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+          <xs:attribute name="polling-interval" type="xs:string"/>
+          <xs:attribute name="error-strategy">
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <xs:enumeration value="throwsException"/>
+                <xs:enumeration value="propagateError"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="server">
+        <xs:annotation>
+          <xs:documentation>SSH server component</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="port" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Port to listen to. Default is 22
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="auto-start" type="xs:boolean">
+            <xs:annotation>
+              <xs:documentation>
+                Whether to start this SSH server automatically. Default is true. If set to false,
+                a test action is responsible for starting/stopping the server
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="auto-connect" type="xs:boolean"/>
+          <xs:attribute name="auto-login" type="xs:boolean"/>
+          <xs:attribute name="host-key-path" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Path to PEM encoded key pair (public and private key) which is used as host key.
+                By default, a standard, fixed keypair is used.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="user-home-path" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Path to user home directory. If not set ${user.dir}/target/{serverName}/home/{user} is used by default.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="user" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                User which is allowed to connect.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="password" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Password for authenticating the user.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="allowed-key-path" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Path to a public key in PEM format. If prefixed with 'classpath:' it is read
+                as a resource.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="endpoint-adapter" type="xs:string"/>
+          <xs:attribute name="interceptors" type="xs:string"/>
+          <xs:attribute name="debug-logging" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="SftpEndpoints">
+    <xs:choice>
+      <xs:element name="client">
+        <xs:annotation>
+          <xs:documentation>Sftp client component sends commands to server instance and receives reply messages.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="host" type="xs:string"/>
+          <xs:attribute name="port" type="xs:string"/>
+          <xs:attribute name="username" type="xs:string"/>
+          <xs:attribute name="password" type="xs:string"/>
+          <xs:attribute name="private-key-path" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Path to a private key, which can be either a plain file path or an class resource if prefixed with 'classpath:'
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="private-key-password" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Optional password for the private key
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="strict-host-checking" type="xs:boolean"/>
+          <xs:attribute name="known-hosts-path" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Path to a known hosts file. If prefixed with 'classpath:' this file is looked up as a resource in the classpath.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="preferred-authentications" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Ordered list of preferred authentications. Client will try to authentication with these methods first.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="session-configs" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Reference to a map of session properties as key-value pairs. Applied on Jsch session on client.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="message-correlator" type="xs:string"/>
+          <xs:attribute name="actor" type="xs:string"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+          <xs:attribute name="auto-read-files" type="xs:boolean"/>
+          <xs:attribute name="local-passive-mode" type="xs:boolean"/>
+          <xs:attribute name="polling-interval" type="xs:string"/>
+          <xs:attribute name="error-strategy">
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <xs:enumeration value="throwsException"/>
+                <xs:enumeration value="propagateError"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="server">
+        <xs:annotation>
+          <xs:documentation>SSH server component</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="port" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Port to listen to. Default is 22
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="auto-start" type="xs:boolean">
+            <xs:annotation>
+              <xs:documentation>
+                Whether to start this SSH server automatically. Default is true. If set to false,
+                a test action is responsible for starting/stopping the server
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="auto-connect" type="xs:boolean"/>
+          <xs:attribute name="auto-login" type="xs:boolean"/>
+          <xs:attribute name="host-key-path" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Path to PEM encoded key pair (public and private key) which is used as host key.
+                By default, a standard, fixed keypair is used.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="user-home-path" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Path to user home directory. If not set ${user.dir}/target/{serverName}/home/{user} is used by default.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="user" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                User which is allowed to connect.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="password" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Password for authenticating the user.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="allowed-key-path" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Path to a public key in PEM format. If prefixed with 'classpath:' it is read
+                as a resource.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="endpoint-adapter" type="xs:string"/>
+          <xs:attribute name="interceptors" type="xs:string"/>
+          <xs:attribute name="debug-logging" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="HttpEndpoints">
+    <xs:choice>
+      <xs:element name="client">
+        <xs:annotation>
+          <xs:documentation>Http client component sends messages to some Http server instance and receives synchronous response message.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="request-url" type="xs:string"/>
+          <xs:attribute name="request-method" type="xs:string"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="message-correlator" type="xs:string"/>
+          <xs:attribute name="endpoint-resolver" type="xs:string"/>
+          <xs:attribute name="request-factory" type="xs:string"/>
+          <xs:attribute name="rest-template" type="xs:string"/>
+          <xs:attribute name="charset" type="xs:string"/>
+          <xs:attribute name="content-type" type="xs:string"/>
+          <xs:attribute name="default-accept-header" type="xs:boolean"/>
+          <xs:attribute name="handle-cookies" type="xs:boolean"/>
+          <xs:attribute name="disable-redirect-handling" type="xs:boolean"/>
+          <xs:attribute name="interceptors" type="xs:string"/>
+          <xs:attribute name="binary-media-types" type="xs:string"/>
+          <xs:attribute name="error-handler" type="xs:string"/>
+          <xs:attribute name="error-handling-strategy">
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <xs:enumeration value="throwsException"/>
+                <xs:enumeration value="propagateError"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="actor" type="xs:string"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+          <xs:attribute name="polling-interval" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="server">
+        <xs:annotation>
+          <xs:documentation>Http server implementation accepts client connections and receives messages via Http transport protocol.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="port" type="xs:string"/>
+          <xs:attribute name="auto-start" type="xs:boolean"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+          <xs:attribute name="context-config-location" type="xs:string"/>
+          <xs:attribute name="resource-base" type="xs:string"/>
+          <xs:attribute name="root-parent-context" type="xs:boolean"/>
+          <xs:attribute name="connector" type="xs:string"/>
+          <xs:attribute name="connectors" type="xs:string"/>
+          <xs:attribute name="filters" type="xs:string"/>
+          <xs:attribute name="filter-mappings" type="xs:string"/>
+          <xs:attribute name="binary-media-types" type="xs:string"/>
+          <xs:attribute name="servlet-name" type="xs:string"/>
+          <xs:attribute name="servlet-mapping-path" type="xs:string"/>
+          <xs:attribute name="context-path" type="xs:string"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="servlet-handler" type="xs:string"/>
+          <xs:attribute name="security-handler" type="xs:string"/>
+          <xs:attribute name="endpoint-adapter" type="xs:string"/>
+          <xs:attribute name="handle-header-attributes" type="xs:boolean"/>
+          <xs:attribute name="handle-cookies" type="xs:boolean"/>
+          <xs:attribute name="default-status-code" type="xs:string"/>
+          <xs:attribute name="response-cache-size" type="xs:integer"/>
+          <xs:attribute name="interceptors" type="xs:string"/>
+          <xs:attribute name="debug-logging" type="xs:boolean"/>
+          <xs:attribute name="actor" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="JmsEndpoints">
+    <xs:choice>
+      <xs:element name="asynchronous">
+        <xs:annotation>
+          <xs:documentation>JMS endpoint able to produce and consume messages on a JMS destination (queue or topic).</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:complexContent>
+            <xs:extension base="tns:JmsEndpointType">
+              <xs:attribute name="auto-start" type="xs:boolean"/>
+              <xs:attribute name="durable-subscription" type="xs:boolean"/>
+              <xs:attribute name="durable-subscriber-name" type="xs:string"/>
+            </xs:extension>
+          </xs:complexContent>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="synchronous">
+        <xs:annotation>
+          <xs:documentation>JMS synchronous endpoint able to produce and consume messages on a synchronous JMS
+            destination with reply message handling.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:complexContent>
+            <xs:extension base="tns:JmsEndpointType">
+              <xs:attribute name="reply-destination" type="xs:string"/>
+              <xs:attribute name="reply-destination-name" type="xs:string"/>
+              <xs:attribute name="message-correlator" type="xs:string"/>
+            </xs:extension>
+          </xs:complexContent>
+        </xs:complexType>
+      </xs:element>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="JmsEndpointType">
+    <xs:annotation>
+      <xs:documentation>Basic JMS endpoint properties.</xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="name" type="xs:ID"/>
+    <xs:attribute name="destination" type="xs:string"/>
+    <xs:attribute name="destination-name" type="xs:string"/>
+    <xs:attribute name="connection-factory" type="xs:string"/>
+    <xs:attribute name="jms-template" type="xs:string"/>
+    <xs:attribute name="message-converter" type="xs:string"/>
+    <xs:attribute name="destination-resolver" type="xs:string"/>
+    <xs:attribute name="destination-name-resolver" type="xs:string"/>
+    <xs:attribute name="pub-sub-domain" type="xs:boolean"/>
+    <xs:attribute name="filter-internal-headers" type="xs:boolean" default="true"/>
+    <xs:attribute name="use-object-messages" type="xs:boolean"/>
+    <xs:attribute name="actor" type="xs:string"/>
+    <xs:attribute name="timeout" type="xs:string"/>
+    <xs:attribute name="polling-interval" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="JmxEndpoints">
+    <xs:choice>
+      <xs:element name="client">
+        <xs:annotation>
+          <xs:documentation>Jmx Http client component able to execute jmx commands such as exec.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="server-url" type="xs:string" default="platform"/>
+          <xs:attribute name="username" type="xs:string"/>
+          <xs:attribute name="password" type="xs:string"/>
+          <xs:attribute name="auto-reconnect" type="xs:string"/>
+          <xs:attribute name="delay-on-reconnect" type="xs:string"/>
+          <xs:attribute name="notification-filter" type="xs:string"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="message-correlator" type="xs:string"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+          <xs:attribute name="polling-interval" type="xs:string"/>
+          <xs:attribute name="actor" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="server">
+        <xs:annotation>
+          <xs:documentation>RMI server implementation registers one service in RMI registry and receives messages via RMI invocation.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="mbeans">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="mbean" minOccurs="1" maxOccurs="unbounded">
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element name="operations" minOccurs="0">
+                          <xs:complexType>
+                            <xs:sequence>
+                              <xs:element name="operation" minOccurs="1" maxOccurs="unbounded">
+                                <xs:complexType>
+                                  <xs:sequence>
+                                    <xs:element name="parameter" minOccurs="0">
+                                      <xs:complexType>
+                                        <xs:sequence>
+                                          <xs:element name ="param" minOccurs="1" maxOccurs="unbounded">
+                                            <xs:complexType>
+                                              <xs:attribute name="type" type="xs:string"/>
+                                            </xs:complexType>
+                                          </xs:element>
+                                        </xs:sequence>
+                                      </xs:complexType>
+                                    </xs:element>
+                                  </xs:sequence>
+                                  <xs:attribute name="name" type="xs:string" use="required"/>
+                                  <xs:attribute name="return-type" type="xs:string"/>
+                                </xs:complexType>
+                              </xs:element>
+                            </xs:sequence>
+                          </xs:complexType>
+                        </xs:element>
+                        <xs:element name="attributes" minOccurs="0">
+                          <xs:complexType>
+                            <xs:sequence>
+                              <xs:element name="attribute" minOccurs="1" maxOccurs="unbounded">
+                                <xs:complexType>
+                                  <xs:attribute name="name" type="xs:string" use="required"/>
+                                  <xs:attribute name="type" type="xs:string" use="required"/>
+                                </xs:complexType>
+                              </xs:element>
+                            </xs:sequence>
+                          </xs:complexType>
+                        </xs:element>
+                      </xs:sequence>
+                      <xs:attribute name="type" type="xs:string"/>
+                      <xs:attribute name="name" type="xs:string"/>
+                      <xs:attribute name="objectDomain" type="xs:string"/>
+                      <xs:attribute name="objectName" type="xs:string"/>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="server-url" type="xs:string"/>
+          <xs:attribute name="host" type="xs:string" default="localhost"/>
+          <xs:attribute name="port" type="xs:string"/>
+          <xs:attribute name="protocol" type="xs:string" default="rmi"/>
+          <xs:attribute name="mbeans" type="xs:string"/>
+          <xs:attribute name="binding" type="xs:string"/>
+          <xs:attribute name="create-registry" type="xs:boolean"/>
+          <xs:attribute name="auto-start" type="xs:boolean"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="environment-properties" type="xs:string"/>
+          <xs:attribute name="debug-logging" type="xs:boolean"/>
+          <xs:attribute name="actor" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="KafkaEndpoints">
+    <xs:choice>
+      <xs:element name="asynchronous">
+        <xs:annotation>
+          <xs:documentation>Kafka endpoint able to produce and consume messages to and from topics on a Kafka message broker.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID"/>
+          <xs:attribute name="client-id" type="xs:string"/>
+          <xs:attribute name="consumer-group" type="xs:string"/>
+          <xs:attribute name="random-consumer-group" type="xs:boolean" default="false"/>
+          <xs:attribute name="auto-commit" type="xs:string"/>
+          <xs:attribute name="auto-commit-interval" type="xs:int"/>
+          <xs:attribute name="server" type="xs:string"/>
+          <xs:attribute name="offset-reset" type="xs:string"/>
+          <xs:attribute name="topic" type="xs:string"/>
+          <xs:attribute name="partition" type="xs:int"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="header-mapper" type="xs:string"/>
+          <xs:attribute name="actor" type="xs:string"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+          <xs:attribute name="key-serializer" type="xs:string"/>
+          <xs:attribute name="key-deserializer" type="xs:string"/>
+          <xs:attribute name="value-serializer" type="xs:string"/>
+          <xs:attribute name="value-deserializer" type="xs:string"/>
+          <xs:attribute name="producer-properties" type="xs:string"/>
+          <xs:attribute name="consumer-properties" type="xs:string"/>
+          <xs:attribute name="use-thread-safe-consumer" type="xs:boolean" default="false"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="synchronous">
+        <xs:annotation>
+          <xs:documentation>Kafka endpoint able to produce and consume messages to and from topics on a Kafka message broker.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID"/>
+          <xs:attribute name="client-id" type="xs:string"/>
+          <xs:attribute name="consumer-group" type="xs:string"/>
+          <xs:attribute name="random-consumer-group" type="xs:boolean" default="false"/>
+          <xs:attribute name="auto-commit" type="xs:string"/>
+          <xs:attribute name="auto-commit-interval" type="xs:int"/>
+          <xs:attribute name="server" type="xs:string"/>
+          <xs:attribute name="offset-reset" type="xs:string"/>
+          <xs:attribute name="topic" type="xs:string"/>
+          <xs:attribute name="partition" type="xs:int"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="header-mapper" type="xs:string"/>
+          <xs:attribute name="actor" type="xs:string"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+          <xs:attribute name="key-serializer" type="xs:string"/>
+          <xs:attribute name="key-deserializer" type="xs:string"/>
+          <xs:attribute name="value-serializer" type="xs:string"/>
+          <xs:attribute name="value-deserializer" type="xs:string"/>
+          <xs:attribute name="producer-properties" type="xs:string"/>
+          <xs:attribute name="consumer-properties" type="xs:string"/>
+          <xs:attribute name="thread-safe-consumer" type="xs:boolean" default="false"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="KubernetesEndpoints">
+    <xs:sequence>
+      <xs:element name="client">
+        <xs:annotation>
+          <xs:documentation>Kubernetes Http client component able to execute kubernetes commands such as inspect, start, stop.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="url" type="xs:string"/>
+          <xs:attribute name="version" type="xs:string"/>
+          <xs:attribute name="username" type="xs:string"/>
+          <xs:attribute name="password" type="xs:string"/>
+          <xs:attribute name="oauth-token" type="xs:string"/>
+          <xs:attribute name="namespace" type="xs:string"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="json-mapper" type="xs:string"/>
+          <xs:attribute name="cert-file" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="MailEndpoints">
+    <xs:choice>
+      <xs:element name="client">
+        <xs:annotation>
+          <xs:documentation>Mail client connects to SMTP server for publishing mail messages to recipients.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="host" type="xs:string" use="required"/>
+          <xs:attribute name="port" type="xs:string" use="required"/>
+          <xs:attribute name="protocol" type="xs:string"/>
+          <xs:attribute name="username" type="xs:string"/>
+          <xs:attribute name="password" type="xs:string"/>
+          <xs:attribute name="mail-properties" type="xs:string"/>
+          <xs:attribute name="actor" type="xs:string"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="marshaller" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="server">
+        <xs:annotation>
+          <xs:documentation>Mail SMTP server component - accepts mail requests and validates mail content</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="port" type="xs:string"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+          <xs:attribute name="endpoint-adapter" type="xs:string"/>
+          <xs:attribute name="auth-required" type="xs:boolean"/>
+          <xs:attribute name="auto-start" type="xs:boolean"/>
+          <xs:attribute name="auto-accept" type="xs:boolean"/>
+          <xs:attribute name="split-multipart" type="xs:boolean"/>
+          <xs:attribute name="mail-properties" type="xs:string"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="known-users" type="xs:string"/>
+          <xs:attribute name="marshaller" type="xs:string"/>
+          <xs:attribute name="debug-logging" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="SshEndpoints">
+    <xs:choice>
+      <xs:element name="client">
+        <xs:annotation>
+          <xs:documentation>Executes an SSH client request to a given server</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="host" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Host to connect to for sending an SSH Exec request. Default is 'localhost'
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="port" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Port to use. Default is 2222
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="private-key-path" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Path to a private key, which can be either a plain file path or an class resource
+                if prefixed with 'classpath:'
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="private-key-password" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Optional password for the private key
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="user" type="xs:string" use="required">
+            <xs:annotation>
+              <xs:documentation>
+                User used for connecting to the SSH server.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="password" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Password used for password based authentication. Might be combined
+                with "private-key-path" in which case both authentication mechanism are tried.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="strict-host-checking" type="xs:boolean">
+            <xs:annotation>
+              <xs:documentation>
+                Whether the host key should be verified by looking it up in a 'known_hosts' file.
+                Default is false.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="known-hosts-path" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Path to a known hosts file. If prefixed with 'classpath:' this file is looked up as
+                a resource in the classpath.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="command-timeout" type="xs:int">
+            <xs:annotation>
+              <xs:documentation>
+                Timeout in milliseconds for how long to wait for the SSH command to complete.
+                Default is 5 minutes.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="connection-timeout" type="xs:int">
+            <xs:annotation>
+              <xs:documentation>
+                Timeout in milliseconds for how long to for a connectiuon to connect.
+                Default is 1 minute.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="actor" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Actor used for switching groups of actions. See the reference documentation
+                for details.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="message-correlator" type="xs:string"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+          <xs:attribute name="polling-interval" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="server">
+        <xs:annotation>
+          <xs:documentation>SSH server component</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="port" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Port to listen to. Default is 22
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="auto-start" type="xs:boolean">
+            <xs:annotation>
+              <xs:documentation>
+                Whether to start this SSH server automatically. Default is true. If set to false,
+                a test action is responsible for starting/stopping the server
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="host-key-path" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Path to PEM encoded key pair (public and private key) which is used as host key.
+                By default, a standard, fixed keypair is used.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="user-home-path" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Path to user home directory. If not set ${user.dir}/target/{serverName}/home/{user} is used by default.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="user" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                User which is allowed to connect.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="password" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Password for authenticating the user.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="allowed-key-path" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                Path to a public key in PEM format. If prefixed with 'classpath:' it is read
+                as a resource.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="endpoint-adapter" type="xs:string"/>
+          <xs:attribute name="interceptors" type="xs:string"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="debug-logging" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="RmiEndpoints">
+    <xs:choice>
+      <xs:element name="client">
+        <xs:annotation>
+          <xs:documentation>RMI client component sends messages to some RMI server instance and receives synchronous response message.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="server-url" type="xs:string"/>
+          <xs:attribute name="host" type="xs:string"/>
+          <xs:attribute name="port" type="xs:string"/>
+          <xs:attribute name="binding" type="xs:string"/>
+          <xs:attribute name="method" type="xs:string"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="message-correlator" type="xs:string"/>
+          <xs:attribute name="actor" type="xs:string"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+          <xs:attribute name="polling-interval" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="server">
+        <xs:annotation>
+          <xs:documentation>RMI server implementation registers one service in RMI registry and receives messages via RMI invocation.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="host" type="xs:string"/>
+          <xs:attribute name="port" type="xs:string"/>
+          <xs:attribute name="binding" type="xs:string" use="required"/>
+          <xs:attribute name="interface" type="xs:string" use="required"/>
+          <xs:attribute name="create-registry" type="xs:boolean"/>
+          <xs:attribute name="auto-start" type="xs:boolean"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="debug-logging" type="xs:boolean"/>
+          <xs:attribute name="actor" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="SeleniumEndpoints">
+    <xs:sequence>
+      <xs:element name="browser">
+        <xs:annotation>
+          <xs:documentation>Selenium browser configuration.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="type">
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <xs:enumeration value="custom"/>
+                <xs:enumeration value="htmlunit"/>
+                <xs:enumeration value="firefox"/>
+                <xs:enumeration value="safari"/>
+                <xs:enumeration value="chrome"/>
+                <xs:enumeration value="googlechrome"/>
+                <xs:enumeration value="internet explorer"/>
+                <xs:enumeration value="edge"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="start-page" type="xs:string"/>
+          <xs:attribute name="event-listeners" type="xs:string"/>
+          <xs:attribute name="remote-server" type="xs:string"/>
+          <xs:attribute name="javascript" type="xs:boolean"/>
+          <xs:attribute name="version" type="xs:string"/>
+          <xs:attribute name="web-driver" type="xs:string"/>
+          <xs:attribute name="firefox-profile" type="xs:string"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="SoapWebServiceEndpoints">
+    <xs:choice>
+      <xs:element name="client">
+        <xs:annotation>
+          <xs:documentation>SOAP client component sends SOAP messages to some Http web server instance and receives synchronous SOAP response message.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="request-url" type="xs:string" use="required"/>
+          <xs:attribute name="web-service-template" type="xs:string"/>
+          <xs:attribute name="message-factory" type="xs:string"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="message-sender" type="xs:string"/>
+          <xs:attribute name="message-correlator" type="xs:string"/>
+          <xs:attribute name="interceptor" type="xs:string"/>
+          <xs:attribute name="interceptors" type="xs:string"/>
+          <xs:attribute name="endpoint-resolver" type="xs:string"/>
+          <xs:attribute name="fault-strategy">
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <xs:enumeration value="throwsException"/>
+                <xs:enumeration value="propagateError"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="actor" type="xs:string"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+          <xs:attribute name="polling-interval" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="server">
+        <xs:annotation>
+          <xs:documentation>Http web server implementation accepts client connections and receives WebService messages via SOAP message protocol.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="port" type="xs:string"/>
+          <xs:attribute name="auto-start" type="xs:boolean"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+          <xs:attribute name="context-config-location" type="xs:string"/>
+          <xs:attribute name="resource-base" type="xs:string"/>
+          <xs:attribute name="root-parent-context" type="xs:boolean"/>
+          <xs:attribute name="connector" type="xs:string"/>
+          <xs:attribute name="connectors" type="xs:string"/>
+          <xs:attribute name="servlet-name" type="xs:string"/>
+          <xs:attribute name="servlet-mapping-path" type="xs:string"/>
+          <xs:attribute name="context-path" type="xs:string"/>
+          <xs:attribute name="servlet-handler" type="xs:string"/>
+          <xs:attribute name="security-handler" type="xs:string"/>
+          <xs:attribute name="endpoint-adapter" type="xs:string"/>
+          <xs:attribute name="interceptors" type="xs:string"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="message-factory" type="xs:string"/>
+          <xs:attribute name="handle-mime-headers" type="xs:boolean"/>
+          <xs:attribute name="handle-header-attributes" type="xs:boolean"/>
+          <xs:attribute name="keep-soap-envelope" type="xs:boolean"/>
+          <xs:attribute name="soap-header-namespace" type="xs:string"/>
+          <xs:attribute name="soap-header-prefix" type="xs:string"/>
+          <xs:attribute name="debug-logging" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="WebsocketEndpoints">
+    <xs:choice>
+      <xs:element name="client">
+        <xs:annotation>
+          <xs:documentation>WebSocket client component for sending and receiving asynchronous requests to and from WebSocket server</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="url" type="xs:string"/>
+          <xs:attribute name="http-headers" type="xs:string"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="endpoint-resolver" type="xs:string"/>
+          <xs:attribute name="actor" type="xs:string"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+          <xs:attribute name="polling-interval" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="server">
+        <xs:annotation>
+          <xs:documentation>Http websocket server implementation accepts client connections and receives messages via Http WebSocket transport protocol.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="endpoints" minOccurs="0">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="endpoint" maxOccurs="unbounded">
+                    <xs:complexType>
+                      <xs:attribute name="ref" type="xs:string" use="required" />
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="port" type="xs:string"/>
+          <xs:attribute name="auto-start" type="xs:boolean"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+          <xs:attribute name="context-config-location" type="xs:string"/>
+          <xs:attribute name="resource-base" type="xs:string"/>
+          <xs:attribute name="root-parent-context" type="xs:boolean"/>
+          <xs:attribute name="connector" type="xs:string"/>
+          <xs:attribute name="connectors" type="xs:string"/>
+          <xs:attribute name="servlet-name" type="xs:string"/>
+          <xs:attribute name="servlet-mapping-path" type="xs:string"/>
+          <xs:attribute name="context-path" type="xs:string"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="servlet-handler" type="xs:string"/>
+          <xs:attribute name="security-handler" type="xs:string"/>
+          <xs:attribute name="endpoints" type="xs:string"/>
+          <xs:attribute name="endpoint-adapter" type="xs:string"/>
+          <xs:attribute name="interceptors" type="xs:string"/>
+          <xs:attribute name="debug-logging" type="xs:boolean"/>
+          <xs:attribute name="actor" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="VertxEndpoints">
+    <xs:choice>
+      <xs:element name="asynchronous">
+        <xs:annotation>
+          <xs:documentation>Vert.x endpoint for asynchronous communication</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="host" type="xs:string"/>
+          <xs:attribute name="port" type="xs:string"/>
+          <xs:attribute name="address" type="xs:string" use="required"/>
+          <xs:attribute name="vertx-factory" type="xs:string"/>
+          <xs:attribute name="pub-sub-domain" type="xs:boolean"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="polling-interval" type="xs:string"/>
+          <xs:attribute name="actor" type="xs:string"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="synchronous">
+        <xs:annotation>
+          <xs:documentation>Vert.x endpoint for synchronous communication</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="name" type="xs:ID" use="required"/>
+          <xs:attribute name="host" type="xs:string"/>
+          <xs:attribute name="port" type="xs:string"/>
+          <xs:attribute name="address" type="xs:string" use="required"/>
+          <xs:attribute name="message-correlator" type="xs:string"/>
+          <xs:attribute name="vertx-factory" type="xs:string"/>
+          <xs:attribute name="pub-sub-domain" type="xs:boolean"/>
+          <xs:attribute name="message-converter" type="xs:string"/>
+          <xs:attribute name="polling-interval" type="xs:string"/>
+          <xs:attribute name="actor" type="xs:string"/>
+          <xs:attribute name="timeout" type="xs:string"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:choice>
   </xs:complexType>
 
   <xs:complexType name="TestEndpoint">
@@ -403,6 +1624,39 @@
       <xs:element name="description" type="xs:string" minOccurs="0"/>
       <xs:element name="variable" type="tns:VariableType" maxOccurs="unbounded"/>
     </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="CreateEndpoint">
+    <xs:complexContent>
+      <xs:extension base="tns:TestEndpoint">
+        <xs:sequence>
+          <xs:element name="description" type="xs:string" minOccurs="0"/>
+          <xs:choice minOccurs="0">
+            <xs:element name="camel" type="tns:CamelEndpoints"/>
+            <xs:element name="channel" type="tns:SpringMessageChannelEndpoints"/>
+            <xs:element name="context" type="tns:ContextEndpoints"/>
+            <xs:element name="direct" type="tns:DirectEndpoints"/>
+            <xs:element name="docker" type="tns:DockerEndpoints"/>
+            <xs:element name="ftp" type="tns:FtpEndpoints"/>
+            <xs:element name="scp" type="tns:ScpEndpoints"/>
+            <xs:element name="sftp" type="tns:SftpEndpoints"/>
+            <xs:element name="http" type="tns:HttpEndpoints"/>
+            <xs:element name="jms" type="tns:JmsEndpoints"/>
+            <xs:element name="jmx" type="tns:JmxEndpoints"/>
+            <xs:element name="kafka" type="tns:KafkaEndpoints"/>
+            <xs:element name="kubernetes" type="tns:KubernetesEndpoints"/>
+            <xs:element name="mail" type="tns:MailEndpoints"/>
+            <xs:element name="rmi" type="tns:RmiEndpoints"/>
+            <xs:element name="selenium" type="tns:SeleniumEndpoints"/>
+            <xs:element name="ssh" type="tns:SshEndpoints"/>
+            <xs:element name="soap" type="tns:SoapWebServiceEndpoints"/>
+            <xs:element name="websocket" type="tns:WebsocketEndpoints"/>
+            <xs:element name="vertx" type="tns:VertxEndpoints"/>
+          </xs:choice>
+          <xs:any processContents="lax" minOccurs="0"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
   </xs:complexType>
 
   <xs:complexType name="StopTimer">
@@ -732,7 +1986,7 @@
   <xs:element name="catch" type="tns:Catch"/>
   <xs:element name="conditional" type="tns:Conditional"/>
   <xs:element name="create-variables" type="tns:CreateVariables"/>
-  <xs:element name="create-endpoint" type="tns:TestEndpoint"/>
+  <xs:element name="create-endpoint" type="tns:CreateEndpoint"/>
   <xs:element name="delay" type="tns:Delay"/>
   <xs:element name="echo" type="tns:Echo"/>
   <xs:element name="expect-timeout" type="tns:ExpectTimeout"/>

--- a/runtime/citrus-xml/src/test/java/org/citrusframework/xml/actions/CreateEndpointTest.java
+++ b/runtime/citrus-xml/src/test/java/org/citrusframework/xml/actions/CreateEndpointTest.java
@@ -19,6 +19,8 @@ package org.citrusframework.xml.actions;
 import org.citrusframework.TestCase;
 import org.citrusframework.TestCaseMetaInfo;
 import org.citrusframework.actions.CreateEndpointAction;
+import org.citrusframework.endpoint.direct.DirectEndpoint;
+import org.citrusframework.endpoint.direct.DirectEndpointsBuilder;
 import org.citrusframework.xml.XmlTestLoader;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -34,9 +36,15 @@ public class CreateEndpointTest extends AbstractXmlActionTest {
         Assert.assertEquals(result.getName(), "CreateEndpointTest");
         Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
         Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
-        Assert.assertEquals(result.getActionCount(), 2L);
+        Assert.assertEquals(result.getActionCount(), 3L);
         Assert.assertEquals(result.getTestAction(0).getClass(), CreateEndpointAction.class);
         Assert.assertEquals(((CreateEndpointAction) result.getTestAction(0)).getEndpointUri(), "direct:hello");
         Assert.assertEquals(((CreateEndpointAction) result.getTestAction(1)).getEndpointUri(), "direct?autoClose=true&autoRemove=true&queueName=hello&timeout=2000");
+        Assert.assertNotNull(((CreateEndpointAction) result.getTestAction(2)).getEndpointBuilder());
+        Assert.assertEquals(((CreateEndpointAction) result.getTestAction(2)).getEndpointBuilder().getClass(), DirectEndpointsBuilder.class);
+
+        DirectEndpoint directEndpoint = (DirectEndpoint) ((CreateEndpointAction) result.getTestAction(2)).getEndpointBuilder().build();
+        Assert.assertEquals(directEndpoint.getName(), "foo");
+        Assert.assertEquals(directEndpoint.getEndpointConfiguration().getQueueName(), "fooQueue");
     }
 }

--- a/runtime/citrus-xml/src/test/resources/org/citrusframework/xml/actions/create-endpoint.citrus.it.xml
+++ b/runtime/citrus-xml/src/test/resources/org/citrusframework/xml/actions/create-endpoint.citrus.it.xml
@@ -26,5 +26,10 @@
         <property name="timeout" value="2000"/>
       </properties>
     </create-endpoint>
+    <create-endpoint name="foo">
+      <direct>
+        <asynchronous queue="fooQueue"/>
+      </direct>
+    </create-endpoint>
   </actions>
 </test>

--- a/tools/schema-generator/pom.xml
+++ b/tools/schema-generator/pom.xml
@@ -109,6 +109,16 @@
     </dependency>
     <dependency>
       <groupId>org.citrusframework</groupId>
+      <artifactId>citrus-jmx</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.citrusframework</groupId>
+      <artifactId>citrus-rmi</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.citrusframework</groupId>
       <artifactId>citrus-vertx</artifactId>
       <version>${project.version}</version>
     </dependency>


### PR DESCRIPTION
- Allow users to create typed endpoint specifications with schema support
- Add XML schema properties mappings for available endpoints
- Support typed endpoint specifications in XML DSL when creating endpoints

Fixes #1519 