### PR TITLE
fix(#1533): Support message processors in YAML DSL

### DIFF
--- a/core/citrus-api/src/main/java/org/citrusframework/actions/ReceiveActionBuilder.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/actions/ReceiveActionBuilder.java
@@ -54,6 +54,11 @@ public interface ReceiveActionBuilder<T extends TestAction, M extends ReceiveMes
     }
 
     /**
+     * Adds message processor referenced by its name in the bean registry.
+     */
+    B transform(String messageProcessor);
+
+    /**
      * Adds message processor on the message.
      */
     B transform(MessageProcessor processor);
@@ -104,9 +109,12 @@ public interface ReceiveActionBuilder<T extends TestAction, M extends ReceiveMes
     B validate(ValidationProcessor processor);
 
     /**
+     * Adds message processor referenced by its name in the bean registry.
+     */
+    B process(String messageProcessor);
+
+    /**
      * Adds message processor on the message.
-     * @param processor
-     * @return
      */
     B process(MessageProcessor processor);
 

--- a/core/citrus-api/src/main/java/org/citrusframework/actions/SendActionBuilder.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/actions/SendActionBuilder.java
@@ -46,6 +46,11 @@ public interface SendActionBuilder<T extends TestAction, M extends SendMessageBu
     }
 
     /**
+     * Adds message processor referenced by its name in the bean registry.
+     */
+    B transform(String messageProcessor);
+
+    /**
      * Adds message processor on the message.
      */
     B transform(MessageProcessor processor);
@@ -61,9 +66,12 @@ public interface SendActionBuilder<T extends TestAction, M extends SendMessageBu
     B transform(MessageProcessor.Builder<?, ?> builder);
 
     /**
+     * Adds message processor referenced by its name in the bean registry.
+     */
+    B process(String messageProcessor);
+
+    /**
      * Adds message processor on the message.
-     * @param processor
-     * @return
      */
     B process(MessageProcessor processor);
 

--- a/core/citrus-api/src/main/java/org/citrusframework/message/processor/camel/CamelDataFormatMessageProcessorBuilder.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/message/processor/camel/CamelDataFormatMessageProcessorBuilder.java
@@ -16,6 +16,8 @@
 
 package org.citrusframework.message.processor.camel;
 
+import java.util.Map;
+
 import org.citrusframework.message.MessageProcessor;
 
 public interface CamelDataFormatMessageProcessorBuilder<T extends MessageProcessor, B extends CamelDataFormatMessageProcessorBuilder<T, B>>
@@ -24,6 +26,8 @@ public interface CamelDataFormatMessageProcessorBuilder<T extends MessageProcess
     B operation(String operation);
 
     B dataFormat(Object dataFormat);
+
+    B spec(Map<String, Object> spec);
 
     B allowNullBody(boolean allowNullBody);
 

--- a/core/citrus-api/src/main/java/org/citrusframework/message/processor/camel/CamelExpressionClause.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/message/processor/camel/CamelExpressionClause.java
@@ -30,6 +30,8 @@ public interface CamelExpressionClause<T extends MessageProcessor.Builder<?, ?>,
 
     T language(F factory);
 
+    T spec(Map<String, Object> spec);
+
     /**
      * Specify the constant expression value. <b>Important:</b> this is a fixed constant value that is only set once
      * during starting up the route, do not use this if you want dynamic values during routing.

--- a/core/citrus-api/src/main/java/org/citrusframework/message/processor/camel/CamelMessageProcessors.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/message/processor/camel/CamelMessageProcessors.java
@@ -26,6 +26,8 @@ public interface CamelMessageProcessors extends MessageProcessor.Builder<Message
 
     CamelRouteProcessorBuilder<?, ?> route();
 
+    CamelDataFormatMessageProcessorBuilder<?, ?> dataFormat();
+
     CamelDataFormatClause<? extends MessageProcessor.Builder<?, ?>, ?> marshal();
 
     CamelDataFormatClause<? extends MessageProcessor.Builder<?, ?>, ?> unmarshal();

--- a/core/citrus-base/src/main/java/org/citrusframework/actions/ReceiveMessageAction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/actions/ReceiveMessageAction.java
@@ -16,6 +16,16 @@
 
 package org.citrusframework.actions;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.citrusframework.CitrusSettings;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.endpoint.Endpoint;
@@ -58,16 +68,6 @@ import org.citrusframework.variable.VariableExtractor;
 import org.citrusframework.variable.dictionary.DataDictionary;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
@@ -670,6 +670,12 @@ public class ReceiveMessageAction extends AbstractTestAction implements MessageA
         }
 
         @Override
+        public B process(MessageProcessor.Builder<?, ?> builder) {
+            this.messageProcessorBuilders.add(builder);
+            return self;
+        }
+
+        @Override
         public final T build() {
             if (messageBuilderSupport == null) {
                 messageBuilderSupport = getMessageBuilderSupport();
@@ -701,6 +707,38 @@ public class ReceiveMessageAction extends AbstractTestAction implements MessageA
                     messageBuilderSupport.dictionary(
                             referenceResolver.resolve(messageBuilderSupport.getDataDictionaryName(), DataDictionary.class));
                 }
+
+                for (String messageProcessor : getMessageProcessorRefs()) {
+                    if (referenceResolver.isResolvable(messageProcessor, MessageProcessor.class)) {
+                        process(referenceResolver.resolve(messageProcessor, MessageProcessor.class));
+                    }
+                }
+
+                for (MessageProcessor.Builder<?, ?> builder : messageProcessorBuilders) {
+                    if (builder instanceof ReferenceResolverAware referenceResolverAware) {
+                        referenceResolverAware.setReferenceResolver(referenceResolver);
+                    }
+                }
+
+                for (MessageProcessor processor : getMessageBuilderSupport().getControlMessageProcessors()) {
+                    if (processor instanceof ReferenceResolverAware referenceResolverAware) {
+                        referenceResolverAware.setReferenceResolver(referenceResolver);
+                    }
+                }
+
+                for (MessageProcessor.Builder<?, ?> builder : getMessageBuilderSupport().getControlMessageProcessorBuilders()) {
+                    if (builder instanceof ReferenceResolverAware referenceResolverAware) {
+                        referenceResolverAware.setReferenceResolver(referenceResolver);
+                    }
+                }
+            }
+
+            for (MessageProcessor.Builder<?, ?> builder : messageProcessorBuilders) {
+                process(builder.build());
+            }
+
+            for (MessageProcessor.Builder<?, ?> builder : getMessageBuilderSupport().getControlMessageProcessorBuilders()) {
+                getMessageBuilderSupport().process(builder.build());
             }
 
             return doBuild();

--- a/core/citrus-base/src/main/java/org/citrusframework/actions/SendMessageAction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/actions/SendMessageAction.java
@@ -31,6 +31,7 @@ import org.citrusframework.message.MessageDirection;
 import org.citrusframework.message.MessageProcessor;
 import org.citrusframework.message.builder.MessageBuilderSupport;
 import org.citrusframework.message.builder.SendMessageBuilderSupport;
+import org.citrusframework.spi.ReferenceResolverAware;
 import org.citrusframework.variable.VariableExtractor;
 import org.citrusframework.variable.dictionary.DataDictionary;
 import org.slf4j.Logger;
@@ -416,6 +417,22 @@ public class SendMessageAction extends AbstractTestAction implements Completable
                     this.messageBuilderSupport.dictionary(
                         referenceResolver.resolve(messageBuilderSupport.getDataDictionaryName(), DataDictionary.class));
                 }
+
+                for (String messageProcessor : getMessageProcessorRefs()) {
+                    if (referenceResolver.isResolvable(messageProcessor, MessageProcessor.class)) {
+                        process(referenceResolver.resolve(messageProcessor, MessageProcessor.class));
+                    }
+                }
+
+                for (MessageProcessor.Builder<?, ?> builder : messageProcessorBuilders) {
+                    if (builder instanceof ReferenceResolverAware referenceResolverAware) {
+                        referenceResolverAware.setReferenceResolver(referenceResolver);
+                    }
+                }
+            }
+
+            for (MessageProcessor.Builder<?, ?> builder : messageProcessorBuilders) {
+                process(builder.build());
             }
 
             return doBuild();

--- a/core/citrus-base/src/main/java/org/citrusframework/message/builder/MessageBuilderSupport.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/message/builder/MessageBuilderSupport.java
@@ -19,8 +19,10 @@ package org.citrusframework.message.builder;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.citrusframework.AbstractTestActionBuilder;
 import org.citrusframework.CitrusSettings;
@@ -211,7 +213,8 @@ public abstract class MessageBuilderSupport<T extends TestAction, B extends Mess
 
     @Override
     public S process(MessageProcessor.Builder<?, ?> builder) {
-        return process(builder.build());
+        delegate.process(builder);
+        return self;
     }
 
     @Override
@@ -303,13 +306,14 @@ public abstract class MessageBuilderSupport<T extends TestAction, B extends Mess
 
         protected M messageBuilderSupport;
 
+        protected final List<MessageProcessor.Builder<?, ?>> messageProcessorBuilders = new ArrayList<>();
+        protected final Set<String> messageProcessorRefs = new HashSet<>();
+
         /** Basic bean reference resolver */
         protected ReferenceResolver referenceResolver;
 
         /**
          * Sets the message endpoint to send messages to.
-         * @param messageEndpoint
-         * @return
          */
         public B endpoint(Endpoint messageEndpoint) {
             this.endpoint = messageEndpoint;
@@ -318,8 +322,6 @@ public abstract class MessageBuilderSupport<T extends TestAction, B extends Mess
 
         /**
          * Sets the message endpoint uri to send messages to.
-         * @param messageEndpointUri
-         * @return
          */
         public B endpoint(String messageEndpointUri) {
             this.endpointUri = messageEndpointUri;
@@ -328,7 +330,6 @@ public abstract class MessageBuilderSupport<T extends TestAction, B extends Mess
 
         /**
          * Construct the control message for this action.
-         * @return
          */
         public M message() {
             return getMessageBuilderSupport();
@@ -336,8 +337,6 @@ public abstract class MessageBuilderSupport<T extends TestAction, B extends Mess
 
         /**
          * Sets the control message for this action.
-         * @param messageBuilder
-         * @return
          */
         public M message(MessageBuilder messageBuilder) {
             return getMessageBuilderSupport().from(messageBuilder);
@@ -345,9 +344,6 @@ public abstract class MessageBuilderSupport<T extends TestAction, B extends Mess
 
         /**
          * Builds message from given message.
-         *
-         * @param message
-         * @return
          */
         public M message(final Message message) {
             return getMessageBuilderSupport().from(message);
@@ -361,9 +357,15 @@ public abstract class MessageBuilderSupport<T extends TestAction, B extends Mess
         }
 
         /**
+         * Adds message processor referenced by its name in the bean registry.
+         */
+        public B transform(String messageProcessor) {
+            this.messageProcessorRefs.add(messageProcessor);
+            return self;
+        }
+
+        /**
          * Adds message processor on the message.
-         * @param processor
-         * @return
          */
         public B transform(MessageProcessor processor) {
             return process(processor);
@@ -371,8 +373,6 @@ public abstract class MessageBuilderSupport<T extends TestAction, B extends Mess
 
         /**
          * Adds message processor on the message.
-         * @param adapter
-         * @return
          */
         public B transform(MessageProcessorAdapter adapter) {
             return process(adapter);
@@ -380,17 +380,21 @@ public abstract class MessageBuilderSupport<T extends TestAction, B extends Mess
 
         /**
          * Adds message processor on the message as fluent builder.
-         * @param builder
-         * @return
          */
         public B transform(MessageProcessor.Builder<?, ?> builder) {
-            return transform(builder.build());
+            return process(builder);
+        }
+
+        /**
+         * Adds message processor referenced by its name in the bean registry.
+         */
+        public B process(String messageProcessor) {
+            this.messageProcessorRefs.add(messageProcessor);
+            return self;
         }
 
         /**
          * Adds message processor on the message.
-         * @param processor
-         * @return
          */
         public B process(MessageProcessor processor) {
             if (processor instanceof VariableExtractor variableExtractor) {
@@ -403,17 +407,14 @@ public abstract class MessageBuilderSupport<T extends TestAction, B extends Mess
 
         /**
          * Adds message processor on the message as fluent builder.
-         * @param builder
-         * @return
          */
         public B process(MessageProcessor.Builder<?, ?> builder) {
-            return process(builder.build());
+            this.messageProcessorBuilders.add(builder);
+            return self;
         }
 
         /**
          * Adds message processor on the message as fluent builder.
-         * @param adapter
-         * @return
          */
         public B process(MessageProcessorAdapter adapter) {
             return process(adapter.asProcessor());
@@ -449,9 +450,16 @@ public abstract class MessageBuilderSupport<T extends TestAction, B extends Mess
             return messageProcessors;
         }
 
+        public Set<String> getMessageProcessorRefs() {
+            return messageProcessorRefs;
+        }
+
+        public List<MessageProcessor.Builder<?, ?>> getMessageProcessorBuilders() {
+            return messageProcessorBuilders;
+        }
+
         /**
          * Build method implemented by subclasses.
-         * @return
          */
         protected abstract T doBuild();
     }

--- a/core/citrus-base/src/main/java/org/citrusframework/message/builder/ReceiveMessageBuilderSupport.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/message/builder/ReceiveMessageBuilderSupport.java
@@ -35,6 +35,7 @@ public class ReceiveMessageBuilderSupport<T extends ReceiveMessageAction, B exte
         extends MessageBuilderSupport<T, B, S> implements ReceiveMessageBuilderFactory<T, S> {
 
     private final List<MessageProcessor> controlMessageProcessors = new ArrayList<>();
+    private final List<MessageProcessor.Builder<?, ?>> controlMessageProcessorBuilders = new ArrayList<>();
 
     private boolean headerNameIgnoreCase = false;
 
@@ -151,8 +152,18 @@ public class ReceiveMessageBuilderSupport<T extends ReceiveMessageAction, B exte
         return self;
     }
 
+    @Override
+    public S process(MessageProcessor.Builder<?, ?> builder) {
+        this.controlMessageProcessorBuilders.add(builder);
+        return self;
+    }
+
     public List<MessageProcessor> getControlMessageProcessors() {
         return controlMessageProcessors;
+    }
+
+    public List<MessageProcessor.Builder<?, ?>> getControlMessageProcessorBuilders() {
+        return controlMessageProcessorBuilders;
     }
 
     public boolean isHeaderNameIgnoreCase() {

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/message/CamelDataFormatMessageProcessor.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/message/CamelDataFormatMessageProcessor.java
@@ -16,15 +16,21 @@
 
 package org.citrusframework.camel.message;
 
+import java.util.Collections;
+import java.util.Map;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.Processor;
 import org.apache.camel.builder.DataFormatClause;
+import org.apache.camel.dsl.yaml.deserializers.ModelDeserializersResolver;
 import org.apache.camel.model.DataFormatDefinition;
 import org.apache.camel.reifier.dataformat.DataFormatReifier;
+import org.apache.camel.spi.DataFormat;
 import org.apache.camel.support.processor.MarshalProcessor;
 import org.apache.camel.support.processor.UnmarshalProcessor;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.message.processor.camel.CamelDataFormatMessageProcessorBuilder;
+import org.snakeyaml.engine.v2.api.ConstructNode;
 
 /**
  * Camel message processor working with data formats to marshal/unmarshal the message body.
@@ -46,7 +52,7 @@ public class CamelDataFormatMessageProcessor extends CamelMessageProcessor {
             implements CamelDataFormatMessageProcessorBuilder<CamelDataFormatMessageProcessor, Builder> {
 
         private final InlineProcessDefinition processDefinition = new InlineProcessDefinition(this);
-        private DataFormatClause.Operation operation;
+        private DataFormatClause.Operation operation = DataFormatClause.Operation.Marshal;
 
         private DataFormatDefinition dataFormat;
         private boolean allowNullBody;
@@ -96,6 +102,20 @@ public class CamelDataFormatMessageProcessor extends CamelMessageProcessor {
             }
         }
 
+        @Override
+        public Builder spec(Map<String, Object> spec) {
+            String format = spec.keySet().iterator().next();
+            Object value = spec.get(format);
+            ConstructNode constructNode = new ModelDeserializersResolver().resolve(format);
+            if (value instanceof Map<?, ?> map) {
+                dataFormat(constructNode.construct(CamelMessageConverter.createMappingNode(map)));
+            } else {
+                dataFormat(constructNode.construct(CamelMessageConverter.createMappingNode(Collections.emptyMap())));
+            }
+
+            return this;
+        }
+
         public Builder dataFormat(DataFormatDefinition dataFormat) {
             this.dataFormat = dataFormat;
             return this;
@@ -119,10 +139,12 @@ public class CamelDataFormatMessageProcessor extends CamelMessageProcessor {
             }
 
             Processor processor;
+            DataFormat df = DataFormatReifier.getDataFormat(camelContext, dataFormat);
+            df.start();
             if (operation.equals(DataFormatClause.Operation.Marshal)) {
-                processor = new MarshalProcessor(DataFormatReifier.getDataFormat(camelContext, dataFormat));
+                processor = new MarshalProcessor(df);
             } else {
-                processor = new UnmarshalProcessor(DataFormatReifier.getDataFormat(camelContext, dataFormat), allowNullBody);
+                processor = new UnmarshalProcessor(df, allowNullBody);
             }
 
             return new CamelDataFormatMessageProcessor(camelContext, processor);

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/message/CamelExpressionClauseSupport.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/message/CamelExpressionClauseSupport.java
@@ -16,20 +16,38 @@
 
 package org.citrusframework.camel.message;
 
+import java.util.Collections;
+import java.util.Map;
+
 import org.apache.camel.BeanScope;
 import org.apache.camel.Expression;
 import org.apache.camel.ExpressionFactory;
 import org.apache.camel.builder.ExpressionClauseSupport;
+import org.apache.camel.dsl.yaml.deserializers.ModelDeserializersResolver;
 import org.apache.camel.support.builder.Namespaces;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.message.MessageProcessor;
 import org.citrusframework.message.processor.camel.CamelExpressionClause;
+import org.snakeyaml.engine.v2.api.ConstructNode;
 
 public class CamelExpressionClauseSupport<T extends MessageProcessor.Builder<?, ?>> extends ExpressionClauseSupport<T>
         implements CamelExpressionClause<T, ExpressionFactory, Expression> {
 
     public CamelExpressionClauseSupport(T result) {
         super(result);
+    }
+
+    @Override
+    public T spec(Map<String, Object> spec) {
+        String language = spec.keySet().iterator().next();
+
+        Object value = spec.get(language);
+        ConstructNode constructNode = new ModelDeserializersResolver().resolve(language);
+        if (value instanceof Map<?, ?> map) {
+            return expression((Expression) constructNode.construct(CamelMessageConverter.createMappingNode(map)));
+        }
+
+        return expression((Expression) constructNode.construct(CamelMessageConverter.createMappingNode(Collections.emptyMap())));
     }
 
     @Override

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/message/CamelMessageConverter.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/message/CamelMessageConverter.java
@@ -16,6 +16,8 @@
 
 package org.citrusframework.camel.message;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.camel.Exchange;
@@ -27,6 +29,12 @@ import org.citrusframework.message.DefaultMessage;
 import org.citrusframework.message.Message;
 import org.citrusframework.message.MessageConverter;
 import org.citrusframework.message.MessageHeaderUtils;
+import org.snakeyaml.engine.v2.common.FlowStyle;
+import org.snakeyaml.engine.v2.common.ScalarStyle;
+import org.snakeyaml.engine.v2.nodes.MappingNode;
+import org.snakeyaml.engine.v2.nodes.NodeTuple;
+import org.snakeyaml.engine.v2.nodes.ScalarNode;
+import org.snakeyaml.engine.v2.nodes.Tag;
 
 /**
  * Message converter able to read Camel exchange and create proper Spring Integration message
@@ -78,5 +86,34 @@ public class CamelMessageConverter implements MessageConverter<Exchange, Exchang
         }
 
         return message;
+    }
+
+    /**
+     * Converts a basic Java Map<String, String> into a mapping node.
+     * Supports only String and boolean scalars as this is sufficient for data formats in Camel.
+     */
+    public static MappingNode createMappingNode(Map<?, ?> spec) {
+        List<NodeTuple> tuples = new ArrayList<>();
+
+        for (Map.Entry<?, ?> entry : spec.entrySet()) {
+            // Create a ScalarNode for the key
+            ScalarNode keyNode = new ScalarNode(Tag.STR, entry.getKey().toString(), ScalarStyle.PLAIN);
+
+            ScalarNode valueNode;
+            String stringValue = String.valueOf(entry.getValue());
+            // Create a ScalarNode for the value
+            if (stringValue.equals("true") || stringValue.equals("false")) {
+                valueNode = new ScalarNode(Tag.BOOL, stringValue, ScalarStyle.PLAIN);
+            } else {
+                valueNode = new ScalarNode(Tag.STR, stringValue, ScalarStyle.PLAIN);
+            }
+
+            // Pair them together in a NodeTuple
+            tuples.add(new NodeTuple(keyNode, valueNode));
+        }
+
+        // Return a new MappingNode holding the list of tuples
+        // Tag.MAP indicates it's a map, and FlowStyle.BLOCK outputs it nicely formatted on separate lines
+        return new MappingNode(Tag.MAP, tuples, FlowStyle.BLOCK);
     }
 }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/message/CamelMessageProcessor.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/message/CamelMessageProcessor.java
@@ -174,7 +174,6 @@ public class CamelMessageProcessor implements MessageProcessor {
 
         /**
          * Subclasses must build message processor.
-         * @return
          */
         public abstract T doBuild();
 

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/message/CamelMessageProcessorSupport.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/message/CamelMessageProcessorSupport.java
@@ -61,6 +61,14 @@ public class CamelMessageProcessorSupport implements CamelMessageProcessors {
     }
 
     @Override
+    public CamelDataFormatMessageProcessor.Builder dataFormat() {
+        CamelDataFormatMessageProcessor.Builder builder = new CamelDataFormatMessageProcessor.Builder()
+                .camelContext(camelContext);
+        this.delegate = builder;
+        return builder;
+    }
+
+    @Override
     public CamelDataFormatClauseSupport<InlineProcessDefinition> marshal() {
         CamelDataFormatMessageProcessor.Builder builder = new CamelDataFormatMessageProcessor.Builder()
                 .camelContext(camelContext)

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/yaml/CamelMessageProcessorTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/yaml/CamelMessageProcessorTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.yaml;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.actions.SendMessageAction;
+import org.citrusframework.camel.CamelSettings;
+import org.citrusframework.message.Message;
+import org.citrusframework.message.MessageQueue;
+import org.citrusframework.util.FileUtils;
+import org.citrusframework.util.StringUtils;
+import org.citrusframework.yaml.YamlTestLoader;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class CamelMessageProcessorTest extends AbstractYamlActionTest {
+
+    @Test
+    public void shouldLoadCamelActions() throws IOException {
+        YamlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/camel/yaml/camel-message-processor.citrus.it.yaml");
+
+        CamelContext citrusCamelContext = new DefaultCamelContext();
+        citrusCamelContext.start();
+
+        context.getReferenceResolver().bind(CamelSettings.getContextName(), citrusCamelContext);
+        context.getReferenceResolver().bind("camelContext", citrusCamelContext);
+
+        testLoader.load();
+
+        MessageQueue messageQueue = context.getReferenceResolver().resolve("messages", MessageQueue.class);
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "CamelMessageProcessorTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 4L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), SendMessageAction.class);
+
+        Message receivedMessage = messageQueue.receive();
+        Assert.assertNotNull(receivedMessage);
+        Assert.assertTrue(receivedMessage.getPayload() instanceof InputStream);
+        Assert.assertEquals(FileUtils.readToString(receivedMessage.getPayload(InputStream.class)).trim(), "SGVsbG8gZnJvbSBDaXRydXMh");
+
+        receivedMessage = messageQueue.receive();
+        Assert.assertNotNull(receivedMessage);
+        Assert.assertTrue(receivedMessage.getPayload() instanceof InputStream);
+        Assert.assertEquals(StringUtils.normalizeWhitespace(
+                FileUtils.readToString(receivedMessage.getPayload(InputStream.class)), false, true), """
+                SGVs
+                bG8g
+                ZnJv
+                bSBD
+                aXRy
+                dXMh
+                """);
+
+        receivedMessage = messageQueue.receive();
+        Assert.assertNotNull(receivedMessage);
+        Assert.assertTrue(receivedMessage.getPayload() instanceof InputStream);
+        Assert.assertEquals(FileUtils.readToString(receivedMessage.getPayload(InputStream.class)), "Hello from Citrus!");
+
+        receivedMessage = messageQueue.receive();
+        Assert.assertNotNull(receivedMessage);
+        Assert.assertEquals(receivedMessage.getPayload(String.class), "Citrus rocks!");
+    }
+}

--- a/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/yaml/camel-message-processor.citrus.it.yaml
+++ b/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/yaml/camel-message-processor.citrus.it.yaml
@@ -1,0 +1,48 @@
+name: CamelMessageProcessorTest
+author: Christoph
+status: FINAL
+endpoints:
+  - type: "direct"
+    name: "messages"
+    properties:
+      queueName: "messages"
+actions:
+  - send:
+      endpoint: messages
+      message:
+        body:
+          data: "Hello from Citrus!"
+      process:
+        - camel:
+            marshal:
+              base64: {}
+  - send:
+      endpoint: messages
+      message:
+        body:
+          data: "Hello from Citrus!"
+      process:
+        - camel:
+            marshal:
+              base64:
+                lineLength: 5
+  - send:
+      endpoint: messages
+      message:
+        body:
+          data: "Hello from Citrus!"
+      process:
+        - camel:
+            convertBodyTo:
+              type: "java.io.InputStream"
+  - send:
+      endpoint: messages
+      message:
+        body:
+          data: |
+            { "message": "Citrus rocks!" }
+      process:
+        - camel:
+            transform:
+              jsonpath:
+                expression: $.message

--- a/runtime/citrus-yaml/src/main/java/org/citrusframework/yaml/actions/Message.java
+++ b/runtime/citrus-yaml/src/main/java/org/citrusframework/yaml/actions/Message.java
@@ -18,6 +18,7 @@ package org.citrusframework.yaml.actions;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import org.citrusframework.CitrusSettings;
@@ -309,6 +310,260 @@ public class Message {
         @SchemaProperty(required = true, description = "The expected expression result value.")
         public void setValue(String value) {
             this.value = value;
+        }
+    }
+
+    public static class Processor {
+        protected Gzip gzip;
+        protected Binary binary;
+        protected Xpath xpath;
+        protected Json json;
+        protected Camel camel;
+
+        @SchemaProperty(description = "Gzip message processor transforms content into zipped content.")
+        public void setGzip(Gzip gzip) {
+            this.gzip = gzip;
+        }
+
+        public Gzip getGzip() {
+            return gzip;
+        }
+
+        @SchemaProperty(description = "Message processor to create binary message content.")
+        public void setBinary(Binary binary) {
+            this.binary = binary;
+        }
+
+        public Binary getBinary() {
+            return binary;
+        }
+
+        @SchemaProperty(description = "Xml message processors.")
+        public void setXpath(Xpath xpath) {
+            this.xpath = xpath;
+        }
+
+        public Xpath getXpath() {
+            return xpath;
+        }
+
+        @SchemaProperty(description = "Json message processors.")
+        public void setJson(Json json) {
+            this.json = json;
+        }
+
+        public Json getJson() {
+            return json;
+        }
+
+        @SchemaProperty(description = "Camel message processors using transform capabilities of Apache Camel with supported data formats.")
+        public void setCamel(Camel camel) {
+            this.camel = camel;
+        }
+
+        public Camel getCamel() {
+            return camel;
+        }
+
+        public static class Gzip {
+            protected String encoding;
+
+            public String getEncoding() {
+                return encoding;
+            }
+
+            @SchemaProperty(description = "Sets a custom file encoding.", advanced = true)
+            public void setEncoding(String value) {
+                this.encoding = value;
+            }
+        }
+
+        public static class Binary {
+            protected String encoding;
+
+            public String getEncoding() {
+                return encoding;
+            }
+
+            @SchemaProperty(description = "Sets a custom file encoding.", advanced = true)
+            public void setEncoding(String value) {
+                this.encoding = value;
+            }
+        }
+
+        public static class Json {
+            protected List<Expression> expressions;
+
+            @SchemaProperty(description = "List of expressions to evaluate")
+            public void setExpressions(List<Expression> expressions) {
+                this.expressions = expressions;
+            }
+
+            public List<Expression> getExpressions() {
+                if (expressions == null) {
+                    expressions = new ArrayList<>();
+                }
+
+                return expressions;
+            }
+        }
+
+        public static class Xpath {
+            protected List<Expression> expressions;
+            protected List<Namespace> namespaces;
+
+            @SchemaProperty(description = "List of expressions to evaluate")
+            public void setExpressions(List<Expression> expressions) {
+                this.expressions = expressions;
+            }
+
+            public List<Expression> getExpressions() {
+                if (expressions == null) {
+                    expressions = new ArrayList<>();
+                }
+
+                return expressions;
+            }
+
+            @SchemaProperty(description = "List of namespaces that should be used with the expression evaluation.")
+            public void setNamespaces(List<Namespace> namespaces) {
+                this.namespaces = namespaces;
+            }
+
+            public List<Namespace> getNamespaces() {
+                if (namespaces == null) {
+                    namespaces = new ArrayList<>();
+                }
+
+                return namespaces;
+            }
+
+            public static class Namespace {
+                protected String prefix;
+                protected String uri;
+
+                public String getPrefix() {
+                    return prefix;
+                }
+
+                @SchemaProperty(required = true, description = "The namespace prefix.")
+                public void setPrefix(String value) {
+                    this.prefix = value;
+                }
+
+                public String getUri() {
+                    return uri;
+                }
+
+                @SchemaProperty(required = true, description = "The namespace uri.")
+                public void setUri(String value) {
+                    this.uri = value;
+                }
+            }
+        }
+
+        public static class Expression {
+            protected String path;
+            protected String value;
+
+            public String getPath() {
+                return path;
+            }
+
+            @SchemaProperty(description = "The path expression to evaluate.")
+            public void setPath(String value) {
+                this.path = value;
+            }
+
+            public String getValue() {
+                return value;
+            }
+
+            @SchemaProperty(required = true, description = "The path expression value.")
+            public void setValue(String value) {
+                this.value = value;
+            }
+
+        }
+
+        public static class Camel {
+            protected String camelContext;
+            protected String processor;
+            protected Map<String, Object> transform;
+            protected Map<String, Object> marshal;
+            protected Map<String, Object> unmarshal;
+            protected ConvertBodyTo convertBodyTo;
+
+            public String getCamelContext() {
+                return camelContext;
+            }
+
+            @SchemaProperty(description = "Camel context used with this processor.")
+            public void setCamelContext(String camelContext) {
+                this.camelContext = camelContext;
+            }
+
+            public String getProcessor() {
+                return processor;
+            }
+
+            @SchemaProperty(description = "Camel message processor referenced by its bean name.")
+            public void setProcessor(String processor) {
+                this.processor = processor;
+            }
+
+            public Map<String, Object> getTransform() {
+                return transform;
+            }
+
+            @SchemaProperty(description = "Transform message content with a Camel expression.")
+            public void setTransform(Map<String, Object> transform) {
+                this.transform = transform;
+            }
+
+            public Map<String, Object> getMarshal() {
+                return marshal;
+            }
+
+            @SchemaProperty(description = "Marshal message content with a Camel data format.")
+            public void setMarshal(Map<String, Object> node) {
+                this.marshal = node;
+            }
+
+            public Map<String, Object> getUnmarshal() {
+                return unmarshal;
+            }
+
+            @SchemaProperty(description = "Unmarshal message content with a Camel data format.")
+            public void setUnmarshal(Map<String, Object> unmarshal) {
+                this.unmarshal = unmarshal;
+            }
+
+            public ConvertBodyTo getConvertBodyTo() {
+                return convertBodyTo;
+            }
+
+            @SchemaProperty(description = "Converts message body to given type.")
+            public void setConvertBodyTo(ConvertBodyTo convertBodyTo) {
+                this.convertBodyTo = convertBodyTo;
+            }
+
+            public static class ConvertBodyTo {
+                protected String type;
+
+                public String getType() {
+                    return type;
+                }
+
+                @SchemaProperty(required = true, description = "Fully qualified class name of the target type.")
+                public void setType(String type) {
+                    this.type = type;
+                }
+            }
+
+            public static class DataFormat {
+
+            }
         }
     }
 

--- a/runtime/citrus-yaml/src/main/java/org/citrusframework/yaml/actions/MessageSupport.java
+++ b/runtime/citrus-yaml/src/main/java/org/citrusframework/yaml/actions/MessageSupport.java
@@ -20,13 +20,17 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.message.DefaultMessageProcessors;
 import org.citrusframework.message.DelegatingPathExpressionProcessor;
 import org.citrusframework.message.MessageHeaderType;
+import org.citrusframework.message.MessageProcessorSupport;
 import org.citrusframework.message.MessageType;
 import org.citrusframework.message.ScriptPayloadBuilder;
 import org.citrusframework.message.builder.MessageBuilderSupport;
+import org.citrusframework.util.ClassLoaderHelper;
 import org.citrusframework.util.FileUtils;
 import org.citrusframework.util.StringUtils;
 import org.citrusframework.validation.DelegatingPayloadVariableExtractor;
@@ -169,6 +173,74 @@ public final class MessageSupport {
             }
             builder.message().extract(new DelegatingPayloadVariableExtractor.Builder()
                     .expressions(expressions));
+        }
+    }
+
+    public static void configureProcessOrTransform(MessageBuilderSupport.MessageActionBuilder<?, ?, ?> builder,
+                                                   Message.Processor value) {
+        MessageProcessorSupport processors = new DefaultMessageProcessors();
+
+        if (value.getGzip() != null) {
+            if (StringUtils.hasText(value.getGzip().getEncoding())) {
+                builder.process(processors.toGzip().encoding(value.getGzip().getEncoding()));
+            } else {
+                builder.process(processors.toGzip());
+            }
+        }
+
+        if (value.getBinary() != null) {
+            if (StringUtils.hasText(value.getGzip().getEncoding())) {
+                builder.process(processors.toBinary().encoding(value.getGzip().getEncoding()));
+            } else {
+                builder.process(processors.toBinary());
+            }
+        }
+
+        if (value.getXpath() != null) {
+            builder.process(processors.xpath()
+                    .expressions(value.getXpath().getExpressions()
+                            .stream()
+                            .collect(Collectors.toMap(Message.Processor.Expression::getPath,
+                                    Message.Processor.Expression::getValue)))
+            );
+        }
+
+        if (value.getJson() != null) {
+            builder.process(processors.jsonPath()
+                    .expressions(value.getJson().getExpressions()
+                            .stream()
+                            .collect(Collectors.toMap(Message.Processor.Expression::getPath,
+                                    Message.Processor.Expression::getValue)))
+            );
+        }
+
+        if (value.getCamel() != null) {
+            Message.Processor.Camel camel = value.getCamel();
+            if (StringUtils.hasText(camel.getProcessor())) {
+                builder.process(camel.getProcessor());
+            }
+
+            if (camel.getConvertBodyTo() != null) {
+                try {
+                    builder.process(processors.camel().convertBodyTo(
+                            Class.forName(camel.getConvertBodyTo().getType(), false,
+                                    ClassLoaderHelper.getClassLoader())));
+                } catch (ClassNotFoundException e) {
+                    throw new CitrusRuntimeException("Failed to load type %s"
+                            .formatted(camel.getConvertBodyTo().getType()), e);
+                }
+            }
+
+            if (camel.getMarshal() != null) {
+                builder.process(processors.camel().dataFormat()
+                        .spec(value.getCamel().getMarshal())
+                        .operation("Marshal"));
+            }
+
+            if (camel.getTransform() != null) {
+                builder.process(processors.camel().transform()
+                        .spec(value.getCamel().getTransform()));
+            }
         }
     }
 }

--- a/runtime/citrus-yaml/src/main/java/org/citrusframework/yaml/actions/Receive.java
+++ b/runtime/citrus-yaml/src/main/java/org/citrusframework/yaml/actions/Receive.java
@@ -319,6 +319,24 @@ public class Receive implements TestActionBuilder<ReceiveMessageAction>, Referen
         MessageSupport.configureExtract(builder, value);
     }
 
+    @SchemaProperty(
+            metadata = { @SchemaProperty.MetaData( key = "$comment", value = "group:process") },
+            description = "Process the message content when received.")
+    public void setProcess(List<Message.Processor> processors) {
+        for (Message.Processor processor : processors) {
+            MessageSupport.configureProcessOrTransform(builder, processor);
+        }
+    }
+
+    @SchemaProperty(
+            metadata = { @SchemaProperty.MetaData( key = "$comment", value = "group:transform") },
+            description = "Transforms the message content before the message is validated.")
+    public void setTransform(List<Message.Processor> processors) {
+        for (Message.Processor processor : processors) {
+            MessageSupport.configureProcessOrTransform(builder, processor);
+        }
+    }
+
     @SchemaProperty(required = true, description = "The message endpoint name or URI used to receive the message. " +
             "Uses an endpoint URI or references an endpoint name.")
     public void setEndpoint(String value) {

--- a/runtime/citrus-yaml/src/main/java/org/citrusframework/yaml/actions/Send.java
+++ b/runtime/citrus-yaml/src/main/java/org/citrusframework/yaml/actions/Send.java
@@ -15,6 +15,8 @@
  */
 package org.citrusframework.yaml.actions;
 
+import java.util.List;
+
 import org.citrusframework.TestActionBuilder;
 import org.citrusframework.TestActor;
 import org.citrusframework.actions.SendMessageAction;
@@ -61,6 +63,24 @@ public class Send implements TestActionBuilder<SendMessageAction>, ReferenceReso
             description = "Extract message content to test variables before the message is sent.")
     public void setExtract(Message.Extract value) {
         MessageSupport.configureExtract(builder, value);
+    }
+
+    @SchemaProperty(
+            metadata = { @SchemaProperty.MetaData( key = "$comment", value = "group:process") },
+            description = "Process the message content when received.")
+    public void setProcess(List<Message.Processor> processors) {
+        for (Message.Processor processor : processors) {
+            MessageSupport.configureProcessOrTransform(builder, processor);
+        }
+    }
+
+    @SchemaProperty(
+            metadata = { @SchemaProperty.MetaData( key = "$comment", value = "group:transform") },
+            description = "Transforms the message content before the message is validated.")
+    public void setTransform(List<Message.Processor> processors) {
+        for (Message.Processor processor : processors) {
+            MessageSupport.configureProcessOrTransform(builder, processor);
+        }
     }
 
     @SchemaProperty(required = true, description = "The message endpoint name or URI. " +


### PR DESCRIPTION
- Users are able to define message processors on send/receive message actions
- Support both process and transform message processors
- Supports binary and gzip message processors
- Supports Apache Camel data format and transform message processors

Fixes #1533 