### PR TITLE
fix(#1562): Fix handling of Citrus file resources in CamelMessageConverter

### DIFF
--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/message/CamelMessageConverter.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/message/CamelMessageConverter.java
@@ -29,6 +29,7 @@ import org.citrusframework.message.DefaultMessage;
 import org.citrusframework.message.Message;
 import org.citrusframework.message.MessageConverter;
 import org.citrusframework.message.MessageHeaderUtils;
+import org.citrusframework.spi.Resource;
 import org.snakeyaml.engine.v2.common.FlowStyle;
 import org.snakeyaml.engine.v2.common.ScalarStyle;
 import org.snakeyaml.engine.v2.nodes.MappingNode;
@@ -60,7 +61,13 @@ public class CamelMessageConverter implements MessageConverter<Exchange, Exchang
                 in.setHeader(header.getKey(), header.getValue());
             }
         }
-        in.setBody(message.getPayload());
+
+        if (message.getPayload() instanceof Resource payloadResource) {
+            // Camel does not know how to handle Citrus file resources, so convert to InputStream
+            in.setBody(payloadResource.getInputStream());
+        } else {
+            in.setBody(message.getPayload());
+        }
     }
 
     @Override

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/integration/CamelDataFormatIT.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/integration/CamelDataFormatIT.java
@@ -16,11 +16,15 @@
 
 package org.citrusframework.camel.integration;
 
+import java.nio.charset.StandardCharsets;
+
 import org.apache.camel.CamelContext;
 import org.citrusframework.TestActionSupport;
 import org.citrusframework.annotations.CitrusTest;
 import org.citrusframework.camel.dsl.CamelSupport;
+import org.citrusframework.message.DefaultMessage;
 import org.citrusframework.message.MessageType;
+import org.citrusframework.spi.Resources;
 import org.citrusframework.testng.spring.TestNGCitrusSpringSupport;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.testng.annotations.Test;
@@ -54,5 +58,20 @@ public class CamelDataFormatIT extends TestNGCitrusSpringSupport implements Test
                 .message()
                 .type(MessageType.PLAINTEXT)
                 .body("Citrus rocks!"));
+    }
+
+    @Test
+    @CitrusTest
+    public void shouldApplyDataFormatForFileResources() {
+        when(send(camel.endpoint(seda("data")::getRawUri))
+                .message(new DefaultMessage(Resources.create("Citrus rocks your socks off!".getBytes(StandardCharsets.UTF_8))))
+        );
+
+        then(receive("camel:" + camel.endpoints().seda("data").getRawUri())
+                .transform(camel.camelContext(camelContext)
+                        .convertBodyTo(String.class))
+                .message()
+                .type(MessageType.PLAINTEXT)
+                .body("Citrus rocks your socks off!"));
     }
 }


### PR DESCRIPTION
Fixes #1562

- Apache Camel is not aware of Citrus file resource SPI, but it is able to handle InputStreams
- Convert Citus file resources to InputStream before passing it over to Apache Camel
- Avoids message processing errors in Apache Camel due to missing conversion strategy for Citrus file resources