### PR TITLE
fix(#1523): Improve handling of binary file resource message payloads

### DIFF
--- a/core/citrus-base/src/main/java/org/citrusframework/actions/ReceiveMessageAction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/actions/ReceiveMessageAction.java
@@ -826,6 +826,22 @@ public class ReceiveMessageAction extends AbstractTestAction implements MessageA
                 }
             }
 
+            if (validationContext == null) {
+                Optional<String> resource = getMessageResource();
+                if (resource.isPresent()) {
+                    String fileExt = FileUtils.getFileExtension(resource.get());
+                    if ("xml".equalsIgnoreCase(fileExt)) {
+                        validationContext = new XmlMessageValidationContext();
+                    } else if ("json".equalsIgnoreCase(fileExt)) {
+                        validationContext = new JsonMessageValidationContext();
+                    } else if ("yaml".equals(fileExt) || "yml".equalsIgnoreCase(fileExt)) {
+                        validationContext = new YamlMessageValidationContext();
+                    } else {
+                        validationContext = new DefaultMessageValidationContext();
+                    }
+                }
+            }
+
             // If we have not yet added a context, we might have a typed builder capable to create a
             // message. In that case add a context for the respective type.
             if (validationContext == null && messageBuilderSupport != null) {
@@ -838,20 +854,6 @@ public class ReceiveMessageAction extends AbstractTestAction implements MessageA
                     validationContext = new YamlMessageValidationContext();
                 } else if (type == MessageType.PLAINTEXT) {
                     validationContext = new DefaultMessageValidationContext();
-                }
-            }
-
-            if (validationContext == null) {
-                Optional<String> resource = getMessageResource();
-                if (resource.isPresent()) {
-                    String fileExt = FileUtils.getFileExtension(resource.get());
-                    if ("xml".equalsIgnoreCase(fileExt)) {
-                        validationContext = new XmlMessageValidationContext();
-                    } else if ("json".equalsIgnoreCase(fileExt)) {
-                        validationContext = new JsonMessageValidationContext();
-                    } else {
-                        validationContext = new DefaultMessageValidationContext();
-                    }
                 }
             }
 

--- a/core/citrus-base/src/main/java/org/citrusframework/message/builder/BinaryFileResourcePayloadBuilder.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/message/builder/BinaryFileResourcePayloadBuilder.java
@@ -16,6 +16,8 @@
 
 package org.citrusframework.message.builder;
 
+import java.util.Optional;
+
 import org.citrusframework.context.TestContext;
 import org.citrusframework.message.MessageType;
 import org.citrusframework.spi.Resource;
@@ -58,7 +60,13 @@ public class BinaryFileResourcePayloadBuilder extends FileResourcePayloadBuilder
 
     @Override
     public Object buildPayload(TestContext context) {
-        setMessageType(MessageType.BINARY.name());
+        if (Optional.ofNullable(getMessageType())
+                .filter(MessageType::isBinary)
+                .isEmpty()) {
+            // Set or overwrite message type to binary
+            setMessageType(MessageType.BINARY.name());
+        }
+
         return super.buildPayload(context);
     }
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/message/builder/MessageBuilderSupport.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/message/builder/MessageBuilderSupport.java
@@ -133,12 +133,11 @@ public abstract class MessageBuilderSupport<T extends TestAction, B extends Mess
 
     @Override
     public S body(final Resource payloadResource, final Charset charset) {
-        try {
-            body(readToString(payloadResource, charset));
-        } catch (IOException e) {
-            throw new CitrusRuntimeException("Failed to read payload resource", e);
+        if (MessageType.isBinary(messageType)) {
+            return body(new BinaryFileResourcePayloadBuilder(payloadResource));
         }
-        return self;
+
+        return body(new FileResourcePayloadBuilder(payloadResource, charset.name()));
     }
 
     @Override

--- a/core/citrus-base/src/test/java/org/citrusframework/actions/ReceiveMessageBuilderTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/actions/ReceiveMessageBuilderTest.java
@@ -243,7 +243,7 @@ public class ReceiveMessageBuilderTest implements TestActionSupport {
 		when(mocked.readAllBytes()).thenThrow(new IOException("Something went wrong"));
 
         //WHEN
-        final Assert.ThrowingRunnable setPayload = () -> builder.message().body(this.resource, Charset.defaultCharset());
+        final Assert.ThrowingRunnable setPayload = () -> builder.message().body(this.resource, Charset.defaultCharset()).getMessageBuilder().build(context, MessageType.PLAINTEXT.name());
 
         //THEN
         Assert.assertThrows("Missing exception due to payload resource IOException", CitrusRuntimeException.class, setPayload);

--- a/core/citrus-base/src/test/java/org/citrusframework/actions/dsl/ReceiveMessageActionBuilderTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/actions/dsl/ReceiveMessageActionBuilderTest.java
@@ -227,7 +227,8 @@ public class ReceiveMessageActionBuilderTest extends UnitTestSupport implements 
                         .setHeader("operation", "foo"));
 
         when(resource.exists()).thenReturn(true);
-        when(resource.getInputStream()).thenReturn(new ByteArrayInputStream("<TestRequest><Message>Hello World!</Message></TestRequest>".getBytes()));
+        when(resource.location()).thenReturn("message.xml");
+        when(resource.getInputStream()).thenAnswer((invocation) -> new ByteArrayInputStream("<TestRequest><Message>Hello World!</Message></TestRequest>".getBytes()));
         DefaultTestCaseRunner runner = new DefaultTestCaseRunner(context);
         runner.run(receive(messageEndpoint)
                 .message()

--- a/core/citrus-base/src/test/java/org/citrusframework/actions/dsl/SendMessageActionBuilderTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/actions/dsl/SendMessageActionBuilderTest.java
@@ -282,7 +282,7 @@ public class SendMessageActionBuilderTest extends UnitTestSupport implements Tes
         }).when(messageProducer).send(any(Message.class), any(TestContext.class));
 
         when(resource.exists()).thenReturn(true);
-        when(resource.getInputStream()).thenReturn(new ByteArrayInputStream("<TestRequest><Message>Hello World!</Message></TestRequest>".getBytes()));
+        when(resource.getInputStream()).thenAnswer((invocation) -> new ByteArrayInputStream("<TestRequest><Message>Hello World!</Message></TestRequest>".getBytes()));
         DefaultTestCaseRunner runner = new DefaultTestCaseRunner(context);
         runner.run(send(messageEndpoint)
                         .message()

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/actions/dsl/ReceiveSoapMessageTestActionBuilderTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/actions/dsl/ReceiveSoapMessageTestActionBuilderTest.java
@@ -17,7 +17,6 @@
 package org.citrusframework.ws.actions.dsl;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 
@@ -211,7 +210,8 @@ public class ReceiveSoapMessageTestActionBuilderTest extends UnitTestSupport {
                 .addAttachment(testAttachment));
 
         when(resource.exists()).thenReturn(true);
-        when(resource.getInputStream()).thenReturn(new ByteArrayInputStream("<TestRequest><Message>Hello World!</Message></TestRequest>".getBytes()));
+        when(resource.location()).thenReturn("message.xml");
+        when(resource.getInputStream()).thenAnswer((invocation) -> new ByteArrayInputStream("<TestRequest><Message>Hello World!</Message></TestRequest>".getBytes()));
         when(attachmentResource.exists()).thenReturn(true);
         when(attachmentResource.getInputStream()).thenReturn(new ByteArrayInputStream("This is an attachment".getBytes()));
 

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/ReceiveTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/ReceiveTest.java
@@ -232,7 +232,7 @@ public class ReceiveTest extends AbstractGroovyActionDslTest {
         messageBuilder = (DefaultMessageBuilder)action.getMessageBuilder();
 
         Assert.assertEquals(messageBuilder.buildMessagePayload(context, action.getMessageType()),
-                FileUtils.readToString(FileUtils.getFileResource("classpath:org/citrusframework/groovy/test-request-payload.xml")).trim());
+                FileUtils.readToString(FileUtils.getFileResource("classpath:org/citrusframework/groovy/test-request-payload.xml")));
         Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 0);
         Assert.assertEquals(action.getMessageProcessors().size(), 0);
         Assert.assertEquals(action.getControlMessageProcessors().size(), 0);

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/SendTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/SendTest.java
@@ -131,7 +131,7 @@ public class SendTest extends AbstractGroovyActionDslTest {
         messageBuilder = (DefaultMessageBuilder)action.getMessageBuilder();
 
         Assert.assertEquals(messageBuilder.buildMessagePayload(context, action.getMessageType()),
-                FileUtils.readToString(FileUtils.getFileResource("classpath:org/citrusframework/groovy/test-request-payload.xml")).trim());
+                FileUtils.readToString(FileUtils.getFileResource("classpath:org/citrusframework/groovy/test-request-payload.xml")));
         Assert.assertEquals(messageBuilder.buildMessageHeaders(context).size(), 0);
         Assert.assertEquals(action.getMessageProcessors().size(), 0);
         Assert.assertEquals(action.getEndpointUri(), "helloEndpoint");

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/ReceiveMessageTestActionBuilderTest.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/ReceiveMessageTestActionBuilderTest.java
@@ -17,7 +17,6 @@
 package org.citrusframework.actions.dsl;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -160,7 +159,8 @@ public class ReceiveMessageTestActionBuilderTest extends UnitTestSupport {
                         .setHeader("operation", "foo"));
 
         when(resource.exists()).thenReturn(true);
-        when(resource.getInputStream()).thenReturn(new ByteArrayInputStream("<TestRequest><Message>Hello World!</Message></TestRequest>".getBytes()));
+        when(resource.location()).thenReturn("message.xml");
+        when(resource.getInputStream()).thenAnswer((invocation) -> new ByteArrayInputStream("<TestRequest><Message>Hello World!</Message></TestRequest>".getBytes()));
         DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
         builder.$(receive().endpoint(messageEndpoint)
                         .message()

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/SendMessageTestActionBuilderTest.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/SendMessageTestActionBuilderTest.java
@@ -17,7 +17,6 @@
 package org.citrusframework.actions.dsl;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 
@@ -221,7 +220,7 @@ public class SendMessageTestActionBuilderTest extends UnitTestSupport {
         }).when(messageProducer).send(any(Message.class), any(TestContext.class));
 
         when(resource.exists()).thenReturn(true);
-        when(resource.getInputStream()).thenReturn(new ByteArrayInputStream("<TestRequest><Message>Hello World!</Message></TestRequest>".getBytes()));
+        when(resource.getInputStream()).thenAnswer((invocation) -> new ByteArrayInputStream("<TestRequest><Message>Hello World!</Message></TestRequest>".getBytes()));
         DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
         builder.$(send().endpoint(messageEndpoint)
                 .message()

--- a/validation/citrus-validation-xml/src/test/java/org/citrusframework/actions/dsl/ReceiveMessageActionBuilderTest.java
+++ b/validation/citrus-validation-xml/src/test/java/org/citrusframework/actions/dsl/ReceiveMessageActionBuilderTest.java
@@ -309,7 +309,8 @@ public class ReceiveMessageActionBuilderTest extends UnitTestSupport implements 
                         .setHeader("operation", "foo"));
 
         when(resource.exists()).thenReturn(true);
-        when(resource.getInputStream()).thenReturn(new ByteArrayInputStream("<TestRequest><Message>Hello World!</Message></TestRequest>".getBytes()));
+        when(resource.location()).thenReturn("message.xml");
+        when(resource.getInputStream()).thenAnswer((invocation) -> new ByteArrayInputStream("<TestRequest><Message>Hello World!</Message></TestRequest>".getBytes()));
         DefaultTestCaseRunner runner = new DefaultTestCaseRunner(context);
         runner.run(receive(messageEndpoint)
                 .message()


### PR DESCRIPTION
- Skip test variable replacement for binary message file content (when message type is set to binary)
- Make sure to skip converting binary file content to String when setting the message payload
- Avoid corruption of binary file content such as zipped file content when processing message content via send and receive
- Adjust unit tests mocks to return proper file names and input stream content
- Use BinaryFileResourcePayloadBuilder and FileResourcePayloadBuilder for file resource message content instead of reading content to String
- Improve validation context detection in receive message action
- Add missing YAML validation context detection for file resources ending with .yaml and .yml

Fixes #1523