### PR TITLE
fix(#1555): Add Strimzi Kafka container implementation option

### DIFF
--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/KafkaImplementation.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/KafkaImplementation.java
@@ -20,4 +20,5 @@ public enum KafkaImplementation {
     DEFAULT,
     CONFLUENT,
     APACHE,
+    STRIMZI,
 }

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/KafkaSettings.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/KafkaSettings.java
@@ -30,7 +30,9 @@ public class KafkaSettings {
     private static final String KAFKA_PROPERTY_PREFIX = TestContainersSettings.TESTCONTAINERS_PROPERTY_PREFIX + "kafka.";
     private static final String KAFKA_ENV_PREFIX = TestContainersSettings.TESTCONTAINERS_ENV_PREFIX + "KAFKA_";
 
+    public static final String NODE_ID = "1";
     public static final int KAFKA_PORT = 9092;
+    public static final int CONTROLLER_PORT = 9093;
 
     private static final String SERVICE_NAME_PROPERTY = KAFKA_PROPERTY_PREFIX + "service.name";
     private static final String SERVICE_NAME_ENV = KAFKA_ENV_PREFIX + "SERVICE_NAME";
@@ -55,6 +57,14 @@ public class KafkaSettings {
     private static final String APACHE_VERSION_PROPERTY = KAFKA_PROPERTY_PREFIX + "apache.version";
     private static final String APACHE_VERSION_ENV = KAFKA_ENV_PREFIX + "APACHE_VERSION";
     private static final String APACHE_VERSION_DEFAULT = "4.2.1";
+
+    private static final String STRIMZI_IMAGE_NAME_PROPERTY = KAFKA_PROPERTY_PREFIX + "strimzi.image.name";
+    private static final String STRIMZI_IMAGE_NAME_ENV = KAFKA_ENV_PREFIX + "STRIMZI_IMAGE_NAME";
+    protected static final String STRIMZI_IMAGE_NAME_DEFAULT = "quay.io/strimzi/kafka";
+
+    private static final String STRIMZI_VERSION_PROPERTY = KAFKA_PROPERTY_PREFIX + "strimzi.version";
+    private static final String STRIMZI_VERSION_ENV = KAFKA_ENV_PREFIX + "STRIMZI_VERSION";
+    private static final String STRIMZI_VERSION_DEFAULT = "0.51.0-kafka-4.2.0";
 
     private static final String CONFLUENT_IMAGE_NAME_PROPERTY = KAFKA_PROPERTY_PREFIX + "confluent.image.name";
     private static final String CONFLUENT_IMAGE_NAME_ENV = KAFKA_ENV_PREFIX + "CONFLUENT_IMAGE_NAME";
@@ -85,6 +95,8 @@ public class KafkaSettings {
                     System.getenv(CONFLUENT_IMAGE_NAME_ENV) != null ? System.getenv(CONFLUENT_IMAGE_NAME_ENV) : CONFLUENT_IMAGE_NAME_DEFAULT);
             case APACHE -> TestContainersSettings.getDockerRegistry() + System.getProperty(APACHE_IMAGE_NAME_PROPERTY,
                     System.getenv(APACHE_IMAGE_NAME_ENV) != null ? System.getenv(APACHE_IMAGE_NAME_ENV) : APACHE_IMAGE_NAME_DEFAULT);
+            case STRIMZI -> TestContainersSettings.getDockerRegistry() + System.getProperty(STRIMZI_IMAGE_NAME_PROPERTY,
+                    System.getenv(STRIMZI_IMAGE_NAME_ENV) != null ? System.getenv(STRIMZI_IMAGE_NAME_ENV) : STRIMZI_IMAGE_NAME_DEFAULT);
             case DEFAULT -> TestContainersSettings.getDockerRegistry() + System.getProperty(IMAGE_NAME_PROPERTY,
                     System.getenv(IMAGE_NAME_ENV) != null ? System.getenv(IMAGE_NAME_ENV) : IMAGE_NAME_DEFAULT);
         };
@@ -99,6 +111,8 @@ public class KafkaSettings {
                     System.getenv(CONFLUENT_VERSION_ENV) != null ? System.getenv(CONFLUENT_VERSION_ENV) : CONFLUENT_VERSION_DEFAULT);
             case APACHE -> System.getProperty(APACHE_VERSION_PROPERTY,
                     System.getenv(APACHE_VERSION_ENV) != null ? System.getenv(APACHE_VERSION_ENV) : APACHE_VERSION_DEFAULT);
+            case STRIMZI -> System.getProperty(STRIMZI_VERSION_PROPERTY,
+                    System.getenv(STRIMZI_VERSION_ENV) != null ? System.getenv(STRIMZI_VERSION_ENV) : STRIMZI_VERSION_DEFAULT);
             case DEFAULT -> System.getProperty(VERSION_PROPERTY,
                     System.getenv(VERSION_ENV) != null ? System.getenv(VERSION_ENV) : VERSION_DEFAULT);
         };

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/StartKafkaAction.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/StartKafkaAction.java
@@ -16,6 +16,8 @@
 
 package org.citrusframework.testcontainers.kafka;
 
+import java.util.Locale;
+
 import org.citrusframework.actions.testcontainers.TestcontainersKafkaStartActionBuilder;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.testcontainers.TestContainersSettings;
@@ -52,7 +54,7 @@ public class StartKafkaAction<T extends GenericContainer<?>> extends StartTestco
 
         @Override
         public Builder<T> implementation(String implementation) {
-           this.implementation = KafkaImplementation.valueOf(implementation);
+           this.implementation = KafkaImplementation.valueOf(implementation.toUpperCase(Locale.US));
            return this;
         }
 
@@ -99,6 +101,7 @@ public class StartKafkaAction<T extends GenericContainer<?>> extends StartTestco
 
             Class<?> kafkaContainerType = switch (implementation) {
                 case DEFAULT, CONFLUENT -> ConfluentKafkaContainer.class;
+                case STRIMZI -> StrimziContainer.class;
                 case APACHE -> KafkaContainer.class;
             };
             GenericContainer<?> kafkaContainer;
@@ -130,11 +133,16 @@ public class StartKafkaAction<T extends GenericContainer<?>> extends StartTestco
                                 super.start();
                             }
                         };
+                        case STRIMZI -> new StrimziContainer(imageName)
+                                .withServiceName(serviceName)
+                                .withPort(port);
                     };
                 } else {
                     kafkaContainer = switch(implementation) {
                         case DEFAULT, CONFLUENT -> new ConfluentKafkaContainer(imageName);
                         case APACHE ->  new KafkaContainer(imageName);
+                        case STRIMZI ->  new StrimziContainer(imageName)
+                                .withServiceName(serviceName);
                     };
                 }
 

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/StrimziContainer.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/StrimziContainer.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.testcontainers.kafka;
+
+import java.util.UUID;
+
+import org.citrusframework.util.SocketUtils;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Testcontainers implementation for Strimzi Kafka.
+ */
+public class StrimziContainer extends GenericContainer<StrimziContainer> {
+
+    private static final String DOCKER_IMAGE_NAME = KafkaSettings.getImageName(KafkaImplementation.STRIMZI);
+    private static final String DOCKER_IMAGE_TAG = KafkaSettings.getKafkaVersion(KafkaImplementation.STRIMZI);
+
+    private String serviceName = KafkaSettings.getServiceName();
+    private int port = -1;
+
+    public StrimziContainer() {
+        this(DOCKER_IMAGE_TAG);
+    }
+
+    public StrimziContainer(String version) {
+        this(DOCKER_IMAGE_NAME, version);
+    }
+
+    public StrimziContainer(String imageName, String version) {
+        this(DockerImageName.parse(imageName).withTag(version));
+    }
+
+    public StrimziContainer(DockerImageName dockerImageName) {
+        super(dockerImageName);
+    }
+
+    public StrimziContainer withPort(int port) {
+        this.port = port;
+        return this;
+    }
+
+    public StrimziContainer withServiceName(String serviceName) {
+        this.serviceName = serviceName;
+        return this;
+    }
+
+    @Override
+    protected void configure() {
+        super.configure();
+
+        String clusterId = UUID.randomUUID().toString().replace("-", "").substring(0, 22);
+
+        withEnv("LOG_DIR", "/tmp/logs")
+            .withExposedPorts(KafkaSettings.KAFKA_PORT)
+            .withEnv("KAFKA_BROKER_ID", KafkaSettings.NODE_ID)
+            .withEnv("KAFKA_NODE_ID", KafkaSettings.NODE_ID)
+            .withEnv("KAFKA_PROCESS_ROLES", "broker,controller")
+            .withEnv("KAFKA_LISTENERS", "BROKER://0.0.0.0:%d,CONTROLLER://0.0.0.0:%d".formatted(KafkaSettings.KAFKA_PORT, KafkaSettings.CONTROLLER_PORT))
+            .withEnv("KAFKA_INTER_BROKER_LISTENER_NAME", "BROKER")
+            .withEnv("KAFKA_CONTROLLER_LISTENER_NAMES", "CONTROLLER")
+            .withEnv("KAFKA_LISTENER_SECURITY_PROTOCOL_MAP", "BROKER:PLAINTEXT,CONTROLLER:PLAINTEXT")
+            .withEnv("KAFKA_CONTROLLER_QUORUM_VOTERS", "%s@localhost:%d".formatted(KafkaSettings.NODE_ID, KafkaSettings.CONTROLLER_PORT))
+            .withEnv("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", "1")
+            .withEnv("KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", "1")
+            .withEnv("KAFKA_TRANSACTION_STATE_LOG_MIN_ISR", "1")
+            .withEnv("KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS", "0")
+            .withCreateContainerCmdModifier(createContainerCmd -> createContainerCmd.withHostName(serviceName))
+            .withCommand("sh", "-c",
+                    "bin/kafka-storage.sh format -t " + clusterId + " -c config/server.properties --standalone && "
+                            + "bin/kafka-server-start.sh config/server.properties "
+                            + "--override listeners=${KAFKA_LISTENERS} "
+                            + "--override advertised.listeners=${KAFKA_ADVERTISED_LISTENERS} "
+                            + "--override listener.security.protocol.map=${KAFKA_LISTENER_SECURITY_PROTOCOL_MAP} "
+                            + "--override inter.broker.listener.name=${KAFKA_INTER_BROKER_LISTENER_NAME} "
+                            + "--override controller.listener.names=${KAFKA_CONTROLLER_LISTENER_NAMES} "
+                            + "--override controller.quorum.voters=${KAFKA_CONTROLLER_QUORUM_VOTERS} "
+                            + "--override broker.id=${KAFKA_BROKER_ID} "
+                            + "--override node.id=${KAFKA_NODE_ID} "
+                            + "--override process.roles=${KAFKA_PROCESS_ROLES} "
+                            + "--override offsets.topic.replication.factor=${KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR} "
+                            + "--override transaction.state.log.replication.factor=${KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR} "
+                            + "--override transaction.state.log.min.isr=${KAFKA_TRANSACTION_STATE_LOG_MIN_ISR} "
+                            + "--override group.initial.rebalance.delay.ms=${KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS}")
+            .waitingFor(Wait.forListeningPort());
+    }
+
+    @Override
+    public void start() {
+        withEnv("KAFKA_ADVERTISED_LISTENERS", String.format("BROKER://%s:%d".formatted(getHost(), resolveHostPort())));
+        super.start();
+    }
+
+    private int resolveHostPort() {
+        String suffix = ":" + KafkaSettings.KAFKA_PORT;
+        for (String binding : getPortBindings()) {
+            if (binding.endsWith(suffix)) {
+                return Integer.parseInt(binding.substring(0, binding.indexOf(':')));
+            }
+        }
+
+        int hostPort;
+        if (port > 0) {
+            hostPort = port;
+        } else {
+            hostPort = SocketUtils.findAvailableTcpPort();
+        }
+
+        addFixedExposedPort(hostPort, KafkaSettings.KAFKA_PORT);
+        return hostPort;
+    }
+}

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/quarkus/strimzi/KafkaContainerResource.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/quarkus/strimzi/KafkaContainerResource.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.testcontainers.kafka.quarkus.strimzi;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.quarkus.test.common.QuarkusTestResourceConfigurableLifecycleManager;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.testcontainers.kafka.KafkaImplementation;
+import org.citrusframework.testcontainers.kafka.StartKafkaAction;
+import org.citrusframework.testcontainers.kafka.StrimziContainer;
+import org.citrusframework.testcontainers.quarkus.ContainerLifecycleListener;
+import org.citrusframework.testcontainers.quarkus.TestcontainersResource;
+
+public class KafkaContainerResource extends TestcontainersResource<StrimziContainer>
+        implements QuarkusTestResourceConfigurableLifecycleManager<KafkaContainerSupport> {
+
+    public KafkaContainerResource() {
+        super(StrimziContainer.class);
+    }
+
+    @Override
+    public void init(KafkaContainerSupport config) {
+        for (Class<? extends ContainerLifecycleListener<StrimziContainer>> lifecycleListenerType :
+                config.containerLifecycleListener()) {
+            try {
+                registerContainerLifecycleListener(lifecycleListenerType.getDeclaredConstructor().newInstance());
+            } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+                throw new CitrusRuntimeException("Failed to instantiate container lifecycle listener from type: %s"
+                        .formatted(lifecycleListenerType), e);
+            }
+        }
+
+        Map<String, String> initArgs = new HashMap<>();
+        if (!config.version().isEmpty()) {
+            initArgs.put("version", config.version());
+        }
+
+        if (config.port() > 0) {
+            initArgs.put("port",  String.valueOf(config.port()));
+        }
+        doInit(initArgs);
+    }
+
+    @Override
+    protected void doInit(Map<String, String> initArgs) {
+        StartKafkaAction.Builder<StrimziContainer> builder = new StartKafkaAction.Builder<StrimziContainer>()
+                .implementation(KafkaImplementation.STRIMZI);
+
+        if (initArgs.containsKey("version")) {
+            builder.version(initArgs.get("version"));
+        }
+
+        if (initArgs.containsKey("port")) {
+            builder.port(Integer.parseInt(initArgs.get("port")));
+        }
+
+        container = builder.build().getContainer();
+    }
+}

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/quarkus/strimzi/KafkaContainerSupport.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/quarkus/strimzi/KafkaContainerSupport.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.testcontainers.kafka.quarkus.strimzi;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import org.citrusframework.testcontainers.kafka.StrimziContainer;
+import org.citrusframework.testcontainers.kafka.quarkus.apache.KafkaContainerResource;
+import org.citrusframework.testcontainers.quarkus.ContainerLifecycleListener;
+
+@QuarkusTestResource(KafkaContainerResource.class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface KafkaContainerSupport {
+
+    /**
+     * Optional fixed container port.
+     */
+    int port() default -1;
+
+    /**
+     * Kafka container image version.
+     */
+    String version() default "";
+
+    /**
+     * Container lifecycle listeners
+     */
+    Class<? extends ContainerLifecycleListener<StrimziContainer>>[] containerLifecycleListener() default {};
+}

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-5.0.0-SNAPSHOT.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-5.0.0-SNAPSHOT.xsd
@@ -3928,6 +3928,8 @@
                     </xs:element>
                   </xs:sequence>
                   <xs:attribute name="name" type="xs:string"/>
+                  <xs:attribute name="implementation" type="xs:string" default="CONFLUENT"/>
+                  <xs:attribute name="port" type="xs:int"/>
                   <xs:attribute name="service-name" type="xs:string"/>
                   <xs:attribute name="version" type="xs:string"/>
                   <xs:attribute name="auto-remove" type="xs:boolean"/>

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
@@ -3928,6 +3928,8 @@
                     </xs:element>
                   </xs:sequence>
                   <xs:attribute name="name" type="xs:string"/>
+                  <xs:attribute name="implementation" type="xs:string" default="CONFLUENT"/>
+                  <xs:attribute name="port" type="xs:int"/>
                   <xs:attribute name="service-name" type="xs:string"/>
                   <xs:attribute name="version" type="xs:string"/>
                   <xs:attribute name="auto-remove" type="xs:boolean"/>

--- a/src/manual/connector-testcontainers.adoc
+++ b/src/manual/connector-testcontainers.adoc
@@ -731,7 +731,159 @@ actions:
 </spring:beans>
 ----
 
-In the test example the Kafka Testcontainers module is started.
+The example above uses a special test actions to start the Kafka container.
+
+[[testcontainers-kafka-implementations]]
+=== Kafka container implementations
+
+Citrus provides support for different Kafka container implementations to give you flexibility in choosing the most suitable option for your testing needs:
+
+* **Confluent Platform** (default) - The Confluent Community Edition Kafka distribution
+* **Apache Kafka** - The official Apache Kafka distribution
+* **Strimzi** - A Kubernetes-native Kafka distribution based on Apache Kafka
+
+By default, Citrus uses the Confluent Platform implementation. You can specify a different implementation using the `implementation()` method:
+
+.Java
+[source,java,indent=0,role="primary"]
+----
+@CitrusTest
+public void testcontainersTest() {
+    given(testcontainers()
+            .kafka()
+            .start()
+            .implementation(KafkaImplementation.STRIMZI));
+}
+----
+
+.XML
+[source,xml,indent=0,role="secondary"]
+----
+<test name="TestcontainersTest" xmlns="http://citrusframework.org/schema/xml/testcase">
+    <actions>
+        <testcontainers>
+          <start>
+            <kafka implementation="STRIMZI"/>
+          </start>
+        </testcontainers>
+    </actions>
+</test>
+----
+
+.YAML
+[source,yaml,indent=0,role="secondary"]
+----
+name: TestcontainersTest
+actions:
+  - testcontainers:
+      start:
+        kafka:
+          implementation: "STRIMZI"
+----
+
+Available implementation values are:
+
+* `CONFLUENT` - Uses the `confluentinc/cp-kafka` image (default)
+* `APACHE` - Uses the `apache/kafka` image
+* `STRIMZI` - Uses the `quay.io/strimzi/kafka` image
+* `DEFAULT` - Same as `CONFLUENT`
+
+[[testcontainers-kafka-configuration]]
+=== Configuration options
+
+You can customize the Kafka container with additional settings:
+
+.Java
+[source,java,indent=0,role="primary"]
+----
+@CitrusTest
+public void testcontainersTest() {
+    given(testcontainers()
+            .kafka()
+            .start()
+            .implementation(KafkaImplementation.APACHE)
+            .version("4.2.1")
+            .port(9092));
+}
+----
+
+.XML
+[source,xml,indent=0,role="secondary"]
+----
+<test name="TestcontainersTest" xmlns="http://citrusframework.org/schema/xml/testcase">
+    <actions>
+        <testcontainers>
+          <start>
+            <kafka implementation="APACHE" version="4.2.1" port="9092"/>
+          </start>
+        </testcontainers>
+    </actions>
+</test>
+----
+
+.YAML
+[source,yaml,indent=0,role="secondary"]
+----
+name: TestcontainersTest
+actions:
+  - testcontainers:
+      start:
+        kafka:
+          implementation: "APACHE"
+          version: "4.2.1"
+          port: 9092
+----
+
+You may also use system properties or environment variables to configure the default Kafka container settings:
+
+|===
+|Setting |System Property |Environment Variable
+
+|Implementation
+|citrus.testcontainers.kafka.implementation
+|CITRUS_TESTCONTAINERS_KAFKA_IMPLEMENTATION
+
+|Confluent image name
+|citrus.testcontainers.kafka.confluent.image.name
+|CITRUS_TESTCONTAINERS_KAFKA_CONFLUENT_IMAGE_NAME
+
+|Confluent version
+|citrus.testcontainers.kafka.confluent.version
+|CITRUS_TESTCONTAINERS_KAFKA_CONFLUENT_VERSION
+
+|Apache image name
+|citrus.testcontainers.kafka.apache.image.name
+|CITRUS_TESTCONTAINERS_KAFKA_APACHE_IMAGE_NAME
+
+|Apache version
+|citrus.testcontainers.kafka.apache.version
+|CITRUS_TESTCONTAINERS_KAFKA_APACHE_VERSION
+
+|Strimzi image name
+|citrus.testcontainers.kafka.strimzi.image.name
+|CITRUS_TESTCONTAINERS_KAFKA_STRIMZI_IMAGE_NAME
+
+|Strimzi version
+|citrus.testcontainers.kafka.strimzi.version
+|CITRUS_TESTCONTAINERS_KAFKA_STRIMZI_VERSION
+
+|Service name
+|citrus.testcontainers.kafka.service.name
+|CITRUS_TESTCONTAINERS_KAFKA_SERVICE_NAME
+
+|Container name
+|citrus.testcontainers.kafka.container.name
+|CITRUS_TESTCONTAINERS_KAFKA_CONTAINER_NAME
+
+|Startup timeout (seconds)
+|citrus.testcontainers.kafka.startup.timeout
+|CITRUS_TESTCONTAINERS_KAFKA_STARTUP_TIMEOUT
+
+|===
+
+[[testcontainers-kafka-variables]]
+=== Exposed connection settings
+
 Citrus exposes special test variables that represent connection settings for the Kafka container:
 
 |===

--- a/tools/cucumber-steps/citrus-cucumber-testcontainers/src/main/java/org/citrusframework/cucumber/steps/testcontainers/KafkaSteps.java
+++ b/tools/cucumber-steps/citrus-cucumber-testcontainers/src/main/java/org/citrusframework/cucumber/steps/testcontainers/KafkaSteps.java
@@ -79,7 +79,7 @@ public class KafkaSteps {
         this.port = port;
     }
 
-    @Given("^Kafka container implementation (DEFAULT|CONFLUENT|APACHE)$")
+    @Given("^Kafka container implementation (DEFAULT|CONFLUENT|APACHE|STRIMZI)$")
     public void setImplementation(String implementation) {
         this.implementation = KafkaImplementation.valueOf(implementation);
     }


### PR DESCRIPTION
- Users can choose to use Strimzi as a Kafka implementation when starting the Testcontainers support for Kafka in Citrus