### PR TITLE
fix(#1536): test message validator hint for default context

### DIFF
--- a/core/citrus-api/src/main/java/org/citrusframework/validation/context/DefaultValidationContext.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/validation/context/DefaultValidationContext.java
@@ -16,17 +16,23 @@
 
 package org.citrusframework.validation.context;
 
+import java.util.Optional;
+
 /**
  * Default validation context keeps track of its status to mark if this context has been processed during the validation.
+ *
  * @since 2.4
  */
 public class DefaultValidationContext implements ValidationContext {
 
-    /** The status of this context */
+    /**
+     * The status of this context
+     */
     private ValidationStatus status = ValidationStatus.UNKNOWN;
 
     /**
      * Updates the validation status if update is allowed according to the current status.
+     *
      * @param status the new status
      */
     public void updateStatus(ValidationStatus status) {
@@ -38,7 +44,6 @@ public class DefaultValidationContext implements ValidationContext {
     /**
      * Determine whether the status update is allowed.
      * In case the current state is FAILED the update is not allowed in order to not loose the failure state.
-     * @return
      */
     private boolean updateAllowed() {
         return this.status != ValidationStatus.FAILED;
@@ -47,5 +52,10 @@ public class DefaultValidationContext implements ValidationContext {
     @Override
     public ValidationStatus getStatus() {
         return status;
+    }
+
+    @Override
+    public Optional<String> getCorrespondingValidationModule() {
+        return Optional.of("org.citrusframework:citrus-validation-text");
     }
 }

--- a/core/citrus-api/src/test/java/org/citrusframework/validation/context/DefaultValidationContextTest.java
+++ b/core/citrus-api/src/test/java/org/citrusframework/validation/context/DefaultValidationContextTest.java
@@ -16,18 +16,24 @@
 
 package org.citrusframework.validation.context;
 
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class DefaultValidationContextTest {
 
-    @Test
-    public void getCorrespondingValidationModule_shouldReturnCitrusValidationJson() {
-        var fixture = new DefaultValidationContext() {
-        };
+    private DefaultValidationContext fixture;
 
+    @BeforeMethod
+    public void beforeMethod() {
+        fixture = new DefaultValidationContext();
+    }
+
+    @Test
+    public void getCorrespondingValidationModule_shouldReturnCitrusValidationText() {
         assertThat(fixture.getCorrespondingValidationModule())
-                .isEmpty();
+                .isNotEmpty()
+                .contains("org.citrusframework:citrus-validation-text");
     }
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/validation/json/JsonMessageValidationContext.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/validation/json/JsonMessageValidationContext.java
@@ -17,6 +17,7 @@
 package org.citrusframework.validation.json;
 
 import java.util.Map;
+import java.util.Optional;
 
 import org.citrusframework.validation.context.DefaultMessageValidationContext;
 import org.citrusframework.validation.context.MessageValidationContext;
@@ -40,6 +41,11 @@ public class JsonMessageValidationContext extends DefaultMessageValidationContex
      */
     public JsonMessageValidationContext(Builder builder) {
         super(builder);
+    }
+
+    @Override
+    public Optional<String> getCorrespondingValidationModule() {
+        return Optional.of("org.citrusframework:citrus-validation-json");
     }
 
     /**

--- a/core/citrus-base/src/test/java/org/citrusframework/validation/json/JsonMessageValidationContextTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/validation/json/JsonMessageValidationContextTest.java
@@ -14,26 +14,26 @@
  * limitations under the License.
  */
 
-package org.citrusframework.validation.xml;
+package org.citrusframework.validation.json;
 
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class XmlMessageValidationContextTest {
+public class JsonMessageValidationContextTest {
 
-    private XmlMessageValidationContext fixture;
+    private JsonMessageValidationContext fixture;
 
     @BeforeMethod
     public void beforeMethod() {
-        fixture = new XmlMessageValidationContext();
+        fixture = new JsonMessageValidationContext();
     }
 
     @Test
-    public void getCorrespondingValidationModule_shouldReturnCitrusValidationXml() {
+    public void getCorrespondingValidationModule_shouldReturnCitrusValidationJson() {
         assertThat(fixture.getCorrespondingValidationModule())
                 .isNotEmpty()
-                .contains("org.citrusframework:citrus-validation-xml");
+                .contains("org.citrusframework:citrus-validation-json");
     }
 }


### PR DESCRIPTION
closes https://github.com/citrusframework/citrus/issues/1536. in addition to: https://github.com/citrusframework/citrus/pull/1530.