### PR TITLE
fix(#1572): Improve JBang init and run commands

### DIFF
--- a/core/citrus-api/src/main/java/org/citrusframework/common/TestLoader.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/common/TestLoader.java
@@ -96,14 +96,24 @@ public interface TestLoader {
      * Resolves test loader from resource path lookup with given resource name. Scans classpath for test loader meta information
      * with given name and returns instance of the loader. Returns optional instead of throwing exception when no test loader
      * could be found.
-     * @param loader
-     * @return
      */
     static Optional<TestLoader> lookup(String loader) {
+        return lookup(loader, false);
+    }
+
+    /**
+     * Resolves test loader from resource path lookup with given resource name. Scans classpath for test loader meta information
+     * with given name and returns instance of the loader. Returns optional instead of throwing exception when no test loader
+     * could be found. The silent option may be useful when probing the existence of a loader in classpath,
+     * so no warning messages will be printed.
+     */
+    static Optional<TestLoader> lookup(String loader, boolean silent) {
         try {
             return Optional.of(TYPE_RESOLVER.resolve(loader));
         } catch (CitrusRuntimeException e) {
-            logger.warn("Failed to resolve test loader from resource '{}/{}' - caused by: {}", RESOURCE_PATH, loader, e.getMessage());
+            if (!silent) {
+                logger.warn("Failed to resolve test loader from resource '{}/{}' - caused by: {}", RESOURCE_PATH, loader, e.getMessage());
+            }
         }
 
         return Optional.empty();

--- a/runtime/citrus-cucumber/src/main/java/org/citrusframework/cucumber/CucumberTestEngine.java
+++ b/runtime/citrus-cucumber/src/main/java/org/citrusframework/cucumber/CucumberTestEngine.java
@@ -16,6 +16,18 @@
 
 package org.citrusframework.cucumber;
 
+import java.io.File;
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 import io.cucumber.core.backend.ObjectFactory;
 import io.cucumber.core.eventbus.RandomUuidGenerator;
 import io.cucumber.core.eventbus.UuidGenerator;
@@ -42,18 +54,6 @@ import org.citrusframework.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.IOException;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
 public class CucumberTestEngine extends AbstractTestEngine {
 
     private static final Logger logger = LoggerFactory.getLogger(CucumberTestEngine.class);
@@ -70,11 +70,22 @@ public class CucumberTestEngine extends AbstractTestEngine {
         Optional<TestSource> javaClass = getConfiguration().getTestSources()
                 .stream()
                 .filter(source -> "java".equals(source.getType()))
+                .filter(source -> {
+                    try {
+                        Class<?> type = Class.forName(source.getName(), false, ClassLoaderHelper.getClassLoader());
+                        return Arrays.stream(type.getAnnotations())
+                                .anyMatch(annotation -> annotation.annotationType().getSimpleName().equals("CucumberOptions"));
+                    } catch (Exception e) {
+                        try {
+                            return FileUtils.readToString(source.getSourceFile()).contains("@CucumberOptions");
+                        } catch (Exception ex) {
+                            return false;
+                        }
+                    }
+                })
                 .findFirst();
 
-        if (javaClass.isEmpty()) {
-            annotationOptions = propertiesFileOptions;
-        } else {
+        if (javaClass.isPresent()) {
             try {
                 annotationOptions = new CucumberOptionsAnnotationParser()
                         .withOptionsProvider(GenericCucumberOptions::new)
@@ -85,6 +96,8 @@ public class CucumberTestEngine extends AbstractTestEngine {
             } catch (ClassNotFoundException e) {
                 throw new CitrusRuntimeException("Unable to find test class in classpath: " + javaClass.get().getName());
             }
+        } else {
+            annotationOptions = propertiesFileOptions;
         }
 
         List<String> features = new ArrayList<>();

--- a/tools/jbang/src/main/java/org/citrusframework/jbang/commands/Init.java
+++ b/tools/jbang/src/main/java/org/citrusframework/jbang/commands/Init.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Stack;
 
 import org.citrusframework.exceptions.CitrusRuntimeException;
@@ -41,9 +42,7 @@ public class Init extends CitrusCommand {
 
     private String file;
 
-    @Option(names = {
-            "-dir",
-            "--directory" }, description = "Directory where the files will be created", defaultValue = ".")
+    @Option(names = {"--directory" }, description = "Directory where the files will be created", defaultValue = ".")
     private String directory;
 
     public Init(CitrusJBangMain main) {
@@ -57,25 +56,68 @@ public class Init extends CitrusCommand {
         String content;
         try (InputStream is = ClassLoaderHelper.getClassLoader().getResourceAsStream("templates/" + ext + ".tmpl")) {
             if (is == null) {
-                printer().println("Error: Unsupported file type: " + ext);
+                printer().println("Error: Unsupported file type '%s' (supported types are: feature, java, yaml, xml, groovy)".formatted(ext));
                 return 1;
             }
             content = FileUtils.readToString(is, StandardCharsets.UTF_8);
-        }
 
-        if (!directory.equals(".")) {
-            File dir = new File(directory);
-            // ensure target dir is created
-            if (!dir.mkdirs()) {
-                throw new CitrusRuntimeException("Failed creating target directory");
+            String targetDir = resolveTargetDirectory(directory);
+            Path currentDir = Paths.get(".");
+            Path workingDir = getWorkingDir(targetDir, currentDir);
+
+            if (!workingDir.toFile().exists() && !workingDir.toFile().mkdirs()) {
+                printer().println("Failed to create working directory in: " + workingDir);
+                return 1;
             }
+
+            File target = workingDir.resolve(file).toFile();
+            content = content.replaceFirst("\\{\\{ \\.Name }}", name);
+
+            writeString(target.toPath(), content);
+
+            // allow subclasses to add custom files or perform some validation tasks with the working directory
+            initAdditionalFiles(workingDir);
+        } catch (Exception e) {
+            printer().println("Error: Failed to initialize test: %s %s".formatted(e.getClass().getName(), e.getMessage()));
+            return 1;
         }
 
-        File target = new File(directory, file);
-        content = content.replaceFirst("\\{\\{ \\.Name }}", name);
-
-        writeString(target.toPath(), content);
         return 0;
+    }
+
+    private static Path getWorkingDir(String targetDir, Path currentDir) {
+        Path targetDirPath = Paths.get(targetDir);
+        Path workingDir;
+
+        if (targetDir.equals(".") || targetDir.equals(currentDir.getFileName().toString())) {
+            // current directory is already the target subfolder
+            workingDir = currentDir;
+        } else if (targetDirPath.isAbsolute()) {
+            workingDir = targetDirPath;
+        } else if (currentDir.resolve(targetDir).toFile().exists()) {
+            // navigate to existing target subfolder
+            workingDir = currentDir.resolve(targetDir);
+        } else if (currentDir.resolve(targetDir).toFile().mkdirs()) {
+            // create target subfolder and navigate to it
+            workingDir = currentDir.resolve(targetDir);
+        } else {
+            throw new CitrusRuntimeException("Failed to create working directory in: " + currentDir);
+        }
+
+        return workingDir;
+    }
+
+    /**
+     * Allows subclasses to adjust the default target directory.
+     */
+    protected String resolveTargetDirectory(String directory) {
+        return directory;
+    }
+
+    /**
+     * Subclasses may add additional files in working dir.
+     */
+    protected void initAdditionalFiles(Path workingDir) {
     }
 
     static class FileConsumer extends ParameterConsumer<Init> {

--- a/tools/jbang/src/main/java/org/citrusframework/jbang/commands/Run.java
+++ b/tools/jbang/src/main/java/org/citrusframework/jbang/commands/Run.java
@@ -29,6 +29,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -43,6 +44,7 @@ import org.apache.camel.tooling.maven.MavenArtifact;
 import org.citrusframework.CitrusInstanceManager;
 import org.citrusframework.CitrusSettings;
 import org.citrusframework.agent.CitrusAgentConfiguration;
+import org.citrusframework.common.TestLoader;
 import org.citrusframework.common.TestSourceHelper;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.jbang.CitrusJBangMain;
@@ -170,27 +172,37 @@ public class Run extends CitrusCommand {
             workDir = basePath;
         }
 
-        final TestRunConfiguration configuration = getRunConfiguration(tests);
-
-        // Set properties as System properties
-        configuration.setDefaultProperties();
-
-        final TestEngine engine = TestEngine.lookup(configuration);
         final ExitStatusTestReporter exitStatus = new ExitStatusTestReporter();
         CitrusInstanceManager.addInstanceProcessor(instance -> instance.addTestReporter(exitStatus));
-
-        if (logging) {
-            LoggingSupport.configureLog(loggingLevel, loggingColor, configuration.getEngine());
-        } else {
-            LoggingSupport.configureLog("off", false, configuration.getEngine());
-        }
 
         if (!offline) {
             resolveArtifacts(tests);
         }
 
-        engine.run();
-        return exitStatus.exitStatus();
+        final List<TestRunConfiguration> configurations = getRunConfigurations(tests);
+
+        int exitCode = 0;
+        for (TestRunConfiguration configuration : configurations) {
+            // Set properties as System properties
+            configuration.setDefaultProperties();
+
+            final TestEngine engine = TestEngine.lookup(configuration);
+
+            if (logging) {
+                LoggingSupport.configureLog(loggingLevel, loggingColor, configuration.getEngine());
+            } else {
+                LoggingSupport.configureLog("off", false, configuration.getEngine());
+            }
+
+            engine.run();
+
+            if (exitStatus.exitStatus() != 0) {
+                // make sure to save failed state in exit status
+                exitCode = exitStatus.exitStatus();
+            }
+        }
+
+        return exitCode;
     }
 
     private void resolveArtifacts(List<String> tests) {
@@ -199,6 +211,24 @@ public class Run extends CitrusCommand {
         Set<String> allDependencies = new HashSet<>();
 
         List<MavenArtifact> additionalArtifacts = new ArrayList<>();
+
+        // Handle DSL test loaders according to file extensions
+        tests.stream().map(FileUtils::getFileExtension).distinct().forEach(ext -> {
+            if (StringUtils.hasText(ext)) {
+
+
+                Optional<TestLoader> existing = TestLoader.lookup(ext, true);
+                if (existing.isEmpty()) {
+                    if ("feature".equals(ext)) {
+                        // Add Cucumber DSL support modules and a set of default Citrus steps
+                        allModules.add("citrus-cucumber");
+                        allModules.add("citrus-cucumber-core");
+                    } else {
+                        allModules.add("citrus-" + ext);
+                    }
+                }
+            }
+        });
 
         // Handle Citrus modules from envVar settings
         Arrays.stream(CitrusJBangMain.Settings.getModules())
@@ -325,6 +355,35 @@ public class Run extends CitrusCommand {
         }
     }
 
+    /**
+     * Construct run configurations for given list of tests.
+     * Makes sure to choose the right test engine for respective test types (e.g. Cucumber BDD tests).
+     * If applicable uses multiple test runt configurations for different test types.
+     */
+    protected List<TestRunConfiguration> getRunConfigurations(List<String> files) {
+        Set<String> extensions = files.stream().map(FileUtils::getFileExtension).collect(Collectors.toSet());
+        if (extensions.stream().noneMatch(this::isCucumberFeature) || extensions.stream().allMatch(this::isCucumberFeature)) {
+            // Homogeneous test sources - All files are either feature files or arbitrary test DSL files
+            return Collections.singletonList(getRunConfiguration(files));
+        } else {
+            List<TestRunConfiguration> runConfigurations = new ArrayList<>();
+            // Add arbitrary test DSL files first
+            runConfigurations.add(getRunConfiguration(files.stream()
+                    .filter(file -> !isCucumberFeature(FileUtils.getFileExtension(file)))
+                    .collect(Collectors.toList())));
+
+            // Add Cucumber BDD feature files in a separate run configuration
+            runConfigurations.add(getRunConfiguration(files.stream()
+                    .filter(file -> isCucumberFeature(FileUtils.getFileExtension(file)))
+                    .collect(Collectors.toList())));
+            return runConfigurations;
+        }
+    }
+
+    /**
+     * Gets the run configuration for given list of tests.
+     * The list of test sources should be homogeneous in terms of its type (e.g. Cucumber BDD feature files only, arbitrary test DSL files only).
+     */
     protected TestRunConfiguration getRunConfiguration(List<String> files) {
         CitrusAgentConfiguration configuration = fromCliOptions(CitrusAgentConfiguration.fromEnvVars(TestSourceHelper::create));
 
@@ -362,6 +421,10 @@ public class Run extends CitrusCommand {
             }
         }
         return configuration;
+    }
+
+    private boolean isCucumberFeature(String extension) {
+        return "feature".equals(extension);
     }
 
     private CitrusAgentConfiguration fromCliOptions(CitrusAgentConfiguration configuration) {

--- a/tools/jbang/src/main/java/org/citrusframework/jbang/maven/MavenDependencyResolver.java
+++ b/tools/jbang/src/main/java/org/citrusframework/jbang/maven/MavenDependencyResolver.java
@@ -16,19 +16,20 @@
 
 package org.citrusframework.jbang.maven;
 
-import org.apache.camel.tooling.maven.MavenArtifact;
-import org.apache.camel.tooling.maven.MavenDownloader;
-import org.apache.camel.tooling.maven.MavenDownloaderImpl;
-import org.citrusframework.CitrusVersion;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import org.apache.camel.tooling.maven.MavenArtifact;
+import org.apache.camel.tooling.maven.MavenDownloader;
+import org.apache.camel.tooling.maven.MavenDownloaderImpl;
+import org.citrusframework.CitrusVersion;
+import org.citrusframework.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Dependency resolver is able to load Maven dependencies as artifacts and add it to the given classloader.
@@ -89,7 +90,12 @@ public class MavenDependencyResolver {
             moduleName = "citrus-" + module;
         }
 
-        return resolve("org.citrusframework:%s:%s".formatted(moduleName, CitrusVersion.version()),
+        String version = CitrusVersion.version();
+        if (StringUtils.isEmpty(version)) {
+            version = "5.0.0-SNAPSHOT";
+        }
+
+        return resolve("org.citrusframework:%s:%s".formatted(moduleName, version),
                 CitrusVersion.version().contains("-SNAPSHOT"), true);
     }
 

--- a/tools/jbang/src/test/java/org/citrusframework/jbang/commands/CommandTest.java
+++ b/tools/jbang/src/test/java/org/citrusframework/jbang/commands/CommandTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.jbang.commands;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.jbang.CitrusJBangMain;
+import org.citrusframework.jbang.Printer;
+import org.citrusframework.jbang.StringPrinter;
+import org.testng.annotations.BeforeMethod;
+
+public class CommandTest {
+
+    protected final Path workingDir = Paths.get("target").toAbsolutePath();
+    protected StringPrinter printer;
+
+    @BeforeMethod
+    public void setup() {
+        printer = new StringPrinter();
+    }
+
+    /**
+     * Creates CitrusJBangMain instance ready for unit testing.
+     * Automatically sets the out printer.
+     */
+    protected CitrusJBangMain createCitrusJBangMain() {
+        return createCitrusJBangMain(0);
+    }
+
+    /**
+     * Creates CitrusJBangMain instance ready for unit testing.
+     * Automatically sets the out printer.
+     */
+    protected CitrusJBangMain createCitrusJBangMain(int expectedExitCode) {
+        return new CitrusJBangMain() {
+            @Override
+            public void quit(int exitCode) {
+                if (exitCode != expectedExitCode) {
+                    throw new CitrusRuntimeException("Unexpected exit code: " + exitCode);
+                }
+            }
+
+            @Override
+            public int execute(String... args) {
+                int exitCode = super.execute(args);
+                if (exitCode != expectedExitCode) {
+                    throw new CitrusRuntimeException("Unexpected exit code: " + exitCode);
+                }
+                return exitCode;
+            }
+
+            @Override
+            public Printer getOut() {
+                return printer;
+            }
+        };
+    }
+}

--- a/tools/jbang/src/test/java/org/citrusframework/jbang/commands/InitTest.java
+++ b/tools/jbang/src/test/java/org/citrusframework/jbang/commands/InitTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.jbang.commands;
+
+import java.nio.file.Path;
+
+import org.citrusframework.jbang.CitrusJBangMain;
+import org.junit.jupiter.api.Assertions;
+import org.testng.annotations.Test;
+
+public class InitTest extends CommandTest {
+
+    @Test
+    public void shouldInitJavaTest() {
+        Path targetDir = workingDir.resolve("test");
+
+        CitrusJBangMain main = createCitrusJBangMain();
+        main.execute("init", "SampleIT.java",
+                "--directory", targetDir.toString());
+
+        Assertions.assertEquals("", printer.getOutput());
+        Assertions.assertTrue(targetDir.resolve("SampleIT.java").toFile().exists());
+    }
+
+    @Test
+    public void shouldInitYamlTest() {
+        Path targetDir = workingDir.resolve("test");
+
+        CitrusJBangMain main = createCitrusJBangMain();
+        main.execute("init", "sample.citrus.it.yaml",
+                "--directory", targetDir.toString());
+
+        Assertions.assertEquals("", printer.getOutput());
+        Assertions.assertTrue(targetDir.resolve("sample.citrus.it.yaml").toFile().exists());
+    }
+
+    @Test
+    public void shouldInitXmlTest() {
+        Path targetDir = workingDir.resolve("test");
+
+        CitrusJBangMain main = createCitrusJBangMain();
+        main.execute("init", "sample.citrus.it.xml",
+                "--directory", targetDir.toString());
+
+        Assertions.assertEquals("", printer.getOutput());
+        Assertions.assertTrue(targetDir.resolve("sample.citrus.it.xml").toFile().exists());
+    }
+
+    @Test
+    public void shouldInitGroovyTest() {
+        Path targetDir = workingDir.resolve("test");
+
+        CitrusJBangMain main = createCitrusJBangMain();
+        main.execute("init", "sample.citrus.it.groovy",
+                "--directory", targetDir.toString());
+
+        Assertions.assertEquals("", printer.getOutput());
+        Assertions.assertTrue(targetDir.resolve("sample.citrus.it.groovy").toFile().exists());
+    }
+
+    @Test
+    public void shouldInitFeatureTest() {
+        Path targetDir = workingDir.resolve("test");
+
+        CitrusJBangMain main = createCitrusJBangMain();
+        main.execute("init", "sample.citrus.it.feature",
+                "--directory", targetDir.toString());
+
+        Assertions.assertEquals("", printer.getOutput());
+        Assertions.assertTrue(targetDir.resolve("sample.citrus.it.feature").toFile().exists());
+    }
+
+    @Test
+    public void shouldHandleUnknownTestType() {
+        Path targetDir = workingDir.resolve("test");
+
+        CitrusJBangMain main = createCitrusJBangMain(1);
+        main.execute("init", "sample.citrus.it.foo",
+                "--directory", targetDir.toString());
+
+        Assertions.assertEquals("Error: Unsupported file type 'foo' (supported types are: feature, java, yaml, xml, groovy)", printer.getOutput());
+    }
+}

--- a/tools/jbang/src/test/java/org/citrusframework/jbang/commands/InspectTest.java
+++ b/tools/jbang/src/test/java/org/citrusframework/jbang/commands/InspectTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.jbang.commands;
+
+import java.nio.file.Path;
+
+import org.citrusframework.jbang.CitrusJBangMain;
+import org.citrusframework.spi.Resources;
+import org.junit.jupiter.api.Assertions;
+import org.testng.annotations.Test;
+
+public class InspectTest extends CommandTest {
+
+    @Test
+    public void shouldInspectTest() {
+        Path source = Resources.fromClasspath("sample.citrus.it.yaml").file().toPath();
+
+        CitrusJBangMain main = createCitrusJBangMain();
+        main.execute("inspect", source.toString());
+
+        Assertions.assertTrue(printer.getOutput().contains("\"name\": \"sample.citrus.it.yaml\""));
+        Assertions.assertTrue(printer.getOutput().contains("""
+            "modules": [
+                "citrus-kafka",
+                "citrus-http",
+                "citrus-camel",
+                "citrus-testcontainers",
+                "citrus-base",
+                "citrus-jms"
+              ],
+            """));
+        Assertions.assertTrue(printer.getOutput().contains("""
+           "actions": [
+               "receive",
+               "print",
+               "send"
+             ],
+           """));
+    }
+}

--- a/tools/jbang/src/test/java/org/citrusframework/jbang/commands/ListTest.java
+++ b/tools/jbang/src/test/java/org/citrusframework/jbang/commands/ListTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.jbang.commands;
+
+import org.citrusframework.jbang.CitrusJBangMain;
+import org.junit.jupiter.api.Assertions;
+import org.testng.annotations.Test;
+
+public class ListTest extends CommandTest {
+
+    @Test
+    public void shouldListTests() {
+        CitrusJBangMain main = createCitrusJBangMain();
+
+        main.execute("ls");
+
+        Assertions.assertTrue(printer.getOutput().contains("PID  NAME  STATUS  AGE"));
+    }
+}

--- a/tools/jbang/src/test/java/org/citrusframework/jbang/commands/RunTest.java
+++ b/tools/jbang/src/test/java/org/citrusframework/jbang/commands/RunTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.jbang.commands;
+
+import java.nio.file.Path;
+
+import org.citrusframework.jbang.CitrusJBangMain;
+import org.citrusframework.spi.Resources;
+import org.testng.annotations.Test;
+
+public class RunTest extends CommandTest {
+
+    @Test
+    public void shouldRunJavaTest() {
+        Path source = Resources.fromClasspath("runnable/SampleIT.java").file().toPath();
+
+        CitrusJBangMain main = createCitrusJBangMain();
+        main.execute("run", source.toString());
+    }
+
+    @Test
+    public void shouldRunYamlTest() {
+        Path source = Resources.fromClasspath("runnable/yaml-sample.citrus.it.yaml").file().toPath();
+
+        CitrusJBangMain main = createCitrusJBangMain();
+        main.execute("run", source.toString());
+    }
+
+    @Test
+    public void shouldRunXmlTest() {
+        Path source = Resources.fromClasspath("runnable/xml-sample.citrus.it.xml").file().toPath();
+
+        CitrusJBangMain main = createCitrusJBangMain();
+        main.execute("run", source.toString());
+    }
+
+    @Test
+    public void shouldRunGroovyTest() {
+        Path source = Resources.fromClasspath("runnable/groovy-sample.citrus.it.groovy").file().toPath();
+
+        CitrusJBangMain main = createCitrusJBangMain();
+        main.execute("run", source.toString());
+    }
+
+    @Test
+    public void shouldRunCucumberTest() {
+        Path source = Resources.fromClasspath("runnable/cucumber-sample.citrus.it.feature").file().toPath();
+
+        CitrusJBangMain main = createCitrusJBangMain();
+        main.execute("run", source.toString());
+    }
+
+    @Test
+    public void shouldRunAllTest() {
+        Path source = Resources.fromClasspath("runnable").file().toPath();
+
+        CitrusJBangMain main = createCitrusJBangMain();
+        main.execute("run", source.toString());
+    }
+}

--- a/tools/jbang/src/test/resources/runnable/SampleIT.java
+++ b/tools/jbang/src/test/resources/runnable/SampleIT.java
@@ -1,0 +1,22 @@
+package runnable;
+
+import org.citrusframework.TestActionSupport;
+import org.citrusframework.TestCaseRunner;
+import org.citrusframework.annotations.CitrusResource;
+
+public class SampleIT implements Runnable, TestActionSupport {
+
+    @CitrusResource
+    TestCaseRunner t;
+
+    @Override
+    public void run() {
+        t.given(
+            createVariables().variable("message", "Citrus rocks! With Java!")
+        );
+
+        t.then(
+            echo().message("${message}")
+        );
+    }
+}

--- a/tools/jbang/src/test/resources/runnable/cucumber-sample.citrus.it.feature
+++ b/tools/jbang/src/test/resources/runnable/cucumber-sample.citrus.it.feature
@@ -1,0 +1,8 @@
+Feature: cucumber-sample.citrus.it
+
+  Background:
+    Given variables
+      | message | "Citrus rocks! With Cucumber BDD!" |
+
+  Scenario: Print message
+    Then print '${message}'

--- a/tools/jbang/src/test/resources/runnable/groovy-sample.citrus.it.groovy
+++ b/tools/jbang/src/test/resources/runnable/groovy-sample.citrus.it.groovy
@@ -1,0 +1,5 @@
+variables {
+    message = "Citrus rocks! With Groovy!"
+}
+
+$(echo('${message}'))

--- a/tools/jbang/src/test/resources/runnable/xml-sample.citrus.it.xml
+++ b/tools/jbang/src/test/resources/runnable/xml-sample.citrus.it.xml
@@ -1,0 +1,12 @@
+<test name="xml-sample.citrus.it" author="Citrus" status="FINAL" xmlns="http://citrusframework.org/schema/xml/testcase"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://citrusframework.org/schema/xml/testcase http://citrusframework.org/schema/xml/testcase/citrus-testcase.xsd">
+  <description>Sample test in XML</description>
+  <variables>
+    <variable name="message" value="Citrus rocks! With XML!"/>
+  </variables>
+
+  <actions>
+    <echo message="${message}"/>
+  </actions>
+</test>

--- a/tools/jbang/src/test/resources/runnable/yaml-sample.citrus.it.yaml
+++ b/tools/jbang/src/test/resources/runnable/yaml-sample.citrus.it.yaml
@@ -1,0 +1,10 @@
+name: yaml-sample.citrus.it
+author: Citrus
+status: FINAL
+description: Sample test in YAML
+variables:
+  - name: message
+    value: Citrus rocks! With YAML!
+actions:
+  - echo:
+      message: "${message}"


### PR DESCRIPTION
- TestLoader API: Add silent lookup options for test loader resource path lookup
- Init command: improved directory handling, better error messages, extensibility hooks
- Run command: auto-resolves DSL dependencies by file extension, supports mixed test types (Cucumber + others)
- Unit Tests: add comprehensive test coverage for Citrus JBang commands
-  CucumberTestEngine: Smarter CucumberOptions annotation detection in test engine
- Use default Citrus version in Maven dependency resolver
- Adds a default version fallback in Maven dependency resolver when CitrusVersion utils does not provide a proper version
- Used in unit tests when no Maven resource filtering is present