### PR TITLE
migrate swagger-validator-core to openapi-validator-core v3

### DIFF
--- a/connectors/citrus-openapi/pom.xml
+++ b/connectors/citrus-openapi/pom.xml
@@ -47,7 +47,7 @@
     </dependency>
     <dependency>
       <groupId>com.atlassian.oai</groupId>
-      <artifactId>swagger-request-validator-core</artifactId>
+      <artifactId>openapi-request-validator-core</artifactId>
     </dependency>
 
     <!--

--- a/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/random/RandomConfiguration.java
+++ b/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/random/RandomConfiguration.java
@@ -54,7 +54,7 @@ public class RandomConfiguration {
         // Note that the order of generators in the list is relevant, as the list is traversed from start to end, to find the first matching generator for a schema, and some generators match for less significant schemas.
         generators.add(new RandomEnumGenerator());
         generators.add(randomGeneratorBuilder(TYPE_STRING, FORMAT_DATE).build((randomContext, schema) -> randomContext.getRandomModelBuilder().appendSimpleQuoted("citrus:currentDate('yyyy-MM-dd')")));
-        generators.add(randomGeneratorBuilder(TYPE_STRING, FORMAT_DATE_TIME).build((randomContext, schema) -> randomContext.getRandomModelBuilder().appendSimpleQuoted("citrus:currentDate('yyyy-MM-dd'T'hh:mm:ssZ')")));
+        generators.add(randomGeneratorBuilder(TYPE_STRING, FORMAT_DATE_TIME).build((randomContext, schema) -> randomContext.getRandomModelBuilder().appendSimpleQuoted("citrus:currentDate('yyyy-MM-dd'T'hh:mm:ssXXX')")));
         generators.add(randomGeneratorBuilder(TYPE_STRING, FORMAT_UUID).build((randomContext, schema) -> randomContext.getRandomModelBuilder().appendSimpleQuoted("citrus:randomUUID()")));
         generators.add(randomGeneratorBuilder(TYPE_STRING, "email").build((randomContext, schema) -> randomContext.getRandomModelBuilder().appendSimpleQuoted("citrus:randomPattern('" + EMAIL_PATTERN + "')")));
         generators.add(randomGeneratorBuilder(TYPE_STRING, "uri").build((randomContext, schema) -> randomContext.getRandomModelBuilder().appendSimpleQuoted("citrus:randomPattern('" + URI_PATTERN + "')")));

--- a/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/validation/OpenApiValidationContext.java
+++ b/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/validation/OpenApiValidationContext.java
@@ -16,9 +16,6 @@
 
 package org.citrusframework.openapi.validation;
 
-import java.util.List;
-import javax.annotation.Nullable;
-
 import com.atlassian.oai.validator.OpenApiInteractionValidator;
 import com.atlassian.oai.validator.model.ApiOperation;
 import com.atlassian.oai.validator.model.Request;
@@ -26,11 +23,13 @@ import com.atlassian.oai.validator.model.Response;
 import com.atlassian.oai.validator.report.MessageResolver;
 import com.atlassian.oai.validator.report.ValidationReport.Message;
 import com.atlassian.oai.validator.schema.SchemaValidator;
-import com.atlassian.oai.validator.schema.SwaggerV20Library;
 import com.atlassian.oai.validator.whitelist.ValidationErrorsWhitelist;
 import com.atlassian.oai.validator.whitelist.rule.WhitelistRule;
 import io.swagger.v3.oas.models.OpenAPI;
 import jakarta.annotation.Nonnull;
+
+import javax.annotation.Nullable;
+import java.util.List;
 
 /**
  * Represents the context for OpenAPI validation, providing configuration and validators for request and response validation.
@@ -82,7 +81,7 @@ public class OpenApiValidationContext {
 
     public synchronized @Nonnull SchemaValidator getSchemaValidator() {
         if (schemaValidator == null) {
-            schemaValidator = new SchemaValidator(openApi, new MessageResolver(), SwaggerV20Library::schemaFactory);
+            schemaValidator = new SchemaValidator(openApi, new MessageResolver());
         }
         return schemaValidator;
     }

--- a/core/citrus-base/src/main/java/org/citrusframework/functions/core/ChangeDateFunction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/functions/core/ChangeDateFunction.java
@@ -16,64 +16,58 @@
 
 package org.citrusframework.functions.core;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.List;
-
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.exceptions.InvalidFunctionUsageException;
 import org.citrusframework.functions.ParameterizedFunction;
-import org.citrusframework.util.StringUtils;
 import org.citrusframework.yaml.SchemaProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAccessor;
+import java.util.List;
+
+import static org.citrusframework.util.StringUtils.hasText;
+
 /**
- * Function changes given date value by adding/subtracting day/month/year/hour/minute
- * offset values. Class uses special date format to parse date string to Calendar instance.
+ * Function changes given date value by adding/subtracting day/month/year/hour/minute offset values.
+ * Class uses a date format to parse date string to an {@link OffsetDateTime}.
  *
  * @since 1.3.1
  */
 public class ChangeDateFunction implements ParameterizedFunction<ChangeDateFunction.Parameters> {
 
-    /** Logger */
     private static final Logger logger = LoggerFactory.getLogger(ChangeDateFunction.class);
-
-    private final CalendarProvider calendarProvider = new CalendarProvider();
 
     @Override
     public String execute(Parameters params, TestContext context) {
-        Calendar calendar = calendarProvider.getInstance();
+        DateTimeFormatter dateFormat = hasText(params.getDateFormat())
+                ? DateTimeFormatter.ofPattern(params.getDateFormat())
+                : DateTimeFormatter.ofPattern(DateFunctionHelper.getDefaultDateFormat().toPattern());
 
-        SimpleDateFormat dateFormat;
-        String result;
-
-        if (StringUtils.hasText(params.getDateFormat())) {
-            dateFormat = new SimpleDateFormat(params.getDateFormat());
-        } else {
-            dateFormat = DateFunctionHelper.getDefaultDateFormat();
-        }
+        OffsetDateTime date;
 
         try {
-            calendar.setTime(dateFormat.parse(params.getValue()));
-        } catch (ParseException e) {
+            date = parseDate(params.getValue(), dateFormat);
+        } catch (RuntimeException e) {
             throw new CitrusRuntimeException(e);
         }
 
-        if (StringUtils.hasText(params.getOffset())) {
-            DateFunctionHelper.applyDateOffset(calendar, params.getOffset());
+        if (hasText(params.getOffset())) {
+            date = applyDateOffset(date, params.getOffset());
         }
 
         try {
-            result = dateFormat.format(calendar.getTime());
+            return date.format(dateFormat);
         } catch (RuntimeException e) {
             logger.error("Error while formatting dateParameter value ", e);
             throw new CitrusRuntimeException(e);
         }
-
-        return result;
     }
 
     @Override
@@ -81,15 +75,31 @@ public class ChangeDateFunction implements ParameterizedFunction<ChangeDateFunct
         return new Parameters();
     }
 
-    static class CalendarProvider {
+    private OffsetDateTime parseDate(String value, DateTimeFormatter formatter) {
+        TemporalAccessor parsed = formatter.parseBest(value, OffsetDateTime::from, LocalDateTime::from, LocalDate::from);
 
-        private CalendarProvider () {
-            // This class allows mocking in unit tests
+        if (parsed instanceof OffsetDateTime offsetDateTime) {
+            return offsetDateTime;
         }
 
-        Calendar getInstance() {
-            return Calendar.getInstance();
+        if (parsed instanceof LocalDateTime localDateTime) {
+            ZoneId zone = ZoneId.systemDefault();
+            return localDateTime.atZone(zone).toOffsetDateTime();
         }
+
+        LocalDate localDate = (LocalDate) parsed;
+        ZoneId zone = ZoneId.systemDefault();
+        return localDate.atStartOfDay(zone).toOffsetDateTime();
+    }
+
+    private OffsetDateTime applyDateOffset(OffsetDateTime date, String offset) {
+        return date
+                .plusYears(DateFunctionHelper.getDateValueOffset(offset, 'y'))
+                .plusMonths(DateFunctionHelper.getDateValueOffset(offset, 'M'))
+                .plusDays(DateFunctionHelper.getDateValueOffset(offset, 'd'))
+                .plusHours(DateFunctionHelper.getDateValueOffset(offset, 'h'))
+                .plusMinutes(DateFunctionHelper.getDateValueOffset(offset, 'm'))
+                .plusSeconds(DateFunctionHelper.getDateValueOffset(offset, 's'));
     }
 
     public static class Parameters implements FunctionParameters {

--- a/core/citrus-base/src/main/java/org/citrusframework/functions/core/CurrentDateFunction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/functions/core/CurrentDateFunction.java
@@ -16,57 +16,60 @@
 
 package org.citrusframework.functions.core;
 
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.List;
-import java.util.TimeZone;
-
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.functions.ParameterizedFunction;
-import org.citrusframework.util.StringUtils;
 import org.citrusframework.yaml.SchemaProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.TimeZone;
+
+import static org.citrusframework.functions.core.DateFunctionHelper.applyDateOffset;
+import static org.citrusframework.util.StringUtils.hasText;
+
 /**
- * Function returning the actual date as formatted string value. User specifies format string
- * as argument. Function also supports additional date offset in order to manipulate result date value.
- *
+ * Function returning the actual date as formatted string value.
+ * User specifies format string as argument.
+ * Function also supports additional date offset in order to manipulate result date value.
  */
 public class CurrentDateFunction implements ParameterizedFunction<CurrentDateFunction.Parameters> {
 
-    /** Logger */
     private static final Logger logger = LoggerFactory.getLogger(CurrentDateFunction.class);
 
     @Override
     public String execute(Parameters params, TestContext context) {
-        Calendar calendar = Calendar.getInstance();
+        ZoneId zone = hasText(params.getTimeZone())
+                ? TimeZone.getTimeZone(normalizeTimeZoneId(params.getTimeZone())).toZoneId()
+                : ZoneId.systemDefault();
 
-        SimpleDateFormat dateFormat;
-        String result;
-        if (StringUtils.hasText(params.getDateFormat())) {
-            dateFormat = new SimpleDateFormat(params.getDateFormat());
-        } else {
-            dateFormat = DateFunctionHelper.getDefaultDateFormat();
+        OffsetDateTime date = OffsetDateTime.now(zone);
+        if (hasText(params.getOffset())) {
+            date = applyDateOffset(date, params.getOffset());
         }
 
-        if (StringUtils.hasText(params.getOffset())) {
-            DateFunctionHelper.applyDateOffset(calendar, params.getOffset());
-        }
-
-        if (StringUtils.hasText(params.getTimeZone())) {
-            dateFormat.setTimeZone(TimeZone.getTimeZone(params.getTimeZone()));
-        }
+        DateTimeFormatter formatter = hasText(params.getDateFormat())
+                ? DateTimeFormatter.ofPattern(params.getDateFormat())
+                : DateTimeFormatter.ofPattern(DateFunctionHelper.getDefaultDateFormat().toPattern());
 
         try {
-            result = dateFormat.format(calendar.getTime());
+            return date.format(formatter);
         } catch (RuntimeException e) {
-            logger.error("Error while formatting date value ", e);
+            logger.error("Error while formatting date value!", e);
             throw new CitrusRuntimeException(e);
         }
+    }
 
-        return result;
+    private String normalizeTimeZoneId(String timeZone) {
+        if (timeZone.startsWith("UTC+") || timeZone.startsWith("UTC-")) {
+            return "GMT" + timeZone.substring(3);
+        }
+
+        return timeZone;
     }
 
     @Override

--- a/core/citrus-base/src/main/java/org/citrusframework/functions/core/DateFunctionHelper.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/functions/core/DateFunctionHelper.java
@@ -17,8 +17,8 @@
 package org.citrusframework.functions.core;
 
 import java.text.SimpleDateFormat;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
-import java.util.Calendar;
 
 import static java.lang.Integer.parseInt;
 
@@ -26,7 +26,7 @@ import static java.lang.Integer.parseInt;
  * Abstract date value handling function provides base date value manipulation helpers.
  * @since 1.3.1
  */
-public final class DateFunctionHelper {
+final class DateFunctionHelper {
 
     private DateFunctionHelper() {
         //prevent instantiation of utility class.
@@ -36,13 +36,14 @@ public final class DateFunctionHelper {
      * Adds/removes date value offset by parsing offset string for
      * year/month/day/hour/minute/second offsets.
      */
-    static void applyDateOffset(Calendar calendar, String offsetString) {
-        calendar.add(Calendar.YEAR, getDateValueOffset(offsetString, 'y'));
-        calendar.add(Calendar.MONTH, getDateValueOffset(offsetString, 'M'));
-        calendar.add(Calendar.DAY_OF_YEAR, getDateValueOffset(offsetString, 'd'));
-        calendar.add(Calendar.HOUR, getDateValueOffset(offsetString, 'h'));
-        calendar.add(Calendar.MINUTE, getDateValueOffset(offsetString, 'm'));
-        calendar.add(Calendar.SECOND, getDateValueOffset(offsetString, 's'));
+    static OffsetDateTime applyDateOffset(OffsetDateTime date, String offset) {
+        return date
+                .plusYears(DateFunctionHelper.getDateValueOffset(offset, 'y'))
+                .plusMonths(DateFunctionHelper.getDateValueOffset(offset, 'M'))
+                .plusDays(DateFunctionHelper.getDateValueOffset(offset, 'd'))
+                .plusHours(DateFunctionHelper.getDateValueOffset(offset, 'h'))
+                .plusMinutes(DateFunctionHelper.getDateValueOffset(offset, 'm'))
+                .plusSeconds(DateFunctionHelper.getDateValueOffset(offset, 's'));
     }
 
     /**

--- a/core/citrus-base/src/test/java/org/citrusframework/functions/core/ChangeDateFunctionTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/functions/core/ChangeDateFunctionTest.java
@@ -16,183 +16,144 @@
 
 package org.citrusframework.functions.core;
 
-import java.util.Calendar;
-import java.util.Collections;
-
 import org.citrusframework.UnitTestSupport;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.exceptions.InvalidFunctionUsageException;
 import org.citrusframework.functions.FunctionParameterHelper;
-import org.citrusframework.util.ReflectionHelper;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static org.mockito.Mockito.doReturn;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.GregorianCalendar;
 
 public class ChangeDateFunctionTest extends UnitTestSupport {
 
-    @Mock
-    private ChangeDateFunction.CalendarProvider calendarProviderMock;
+    private static final String BASE_DATE = "15.01.2026";
+    private static final String BASE_DATE_TIME = "2026-01-15 10:20:30";
 
-    private AutoCloseable mockitoContext;
-
-    private ChangeDateFunction fixture;
-
-    @BeforeMethod
-    void beforeMethodSetup() {
-        mockitoContext = MockitoAnnotations.openMocks(this);
-
-        fixture = new ChangeDateFunction();
-        ReflectionHelper.setField(ReflectionHelper.findField(ChangeDateFunction.class, "calendarProvider"), fixture, calendarProviderMock);
-    }
+    private final ChangeDateFunction fixture = new ChangeDateFunction();
 
     @Test
     public void testDefaultDateFormat() {
-        Calendar c = getAndInsertMockCalendar();
-        c.add(Calendar.YEAR, 1);
-        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" +
-                String.format("%1$td.%1$tm.%1$tY", Calendar.getInstance()) + "', '+1y'"), context),
-                String.format("%1$td.%1$tm.%1$tY", c));
+        Calendar calendar = defaultBaseCalendar();
+        calendar.add(Calendar.YEAR, 1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" + BASE_DATE + "', '+1y'"), context),
+                String.format("%1$td.%1$tm.%1$tY", calendar));
 
-        c = getAndInsertMockCalendar();
-        c.add(Calendar.MONTH, 1);
-        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" +
-                String.format("%1$td.%1$tm.%1$tY", Calendar.getInstance()) + "', '+1M'"), context),
-                String.format("%1$td.%1$tm.%1$tY", c));
+        calendar = defaultBaseCalendar();
+        calendar.add(Calendar.MONTH, 1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" + BASE_DATE + "', '+1M'"), context),
+                String.format("%1$td.%1$tm.%1$tY", calendar));
 
-        c = getAndInsertMockCalendar();
-        c.add(Calendar.DAY_OF_YEAR, 1);
-        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" +
-                String.format("%1$td.%1$tm.%1$tY", Calendar.getInstance()) + "', '+1d'"), context),
-                String.format("%1$td.%1$tm.%1$tY", c));
+        calendar = defaultBaseCalendar();
+        calendar.add(Calendar.DAY_OF_YEAR, 1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" + BASE_DATE + "', '+1d'"), context),
+                String.format("%1$td.%1$tm.%1$tY", calendar));
     }
 
     @Test
     public void testFunction() {
-        Calendar c = getAndInsertMockCalendar();
-        c.add(Calendar.YEAR, 1);
-        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" +
-                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", Calendar.getInstance()) + "', '+1y', 'yyyy-MM-dd HH:mm:ss'"), context),
-                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        Calendar calendar = dateTimeBaseCalendar();
+        calendar.add(Calendar.YEAR, 1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" + BASE_DATE_TIME + "', '+1y', 'yyyy-MM-dd HH:mm:ss'"), context),
+                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
 
-        c = getAndInsertMockCalendar();
-        c.add(Calendar.MONTH, 1);
-        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" +
-                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", Calendar.getInstance()) + "', '+1M', 'yyyy-MM-dd HH:mm:ss'"), context),
-                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        calendar = dateTimeBaseCalendar();
+        calendar.add(Calendar.MONTH, 1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" + BASE_DATE_TIME + "', '+1M', 'yyyy-MM-dd HH:mm:ss'"), context),
+                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
 
-        c = getAndInsertMockCalendar();
-        c.add(Calendar.DAY_OF_YEAR, 1);
-        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" +
-                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", Calendar.getInstance()) + "', '+1d', 'yyyy-MM-dd HH:mm:ss'"), context),
-                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        calendar = dateTimeBaseCalendar();
+        calendar.add(Calendar.DAY_OF_YEAR, 1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" + BASE_DATE_TIME + "', '+1d', 'yyyy-MM-dd HH:mm:ss'"), context),
+                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
 
-        c = getAndInsertMockCalendar();
-        c.add(Calendar.HOUR, 1);
-        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" +
-                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", Calendar.getInstance()) + "', '+1h', 'yyyy-MM-dd HH:mm:ss'"), context),
-                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        calendar = dateTimeBaseCalendar();
+        calendar.add(Calendar.HOUR, 1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" + BASE_DATE_TIME + "', '+1h', 'yyyy-MM-dd HH:mm:ss'"), context),
+                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
 
-        c = getAndInsertMockCalendar();
-        c.add(Calendar.MINUTE, 1);
-        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" +
-                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", Calendar.getInstance()) + "', '+1m', 'yyyy-MM-dd HH:mm:ss'"), context),
-                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        calendar = dateTimeBaseCalendar();
+        calendar.add(Calendar.MINUTE, 1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" + BASE_DATE_TIME + "', '+1m', 'yyyy-MM-dd HH:mm:ss'"), context),
+                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
 
-        c = getAndInsertMockCalendar();
-        c.add(Calendar.SECOND, 1);
-        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" +
-                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", Calendar.getInstance()) + "', '+1s', 'yyyy-MM-dd HH:mm:ss'"), context),
-                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        calendar = dateTimeBaseCalendar();
+        calendar.add(Calendar.SECOND, 1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" + BASE_DATE_TIME + "', '+1s', 'yyyy-MM-dd HH:mm:ss'"), context),
+                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
 
-        c = getAndInsertMockCalendar();
-        c.add(Calendar.YEAR, 10);
-        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" +
-                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", Calendar.getInstance()) + "', '+10y', 'yyyy-MM-dd HH:mm:ss'"), context),
-                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        calendar = dateTimeBaseCalendar();
+        calendar.add(Calendar.YEAR, 10);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" + BASE_DATE_TIME + "', '+10y', 'yyyy-MM-dd HH:mm:ss'"), context),
+                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
 
-        c = getAndInsertMockCalendar();
-        c.add(Calendar.YEAR, 1);
-        c.add(Calendar.MONTH, 1);
-        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" +
-                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", Calendar.getInstance()) + "', '+1y+1M', 'yyyy-MM-dd HH:mm:ss'"), context),
-                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        calendar = dateTimeBaseCalendar();
+        calendar.add(Calendar.YEAR, 1);
+        calendar.add(Calendar.MONTH, 1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" + BASE_DATE_TIME + "', '+1y+1M', 'yyyy-MM-dd HH:mm:ss'"), context),
+                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
 
-        c.add(Calendar.DAY_OF_YEAR, 1);
-        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" +
-                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", Calendar.getInstance()) + "', '+1y+1M+1d', 'yyyy-MM-dd HH:mm:ss'"), context),
-                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        calendar.add(Calendar.DAY_OF_YEAR, 1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" + BASE_DATE_TIME + "', '+1y+1M+1d', 'yyyy-MM-dd HH:mm:ss'"), context),
+                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
 
-        c.add(Calendar.HOUR, 1);
-        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" +
-                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", Calendar.getInstance()) + "', '+1y+1M+1d+1h', 'yyyy-MM-dd HH:mm:ss'"), context),
-                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        calendar.add(Calendar.HOUR, 1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" + BASE_DATE_TIME + "', '+1y+1M+1d+1h', 'yyyy-MM-dd HH:mm:ss'"), context),
+                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
 
-        c.add(Calendar.MINUTE, 1);
-        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" +
-                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", Calendar.getInstance()) + "', '+1y+1M+1d+1h+1m', 'yyyy-MM-dd HH:mm:ss'"), context),
-                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        calendar.add(Calendar.MINUTE, 1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" + BASE_DATE_TIME + "', '+1y+1M+1d+1h+1m', 'yyyy-MM-dd HH:mm:ss'"), context),
+                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
 
-        c.add(Calendar.SECOND, 1);
-        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" +
-                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", Calendar.getInstance()) + "', '+1y+1M+1d+1h+1m+1s', 'yyyy-MM-dd HH:mm:ss'"), context),
-                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        calendar.add(Calendar.SECOND, 1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" + BASE_DATE_TIME + "', '+1y+1M+1d+1h+1m+1s', 'yyyy-MM-dd HH:mm:ss'"), context),
+                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
 
-        c = getAndInsertMockCalendar();
-        c.add(Calendar.YEAR, -1);
-        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" +
-                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", Calendar.getInstance()) + "', '-1y', 'yyyy-MM-dd HH:mm:ss'"), context),
-                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        calendar = dateTimeBaseCalendar();
+        calendar.add(Calendar.YEAR, -1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" + BASE_DATE_TIME + "', '-1y', 'yyyy-MM-dd HH:mm:ss'"), context),
+                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
 
-        c = getAndInsertMockCalendar();
-        c.add(Calendar.MONTH, -1);
-        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" +
-                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", Calendar.getInstance()) + "', '-1M', 'yyyy-MM-dd HH:mm:ss'"), context),
-                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        calendar = dateTimeBaseCalendar();
+        calendar.add(Calendar.MONTH, -1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" + BASE_DATE_TIME + "', '-1M', 'yyyy-MM-dd HH:mm:ss'"), context),
+                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
 
-        c = getAndInsertMockCalendar();
-        c.add(Calendar.DAY_OF_YEAR, -1);
-        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" +
-                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", Calendar.getInstance()) + "', '-1d', 'yyyy-MM-dd HH:mm:ss'"), context),
-                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        calendar = dateTimeBaseCalendar();
+        calendar.add(Calendar.DAY_OF_YEAR, -1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" + BASE_DATE_TIME + "', '-1d', 'yyyy-MM-dd HH:mm:ss'"), context),
+                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
 
-        c = getAndInsertMockCalendar();
-        c.add(Calendar.HOUR, -1);
-        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" +
-                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", Calendar.getInstance()) + "', '-1h', 'yyyy-MM-dd HH:mm:ss'"), context),
-                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        calendar = dateTimeBaseCalendar();
+        calendar.add(Calendar.HOUR, -1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" + BASE_DATE_TIME + "', '-1h', 'yyyy-MM-dd HH:mm:ss'"), context),
+                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
 
-        c = getAndInsertMockCalendar();
-        c.add(Calendar.MINUTE, -1);
-        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" +
-                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", Calendar.getInstance()) + "', '-1m', 'yyyy-MM-dd HH:mm:ss'"), context),
-                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        calendar = dateTimeBaseCalendar();
+        calendar.add(Calendar.MINUTE, -1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" + BASE_DATE_TIME + "', '-1m', 'yyyy-MM-dd HH:mm:ss'"), context),
+                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
 
-        c = getAndInsertMockCalendar();
-        c.add(Calendar.SECOND, -1);
-        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" +
-                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", Calendar.getInstance()) + "', '-1s', 'yyyy-MM-dd HH:mm:ss'"), context),
-                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        calendar = dateTimeBaseCalendar();
+        calendar.add(Calendar.SECOND, -1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" + BASE_DATE_TIME + "', '-1s', 'yyyy-MM-dd HH:mm:ss'"), context),
+                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
 
-        c = getAndInsertMockCalendar();
-        c.add(Calendar.YEAR, -1);
-        c.add(Calendar.MONTH, 1);
-        c.add(Calendar.DAY_OF_YEAR, -1);
-        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" +
-                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", Calendar.getInstance()) + "', '-1y+1M-1d', 'yyyy-MM-dd HH:mm:ss'"), context),
-                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        calendar = dateTimeBaseCalendar();
+        calendar.add(Calendar.YEAR, -1);
+        calendar.add(Calendar.MONTH, 1);
+        calendar.add(Calendar.DAY_OF_YEAR, -1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" + BASE_DATE_TIME + "', '-1y+1M-1d', 'yyyy-MM-dd HH:mm:ss'"), context),
+                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
 
-        c = getAndInsertMockCalendar();
-        c.add(Calendar.YEAR, 1);
-        c.add(Calendar.MONTH, -1);
-        c.add(Calendar.DAY_OF_YEAR, -1);
-        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" +
-                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", Calendar.getInstance()) + "', '+1y-1M-1d', 'yyyy-MM-dd HH:mm:ss'"), context),
-                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        calendar = dateTimeBaseCalendar();
+        calendar.add(Calendar.YEAR, 1);
+        calendar.add(Calendar.MONTH, -1);
+        calendar.add(Calendar.DAY_OF_YEAR, -1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'" + BASE_DATE_TIME + "', '+1y-1M-1d', 'yyyy-MM-dd HH:mm:ss'"), context),
+                String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
     }
 
     @Test(expectedExceptions = {CitrusRuntimeException.class})
@@ -200,19 +161,16 @@ public class ChangeDateFunctionTest extends UnitTestSupport {
         fixture.execute(FunctionParameterHelper.getParameterList("'1970-01-01', '+1y'"), context);
     }
 
-	@Test(expectedExceptions = {InvalidFunctionUsageException.class})
+    @Test(expectedExceptions = {InvalidFunctionUsageException.class})
     public void testNoParameters() {
         fixture.execute(Collections.EMPTY_LIST, context);
     }
 
-    private Calendar getAndInsertMockCalendar() {
-        Calendar c = Calendar.getInstance();
-        doReturn(c.clone()).when(calendarProviderMock).getInstance();
-        return c;
+    private Calendar defaultBaseCalendar() {
+        return new GregorianCalendar(2026, Calendar.JANUARY, 15, 0, 0, 0);
     }
 
-    @AfterMethod
-    public void afterMethodTeardown() throws Exception {
-        mockitoContext.close();
+    private Calendar dateTimeBaseCalendar() {
+        return new GregorianCalendar(2026, Calendar.JANUARY, 15, 10, 20, 30);
     }
 }

--- a/core/citrus-base/src/test/java/org/citrusframework/functions/core/CurrentDateFunctionTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/functions/core/CurrentDateFunctionTest.java
@@ -16,117 +16,131 @@
 
 package org.citrusframework.functions.core;
 
-import java.util.Calendar;
-import java.util.Collections;
-import java.util.TimeZone;
-
 import org.citrusframework.UnitTestSupport;
 import org.citrusframework.functions.FunctionParameterHelper;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.TimeZone;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class CurrentDateFunctionTest extends UnitTestSupport {
-    CurrentDateFunction function = new CurrentDateFunction();
+
+    private final CurrentDateFunction fixture = new CurrentDateFunction();
 
     @Test
     public void testFunction() {
-        Assert.assertEquals(function.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd'"), context), String.format("%1$tY-%1$tm-%1$td", Calendar.getInstance()));
-        Assert.assertEquals(function.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", Calendar.getInstance()));
-        Assert.assertEquals(function.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd'T'hh:mm:ss'"), context), String.format("%1$tY-%1$tm-%1$tdT%1$tI:%1$tM:%1$tS", Calendar.getInstance()));
+        Calendar calendar = Calendar.getInstance();
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd'"), context), String.format("%1$tY-%1$tm-%1$td", calendar));
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd'T'hh:mm:ss'"), context), String.format("%1$tY-%1$tm-%1$tdT%1$tI:%1$tM:%1$tS", calendar));
 
-        Calendar c = Calendar.getInstance();
-        c.add(Calendar.YEAR, 1);
-        Assert.assertEquals(function.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss', '+1y'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        String zonedResult = fixture.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd'T'hh:mm:ssZ','0h','UTC+2'"), context);
+        assertThat(zonedResult)
+                .contains("T")
+                .endsWith("+0200");
 
-        c = Calendar.getInstance();
-        c.add(Calendar.MONTH, 1);
-        Assert.assertEquals(function.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss', '+1M'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        String rfc3399Result = fixture.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd'T'hh:mm:ssXXX','0h','UTC+2'"), context);
+        assertThat(rfc3399Result)
+                .contains("T")
+                .endsWith("+02:00");
 
-        c = Calendar.getInstance();
-        c.add(Calendar.DAY_OF_YEAR, 1);
-        Assert.assertEquals(function.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss', '+1d'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        calendar = Calendar.getInstance();
+        calendar.add(Calendar.YEAR, 1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss', '+1y'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
 
-        c = Calendar.getInstance();
-        c.add(Calendar.HOUR, 1);
-        Assert.assertEquals(function.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss', '+1h'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        calendar = Calendar.getInstance();
+        calendar.add(Calendar.MONTH, 1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss', '+1M'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
 
-        c = Calendar.getInstance();
-        c.add(Calendar.MINUTE, 1);
-        Assert.assertEquals(function.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss', '+1m'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        calendar = Calendar.getInstance();
+        calendar.add(Calendar.DAY_OF_YEAR, 1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss', '+1d'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
 
-        c = Calendar.getInstance();
-        c.add(Calendar.SECOND, 1);
-        Assert.assertEquals(function.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss', '+1s'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        calendar = Calendar.getInstance();
+        calendar.add(Calendar.HOUR, 1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss', '+1h'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
 
-        c = Calendar.getInstance();
-        c.add(Calendar.YEAR, 10);
-        Assert.assertEquals(function.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss', '+10y'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        calendar = Calendar.getInstance();
+        calendar.add(Calendar.MINUTE, 1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss', '+1m'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
 
-        c = Calendar.getInstance();
-        c.add(Calendar.YEAR, 1);
-        c.add(Calendar.MONTH, 1);
-        Assert.assertEquals(function.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss', '+1y+1M'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        calendar = Calendar.getInstance();
+        calendar.add(Calendar.SECOND, 1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss', '+1s'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
 
-        c.add(Calendar.DAY_OF_YEAR, 1);
-        Assert.assertEquals(function.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss', '+1y+1M+1d'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        calendar = Calendar.getInstance();
+        calendar.add(Calendar.YEAR, 10);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss', '+10y'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
 
-        c.add(Calendar.HOUR, 1);
-        Assert.assertEquals(function.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss', '+1y+1M+1d+1h'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        calendar = Calendar.getInstance();
+        calendar.add(Calendar.YEAR, 1);
+        calendar.add(Calendar.MONTH, 1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss', '+1y+1M'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
 
-        c.add(Calendar.MINUTE, 1);
-        Assert.assertEquals(function.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss', '+1y+1M+1d+1h+1m'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        calendar.add(Calendar.DAY_OF_YEAR, 1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss', '+1y+1M+1d'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
 
-        c.add(Calendar.SECOND, 1);
-        Assert.assertEquals(function.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss', '+1y+1M+1d+1h+1m+1s'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        calendar.add(Calendar.HOUR, 1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss', '+1y+1M+1d+1h'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
 
-        c = Calendar.getInstance();
-        c.add(Calendar.YEAR, -1);
-        Assert.assertEquals(function.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss', '-1y'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        calendar.add(Calendar.MINUTE, 1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss', '+1y+1M+1d+1h+1m'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
 
-        c = Calendar.getInstance();
-        c.add(Calendar.MONTH, -1);
-        Assert.assertEquals(function.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss', '-1M'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        calendar.add(Calendar.SECOND, 1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss', '+1y+1M+1d+1h+1m+1s'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
 
-        c = Calendar.getInstance();
-        c.add(Calendar.DAY_OF_YEAR, -1);
-        Assert.assertEquals(function.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss', '-1d'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        calendar = Calendar.getInstance();
+        calendar.add(Calendar.YEAR, -1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss', '-1y'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
 
-        c = Calendar.getInstance();
-        c.add(Calendar.HOUR, -1);
-        Assert.assertEquals(function.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss', '-1h'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        calendar = Calendar.getInstance();
+        calendar.add(Calendar.MONTH, -1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss', '-1M'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
 
-        c = Calendar.getInstance();
-        c.add(Calendar.MINUTE, -1);
-        Assert.assertEquals(function.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss', '-1m'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        calendar = Calendar.getInstance();
+        calendar.add(Calendar.DAY_OF_YEAR, -1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss', '-1d'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
 
-        c = Calendar.getInstance();
-        c.add(Calendar.SECOND, -1);
-        Assert.assertEquals(function.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss', '-1s'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        calendar = Calendar.getInstance();
+        calendar.add(Calendar.HOUR, -1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss', '-1h'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
 
-        c = Calendar.getInstance();
-        c.add(Calendar.YEAR, -1);
-        c.add(Calendar.MONTH, 1);
-        c.add(Calendar.DAY_OF_YEAR, -1);
-        Assert.assertEquals(function.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss', '-1y+1M-1d'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        calendar = Calendar.getInstance();
+        calendar.add(Calendar.MINUTE, -1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss', '-1m'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
 
-        c = Calendar.getInstance();
-        c.add(Calendar.YEAR, 1);
-        c.add(Calendar.MONTH, -1);
-        c.add(Calendar.DAY_OF_YEAR, -1);
-        Assert.assertEquals(function.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss', '+1y-1M-1d'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        calendar = Calendar.getInstance();
+        calendar.add(Calendar.SECOND, -1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss', '-1s'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
 
-        c = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-        Assert.assertEquals(function.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss','0h','UTC'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", c));
+        calendar = Calendar.getInstance();
+        calendar.add(Calendar.YEAR, -1);
+        calendar.add(Calendar.MONTH, 1);
+        calendar.add(Calendar.DAY_OF_YEAR, -1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss', '-1y+1M-1d'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
+
+        calendar = Calendar.getInstance();
+        calendar.add(Calendar.YEAR, 1);
+        calendar.add(Calendar.MONTH, -1);
+        calendar.add(Calendar.DAY_OF_YEAR, -1);
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss', '+1y-1M-1d'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
+
+        calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        Assert.assertEquals(fixture.execute(FunctionParameterHelper.getParameterList("'yyyy-MM-dd HH:mm:ss','0h','UTC'"), context), String.format("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", calendar));
     }
 
     @Test(expectedExceptions = {IllegalArgumentException.class})
     public void testWrongParameterUsage() {
-        function.execute(Collections.singletonList("no date format string"), context);
+        fixture.execute(Collections.singletonList("no date format string"), context);
     }
 
-	@Test
-	@SuppressWarnings("unchecked")
+    @Test
+    @SuppressWarnings("unchecked")
     public void testNoParameters() {
-        Assert.assertEquals(function.execute(Collections.EMPTY_LIST, context), String.format("%1$td.%1$tm.%1$tY", Calendar.getInstance()));
+        Assert.assertEquals(fixture.execute(Collections.EMPTY_LIST, context), String.format("%1$td.%1$tm.%1$tY", Calendar.getInstance()));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,7 @@
     <jsonschema-generator.version>5.0.0</jsonschema-generator.version>
     <json-path.version>3.0.0</json-path.version>
     <json-patch.version>1.13</json-patch.version>
-    <json-schema-validator.version>3.0.2</json-schema-validator.version>
+    <json-schema-validator.version>2.0.1</json-schema-validator.version>
     <json-smart.version>2.6.0</json-smart.version>
     <jtidy.version>r938</jtidy.version>
     <junit.jupiter.version>6.0.3</junit.jupiter.version>
@@ -256,6 +256,7 @@
     <mockftpserver.version>3.2.0</mockftpserver.version>
     <netty.version>4.2.13.Final</netty.version>
     <okhttp.version>5.3.2</okhttp.version>
+    <openapi-request-validator.version>3.0.0</openapi-request-validator.version>
     <org.openapitools.version>7.21.0</org.openapitools.version>
     <picoli-version>4.7.7</picoli-version>
     <postgresql.version>42.7.11</postgresql.version>
@@ -274,7 +275,6 @@
     <sshd.version>2.16.0</sshd.version>
     <swagger.version>2.2.37</swagger.version>
     <swagger.parser.version>2.1.22</swagger.parser.version>
-    <swagger-request-validator.version>2.46.1</swagger-request-validator.version>
     <system-stubs.version>2.1.8</system-stubs.version>
     <testcontainers.version>2.0.5</testcontainers.version>
     <testng.version>7.12.0</testng.version>
@@ -721,8 +721,8 @@
 
       <dependency>
         <groupId>com.atlassian.oai</groupId>
-        <artifactId>swagger-request-validator-core</artifactId>
-        <version>${swagger-request-validator.version}</version>
+        <artifactId>openapi-request-validator-core</artifactId>
+        <version>${openapi-request-validator.version}</version>
         <exclusions>
           <!--
             force com.sun.mail:mailapi to v2 major.


### PR DESCRIPTION
migration of:

```xml
- <artifactId>swagger-request-validator-core</artifactId>
+ <artifactId>openapi-request-validator-core</artifactId>
```

see: https://github.com/atlassian/openapi-request-validator#important

`openapi-request-validator-core` [supports OpenAPI v3.1](https://github.com/atlassian/openapi-request-validator/blob/master/docs/FEATURES.md), whereas `swagger-request-validator-core` only [supported OpenAPI v3.0](https://github.com/atlassian/openapi-request-validator/blob/swagger-request-validator-2.46.1/docs/FEATURES.md).

I think, this update is quit important. [OpenAPI 3.1 has been around since 2024, with OpenAPI 3.2 also being out since 2025](https://spec.openapis.org/oas/).