### PR TITLE
fix(issue#809) spliting query param by &

### DIFF
--- a/core/citrus-base/src/main/java/org/citrusframework/endpoint/resolver/DynamicEndpointUriResolver.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/endpoint/resolver/DynamicEndpointUriResolver.java
@@ -101,7 +101,7 @@ public class DynamicEndpointUriResolver implements EndpointUriResolver {
         StringBuilder queryParamBuilder = new StringBuilder();
         String queryParams = headers.get(QUERY_PARAM_HEADER_NAME).toString();
 
-        StringTokenizer tok = new StringTokenizer(queryParams, ",");
+        StringTokenizer tok = new StringTokenizer(queryParams, "&");
         if (tok.hasMoreTokens()) {
             while (requestUri.endsWith("/")) {
                 requestUri = requestUri.substring(0, requestUri.length() - 1);

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/controller/HttpMessageController.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/controller/HttpMessageController.java
@@ -161,7 +161,7 @@ public class HttpMessageController {
                 .uri(pathHelper.getRequestUri(servletRequest))
                 .contextPath(pathHelper.getContextPath(servletRequest))
                 .queryParams(Optional.ofNullable(pathHelper.getOriginatingQueryString(servletRequest))
-                                    .map(queryString -> queryString.replaceAll("&", ","))
+                                    .map(queryString -> queryString.replaceAll(",", "&"))
                                     .orElse(""))
                 .version(servletRequest.getProtocol())
                 .method(method);

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/message/HttpMessage.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/message/HttpMessage.java
@@ -224,7 +224,7 @@ public class HttpMessage extends DefaultMessage {
         header(HttpMessageHeaders.HTTP_QUERY_PARAMS, queryParamString);
         header(EndpointUriResolver.QUERY_PARAM_HEADER_NAME, queryParamString);
 
-        Stream.of(queryParamString.split(","))
+        Stream.of(queryParamString.split("&"))
                 .map(keyValue -> keyValue.split("="))
                 .filter(keyValue -> StringUtils.hasText(keyValue[0]))
                 .map(keyValue -> {
@@ -265,7 +265,7 @@ public class HttpMessage extends DefaultMessage {
         final String queryParamString = queryParams.entrySet()
                 .stream()
                 .map(this::outputQueryParam)
-                .collect(Collectors.joining(","));
+                .collect(Collectors.joining("&"));
 
         header(HttpMessageHeaders.HTTP_QUERY_PARAMS, queryParamString);
         header(EndpointUriResolver.QUERY_PARAM_HEADER_NAME, queryParamString);
@@ -583,7 +583,7 @@ public class HttpMessage extends DefaultMessage {
     private String outputQueryParam(final Map.Entry<String, Collection<String>> entry) {
         return entry.getValue().stream()
                 .map(entryValue -> entry.getKey() + (entryValue != null ? "=" + entryValue : ""))
-                .collect(Collectors.joining(","));
+                .collect(Collectors.joining("&"));
     }
 
     private static HttpMessage parseHttpMessage(final BufferedReader reader, final HttpMessage message) throws IOException {

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/message/HttpQueryParamHeaderValidator.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/message/HttpQueryParamHeaderValidator.java
@@ -73,7 +73,7 @@ public class HttpQueryParamHeaderValidator extends DefaultHeaderValidator {
         return Stream.of(Optional.ofNullable(expression)
                 .map(Object::toString)
                 .orElse("")
-                .split(","))
+                .split("&"))
             .map(keyValue -> keyValue.split("="))
             .filter(keyValue -> hasText(keyValue[0]))
             .collect(toMap(

--- a/tools/test-generator/src/main/java/org/citrusframework/generate/provider/http/HttpCodeProvider.java
+++ b/tools/test-generator/src/main/java/org/citrusframework/generate/provider/http/HttpCodeProvider.java
@@ -74,7 +74,7 @@ class HttpCodeProvider {
                     );
         } else if (StringUtils.hasText(message.getQueryParamString())) {
             Stream.of(message.getQueryParamString()
-                    .split(","))
+                    .split("&"))
                     .map(nameValuePair -> nameValuePair.split("="))
                     .forEach(param ->
                             code.add(".queryParam($S, $S)\n", param[0], param[1])

--- a/tools/test-generator/src/main/java/org/citrusframework/generate/provider/http/ReceiveHttpRequestActionProvider.java
+++ b/tools/test-generator/src/main/java/org/citrusframework/generate/provider/http/ReceiveHttpRequestActionProvider.java
@@ -73,7 +73,7 @@ public class ReceiveHttpRequestActionProvider implements MessageActionProvider<R
                     );
         } else if (StringUtils.hasText(message.getQueryParamString())) {
             Stream.of(message.getQueryParamString()
-                    .split(","))
+                    .split("&"))
                     .map(nameValuePair -> nameValuePair.split("="))
                     .forEach(param -> {
                         ParamType paramType = new ParamType();

--- a/tools/test-generator/src/main/java/org/citrusframework/generate/provider/http/SendHttpRequestActionProvider.java
+++ b/tools/test-generator/src/main/java/org/citrusframework/generate/provider/http/SendHttpRequestActionProvider.java
@@ -74,7 +74,7 @@ public class SendHttpRequestActionProvider implements MessageActionProvider<Send
                     );
         } else if (StringUtils.hasText(message.getQueryParamString())) {
             Stream.of(message.getQueryParamString()
-                    .split(","))
+                    .split("&"))
                     .map(nameValuePair -> nameValuePair.split("="))
                     .forEach(param -> {
                         ParamType paramType = new ParamType();


### PR DESCRIPTION
Here I fixed the separation of query params by comma, instead, now it is separeted by ampersand (&).