### PR TITLE
fix(#1520): Support authorization/SASL when starting Redpanda Testcontainers

### DIFF
--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/redpanda/RedpandaSettings.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/redpanda/RedpandaSettings.java
@@ -125,6 +125,9 @@ public class RedpandaSettings {
             context.setVariable(getEnvVarName(containerType, "PORT"), container.getMappedPort(RedpandaSettings.REDPANDA_PORT));
             context.setVariable(getEnvVarName(containerType, "SERVICE_LOCAL_BOOTSTRAP_SERVERS"), container.getBootstrapServers());
 
+            context.setVariable(getEnvVarName(containerType, "ADMIN_ADDRESS"), container.getAdminAddress());
+            context.setVariable(getEnvVarName(containerType, "SCHEMA_REGISTRY_ADDRESS"), container.getSchemaRegistryAddress());
+
             if (!KubernetesSupport.isConnected(context) || !TestContainersSettings.isKubedockEnabled()) {
                 context.setVariable(getEnvVarName(containerType, "SERVICE_NAME"), serviceName);
                 context.setVariable(getEnvVarName(containerType, "SERVICE_BOOTSTRAP_SERVERS"), container.getBootstrapServers());

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/redpanda/StartRedpandaAction.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/redpanda/StartRedpandaAction.java
@@ -21,6 +21,7 @@ import org.citrusframework.context.TestContext;
 import org.citrusframework.testcontainers.TestContainersSettings;
 import org.citrusframework.testcontainers.actions.StartTestcontainersAction;
 import org.citrusframework.testcontainers.postgresql.PostgreSQLSettings;
+import org.citrusframework.util.StringUtils;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.redpanda.RedpandaContainer;
 import org.testcontainers.utility.DockerImageName;
@@ -44,6 +45,11 @@ public class StartRedpandaAction extends StartTestcontainersAction<RedpandaConta
 
         private String redpandaVersion = RedpandaSettings.getRedpandaVersion();
 
+        private boolean enableSasl;
+        private boolean enableAuthorization;
+        private boolean securedSchemaRegistry;
+        private String superuser;
+
         public Builder() {
             withStartupTimeout(PostgreSQLSettings.getStartupTimeout());
         }
@@ -52,6 +58,30 @@ public class StartRedpandaAction extends StartTestcontainersAction<RedpandaConta
         public Builder version(String redpandaVersion) {
            this.redpandaVersion = redpandaVersion;
            return this;
+        }
+
+        @Override
+        public Builder enableSasl(boolean enabled) {
+            this.enableSasl = enabled;
+            return this;
+        }
+
+        @Override
+        public Builder enableAuthorization(boolean enabled) {
+            this.enableAuthorization = enabled;
+            return this;
+        }
+
+        @Override
+        public Builder securedSchemaRegistry(boolean enabled) {
+            this.securedSchemaRegistry = enabled;
+            return this;
+        }
+
+        @Override
+        public Builder superuser(String username) {
+            this.superuser = username;
+            return this;
         }
 
         @Override
@@ -99,6 +129,22 @@ public class StartRedpandaAction extends StartTestcontainersAction<RedpandaConta
                             cmd.withUser("root:root");
                         })
                         .withCommand("redpanda", "start", "--mode=dev-container", "--smp=1", "--memory=1G");
+
+                if (enableSasl) {
+                    redpandaContainer.enableSasl();
+                }
+
+                if (enableAuthorization) {
+                    redpandaContainer.enableAuthorization();
+                }
+
+                if (StringUtils.hasText(superuser)) {
+                    redpandaContainer.withSuperuser(superuser);
+                }
+
+                if (securedSchemaRegistry) {
+                    redpandaContainer.enableSchemaRegistryHttpBasicAuth();
+                }
             }
 
             container(redpandaContainer);

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/xml/Start.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/xml/Start.java
@@ -30,6 +30,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.XmlValue;
 import org.citrusframework.TestActor;
+import org.citrusframework.actions.testcontainers.aws2.AwsService;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.spi.ReferenceResolver;
 import org.citrusframework.spi.ReferenceResolverAware;
@@ -37,7 +38,6 @@ import org.citrusframework.spi.Resources;
 import org.citrusframework.testcontainers.TestContainersSettings;
 import org.citrusframework.testcontainers.actions.AbstractTestcontainersAction;
 import org.citrusframework.testcontainers.actions.StartTestcontainersAction;
-import org.citrusframework.actions.testcontainers.aws2.AwsService;
 import org.citrusframework.testcontainers.aws2.LocalStackSettings;
 import org.citrusframework.testcontainers.aws2.StartLocalStackAction;
 import org.citrusframework.testcontainers.kafka.StartKafkaAction;
@@ -122,6 +122,14 @@ public class Start extends AbstractTestcontainersAction.Builder<StartTestcontain
         StartRedpandaAction.Builder builder = new StartRedpandaAction.Builder();
         if (container.getVersion() != null) {
             builder.version(container.getVersion());
+        }
+
+        builder.enableSasl(container.isEnableSasl());
+        builder.enableAuthorization(container.isEnableAuthorization());
+        builder.securedSchemaRegistry(container.isSecuredSchemaRegistry());
+
+        if (container.getSuperuser() != null) {
+            builder.superuser(container.getSuperuser());
         }
 
         configureStartActionBuilder(builder, container);
@@ -704,6 +712,14 @@ public class Start extends AbstractTestcontainersAction.Builder<StartTestcontain
 
         @XmlAttribute
         protected String version;
+        @XmlAttribute(name = "enable-sasl")
+        protected boolean enableSasl;
+        @XmlAttribute(name = "enable-authorization")
+        protected boolean enableAuthorization;
+        @XmlAttribute(name = "secured-schema-registry")
+        protected boolean securedSchemaRegistry;
+        @XmlAttribute
+        protected String superuser;
 
         public String getVersion() {
             return version;
@@ -711,6 +727,38 @@ public class Start extends AbstractTestcontainersAction.Builder<StartTestcontain
 
         public void setVersion(String version) {
             this.version = version;
+        }
+
+        public boolean isEnableSasl() {
+            return enableSasl;
+        }
+
+        public void setEnableSasl(boolean enabled) {
+            this.enableSasl = enabled;
+        }
+
+        public boolean isEnableAuthorization() {
+            return enableAuthorization;
+        }
+
+        public void setEnableAuthorization(boolean enabled) {
+            this.enableAuthorization = enabled;
+        }
+
+        public boolean isSecuredSchemaRegistry() {
+            return securedSchemaRegistry;
+        }
+
+        public void setSecuredSchemaRegistry(boolean enabled) {
+            this.securedSchemaRegistry = enabled;
+        }
+
+        public String getSuperuser() {
+            return superuser;
+        }
+
+        public void setSuperuser(String username) {
+            this.superuser = username;
         }
     }
 

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/yaml/Start.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/yaml/Start.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.citrusframework.TestActor;
+import org.citrusframework.actions.testcontainers.aws2.AwsService;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.spi.ReferenceResolver;
 import org.citrusframework.spi.ReferenceResolverAware;
@@ -30,7 +31,6 @@ import org.citrusframework.spi.Resources;
 import org.citrusframework.testcontainers.TestContainersSettings;
 import org.citrusframework.testcontainers.actions.AbstractTestcontainersAction;
 import org.citrusframework.testcontainers.actions.StartTestcontainersAction;
-import org.citrusframework.actions.testcontainers.aws2.AwsService;
 import org.citrusframework.testcontainers.aws2.LocalStackSettings;
 import org.citrusframework.testcontainers.aws2.StartLocalStackAction;
 import org.citrusframework.testcontainers.kafka.StartKafkaAction;
@@ -113,6 +113,14 @@ public class Start extends AbstractTestcontainersAction.Builder<StartTestcontain
         StartRedpandaAction.Builder builder = new StartRedpandaAction.Builder();
         if (container.getVersion() != null) {
             builder.version(container.getVersion());
+        }
+
+        builder.enableSasl(container.isEnableSasl());
+        builder.enableAuthorization(container.isEnableAuthorization());
+        builder.securedSchemaRegistry(container.isSecuredSchemaRegistry());
+
+        if (container.getSuperuser() != null) {
+            builder.superuser(container.getSuperuser());
         }
 
         configureStartActionBuilder(builder, container);
@@ -474,6 +482,10 @@ public class Start extends AbstractTestcontainersAction.Builder<StartTestcontain
     public static class Redpanda extends Container {
 
         protected String version;
+        protected boolean enableSasl;
+        protected boolean enableAuthorization;
+        protected boolean securedSchemaRegistry;
+        protected String superuser;
 
         public String getVersion() {
             return version;
@@ -482,6 +494,42 @@ public class Start extends AbstractTestcontainersAction.Builder<StartTestcontain
         @SchemaProperty
         public void setVersion(String version) {
             this.version = version;
+        }
+
+        public boolean isEnableSasl() {
+            return enableSasl;
+        }
+
+        @SchemaProperty(description = "Enables Sasl for the Redpanda container.")
+        public void setEnableSasl(boolean enabled) {
+            this.enableSasl = enabled;
+        }
+
+        public boolean isEnableAuthorization() {
+            return enableAuthorization;
+        }
+
+        @SchemaProperty(description = "Enables authorization for the Redpanda container.")
+        public void setEnableAuthorization(boolean enabled) {
+            this.enableAuthorization = enabled;
+        }
+
+        public boolean isSecuredSchemaRegistry() {
+            return securedSchemaRegistry;
+        }
+
+        @SchemaProperty(description = "Enables a secured schema registry for the Redpanda container. Usually through Http basic auth.")
+        public void setSecuredSchemaRegistry(boolean enabled) {
+            this.securedSchemaRegistry = enabled;
+        }
+
+        public String getSuperuser() {
+            return superuser;
+        }
+
+        @SchemaProperty(description = "Sets a super user for the Redpanda container.")
+        public void setSuperuser(String username) {
+            this.superuser = username;
         }
     }
 

--- a/core/citrus-api/src/main/java/org/citrusframework/actions/testcontainers/TestcontainersRedpandaStartActionBuilder.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/actions/testcontainers/TestcontainersRedpandaStartActionBuilder.java
@@ -22,4 +22,12 @@ public interface TestcontainersRedpandaStartActionBuilder<C extends AutoCloseabl
         extends TestcontainersStartActionBuilderBase<C, T, B> {
 
     B version(String redpandaVersion);
+
+    B enableSasl(boolean enabled);
+
+    B enableAuthorization(boolean enabled);
+
+    B securedSchemaRegistry(boolean enabled);
+
+    B superuser(String username);
 }

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-5.0.0-SNAPSHOT.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-5.0.0-SNAPSHOT.xsd
@@ -3906,6 +3906,10 @@
                   <xs:attribute name="image" type="xs:string"/>
                   <xs:attribute name="command" type="xs:string"/>
                   <xs:attribute name="startup-timeout" type="xs:int"/>
+                  <xs:attribute name="enable-sasl" type="xs:boolean"/>
+                  <xs:attribute name="enable-authorization" type="xs:boolean"/>
+                  <xs:attribute name="secured-schema-registry" type="xs:boolean"/>
+                  <xs:attribute name="superuser" type="xs:string"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="postgresql">

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
@@ -3906,6 +3906,10 @@
                   <xs:attribute name="image" type="xs:string"/>
                   <xs:attribute name="command" type="xs:string"/>
                   <xs:attribute name="startup-timeout" type="xs:int"/>
+                  <xs:attribute name="enable-sasl" type="xs:boolean"/>
+                  <xs:attribute name="enable-authorization" type="xs:boolean"/>
+                  <xs:attribute name="secured-schema-registry" type="xs:boolean"/>
+                  <xs:attribute name="superuser" type="xs:string"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="postgresql">


### PR DESCRIPTION
- Add options to enable authorization/SASL when starting Redpanda Testcontainers in Citrus
- Expose Redpanda container admin address and schema registry address as test variables

Fixes #1520 