### PR TITLE
feat(#1531)!: change default custom validator mode from EXCLUSIVE to COMBINED

### DIFF
--- a/core/citrus-api/src/main/java/org/citrusframework/CitrusSettings.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/CitrusSettings.java
@@ -272,7 +272,7 @@ public final class CitrusSettings {
 
     public static final String CUSTOM_VALIDATOR_STRATEGY_PROPERTY = "citrus.custom.validator.strategy";
     public static final String CUSTOM_VALIDATOR_STRATEGY_ENV = "CITRUS_CUSTOM_VALIDATOR_STRATEGY";
-    public static final CustomValidatorStrategy CUSTOM_VALIDATOR_STRATEGY_DEFAULT = CustomValidatorStrategy.EXCLUSIVE;
+    public static final CustomValidatorStrategy CUSTOM_VALIDATOR_STRATEGY_DEFAULT = CustomValidatorStrategy.COMBINED;
 
     /**
      * Flag to enable/disable input stream caching

--- a/core/citrus-api/src/test/java/org/citrusframework/CitrusSettingsTest.java
+++ b/core/citrus-api/src/test/java/org/citrusframework/CitrusSettingsTest.java
@@ -56,12 +56,12 @@ public class CitrusSettingsTest {
     }
 
     @Test
-    public void getCustomValidatorStrategy_shouldReturnExclusiveByDefault() {
+    public void getCustomValidatorStrategy_shouldReturnCombinedByDefault() {
         systemProperties.remove(CUSTOM_VALIDATOR_STRATEGY_PROPERTY);
         environmentVariables.remove(CUSTOM_VALIDATOR_STRATEGY_ENV);
 
         assertThat(CitrusSettings.getCustomValidatorStrategy())
-                .isEqualTo(EXCLUSIVE);
+                .isEqualTo(COMBINED);
     }
 
     @DataProvider

--- a/core/citrus-base/src/test/java/org/citrusframework/actions/ReceiveMessageActionTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/actions/ReceiveMessageActionTest.java
@@ -1232,6 +1232,8 @@ public class ReceiveMessageActionTest extends UnitTestSupport {
                     """
     )
     public void testReceiveMessage_shouldIgnoreValidationContexts_whenCustomValidatorIsPresent_andValidationStrategyIsExclusive() {
+        environmentVariables.set(CUSTOM_VALIDATOR_STRATEGY_ENV, "EXCLUSIVE");
+
         var testActor = new TestActor();
         testActor.setName("TESTACTOR");
 


### PR DESCRIPTION
When a custom validator is provided, it previously ran exclusively, silently bypassing all other validation. This means any other constraints passed to `validate()` was simply ignored. This BREAKING CHANGE changes the default custom validator mode from `EXCLUSIVE` to `COMBINED`, so that custom validators run alongside other validation rather than replacing it.

Users who genuinely need the old exclusive behaviour can still opt in explicitly, but the footgun default is gone.

BREAKING CHANGE: Change default custom validator mode from `EXCLUSIVE` to `COMBINED`.

Closes #1531.