### PR TITLE
fix(#1558): Auto create Kafka topics on Testcontainers container start

### DIFF
--- a/connectors/citrus-testcontainers/pom.xml
+++ b/connectors/citrus-testcontainers/pom.xml
@@ -56,6 +56,10 @@
       <artifactId>testcontainers-kafka</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.floci</groupId>
       <artifactId>testcontainers-floci</artifactId>
     </dependency>

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/KafkaSettings.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/KafkaSettings.java
@@ -191,6 +191,8 @@ public class KafkaSettings {
                 bootstrapServers = kafkaContainer.getBootstrapServers();
             } else if (container instanceof ConfluentKafkaContainer confluentContainer) {
                 bootstrapServers = confluentContainer.getBootstrapServers();
+            } else if (container instanceof StrimziContainer strimziContainer) {
+                bootstrapServers = strimziContainer.getBootstrapServers();
             } else {
                 bootstrapServers = "localhost:%d".formatted(container.getMappedPort(KafkaSettings.KAFKA_PORT));
             }

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/StartKafkaAction.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/StartKafkaAction.java
@@ -16,12 +16,24 @@
 
 package org.citrusframework.testcontainers.kafka;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
 
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.CreateTopicsResult;
+import org.apache.kafka.clients.admin.NewTopic;
 import org.citrusframework.actions.testcontainers.TestcontainersKafkaStartActionBuilder;
 import org.citrusframework.context.TestContext;
+import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.testcontainers.TestContainersSettings;
 import org.citrusframework.testcontainers.actions.StartTestcontainersAction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.kafka.ConfluentKafkaContainer;
 import org.testcontainers.kafka.KafkaContainer;
@@ -29,13 +41,51 @@ import org.testcontainers.utility.DockerImageName;
 
 public class StartKafkaAction<T extends GenericContainer<?>> extends StartTestcontainersAction<T> {
 
+    private static final Logger logger = LoggerFactory.getLogger(StartKafkaAction.class);
+
+    private final Set<String> topics;
+
     public StartKafkaAction(Builder<T> builder) {
         super(builder);
+        this.topics = builder.topics;
     }
 
     @Override
     protected void exposeConnectionSettings(T container, TestContext context) {
         KafkaSettings.exposeConnectionSettings(container, serviceName, context);
+
+        if (!topics.isEmpty()) {
+            createTopics(container, context);
+        }
+    }
+
+    private void createTopics(T container, TestContext context) {
+        String bootstrapServers;
+        if (container instanceof KafkaContainer kafkaContainer) {
+            bootstrapServers = kafkaContainer.getBootstrapServers();
+        } else if (container instanceof ConfluentKafkaContainer confluentContainer) {
+            bootstrapServers = confluentContainer.getBootstrapServers();
+        } else if (container instanceof StrimziContainer strimziContainer) {
+            bootstrapServers = strimziContainer.getBootstrapServers();
+        } else {
+            bootstrapServers = "localhost:%d".formatted(container.getMappedPort(KafkaSettings.KAFKA_PORT));
+        }
+
+        try (Admin adminClient = Admin.create(Collections.singletonMap(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers))) {
+            Set<NewTopic> newTopics = new HashSet<>();
+            for (String topic : topics) {
+                newTopics.add(new NewTopic(context.replaceDynamicContentInString(topic), 1, (short) 1));
+            }
+
+            CreateTopicsResult result = adminClient.createTopics(newTopics);
+            result.all().get();
+
+            for (String topic : topics) {
+                logger.info("Successfully created Kafka topic: {}", context.replaceDynamicContentInString(topic));
+            }
+        } catch (ExecutionException | InterruptedException e) {
+            throw new CitrusRuntimeException("Failed to create Kafka topics", e);
+        }
     }
 
     /**
@@ -47,6 +97,7 @@ public class StartKafkaAction<T extends GenericContainer<?>> extends StartTestco
         private KafkaImplementation implementation = KafkaSettings.getImplementation();
         private String kafkaVersion;
         private int port = -1;
+        private final Set<String> topics = new HashSet<>();
 
         public Builder() {
             withStartupTimeout(KafkaSettings.getStartupTimeout());
@@ -73,6 +124,12 @@ public class StartKafkaAction<T extends GenericContainer<?>> extends StartTestco
         public Builder<T> version(String kafkaVersion) {
            this.kafkaVersion = kafkaVersion;
            return this;
+        }
+
+        @Override
+        public Builder<T> topics(String... topics) {
+            this.topics.addAll(Arrays.asList(topics));
+            return this;
         }
 
         @Override

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/StrimziContainer.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/StrimziContainer.java
@@ -124,4 +124,8 @@ public class StrimziContainer extends GenericContainer<StrimziContainer> {
         addFixedExposedPort(hostPort, KafkaSettings.KAFKA_PORT);
         return hostPort;
     }
+
+    public String getBootstrapServers() {
+        return getHost() + ":" + getMappedPort(KafkaSettings.KAFKA_PORT);
+    }
 }

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/quarkus/apache/KafkaContainerResource.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/quarkus/apache/KafkaContainerResource.java
@@ -60,6 +60,10 @@ public class KafkaContainerResource extends TestcontainersResource<KafkaContaine
             initArgs.put("nativeMode", "true");
         }
 
+        if (config.topics().length > 0) {
+            initArgs.put("topics", String.join(",", config.topics()));
+        }
+
         doInit(initArgs);
     }
 
@@ -78,6 +82,10 @@ public class KafkaContainerResource extends TestcontainersResource<KafkaContaine
 
         if (initArgs.containsKey("port")) {
             builder.port(Integer.parseInt(initArgs.get("port")));
+        }
+
+        if (initArgs.containsKey("topics")) {
+            builder.topics(initArgs.get("topics").split(","));
         }
 
         container = builder.build().getContainer();

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/quarkus/apache/KafkaContainerSupport.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/quarkus/apache/KafkaContainerSupport.java
@@ -46,6 +46,11 @@ public @interface KafkaContainerSupport {
     boolean nativeMode() default false;
 
     /**
+     * Kafka topics to auto-create on container start.
+     */
+    String[] topics() default {};
+
+    /**
      * Container lifecycle listeners
      */
     Class<? extends ContainerLifecycleListener<KafkaContainer>>[] containerLifecycleListener() default {};

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/quarkus/confluent/KafkaContainerResource.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/quarkus/confluent/KafkaContainerResource.java
@@ -56,6 +56,10 @@ public class KafkaContainerResource extends TestcontainersResource<ConfluentKafk
             initArgs.put("port",  String.valueOf(config.port()));
         }
 
+        if (config.topics().length > 0) {
+            initArgs.put("topics", String.join(",", config.topics()));
+        }
+
         doInit(initArgs);
     }
 
@@ -70,6 +74,10 @@ public class KafkaContainerResource extends TestcontainersResource<ConfluentKafk
 
         if (initArgs.containsKey("port")) {
             builder.port(Integer.parseInt(initArgs.get("port")));
+        }
+
+        if (initArgs.containsKey("topics")) {
+            builder.topics(initArgs.get("topics").split(","));
         }
 
         container = builder.build().getContainer();

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/quarkus/confluent/KafkaContainerSupport.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/quarkus/confluent/KafkaContainerSupport.java
@@ -41,6 +41,11 @@ public @interface KafkaContainerSupport {
     String version() default "";
 
     /**
+     * Kafka topics to auto-create on container start.
+     */
+    String[] topics() default {};
+
+    /**
      * Container lifecycle listeners
      */
     Class<? extends ContainerLifecycleListener<ConfluentKafkaContainer>>[] containerLifecycleListener() default {};

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/quarkus/strimzi/KafkaContainerResource.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/quarkus/strimzi/KafkaContainerResource.java
@@ -55,6 +55,11 @@ public class KafkaContainerResource extends TestcontainersResource<StrimziContai
         if (config.port() > 0) {
             initArgs.put("port",  String.valueOf(config.port()));
         }
+
+        if (config.topics().length > 0) {
+            initArgs.put("topics", String.join(",", config.topics()));
+        }
+
         doInit(initArgs);
     }
 
@@ -69,6 +74,10 @@ public class KafkaContainerResource extends TestcontainersResource<StrimziContai
 
         if (initArgs.containsKey("port")) {
             builder.port(Integer.parseInt(initArgs.get("port")));
+        }
+
+        if (initArgs.containsKey("topics")) {
+            builder.topics(initArgs.get("topics").split(","));
         }
 
         container = builder.build().getContainer();

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/quarkus/strimzi/KafkaContainerSupport.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/quarkus/strimzi/KafkaContainerSupport.java
@@ -42,6 +42,11 @@ public @interface KafkaContainerSupport {
     String version() default "";
 
     /**
+     * Kafka topics to auto-create on container start.
+     */
+    String[] topics() default {};
+
+    /**
      * Container lifecycle listeners
      */
     Class<? extends ContainerLifecycleListener<StrimziContainer>>[] containerLifecycleListener() default {};

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/xml/Start.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/xml/Start.java
@@ -168,6 +168,14 @@ public class Start extends AbstractTestcontainersAction.Builder<StartTestcontain
             builder.implementation(container.getImplementation());
         }
 
+        if (container.getTopics() != null) {
+            container.getTopics().getTopics().forEach(topic -> builder.topics(topic));
+        }
+
+        if (container.getTopicList() != null) {
+            builder.topics(container.getTopicList().split(","));
+        }
+
         configureStartActionBuilder(builder, container);
 
         delegate = builder;
@@ -925,6 +933,7 @@ public class Start extends AbstractTestcontainersAction.Builder<StartTestcontain
 
     @XmlAccessorType(XmlAccessType.FIELD)
     @XmlType(name = "", propOrder = {
+            "topics"
     })
     public static class Kafka extends Container {
 
@@ -936,6 +945,12 @@ public class Start extends AbstractTestcontainersAction.Builder<StartTestcontain
 
         @XmlAttribute
         protected int port;
+
+        @XmlAttribute(name = "topics")
+        protected String topicList;
+
+        @XmlElement
+        protected Topics topics;
 
         public String getVersion() {
             return version;
@@ -959,6 +974,43 @@ public class Start extends AbstractTestcontainersAction.Builder<StartTestcontain
 
         public void setPort(int port) {
             this.port = port;
+        }
+
+        public String getTopicList() {
+            return topicList;
+        }
+
+        public void setTopicList(String topicList) {
+            this.topicList = topicList;
+        }
+
+        public Topics getTopics() {
+            return topics;
+        }
+
+        public void setTopics(Topics topics) {
+            this.topics = topics;
+        }
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(name = "", propOrder = {
+            "topics"
+    })
+    public static class Topics {
+
+        @XmlElement(name = "topic")
+        private List<String> topics;
+
+        public List<String> getTopics() {
+            if (topics == null) {
+                topics = new ArrayList<>();
+            }
+            return topics;
+        }
+
+        public void setTopics(List<String> topics) {
+            this.topics = topics;
         }
     }
 

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/yaml/Start.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/yaml/Start.java
@@ -155,6 +155,10 @@ public class Start extends AbstractTestcontainersAction.Builder<StartTestcontain
             builder.implementation(container.getImplementation());
         }
 
+        if (container.getTopics() != null && !container.getTopics().isEmpty()) {
+            builder.topics(container.getTopics().toArray(String[]::new));
+        }
+
         configureStartActionBuilder(builder, container);
 
         delegate = builder;
@@ -645,6 +649,7 @@ public class Start extends AbstractTestcontainersAction.Builder<StartTestcontain
         protected String version;
         protected String implementation;
         protected int port;
+        protected List<String> topics;
 
         public String getVersion() {
             return version;
@@ -671,6 +676,15 @@ public class Start extends AbstractTestcontainersAction.Builder<StartTestcontain
         @SchemaProperty
         public void setPort(int port) {
             this.port = port;
+        }
+
+        public List<String> getTopics() {
+            return topics;
+        }
+
+        @SchemaProperty
+        public void setTopics(List<String> topics) {
+            this.topics = topics;
         }
     }
 

--- a/connectors/citrus-testcontainers/src/test/java/org/citrusframework/testcontainers/integration/kafka/StartKafkaContainerIT.java
+++ b/connectors/citrus-testcontainers/src/test/java/org/citrusframework/testcontainers/integration/kafka/StartKafkaContainerIT.java
@@ -17,14 +17,20 @@
 package org.citrusframework.testcontainers.integration.kafka;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
 
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.InspectContainerResponse;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.citrusframework.TestActionSupport;
 import org.citrusframework.annotations.CitrusTest;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.testcontainers.integration.AbstractTestcontainersIT;
+import org.citrusframework.testcontainers.kafka.KafkaImplementation;
 import org.citrusframework.testcontainers.kafka.KafkaSettings;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -44,6 +50,20 @@ public class StartKafkaContainerIT extends AbstractTestcontainersIT implements T
         then(this::verifyContainer);
     }
 
+    @CitrusTest
+    public void shouldAutoCreateTopics() {
+        given(doFinally().actions(testcontainers().stop()
+                .containerName(KafkaSettings.CONTAINER_NAME_DEFAULT)));
+
+        when(testcontainers()
+                .kafka()
+                .start()
+                .implementation(KafkaImplementation.APACHE_NATIVE.name())
+                .topics("test-topic-1", "test-topic-2"));
+
+        then(this::verifyTopics);
+    }
+
     private void verifyContainer(TestContext context) {
         try (DockerClient dockerClient = createDockerClient()) {
             InspectContainerResponse response = dockerClient.inspectContainerCmd(context.getVariable("${CITRUS_TESTCONTAINERS_KAFKA_CONTAINER_ID}"))
@@ -53,6 +73,18 @@ public class StartKafkaContainerIT extends AbstractTestcontainersIT implements T
             Assert.assertTrue(response.getState().getRunning());
         } catch (IOException e) {
             throw new CitrusRuntimeException("Failed to verify Docker container", e);
+        }
+    }
+
+    private void verifyTopics(TestContext context) {
+        String bootstrapServers = context.getVariable("${CITRUS_TESTCONTAINERS_KAFKA_BOOTSTRAP_SERVERS}");
+
+        try (Admin adminClient = Admin.create(Collections.singletonMap(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers))) {
+            Set<String> topics = adminClient.listTopics().names().get();
+            Assert.assertTrue(topics.contains("test-topic-1"), "Topic 'test-topic-1' should exist");
+            Assert.assertTrue(topics.contains("test-topic-2"), "Topic 'test-topic-2' should exist");
+        } catch (ExecutionException | InterruptedException e) {
+            throw new CitrusRuntimeException("Failed to verify Kafka topics", e);
         }
     }
 }

--- a/core/citrus-api/src/main/java/org/citrusframework/actions/testcontainers/TestcontainersKafkaStartActionBuilder.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/actions/testcontainers/TestcontainersKafkaStartActionBuilder.java
@@ -32,4 +32,6 @@ public interface TestcontainersKafkaStartActionBuilder<C extends AutoCloseable, 
     B port(int port);
 
     B version(String kafkaVersion);
+
+    B topics(String... topics);
 }

--- a/pom.xml
+++ b/pom.xml
@@ -885,6 +885,11 @@
         <artifactId>kafka-storage</artifactId>
         <version>${kafka.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.apache.kafka</groupId>
+        <artifactId>kafka-clients</artifactId>
+        <version>${kafka.version}</version>
+      </dependency>
 
       <!-- Citrus mail dependencies -->
       <dependency>


### PR DESCRIPTION
## Summary
- Adds auto-creation of Kafka topics when starting a Kafka Testcontainer via the Kafka Admin Client API
- Supports topic creation through the builder API (`.topics("foo", "bar")`), Quarkus annotations (`@KafkaContainerSupport(topics = {"foo", "bar"})`), and XML/YAML DSL
- Topic names support test variable replacement via `context.replaceDynamicContentInString()`
- Works with all Kafka container implementations (Confluent, Apache, Apache Native, Strimzi)

Closes #1558

## Changes
- `TestcontainersKafkaStartActionBuilder` (citrus-api): Added `topics(String... topics)` interface method
- `StartKafkaAction`: Added topics field, `createTopics()` method using Kafka Admin Client in `exposeConnectionSettings()`
- `KafkaContainerSupport` annotations (apache, confluent, strimzi): Added `String[] topics()` attribute
- `KafkaContainerResource` classes (apache, confluent, strimzi): Wire topics from annotation to builder
- XML/YAML `Start.Kafka`: Added topics support (both attribute and element form in XML, list in YAML)
- `StartKafkaContainerIT`: Added `shouldAutoCreateTopics()` integration test
- Added `kafka-clients` dependency to `citrus-testcontainers` module and parent dependency management

## Test plan
- [ ] Existing `shouldStartContainer` integration test still passes
- [ ] New `shouldAutoCreateTopics` integration test verifies topics are created
- [x] Full reactor build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)