### PR TITLE
fix(#1551): Add Localstack auth token option

### DIFF
--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/actions/StartTestcontainersAction.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/actions/StartTestcontainersAction.java
@@ -64,6 +64,9 @@ public class StartTestcontainersAction<C extends GenericContainer<?>> extends Ab
     public void doExecute(TestContext context) {
         logger.info("Starting Testcontainers container '{}'", containerName);
 
+        // Give subclasses a chance to configure the container with the test context.
+        configure(container, context);
+
         container.start();
 
         if (containerName != null && !context.getReferenceResolver().isResolvable(containerName)) {
@@ -87,9 +90,13 @@ public class StartTestcontainersAction<C extends GenericContainer<?>> extends Ab
     }
 
     /**
+     * Subclasses may add custom configuration with the current test context.
+     */
+    protected void configure(C container, TestContext context) {
+    }
+
+    /**
      * Sets the connection settings in current test context in the form of test variables.
-     * @param container
-     * @param context
      */
     protected void exposeConnectionSettings(C container, TestContext context) {
         if (container.getContainerId() != null) {

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/LocalStackContainer.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/LocalStackContainer.java
@@ -32,19 +32,20 @@ import java.util.stream.Collectors;
 
 import org.citrusframework.actions.testcontainers.aws2.AwsService;
 import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.util.StringUtils;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
-import software.amazon.awssdk.regions.Region;
 
 public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
 
     private static final int PORT = 4566;
 
     private static final String HOSTNAME_EXTERNAL_ENV = "HOSTNAME_EXTERNAL";
+    private static final String AUTH_TOKEN_ENV = "LOCALSTACK_AUTH_TOKEN";
 
     private static final String DOCKER_IMAGE_NAME = LocalStackSettings.getImageName();
     private static final String DOCKER_IMAGE_TAG = LocalStackSettings.getVersion();
@@ -52,9 +53,11 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
     private final Set<AwsService> services = new HashSet<>();
     private final Map<AwsService, Object> clients = new HashMap<>();
 
-    private String secretKey = "secretkey";
-    private String accessKey = "accesskey";
-    private String region = Region.US_EAST_1.id();
+    private String authToken = LocalStackSettings.getAuthToken();
+
+    private String secretKey = LocalStackSettings.getSecretKey();
+    private String accessKey = LocalStackSettings.getAccessKey();
+    private String region = LocalStackSettings.getRegion();
 
     public LocalStackContainer() {
         this(DOCKER_IMAGE_TAG);
@@ -91,6 +94,11 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
             throw new CitrusRuntimeException("Must provide at least one service");
         }
 
+        if (StringUtils.hasText(authToken)) {
+            // newer versions of Localstack container require auth token
+            withEnv(AUTH_TOKEN_ENV, authToken);
+        }
+
         withEnv("SERVICE", services.stream().map(AwsService::serviceName).collect(Collectors.joining(",")));
 
         String hostnameExternalReason;
@@ -111,6 +119,11 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
             getEnvMap().get(HOSTNAME_EXTERNAL_ENV),
             hostnameExternalReason
         );
+    }
+
+    public LocalStackContainer withAuthToken(String authToken) {
+        this.authToken = authToken;
+        return self();
     }
 
     public LocalStackContainer withSecretKey(String secretKey) {
@@ -166,11 +179,11 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
 
         AwsCredentials credentials = getCredentialsProvider().resolveCredentials();
 
-        properties.put(LocalStackSettings.ACCESS_KEY_PROPERTY, credentials.accessKeyId());
-        properties.put(LocalStackSettings.SECRET_KEY_PROPERTY, credentials.secretAccessKey());
-        properties.put(LocalStackSettings.REGION_PROPERTY, Region.US_EAST_1.toString());
-        properties.put(LocalStackSettings.HOST_PROPERTY, getHost() + ":" + getMappedPort(PORT));
-        properties.put(LocalStackSettings.PROTOCOL_PROPERTY, "http");
+        properties.put(LocalStackSettings.AWS_ACCESS_KEY_PROPERTY, credentials.accessKeyId());
+        properties.put(LocalStackSettings.AWS_SECRET_KEY_PROPERTY, credentials.secretAccessKey());
+        properties.put(LocalStackSettings.AWS_REGION_PROPERTY, LocalStackSettings.getRegion());
+        properties.put(LocalStackSettings.AWS_HOST_PROPERTY, getHost() + ":" + getMappedPort(PORT));
+        properties.put(LocalStackSettings.AWS_PROTOCOL_PROPERTY, "http");
 
         return properties;
     }

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/LocalStackSettings.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/LocalStackSettings.java
@@ -25,6 +25,7 @@ import java.util.stream.Stream;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.kubernetes.KubernetesSupport;
 import org.citrusframework.testcontainers.TestContainersSettings;
+import software.amazon.awssdk.regions.Region;
 
 import static org.citrusframework.testcontainers.TestcontainersHelper.getEnvVarName;
 
@@ -53,16 +54,31 @@ public class LocalStackSettings {
     private static final String AUTO_CREATE_CLIENTS_ENV = LOCALSTACK_ENV_PREFIX + "AUTO_CREATE_CLIENTS";
     public static final String AUTO_CREATE_CLIENTS_DEFAULT = "true";
 
+    private static final String AUTH_TOKEN_PROPERTY = LOCALSTACK_PROPERTY_PREFIX + "auth.token";
+    private static final String AUTH_TOKEN_ENV = LOCALSTACK_ENV_PREFIX + "AUTH_TOKEN";
+
+    private static final String SECRET_KEY_PROPERTY = LOCALSTACK_PROPERTY_PREFIX + "secret.key";
+    private static final String SECRET_KEY_ENV = LOCALSTACK_ENV_PREFIX + "SECRET_KEY";
+    public static final String SECRET_KEY_DEFAULT = "secretkey";
+
+    private static final String ACCESS_KEY_PROPERTY = LOCALSTACK_PROPERTY_PREFIX + "access.key";
+    private static final String ACCESS_KEY_ENV = LOCALSTACK_ENV_PREFIX + "ACCESS_KEY";
+    public static final String ACCESS_KEY_DEFAULT = "accesskey";
+
+    private static final String REGION_PROPERTY = LOCALSTACK_PROPERTY_PREFIX + "region";
+    private static final String REGION_ENV = LOCALSTACK_ENV_PREFIX + "REGION";
+    public static final String REGION_DEFAULT = Region.US_EAST_1.id();
+
     private static final String STARTUP_TIMEOUT_PROPERTY = LOCALSTACK_PROPERTY_PREFIX + "startup.timeout";
     private static final String STARTUP_TIMEOUT_ENV = LOCALSTACK_ENV_PREFIX + "STARTUP_TIMEOUT";
 
     private static final String AWS_PROPERTY_PREFIX = "aws.";
 
-    public static final String ACCESS_KEY_PROPERTY = AWS_PROPERTY_PREFIX + "access.key";
-    public static final String SECRET_KEY_PROPERTY = AWS_PROPERTY_PREFIX + "secret.key";
-    public static final String REGION_PROPERTY = AWS_PROPERTY_PREFIX + "region";
-    public static final String HOST_PROPERTY = AWS_PROPERTY_PREFIX + "host";
-    public static final String PROTOCOL_PROPERTY = AWS_PROPERTY_PREFIX + "protocol";
+    public static final String AWS_ACCESS_KEY_PROPERTY = AWS_PROPERTY_PREFIX + "access.key";
+    public static final String AWS_SECRET_KEY_PROPERTY = AWS_PROPERTY_PREFIX + "secret.key";
+    public static final String AWS_REGION_PROPERTY = AWS_PROPERTY_PREFIX + "region";
+    public static final String AWS_HOST_PROPERTY = AWS_PROPERTY_PREFIX + "host";
+    public static final String AWS_PROTOCOL_PROPERTY = AWS_PROPERTY_PREFIX + "protocol";
 
     private LocalStackSettings() {
         // prevent instantiation of utility class
@@ -121,6 +137,25 @@ public class LocalStackSettings {
         return Optional.ofNullable(System.getProperty(STARTUP_TIMEOUT_PROPERTY, System.getenv(STARTUP_TIMEOUT_ENV)))
                 .map(Integer::parseInt)
                 .orElseGet(TestContainersSettings::getStartupTimeout);
+    }
+
+    public static String getAuthToken() {
+        return System.getProperty(AUTH_TOKEN_PROPERTY, System.getenv(AUTH_TOKEN_ENV));
+    }
+
+    public static String getSecretKey() {
+        return System.getProperty(SECRET_KEY_PROPERTY,
+                System.getenv(SECRET_KEY_ENV) != null ? System.getenv(SECRET_KEY_ENV) : SECRET_KEY_DEFAULT);
+    }
+
+    public static String getAccessKey() {
+        return System.getProperty(ACCESS_KEY_PROPERTY,
+                System.getenv(ACCESS_KEY_ENV) != null ? System.getenv(ACCESS_KEY_ENV) : ACCESS_KEY_DEFAULT);
+    }
+
+    public static String getRegion() {
+        return System.getProperty(REGION_PROPERTY,
+                System.getenv(REGION_ENV) != null ? System.getenv(REGION_ENV) : REGION_DEFAULT);
     }
 
     /**

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/StartLocalStackAction.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/StartLocalStackAction.java
@@ -29,6 +29,7 @@ import org.citrusframework.context.TestContext;
 import org.citrusframework.testcontainers.TestContainersSettings;
 import org.citrusframework.testcontainers.actions.StartTestcontainersAction;
 import org.citrusframework.util.PropertyUtils;
+import org.citrusframework.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -41,11 +42,38 @@ public class StartLocalStackAction extends StartTestcontainersAction<LocalStackC
     private final boolean autoCreateClients;
 
     private final Map<String, String> options;
+    private final String authToken;
+    private final String secretKey;
+    private final String accessKey;
+    private final String region;
 
     public StartLocalStackAction(Builder builder) {
         super(builder);
         this.autoCreateClients = builder.autoCreateClients;
         this.options = builder.options;
+        this.authToken = builder.authToken;
+        this.secretKey = builder.secretKey;
+        this.accessKey = builder.accessKey;
+        this.region = builder.region;
+    }
+
+    @Override
+    protected void configure(LocalStackContainer container, TestContext context) {
+        if (StringUtils.hasText(authToken)) {
+            container.withAuthToken(context.replaceDynamicContentInString(authToken));
+        }
+
+        if (StringUtils.hasText(secretKey)) {
+            container.withSecretKey(context.replaceDynamicContentInString(secretKey));
+        }
+
+        if (StringUtils.hasText(accessKey)) {
+            container.withAccessKey(context.replaceDynamicContentInString(accessKey));
+        }
+
+        if (StringUtils.hasText(region)) {
+            container.withRegion(context.replaceDynamicContentInString(region));
+        }
     }
 
     @Override
@@ -91,6 +119,12 @@ public class StartLocalStackAction extends StartTestcontainersAction<LocalStackC
 
         private final Map<String, String> options = new HashMap<>();
 
+        private String authToken = LocalStackSettings.getAuthToken();
+
+        private String secretKey = LocalStackSettings.getSecretKey();
+        private String accessKey = LocalStackSettings.getAccessKey();
+        private String region = LocalStackSettings.getRegion();
+
         public Builder() {
             withStartupTimeout(LocalStackSettings.getStartupTimeout());
         }
@@ -99,6 +133,30 @@ public class StartLocalStackAction extends StartTestcontainersAction<LocalStackC
         public Builder version(String localStackVersion) {
            this.localStackVersion = localStackVersion;
            return this;
+        }
+
+        @Override
+        public Builder authToken(String authToken) {
+            this.authToken = authToken;
+            return this;
+        }
+
+        @Override
+        public Builder secretKey(String secretKey) {
+            this.secretKey = secretKey;
+            return this;
+        }
+
+        @Override
+        public Builder accessKey(String accessKey) {
+            this.accessKey = accessKey;
+            return this;
+        }
+
+        @Override
+        public Builder region(String region) {
+            this.region = region;
+            return this;
         }
 
         @Override

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/xml/Start.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/xml/Start.java
@@ -68,6 +68,22 @@ public class Start extends AbstractTestcontainersAction.Builder<StartTestcontain
 
         builder.autoCreateClients(container.isAutoCreateClients());
 
+        if (StringUtils.hasText(container.getAuthToken())) {
+            builder.authToken(container.getAuthToken());
+        }
+
+        if (StringUtils.hasText(container.getSecretKey())) {
+            builder.secretKey(container.getSecretKey());
+        }
+
+        if (StringUtils.hasText(container.getAccessKey())) {
+            builder.accessKey(container.getAccessKey());
+        }
+
+        if (StringUtils.hasText(container.getRegion())) {
+            builder.region(container.getRegion());
+        }
+
         if (container.getOptions() != null) {
             container.getOptions().getOptions().forEach(option -> builder.withOption(option.getName(), option.getValue()));
         }
@@ -530,6 +546,15 @@ public class Start extends AbstractTestcontainersAction.Builder<StartTestcontain
         @XmlAttribute
         protected String version;
 
+        @XmlAttribute(name = "auth-token")
+        protected String authToken;
+        @XmlAttribute(name = "secret-key")
+        protected String secretKey;
+        @XmlAttribute(name = "access-key")
+        protected String accessKey;
+        @XmlAttribute
+        protected String region;
+
         @XmlAttribute(name = "auto-create-clients")
         protected boolean autoCreateClients = LocalStackSettings.isAutoCreateClients();
 
@@ -548,6 +573,38 @@ public class Start extends AbstractTestcontainersAction.Builder<StartTestcontain
 
         public void setVersion(String version) {
             this.version = version;
+        }
+
+        public String getAuthToken() {
+            return authToken;
+        }
+
+        public void setAuthToken(String authToken) {
+            this.authToken = authToken;
+        }
+
+        public String getSecretKey() {
+            return secretKey;
+        }
+
+        public void setSecretKey(String secretKey) {
+            this.secretKey = secretKey;
+        }
+
+        public String getAccessKey() {
+            return accessKey;
+        }
+
+        public void setAccessKey(String accessKey) {
+            this.accessKey = accessKey;
+        }
+
+        public String getRegion() {
+            return region;
+        }
+
+        public void setRegion(String region) {
+            this.region = region;
         }
 
         public String getServiceList() {

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/yaml/Start.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/yaml/Start.java
@@ -63,6 +63,22 @@ public class Start extends AbstractTestcontainersAction.Builder<StartTestcontain
 
         builder.autoCreateClients(container.isAutoCreateClients());
 
+        if (StringUtils.hasText(container.getAuthToken())) {
+            builder.authToken(container.getAuthToken());
+        }
+
+        if (StringUtils.hasText(container.getSecretKey())) {
+            builder.secretKey(container.getSecretKey());
+        }
+
+        if (StringUtils.hasText(container.getAccessKey())) {
+            builder.accessKey(container.getAccessKey());
+        }
+
+        if (StringUtils.hasText(container.getRegion())) {
+            builder.region(container.getRegion());
+        }
+
         if (container.getOptions() != null) {
             builder.withOptions(container.getOptions());
         }
@@ -386,6 +402,11 @@ public class Start extends AbstractTestcontainersAction.Builder<StartTestcontain
 
         protected String version;
 
+        protected String authToken;
+        protected String secretKey;
+        protected String accessKey;
+        protected String region;
+
         protected List<String> services;
 
         protected Map<String, String> options;
@@ -415,6 +436,53 @@ public class Start extends AbstractTestcontainersAction.Builder<StartTestcontain
         @SchemaProperty
         public void setVersion(String version) {
             this.version = version;
+        }
+
+        public String getAuthToken() {
+            return authToken;
+        }
+
+        @SchemaProperty(
+            metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
+            description = "Newer versions of Localstack container require an auth token.")
+        public void setAuthToken(String authToken) {
+            this.authToken = authToken;
+        }
+
+        public String getSecretKey() {
+            return secretKey;
+        }
+
+        @SchemaProperty(
+            metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
+            description = "AWS secret key"
+        )
+        public void setSecretKey(String secretKey) {
+            this.secretKey = secretKey;
+        }
+
+        public String getAccessKey() {
+            return accessKey;
+        }
+
+        @SchemaProperty(
+                metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
+                description = "AWS access key"
+        )
+        public void setAccessKey(String accessKey) {
+            this.accessKey = accessKey;
+        }
+
+        public String getRegion() {
+            return region;
+        }
+
+        @SchemaProperty(
+                metadata = { @SchemaProperty.MetaData(key = "$comment", value = "group:security") },
+                description = "AWS region"
+        )
+        public void setRegion(String region) {
+            this.region = region;
         }
 
         public List<String> getServices() {

--- a/core/citrus-api/src/main/java/org/citrusframework/actions/testcontainers/TestcontainersLocalStackStartActionBuilder.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/actions/testcontainers/TestcontainersLocalStackStartActionBuilder.java
@@ -27,6 +27,14 @@ public interface TestcontainersLocalStackStartActionBuilder<C extends AutoClosea
 
     B version(String localStackVersion);
 
+    B authToken(String authToken);
+
+    B secretKey(String secretKey);
+
+    B accessKey(String accessKey);
+
+    B region(String region);
+
     B withService(AwsService service);
 
     B withServices(AwsService[] services);

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-5.0.0-SNAPSHOT.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-5.0.0-SNAPSHOT.xsd
@@ -3789,6 +3789,10 @@
                   <xs:attribute name="name" type="xs:string"/>
                   <xs:attribute name="service-name" type="xs:string"/>
                   <xs:attribute name="version" type="xs:string"/>
+                  <xs:attribute name="auth-token" type="xs:string"/>
+                  <xs:attribute name="secret-key" type="xs:string"/>
+                  <xs:attribute name="access-key" type="xs:string"/>
+                  <xs:attribute name="region" type="xs:string"/>
                   <xs:attribute name="auto-remove" type="xs:boolean"/>
                   <xs:attribute name="auto-create-clients" type="xs:boolean"/>
                   <xs:attribute name="services" type="xs:string"/>

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
@@ -3789,6 +3789,10 @@
                   <xs:attribute name="name" type="xs:string"/>
                   <xs:attribute name="service-name" type="xs:string"/>
                   <xs:attribute name="version" type="xs:string"/>
+                  <xs:attribute name="auth-token" type="xs:string"/>
+                  <xs:attribute name="secret-key" type="xs:string"/>
+                  <xs:attribute name="access-key" type="xs:string"/>
+                  <xs:attribute name="region" type="xs:string"/>
                   <xs:attribute name="auto-remove" type="xs:boolean"/>
                   <xs:attribute name="auto-create-clients" type="xs:boolean"/>
                   <xs:attribute name="services" type="xs:string"/>

--- a/src/manual/connector-testcontainers.adoc
+++ b/src/manual/connector-testcontainers.adoc
@@ -359,7 +359,7 @@ You can use these test variables to connect to the MongoDB Testcontainers instan
 == LocalStack
 
 The LocalStack Testcontainers module allows you to start lightweight Amazon WebServices such as AWS S3, AWS SQS, AWS SNS or AWS Kinesis.
-You can start a LocslStack instance with the following test action.
+You can start a LocalStack instance with the following test action.
 
 .Java
 [source,java,indent=0,role="primary"]
@@ -410,6 +410,88 @@ actions:
 
 Each LocalStack instance receives a list of services that should be enabled.
 In the example above the AWS S3 service is enabled.
+
+[[testcontainers-localstack-security]]
+=== Container security settings
+
+The LocalStack container uses some default dummy values for `secretKey` and `accessKey`. You may set these properties explicitly as well as the region when starting the container.
+
+.Java
+[source,java,indent=0,role="primary"]
+----
+@CitrusTest
+public void testcontainersTest() {
+    given(testcontainers()
+            .localstack()
+            .start()
+            .secretKey("${secretKey}")
+            .accessKey("${accessKey}")
+            .region("us-east-1")
+            .withService(LocalStackContainer.Service.S3));
+}
+----
+
+.XML
+[source,xml,indent=0,role="secondary"]
+----
+<test name="TestcontainersTest" xmlns="http://citrusframework.org/schema/xml/testcase">
+    <actions>
+        <testcontainers>
+          <start>
+            <localstack
+              secret-key="${secretKey}"
+              access-key="${accessKey}"
+              region="us-east-1"
+              services="S3"/>
+          </start>
+        </testcontainers>
+    </actions>
+</test>
+----
+
+.YAML
+[source,yaml,indent=0,role="secondary"]
+----
+name: TestcontainersTest
+actions:
+  - testcontainers:
+      start:
+        localstack:
+          secretKey: '${secretKey}'
+          accessKey: '${accessKey}'
+          region: us-east-1
+          services:
+            - "S3"
+----
+
+.Spring XML
+[source,xml,indent=0,role="secondary"]
+----
+<spring:beans xmlns="http://www.citrusframework.org/schema/testcase"
+              xmlns:spring="http://www.springframework.org/schema/beans">
+    <!-- NOT SUPPORTED -->
+</spring:beans>
+----
+
+As you can see the settings support test variables so you may load these values from a local file or as a global variable via env setting.
+
+You may also use one of these envVars for a global and secure way of setting these values:
+
+* CITRUS_TESTCONTAINERS_LOCALSTACK_SECRET_KEY
+* CITRUS_TESTCONTAINERS_LOCALSTACK_ACCESS_KEY
+* CITRUS_TESTCONTAINERS_LOCALSTACK_REGION
+* CITRUS_TESTCONTAINERS_LOCALSTACK_AUTH_TOKEN
+
+In the `citrus-application.properties` you can set these keys:
+
+* citrus.testcontainers.localstack.secret.key
+* citrus.testcontainers.localstack.access.key
+* citrus.testcontainers.localstack.region
+* citrus.testcontainers.localstack.auth.token
+
+NOTE: Since mid 2026 newer versions of the LocalStack container require an auth token. You may obtain your personal token from the official LocalStack website.
+
+You can use the `authToken()` setting when starting the container with the respective test action.
 
 [[testcontainers-localstack-settings]]
 === Exposed connection settings


### PR DESCRIPTION
- Allows users to set the auth token that is required in newer Localstack container versions
- Also allows to set custom secretKey, accessKey and region settings on start container test action
- Supports test variable replacement for these security properties so users can use global variables or functions to set these values

Fixes #1551 