### PR TITLE
fix(#1544): Fix Read files documentation code example

### DIFF
--- a/src/manual/endpoint-file.adoc
+++ b/src/manual/endpoint-file.adoc
@@ -112,10 +112,11 @@ public MessageChannel fileChannel() {
 }
 
 @BindToRegistry
-public FileWritingMessageHandler fileOutboundAdapter() {
-    FileWritingMessageHandler messageHandler = new FileWritingMessageHandler(new File("some/directory"));
-    messageHandler.setOutboundChannel(fileChannel());
-    return messageHandler;
+public FileReadingMessageSource fileInboundAdapter() {
+    FileReadingMessageSource messageSource = new FileReadingMessageSource();
+    messageSource.setDirectory(new File("some/directory"));
+    messageSource.setInboundChannel(fileChannel());
+    return messageSource;
 }
 ----
 


### PR DESCRIPTION
Fixes #1544

The 'Read files' section incorrectly showed FileWritingMessageHandler code in the Citrus Bean tab. Changed to FileReadingMessageSource to match the section's purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)