### PR TITLE
fix(#1559): Add native Apache Kafka container implementation option

### DIFF
--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/KafkaImplementation.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/KafkaImplementation.java
@@ -20,5 +20,6 @@ public enum KafkaImplementation {
     DEFAULT,
     CONFLUENT,
     APACHE,
+    APACHE_NATIVE,
     STRIMZI,
 }

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/KafkaSettings.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/KafkaSettings.java
@@ -58,6 +58,14 @@ public class KafkaSettings {
     private static final String APACHE_VERSION_ENV = KAFKA_ENV_PREFIX + "APACHE_VERSION";
     private static final String APACHE_VERSION_DEFAULT = "4.2.1";
 
+    private static final String APACHE_NATIVE_IMAGE_NAME_PROPERTY = KAFKA_PROPERTY_PREFIX + "apache.native.image.name";
+    private static final String APACHE_NATIVE_IMAGE_NAME_ENV = KAFKA_ENV_PREFIX + "APACHE_NATIVE_IMAGE_NAME";
+    protected static final String APACHE_NATIVE_IMAGE_NAME_DEFAULT = "apache/kafka-native";
+
+    private static final String APACHE_NATIVE_VERSION_PROPERTY = KAFKA_PROPERTY_PREFIX + "apache.native.version";
+    private static final String APACHE_NATIVE_VERSION_ENV = KAFKA_ENV_PREFIX + "APACHE_NATIVE_VERSION";
+    private static final String APACHE_NATIVE_VERSION_DEFAULT = APACHE_VERSION_DEFAULT;
+
     private static final String STRIMZI_IMAGE_NAME_PROPERTY = KAFKA_PROPERTY_PREFIX + "strimzi.image.name";
     private static final String STRIMZI_IMAGE_NAME_ENV = KAFKA_ENV_PREFIX + "STRIMZI_IMAGE_NAME";
     protected static final String STRIMZI_IMAGE_NAME_DEFAULT = "quay.io/strimzi/kafka";
@@ -95,6 +103,8 @@ public class KafkaSettings {
                     System.getenv(CONFLUENT_IMAGE_NAME_ENV) != null ? System.getenv(CONFLUENT_IMAGE_NAME_ENV) : CONFLUENT_IMAGE_NAME_DEFAULT);
             case APACHE -> TestContainersSettings.getDockerRegistry() + System.getProperty(APACHE_IMAGE_NAME_PROPERTY,
                     System.getenv(APACHE_IMAGE_NAME_ENV) != null ? System.getenv(APACHE_IMAGE_NAME_ENV) : APACHE_IMAGE_NAME_DEFAULT);
+            case APACHE_NATIVE -> TestContainersSettings.getDockerRegistry() + System.getProperty(APACHE_NATIVE_IMAGE_NAME_PROPERTY,
+                    System.getenv(APACHE_NATIVE_IMAGE_NAME_ENV) != null ? System.getenv(APACHE_NATIVE_IMAGE_NAME_ENV) : APACHE_NATIVE_IMAGE_NAME_DEFAULT);
             case STRIMZI -> TestContainersSettings.getDockerRegistry() + System.getProperty(STRIMZI_IMAGE_NAME_PROPERTY,
                     System.getenv(STRIMZI_IMAGE_NAME_ENV) != null ? System.getenv(STRIMZI_IMAGE_NAME_ENV) : STRIMZI_IMAGE_NAME_DEFAULT);
             case DEFAULT -> TestContainersSettings.getDockerRegistry() + System.getProperty(IMAGE_NAME_PROPERTY,
@@ -111,6 +121,8 @@ public class KafkaSettings {
                     System.getenv(CONFLUENT_VERSION_ENV) != null ? System.getenv(CONFLUENT_VERSION_ENV) : CONFLUENT_VERSION_DEFAULT);
             case APACHE -> System.getProperty(APACHE_VERSION_PROPERTY,
                     System.getenv(APACHE_VERSION_ENV) != null ? System.getenv(APACHE_VERSION_ENV) : APACHE_VERSION_DEFAULT);
+            case APACHE_NATIVE -> System.getProperty(APACHE_NATIVE_VERSION_PROPERTY,
+                    System.getenv(APACHE_NATIVE_VERSION_ENV) != null ? System.getenv(APACHE_NATIVE_VERSION_ENV) : APACHE_NATIVE_VERSION_DEFAULT);
             case STRIMZI -> System.getProperty(STRIMZI_VERSION_PROPERTY,
                     System.getenv(STRIMZI_VERSION_ENV) != null ? System.getenv(STRIMZI_VERSION_ENV) : STRIMZI_VERSION_DEFAULT);
             case DEFAULT -> System.getProperty(VERSION_PROPERTY,

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/StartKafkaAction.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/StartKafkaAction.java
@@ -102,7 +102,7 @@ public class StartKafkaAction<T extends GenericContainer<?>> extends StartTestco
             Class<?> kafkaContainerType = switch (implementation) {
                 case DEFAULT, CONFLUENT -> ConfluentKafkaContainer.class;
                 case STRIMZI -> StrimziContainer.class;
-                case APACHE -> KafkaContainer.class;
+                case APACHE, APACHE_NATIVE -> KafkaContainer.class;
             };
             GenericContainer<?> kafkaContainer;
             if (referenceResolver != null && referenceResolver.isResolvable(containerName, kafkaContainerType)) {
@@ -126,7 +126,7 @@ public class StartKafkaAction<T extends GenericContainer<?>> extends StartTestco
                                 super.start();
                             }
                         };
-                        case APACHE -> new KafkaContainer(imageName) {
+                        case APACHE, APACHE_NATIVE -> new KafkaContainer(imageName) {
                             @Override
                             public void start() {
                                 addFixedExposedPort(port, KafkaSettings.KAFKA_PORT);
@@ -140,7 +140,7 @@ public class StartKafkaAction<T extends GenericContainer<?>> extends StartTestco
                 } else {
                     kafkaContainer = switch(implementation) {
                         case DEFAULT, CONFLUENT -> new ConfluentKafkaContainer(imageName);
-                        case APACHE ->  new KafkaContainer(imageName);
+                        case APACHE, APACHE_NATIVE ->  new KafkaContainer(imageName);
                         case STRIMZI ->  new StrimziContainer(imageName)
                                 .withServiceName(serviceName);
                     };

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/quarkus/apache/KafkaContainerResource.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/quarkus/apache/KafkaContainerResource.java
@@ -55,13 +55,22 @@ public class KafkaContainerResource extends TestcontainersResource<KafkaContaine
         if (config.port() > 0) {
             initArgs.put("port",  String.valueOf(config.port()));
         }
+
+        if (config.nativeMode()) {
+            initArgs.put("nativeMode", "true");
+        }
+
         doInit(initArgs);
     }
 
     @Override
     protected void doInit(Map<String, String> initArgs) {
+        KafkaImplementation implementation = Boolean.parseBoolean(initArgs.getOrDefault("nativeMode", "false"))
+                ? KafkaImplementation.APACHE_NATIVE
+                : KafkaImplementation.APACHE;
+
         StartKafkaAction.Builder<KafkaContainer> builder = new StartKafkaAction.Builder<KafkaContainer>()
-                .implementation(KafkaImplementation.APACHE);
+                .implementation(implementation);
 
         if (initArgs.containsKey("version")) {
             builder.version(initArgs.get("version"));

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/quarkus/apache/KafkaContainerSupport.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/quarkus/apache/KafkaContainerSupport.java
@@ -41,6 +41,11 @@ public @interface KafkaContainerSupport {
     String version() default "";
 
     /**
+     * Enable native Apache Kafka mode (uses apache/kafka-native image).
+     */
+    boolean nativeMode() default false;
+
+    /**
      * Container lifecycle listeners
      */
     Class<? extends ContainerLifecycleListener<KafkaContainer>>[] containerLifecycleListener() default {};

--- a/src/manual/connector-testcontainers.adoc
+++ b/src/manual/connector-testcontainers.adoc
@@ -740,6 +740,7 @@ Citrus provides support for different Kafka container implementations to give yo
 
 * **Confluent Platform** (default) - The Confluent Community Edition Kafka distribution
 * **Apache Kafka** - The official Apache Kafka distribution
+* **Apache Kafka Native** - The Apache Kafka distribution with native GraalVM compilation for faster startup
 * **Strimzi** - A Kubernetes-native Kafka distribution based on Apache Kafka
 
 By default, Citrus uses the Confluent Platform implementation. You can specify a different implementation using the `implementation()` method:
@@ -785,8 +786,27 @@ Available implementation values are:
 
 * `CONFLUENT` - Uses the `confluentinc/cp-kafka` image (default)
 * `APACHE` - Uses the `apache/kafka` image
+* `APACHE_NATIVE` - Uses the `apache/kafka-native` image (GraalVM native compilation for faster startup)
 * `STRIMZI` - Uses the `quay.io/strimzi/kafka` image
 * `DEFAULT` - Same as `CONFLUENT`
+
+==== Choosing between APACHE and APACHE_NATIVE
+
+Both `APACHE` and `APACHE_NATIVE` implementations use the official Apache Kafka distribution, but there are important differences:
+
+* **APACHE** uses the standard JVM-based `apache/kafka` container image
+* **APACHE_NATIVE** uses the `apache/kafka-native` container image, which is compiled ahead-of-time using GraalVM native image technology
+
+The main advantage of `APACHE_NATIVE` is significantly faster container startup time, which can reduce test execution time, especially when running multiple tests that start Kafka containers. However, it has the same runtime behavior and compatibility as the standard `APACHE` implementation.
+
+Use `APACHE_NATIVE` when:
+* You want faster test execution with reduced container startup times
+* Your test suite frequently starts and stops Kafka containers
+* You are comfortable using GraalVM-compiled binaries
+
+Use `APACHE` when:
+* You need the standard JVM-based Kafka distribution
+* You want to ensure full compatibility with the traditional Kafka deployment model
 
 [[testcontainers-kafka-configuration]]
 === Configuration options
@@ -858,6 +878,14 @@ You may also use system properties or environment variables to configure the def
 |Apache version
 |citrus.testcontainers.kafka.apache.version
 |CITRUS_TESTCONTAINERS_KAFKA_APACHE_VERSION
+
+|Apache Native image name
+|citrus.testcontainers.kafka.apache.native.image.name
+|CITRUS_TESTCONTAINERS_KAFKA_APACHE_NATIVE_IMAGE_NAME
+
+|Apache Native version
+|citrus.testcontainers.kafka.apache.native.version
+|CITRUS_TESTCONTAINERS_KAFKA_APACHE_NATIVE_VERSION
 
 |Strimzi image name
 |citrus.testcontainers.kafka.strimzi.image.name


### PR DESCRIPTION
- Add APACHE_NATIVE to KafkaImplementation enum
- Update KafkaSettings to handle apache/kafka-native image
- Add nativeMode field to KafkaContainerSupport annotation
- Update KafkaContainerResource to select APACHE_NATIVE when nativeMode=true
- Update StartKafkaAction switch statements to handle APACHE_NATIVE