### PR TITLE
fix(#1576): Allow Camel Exchange as message payload

### DIFF
--- a/core/citrus-api/src/main/java/org/citrusframework/util/ObjectHelper.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/util/ObjectHelper.java
@@ -38,4 +38,29 @@ public class ObjectHelper {
 
         return object;
     }
+
+    /**
+     * Check if given Object is either a primitive number or an instance of java.lang.Number.
+     * For String values check if given String can be parsed as a number.
+     */
+    public static boolean isNumeric(Object value) {
+        if (value == null) {
+            return false;
+        }
+
+        if (value instanceof Number) {
+            return true;
+        }
+
+        if (value instanceof String stringValue) {
+            try {
+                Double.parseDouble(stringValue);
+                return true;
+            } catch (NumberFormatException e) {
+                return false;
+            }
+        }
+
+        return false;
+    }
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/util/StringUtils.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/util/StringUtils.java
@@ -16,7 +16,11 @@
 
 package org.citrusframework.util;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Utility helper class for Strings.
@@ -182,5 +186,72 @@ public class StringUtils {
         }
 
         return text;
+    }
+
+    /**
+     * Converts given map to a Json style String representation.
+     * Handles null values and numeric values with Json style value representation.
+     * Handles keys and String values with quotes.
+     */
+    public static String convertToString(Map<String, Object> map) {
+        return map.entrySet()
+                .stream()
+                .map(entry -> {
+                    if (entry.getValue() == null) {
+                        return "\"%s\": null".formatted(entry.getKey());
+                    } else if (ObjectHelper.isNumeric(entry.getValue())) {
+                        return "\"%s\": %s".formatted(entry.getKey(), entry.getValue());
+                    }
+
+                    return "\"%s\": \"%s\"".formatted(entry.getKey(), entry.getValue());
+                })
+                .collect(Collectors.joining(", ", "{", "}"));
+    }
+
+    /**
+     * Extract map from given String key value pairs.
+     * Supports Json style object with single level properties.
+     * Supports comma-delimited list of key value pairs with format "key=value".
+     */
+    public static Map<String, Object> extractMap(String value) {
+        if (value == null || value.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        Map<String, Object> result = new HashMap<>();
+        if (value.trim().startsWith("{") && value.trim().endsWith("}")) {
+            // Parse Json style value
+            String json = value.trim().substring(1, value.trim().length() - 1);
+            String[] properties = json.split(",");
+            for (String property : properties) {
+                String[] tokens = property.trim().split(":", 2);
+                if (tokens.length == 2) {
+                    result.put(stripQuotes(tokens[0].trim()), stripQuotes(tokens[1].trim()));
+                }
+            }
+            return result;
+        } else {
+            // assume comma-delimited key value paris
+            String[] keyValuePairs = value.trim().split(",");
+            for (String pair : keyValuePairs) {
+                String[] tokens = pair.trim().split("=", 2);
+                if (tokens.length == 2) {
+                    result.put(stripQuotes(tokens[0].trim()), stripQuotes(tokens[1].trim()));
+                }
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Remove quotes from given value if any.
+     */
+    public static String stripQuotes(String value) {
+        if (value != null && value.trim().startsWith("\"") && value.trim().endsWith("\"")) {
+            return value.trim().substring(1, value.trim().length() - 1);
+        }
+
+        return value;
     }
 }

--- a/core/citrus-base/src/test/java/org/citrusframework/util/StringUtilsTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/util/StringUtilsTest.java
@@ -3,10 +3,17 @@ package org.citrusframework.util;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import static org.citrusframework.util.StringUtils.appendSegmentToUrlPath;
+import static org.citrusframework.util.StringUtils.convertToString;
+import static org.citrusframework.util.StringUtils.extractMap;
 import static org.citrusframework.util.StringUtils.hasText;
 import static org.citrusframework.util.StringUtils.isEmpty;
 import static org.citrusframework.util.StringUtils.quote;
+import static org.citrusframework.util.StringUtils.stripQuotes;
 import static org.citrusframework.util.StringUtils.trimTrailingComma;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -228,5 +235,128 @@ public class StringUtilsTest {
     @Test(dataProvider = "normalizeWhitespaceProvider")
     public void normalizeWhitespace(String text, boolean normalizeWhitespace, boolean normalizeLineEndingsToUnix, String expected) {
         assertEquals(StringUtils.normalizeWhitespace(text, normalizeWhitespace, normalizeLineEndingsToUnix), expected);
+    }
+
+    @Test
+    public void testConvertToStringEmpty() {
+        assertEquals(convertToString(Collections.emptyMap()), "{}");
+    }
+
+    @Test
+    public void testConvertToStringWithStringValues() {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("name", "citrus");
+        map.put("type", "framework");
+        assertEquals(convertToString(map), "{\"name\": \"citrus\", \"type\": \"framework\"}");
+    }
+
+    @Test
+    public void testConvertToStringWithNullValue() {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("body", null);
+        assertEquals(convertToString(map), "{\"body\": null}");
+    }
+
+    @Test
+    public void testConvertToStringWithNumericValue() {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("count", 42);
+        map.put("rate", 3.14);
+        assertEquals(convertToString(map), "{\"count\": 42, \"rate\": 3.14}");
+    }
+
+    @Test
+    public void testConvertToStringWithMixedValues() {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("name", "test");
+        map.put("count", 5);
+        map.put("data", null);
+        assertEquals(convertToString(map), "{\"name\": \"test\", \"count\": 5, \"data\": null}");
+    }
+
+    @Test
+    public void testExtractMapFromNull() {
+        assertTrue(extractMap(null).isEmpty());
+    }
+
+    @Test
+    public void testExtractMapFromEmpty() {
+        assertTrue(extractMap("").isEmpty());
+    }
+
+    @Test
+    public void testExtractMapFromJson() {
+        Map<String, Object> result = extractMap("{\"name\": \"citrus\", \"type\": \"framework\"}");
+        assertEquals(result.size(), 2);
+        assertEquals(result.get("name"), "citrus");
+        assertEquals(result.get("type"), "framework");
+    }
+
+    @Test
+    public void testExtractMapFromJsonWithNullValue() {
+        Map<String, Object> result = extractMap("{\"body\": null}");
+        assertEquals(result.size(), 1);
+        assertEquals(result.get("body"), "null");
+    }
+
+    @Test
+    public void testExtractMapFromJsonWithNumericValue() {
+        Map<String, Object> result = extractMap("{\"count\": 42}");
+        assertEquals(result.size(), 1);
+        assertEquals(result.get("count"), "42");
+    }
+
+    @Test
+    public void testExtractMapFromKeyValuePairs() {
+        Map<String, Object> result = extractMap("name=citrus,type=framework");
+        assertEquals(result.size(), 2);
+        assertEquals(result.get("name"), "citrus");
+        assertEquals(result.get("type"), "framework");
+    }
+
+    @Test
+    public void testExtractMapFromKeyValuePairsWithSpaces() {
+        Map<String, Object> result = extractMap(" name = citrus , type = framework ");
+        assertEquals(result.size(), 2);
+        assertEquals(result.get("name"), "citrus");
+        assertEquals(result.get("type"), "framework");
+    }
+
+    @Test
+    public void testExtractMapFromKeyValuePairsWithQuotes() {
+        Map<String, Object> result = extractMap("\"name\"=\"citrus\",\"type\"=\"framework\"");
+        assertEquals(result.size(), 2);
+        assertEquals(result.get("name"), "citrus");
+        assertEquals(result.get("type"), "framework");
+    }
+
+    @Test
+    public void testStripQuotesWithQuotes() {
+        assertEquals(stripQuotes("\"hello\""), "hello");
+    }
+
+    @Test
+    public void testStripQuotesWithoutQuotes() {
+        assertEquals(stripQuotes("hello"), "hello");
+    }
+
+    @Test
+    public void testStripQuotesWithNull() {
+        assertNull(stripQuotes(null));
+    }
+
+    @Test
+    public void testStripQuotesEmptyQuoted() {
+        assertEquals(stripQuotes("\"\""), "");
+    }
+
+    @Test
+    public void testStripQuotesWithSurroundingSpaces() {
+        assertEquals(stripQuotes("  \"hello\"  "), "hello");
+    }
+
+    @Test
+    public void testStripQuotesSingleQuoteOnly() {
+        assertEquals(stripQuotes("\"hello"), "\"hello");
     }
 }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/endpoint/CamelProducer.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/endpoint/CamelProducer.java
@@ -64,22 +64,20 @@ public class CamelProducer implements Producer {
             logger.debug("Sending message to camel endpoint: '{}'", endpointUri);
         }
 
+        context.onOutboundMessage(message);
+
         Exchange camelExchange;
         if (endpointConfiguration.getEndpoint() != null) {
             camelExchange = getProducerTemplate(context)
-                    .send(endpointConfiguration.getEndpoint(), exchange ->
-                            endpointConfiguration.getMessageConverter().convertOutbound(exchange, message, endpointConfiguration, context));
+                    .send(endpointConfiguration.getEndpoint(), endpointConfiguration.getMessageConverter().convertOutbound(message, endpointConfiguration, context));
         } else {
             camelExchange = getProducerTemplate(context)
-                    .send(endpointUri, exchange ->
-                            endpointConfiguration.getMessageConverter().convertOutbound(exchange, message, endpointConfiguration, context));
+                    .send(endpointUri, endpointConfiguration.getMessageConverter().convertOutbound(message, endpointConfiguration, context));
         }
 
         if (camelExchange.getException() != null) {
             throw new CitrusRuntimeException("Sending message to camel endpoint resulted in exception", camelExchange.getException());
         }
-
-        context.onOutboundMessage(message);
 
         logger.info("Message was sent to camel endpoint '{}'", endpointUri);
     }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/message/CamelMessageConverter.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/message/CamelMessageConverter.java
@@ -20,7 +20,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.camel.CamelException;
+import org.apache.camel.CamelExchangeException;
 import org.apache.camel.Exchange;
+import org.apache.camel.ExchangePattern;
 import org.apache.camel.support.DefaultExchange;
 import org.citrusframework.camel.CamelSettings;
 import org.citrusframework.camel.endpoint.CamelEndpointConfiguration;
@@ -30,6 +33,8 @@ import org.citrusframework.message.Message;
 import org.citrusframework.message.MessageConverter;
 import org.citrusframework.message.MessageHeaderUtils;
 import org.citrusframework.spi.Resource;
+import org.citrusframework.util.ClassLoaderHelper;
+import org.citrusframework.util.StringUtils;
 import org.snakeyaml.engine.v2.common.FlowStyle;
 import org.snakeyaml.engine.v2.common.ScalarStyle;
 import org.snakeyaml.engine.v2.nodes.MappingNode;
@@ -47,6 +52,10 @@ public class CamelMessageConverter implements MessageConverter<Exchange, Exchang
 
     @Override
     public Exchange convertOutbound(Message message, CamelEndpointConfiguration endpointConfiguration, TestContext context) {
+        if (message.getPayload() instanceof Exchange exchange) {
+            return exchange;
+        }
+
         Exchange exchange = new DefaultExchange(endpointConfiguration.getCamelContext());
         convertOutbound(exchange, message, endpointConfiguration, context);
         return exchange;
@@ -60,11 +69,74 @@ public class CamelMessageConverter implements MessageConverter<Exchange, Exchang
                     !MessageHeaderUtils.isInternalMessageHeader(header.getKey())) {
                 in.setHeader(header.getKey(), header.getValue());
             }
+
+            switch (header.getKey()) {
+                case CamelMessageHeaders.EXCHANGE_PATTERN: {
+                    if (header.getValue() instanceof ExchangePattern pattern) {
+                        exchange.setPattern(pattern);
+                    } else if (header.getValue() instanceof String stringValue) {
+                        exchange.setPattern(ExchangePattern.valueOf(stringValue));
+                    }
+                    break;
+                }
+                case CamelMessageHeaders.EXCHANGE_PROPERTIES: {
+                    if (header.getValue() instanceof Map) {
+                        ((Map<String, Object>) header.getValue()).forEach(exchange::setProperty);
+                    } else if (header.getValue() instanceof String stringValue) {
+                        StringUtils.extractMap(stringValue).forEach(exchange::setProperty);
+                    }
+                    break;
+                }
+                case CamelMessageHeaders.EXCHANGE_VARIABLES: {
+                    if (header.getValue() instanceof Map) {
+                        ((Map<String, Object>) header.getValue()).forEach(exchange::setVariable);
+                    } else if (header.getValue() instanceof String stringValue) {
+                        StringUtils.extractMap(stringValue).forEach(exchange::setVariable);
+                    }
+                    break;
+                }
+                case CamelMessageHeaders.EXCHANGE_EXCEPTION: {
+                    if (header.getValue() instanceof Throwable exception) {
+                        exchange.setException(exception);
+                    } else if (header.getValue() instanceof String exceptionType) {
+                        if (message.getHeaders().containsKey(CamelMessageHeaders.EXCHANGE_EXCEPTION_MESSAGE)) {
+                            if (CamelExchangeException.class.getName().equals(exceptionType)) {
+                                exchange.setException(new CamelExchangeException(message.getHeader(CamelMessageHeaders.EXCHANGE_EXCEPTION_MESSAGE).toString(), exchange));
+                            } else {
+                                // Instantiate the exception with given error message
+                                exchange.setException(ClassLoaderHelper.instantiateType(exceptionType,
+                                        message.getHeader(CamelMessageHeaders.EXCHANGE_EXCEPTION_MESSAGE).toString()));
+                            }
+                        } else {
+                            if (CamelExchangeException.class.getName().equals(exceptionType)) {
+                                exchange.setException(new CamelExchangeException("", exchange));
+                            } else {
+                                exchange.setException(ClassLoaderHelper.instantiateType(exceptionType));
+                            }
+                        }
+                    }
+                    break;
+                }
+                case CamelMessageHeaders.EXCHANGE_EXCEPTION_MESSAGE: {
+                    if (!message.getHeaders().containsKey(CamelMessageHeaders.EXCHANGE_EXCEPTION)) {
+                        exchange.setException(new CamelException(header.getValue().toString()));
+                    }
+                    break;
+                }
+            }
         }
 
         if (message.getPayload() instanceof Resource payloadResource) {
             // Camel does not know how to handle Citrus file resources, so convert to InputStream
             in.setBody(payloadResource.getInputStream());
+        } else if (message.getPayload() instanceof Exchange sourceExchange) {
+            if (!exchange.equals(sourceExchange)) {
+                sourceExchange.getProperties().forEach(exchange::setProperty);
+                sourceExchange.getVariables().forEach(exchange::setVariable);
+
+                sourceExchange.getIn().getHeaders().forEach(exchange.getIn()::setHeader);
+                in.setBody(sourceExchange.getIn().getBody());
+            }
         } else {
             in.setBody(message.getPayload());
         }
@@ -78,13 +150,21 @@ public class CamelMessageConverter implements MessageConverter<Exchange, Exchang
 
         Message message = new DefaultMessage(exchange.getMessage().getBody(), exchange.getMessage().getHeaders())
                 .setHeader(CamelMessageHeaders.EXCHANGE_ID, exchange.getExchangeId())
+                .setHeader(CamelMessageHeaders.MESSAGE_ID, exchange.getMessage().getMessageId())
                 .setHeader(CamelMessageHeaders.ROUTE_ID, exchange.getFromRouteId())
                 .setHeader(CamelMessageHeaders.EXCHANGE_PATTERN, exchange.getPattern().name())
+                .setHeader(CamelMessageHeaders.EXCHANGE_PROPERTIES, StringUtils.convertToString(exchange.getProperties()))
+                .setHeader(CamelMessageHeaders.EXCHANGE_VARIABLES, StringUtils.convertToString(exchange.getVariables()))
                 .setHeader(CamelMessageHeaders.EXCHANGE_FAILED, exchange.isFailed());
 
-        //add all exchange properties
+        //add all exchange properties as headers
         for (Map.Entry<String, Object> property : exchange.getProperties().entrySet()) {
             message.setHeader(property.getKey(), property.getValue());
+        }
+
+        //add all exchange variables as headers
+        for (Map.Entry<String, Object> variable : exchange.getVariables().entrySet()) {
+            message.setHeader(variable.getKey(), variable.getValue());
         }
 
         if (exchange.getException() != null) {

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/message/CamelMessageHeaders.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/message/CamelMessageHeaders.java
@@ -37,6 +37,9 @@ public abstract class CamelMessageHeaders {
     public static final String EXCHANGE_FAILED = CAMEL_PREFIX + "exchange_failed";
     public static final String EXCHANGE_EXCEPTION = CAMEL_PREFIX + "exchange_exception";
     public static final String EXCHANGE_EXCEPTION_MESSAGE = CAMEL_PREFIX + "exchange_exception_message";
+    public static final String EXCHANGE_PROPERTIES = CAMEL_PREFIX + "exchange_properties";
+    public static final String EXCHANGE_VARIABLES = CAMEL_PREFIX + "exchange_variables";
+    public static final String MESSAGE_ID = CAMEL_PREFIX + "message_id";
     public static final String ROUTE_ID = CAMEL_PREFIX + "route_id";
 
 }

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/endpoint/CamelEndpointTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/endpoint/CamelEndpointTest.java
@@ -16,22 +16,21 @@
 
 package org.citrusframework.camel.endpoint;
 
-import org.citrusframework.camel.message.CamelMessageHeaders;
-import org.citrusframework.exceptions.CitrusRuntimeException;
-import org.citrusframework.message.Message;
-import org.citrusframework.report.MessageListeners;
-import org.citrusframework.testng.AbstractTestNGUnitTest;
 import org.apache.camel.CamelExchangeException;
 import org.apache.camel.ConsumerTemplate;
 import org.apache.camel.Exchange;
 import org.apache.camel.ExtendedCamelContext;
-import org.apache.camel.Processor;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.impl.engine.AbstractCamelContext;
 import org.apache.camel.impl.engine.DefaultHeadersMapFactory;
 import org.apache.camel.support.DefaultExchange;
 import org.apache.camel.support.DefaultMessage;
 import org.apache.camel.support.SimpleUuidGenerator;
+import org.citrusframework.camel.message.CamelMessageHeaders;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.message.Message;
+import org.citrusframework.report.MessageListeners;
+import org.citrusframework.testng.AbstractTestNGUnitTest;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -67,7 +66,7 @@ public class CamelEndpointTest extends AbstractTestNGUnitTest {
         when(camelContext.createProducerTemplate()).thenReturn(producerTemplate);
         when(camelContext.getCamelContextExtension()).thenReturn(extendedCamelContext);
         when(extendedCamelContext.getHeadersMapFactory()).thenReturn(new DefaultHeadersMapFactory());
-        when(producerTemplate.send(eq(endpointUri), any(Processor.class))).thenReturn(exchange);
+        when(producerTemplate.send(eq(endpointUri), any(Exchange.class))).thenReturn(exchange);
         when(exchange.getException()).thenReturn(null);
 
         camelEndpoint.createProducer().send(requestMessage, context);
@@ -91,7 +90,7 @@ public class CamelEndpointTest extends AbstractTestNGUnitTest {
         when(camelContext.createProducerTemplate()).thenReturn(producerTemplate);
         when(camelContext.getCamelContextExtension()).thenReturn(extendedCamelContext);
         when(extendedCamelContext.getHeadersMapFactory()).thenReturn(new DefaultHeadersMapFactory());
-        when(producerTemplate.send(eq(endpointUri), any(Processor.class))).thenReturn(exchange);
+        when(producerTemplate.send(eq(endpointUri), any(Exchange.class))).thenReturn(exchange);
         when(exchange.getException()).thenReturn(exchangeException);
 
         camelEndpoint.createProducer().send(requestMessage, context);
@@ -152,7 +151,7 @@ public class CamelEndpointTest extends AbstractTestNGUnitTest {
         when(camelContext.createProducerTemplate()).thenReturn(producerTemplate);
         when(camelContext.getCamelContextExtension()).thenReturn(extendedCamelContext);
         when(extendedCamelContext.getHeadersMapFactory()).thenReturn(new DefaultHeadersMapFactory());
-        when(producerTemplate.send(eq(endpointUri), any(Processor.class))).thenReturn(exchange);
+        when(producerTemplate.send(eq(endpointUri), any(Exchange.class))).thenReturn(exchange);
 
         when(camelContext.createConsumerTemplate()).thenReturn(consumerTemplate);
         when(camelContext.getUuidGenerator()).thenReturn(new SimpleUuidGenerator());

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/message/CamelMessageConverterTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/message/CamelMessageConverterTest.java
@@ -16,19 +16,24 @@
 
 package org.citrusframework.camel.message;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.UUID;
 
-import org.citrusframework.camel.endpoint.CamelEndpointConfiguration;
-import org.citrusframework.exceptions.CitrusRuntimeException;
-import org.citrusframework.message.DefaultMessage;
-import org.citrusframework.message.Message;
-import org.citrusframework.testng.AbstractTestNGUnitTest;
+import org.apache.camel.CamelException;
+import org.apache.camel.CamelExchangeException;
 import org.apache.camel.Exchange;
 import org.apache.camel.ExchangePattern;
 import org.apache.camel.ExtendedCamelContext;
 import org.apache.camel.impl.engine.AbstractCamelContext;
 import org.apache.camel.impl.engine.DefaultHeadersMapFactory;
 import org.apache.camel.support.DefaultExchange;
+import org.citrusframework.camel.endpoint.CamelEndpointConfiguration;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.message.DefaultMessage;
+import org.citrusframework.message.Message;
+import org.citrusframework.testng.AbstractTestNGUnitTest;
+import org.citrusframework.util.StringUtils;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
@@ -79,6 +84,193 @@ public class CamelMessageConverterTest extends AbstractTestNGUnitTest {
 
         Assert.assertEquals(exchange.getIn().getBody(), "Hello from Citrus!");
         Assert.assertEquals(exchange.getIn().getHeaders().get("operation"), "sayHello");
+        Assert.assertEquals(exchange.getPattern(), ExchangePattern.InOnly);
+    }
+
+    @Test
+    public void testConvertOutboundExchangeWithExchangePattern() {
+        Message message = new DefaultMessage("Hello from Citrus!")
+                .setHeader("operation", "sayHello")
+                .setHeader(CamelMessageHeaders.EXCHANGE_PATTERN, ExchangePattern.InOut);
+
+        Exchange exchange = new DefaultExchange(camelContext);
+        exchange.setExchangeId(UUID.randomUUID().toString());
+
+        messageConverter.convertOutbound(exchange, message, endpointConfiguration, context);
+
+        Assert.assertEquals(exchange.getIn().getBody(), "Hello from Citrus!");
+        Assert.assertEquals(exchange.getIn().getHeaders().get("operation"), "sayHello");
+        Assert.assertEquals(exchange.getPattern(), ExchangePattern.InOut);
+    }
+
+    @Test
+    public void testConvertOutboundExchangeWithExceptionType() {
+        Message message = new DefaultMessage("Hello from Citrus!")
+                .setHeader("operation", "sayHello")
+                .setHeader(CamelMessageHeaders.EXCHANGE_EXCEPTION, CitrusRuntimeException.class.getName())
+                .setHeader(CamelMessageHeaders.EXCHANGE_EXCEPTION_MESSAGE, "Something went wrong");
+
+        Exchange exchange = new DefaultExchange(camelContext);
+        exchange.setExchangeId(UUID.randomUUID().toString());
+
+        messageConverter.convertOutbound(exchange, message, endpointConfiguration, context);
+
+        Assert.assertEquals(exchange.getIn().getBody(), "Hello from Citrus!");
+        Assert.assertEquals(exchange.getIn().getHeaders().get("operation"), "sayHello");
+        Assert.assertEquals(exchange.getException().getClass(), CitrusRuntimeException.class);
+        Assert.assertEquals(exchange.getException().getMessage(), "Something went wrong");
+    }
+
+    @Test
+    public void testConvertOutboundExchangeWithCamelExchangeExceptionType() {
+        Message message = new DefaultMessage("Hello from Citrus!")
+                .setHeader("operation", "sayHello")
+                .setHeader(CamelMessageHeaders.EXCHANGE_EXCEPTION, CamelExchangeException.class.getName())
+                .setHeader(CamelMessageHeaders.EXCHANGE_EXCEPTION_MESSAGE, "Something went wrong");
+
+        Exchange exchange = new DefaultExchange(camelContext);
+        exchange.setExchangeId(UUID.randomUUID().toString());
+
+        messageConverter.convertOutbound(exchange, message, endpointConfiguration, context);
+
+        Assert.assertEquals(exchange.getIn().getBody(), "Hello from Citrus!");
+        Assert.assertEquals(exchange.getIn().getHeaders().get("operation"), "sayHello");
+        Assert.assertEquals(exchange.getException().getClass(), CamelExchangeException.class);
+        Assert.assertEquals(((CamelExchangeException) exchange.getException()).getExchange(), exchange);
+        Assert.assertEquals(exchange.getException().getMessage(), "Something went wrong. %s".formatted(exchange));
+    }
+
+    @Test
+    public void testConvertOutboundExchangeWithException() {
+        Message message = new DefaultMessage("Hello from Citrus!")
+                .setHeader("operation", "sayHello")
+                .setHeader(CamelMessageHeaders.EXCHANGE_EXCEPTION, new CitrusRuntimeException("Something went wrong"));
+
+        Exchange exchange = new DefaultExchange(camelContext);
+        exchange.setExchangeId(UUID.randomUUID().toString());
+
+        messageConverter.convertOutbound(exchange, message, endpointConfiguration, context);
+
+        Assert.assertEquals(exchange.getIn().getBody(), "Hello from Citrus!");
+        Assert.assertEquals(exchange.getIn().getHeaders().get("operation"), "sayHello");
+        Assert.assertEquals(exchange.getException().getClass(), CitrusRuntimeException.class);
+        Assert.assertEquals(exchange.getException().getMessage(), "Something went wrong");
+    }
+
+    @Test
+    public void testConvertOutboundExchangeWithExceptionMessage() {
+        Message message = new DefaultMessage("Hello from Citrus!")
+                .setHeader("operation", "sayHello")
+                .setHeader(CamelMessageHeaders.EXCHANGE_EXCEPTION_MESSAGE, "Something went completely wrong");
+
+        Exchange exchange = new DefaultExchange(camelContext);
+        exchange.setExchangeId(UUID.randomUUID().toString());
+
+        messageConverter.convertOutbound(exchange, message, endpointConfiguration, context);
+
+        Assert.assertEquals(exchange.getIn().getBody(), "Hello from Citrus!");
+        Assert.assertEquals(exchange.getIn().getHeaders().get("operation"), "sayHello");
+        Assert.assertEquals(exchange.getException().getClass(), CamelException.class);
+        Assert.assertEquals(exchange.getException().getMessage(), "Something went completely wrong");
+    }
+
+    @Test
+    public void testConvertOutboundExchangeWithProperties() {
+        Message message = new DefaultMessage("Hello from Citrus!")
+                .setHeader("operation", "sayHello")
+                .setHeader(CamelMessageHeaders.EXCHANGE_PROPERTIES, StringUtils.convertToString(Collections.singletonMap("foo_prop", "bar")));
+
+        Exchange exchange = new DefaultExchange(camelContext);
+        exchange.setExchangeId(UUID.randomUUID().toString());
+
+        messageConverter.convertOutbound(exchange, message, endpointConfiguration, context);
+
+        Assert.assertEquals(exchange.getIn().getBody(), "Hello from Citrus!");
+        Assert.assertEquals(exchange.getIn().getHeaders().get("operation"), "sayHello");
+        Assert.assertEquals(exchange.getProperty("foo_prop"), "bar");
+    }
+
+    @Test
+    public void testConvertOutboundExchangeWithVariables() {
+        Message message = new DefaultMessage("Hello from Citrus!")
+                .setHeader("operation", "sayHello")
+                .setHeader(CamelMessageHeaders.EXCHANGE_VARIABLES, StringUtils.convertToString(
+                        Map.of("foo_var", "bar", "bar_var", "baz")));
+
+        Exchange exchange = new DefaultExchange(camelContext);
+        exchange.setExchangeId(UUID.randomUUID().toString());
+
+        messageConverter.convertOutbound(exchange, message, endpointConfiguration, context);
+
+        Assert.assertEquals(exchange.getIn().getBody(), "Hello from Citrus!");
+        Assert.assertEquals(exchange.getIn().getHeaders().get("operation"), "sayHello");
+        Assert.assertEquals(exchange.getVariable("foo_var"), "bar");
+        Assert.assertEquals(exchange.getVariable("bar_var"), "baz");
+    }
+
+    @Test
+    public void testConvertOutboundExchangeAsPayload() {
+        Exchange exchange = new DefaultExchange(camelContext);
+        exchange.setExchangeId(UUID.randomUUID().toString());
+        exchange.getIn().setBody("Hello from Citrus!");
+        exchange.getIn().setHeader("operation", "sayHello");
+        exchange.setProperty("foo_prop", "bar");
+        exchange.setVariable("foo_var", "baz");
+
+        Message message = new DefaultMessage(exchange);
+        message.setHeader("additional", "Something to add");
+
+        messageConverter.convertOutbound(exchange, message, endpointConfiguration, context);
+
+        Assert.assertEquals(exchange.getIn().getBody(), "Hello from Citrus!");
+        Assert.assertEquals(exchange.getIn().getHeaders().get("operation"), "sayHello");
+        Assert.assertEquals(exchange.getIn().getHeaders().get("additional"), "Something to add");
+        Assert.assertEquals(exchange.getProperty("foo_prop"), "bar");
+        Assert.assertEquals(exchange.getVariable("foo_var"), "baz");
+    }
+
+    @Test
+    public void testConvertOutboundCopyExchange() {
+        Exchange exchange = new DefaultExchange(camelContext);
+        exchange.setExchangeId(UUID.randomUUID().toString());
+
+        Exchange sourceExchange = new DefaultExchange(camelContext);
+        sourceExchange.setExchangeId(UUID.randomUUID().toString());
+        sourceExchange.getIn().setBody("Hello from Citrus!");
+        sourceExchange.getIn().setHeader("operation", "sayHello");
+        sourceExchange.setProperty("foo_prop", "bar");
+        sourceExchange.setVariable("foo_var", "baz");
+
+        Message message = new DefaultMessage(sourceExchange);
+        message.setHeader("additional", "Something to add");
+
+        messageConverter.convertOutbound(exchange, message, endpointConfiguration, context);
+
+        Assert.assertEquals(exchange.getIn().getBody(), "Hello from Citrus!");
+        Assert.assertEquals(exchange.getIn().getHeaders().get("operation"), "sayHello");
+        Assert.assertEquals(exchange.getIn().getHeaders().get("additional"), "Something to add");
+        Assert.assertEquals(exchange.getProperty("foo_prop"), "bar");
+        Assert.assertEquals(exchange.getVariable("foo_var"), "baz");
+    }
+
+    @Test
+    public void testConvertOutboundUserProvidedExchange() {
+        Exchange exchange = new DefaultExchange(camelContext);
+        exchange.setExchangeId(UUID.randomUUID().toString());
+        exchange.getIn().setBody("Hello from Citrus!");
+        exchange.getIn().setHeader("operation", "sayHello");
+        exchange.setProperty("foo_prop", "bar");
+        exchange.setVariable("foo_var", "baz");
+
+        Message message = new DefaultMessage(exchange);
+
+        Exchange converted = messageConverter.convertOutbound(message, endpointConfiguration, context);
+
+        Assert.assertEquals(converted, exchange);
+        Assert.assertEquals(converted.getIn().getBody(), "Hello from Citrus!");
+        Assert.assertEquals(converted.getIn().getHeaders().get("operation"), "sayHello");
+        Assert.assertEquals(converted.getProperty("foo_prop"), "bar");
+        Assert.assertEquals(converted.getVariable("foo_var"), "baz");
     }
 
     @Test
@@ -112,10 +304,37 @@ public class CamelMessageConverterTest extends AbstractTestNGUnitTest {
         Assert.assertEquals(result.getPayload(), "Hello from Citrus!");
         Assert.assertEquals(result.getHeader(CamelMessageHeaders.EXCHANGE_ID), exchange.getExchangeId());
         Assert.assertEquals(result.getHeader(CamelMessageHeaders.EXCHANGE_PATTERN), ExchangePattern.InOnly.name());
+        Assert.assertTrue(result.getHeader(CamelMessageHeaders.EXCHANGE_PROPERTIES).toString().contains("\"VerySpecialProperty\": \"bar\""));
+        Assert.assertTrue(result.getHeader(CamelMessageHeaders.EXCHANGE_PROPERTIES).toString().contains("\"SpecialProperty\": \"foo\""));
+        Assert.assertEquals(result.getHeader(CamelMessageHeaders.EXCHANGE_VARIABLES), "{}");
         Assert.assertEquals(result.getHeader(CamelMessageHeaders.EXCHANGE_FAILED), false);
         Assert.assertEquals(result.getHeader("operation"), "sayHello");
         Assert.assertEquals(result.getHeader("SpecialProperty"), "foo");
         Assert.assertEquals(result.getHeader("VerySpecialProperty"), "bar");
+    }
+
+    @Test
+    public void testConvertInboundWithVariables() {
+        DefaultExchange exchange = new DefaultExchange(camelContext);
+        exchange.setExchangeId(UUID.randomUUID().toString());
+        exchange.getIn().setBody("Hello from Citrus!");
+        exchange.getIn().setHeader("operation", "sayHello");
+
+        exchange.setVariable("SpecialVariable", "foo");
+        exchange.setVariable("VerySpecialVariable", "bar");
+
+        Message result = messageConverter.convertInbound(exchange, endpointConfiguration, context);
+
+        Assert.assertEquals(result.getPayload(), "Hello from Citrus!");
+        Assert.assertEquals(result.getHeader(CamelMessageHeaders.EXCHANGE_ID), exchange.getExchangeId());
+        Assert.assertEquals(result.getHeader(CamelMessageHeaders.EXCHANGE_PATTERN), ExchangePattern.InOnly.name());
+        Assert.assertEquals(result.getHeader(CamelMessageHeaders.EXCHANGE_PROPERTIES), "{}");
+        Assert.assertTrue(result.getHeader(CamelMessageHeaders.EXCHANGE_VARIABLES).toString().contains("\"VerySpecialVariable\": \"bar\""));
+        Assert.assertTrue(result.getHeader(CamelMessageHeaders.EXCHANGE_VARIABLES).toString().contains("\"SpecialVariable\": \"foo\""));
+        Assert.assertEquals(result.getHeader(CamelMessageHeaders.EXCHANGE_FAILED), false);
+        Assert.assertEquals(result.getHeader("operation"), "sayHello");
+        Assert.assertEquals(result.getHeader("SpecialVariable"), "foo");
+        Assert.assertEquals(result.getHeader("VerySpecialVariable"), "bar");
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Allow users to specify a Camel `Exchange` directly as the message payload, bypassing automatic Exchange construction in the message converter
- Support setting Exchange properties, variables, pattern, and exceptions via Citrus message headers (`CamelExchangeProperties`, `CamelExchangeVariables`, `CamelExchangePattern`, `CamelExchangeException`)
- Enrich inbound conversion to capture Exchange properties, variables, and message ID as Citrus headers
- Add `StringUtils` utility methods (`convertToString`, `extractMap`, `stripQuotes`) and `ObjectHelper.isNumeric` to support map-to-string and string-to-map conversions for header values

Closes #1576

## Test plan

- [x] Unit tests for `CamelMessageConverter` covering Exchange-as-payload pass-through, Exchange property/variable/pattern/exception header handling
- [x] Unit tests for `StringUtils.convertToString`, `extractMap`, and `stripQuotes` with various input types (null, empty, JSON-style, key=value pairs, numeric, mixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)