### PR TITLE
fix(#1567): Add Maven build skipTests option

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -288,8 +288,9 @@
     <xstream.version>1.4.21</xstream.version>
     <zookeeper.version>3.9.5</zookeeper.version>
 
-    <skip.integration.tests>false</skip.integration.tests>
-    <skip.unit.tests>false</skip.unit.tests>
+    <skipTests>false</skipTests>
+    <skip.integration.tests>${skipTests}</skip.integration.tests>
+    <skip.unit.tests>${skipTests}</skip.unit.tests>
     <skip.gpg>false</skip.gpg>
   </properties>
 

--- a/scripts/commands/release
+++ b/scripts/commands/release
@@ -214,7 +214,7 @@ extract_maven_opts() {
 
     if [ $(hasflag --skip-tests) ]; then
         # Do not run any tests but compile test sources
-        maven_opts="$maven_opts -Dtest -Dit.test -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dfailsafe.failIfNoSpecifiedTests=false"
+        maven_opts="$maven_opts -Dtest -Dit.test -Dsurefire.failIfNoSpecifiedTests=false -Dfailsafe.failIfNoSpecifiedTests=false"
     fi
 
     if [ ! $(hasflag --no-strict-checksums) ]; then


### PR DESCRIPTION
## Summary

- Introduces a `skipTests` Maven property that cascades to both `skip.unit.tests` (Surefire) and `skip.integration.tests` (Failsafe), enabling `-DskipTests` to skip all tests
- Removes redundant `-DfailIfNoTests=false` from the release script since it's already configured in the plugin definitions
- Preserves backward compatibility: `-Dskip.unit.tests` and `-Dskip.integration.tests` still work independently

Fixes #1567

## Test plan

- [x] Full reactor build passes with `-DskipTests` (verified locally)
- [x] Verify `mvn verify` still runs all tests (no flag)
- [x] Verify `mvn verify -DskipTests` skips both unit and integration tests
- [x] Verify `mvn verify -Dskip.unit.tests=true` skips only unit tests
- [x] Verify `mvn verify -Dskip.integration.tests=true` skips only integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)