### PR TITLE
fix(#1578): Allow function and validation matcher bean injection

### DIFF
--- a/core/citrus-api/src/main/java/org/citrusframework/CitrusSettings.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/CitrusSettings.java
@@ -338,6 +338,20 @@ public final class CitrusSettings {
     public static final String PRINT_BANNER_DEFAULT = TRUE.toString();
 
     /**
+     * Flag to allow override of default functions in library.
+     */
+    public static final String ALLOW_FUNCTION_OVERRIDE_PROPERTY = "citrus.allow.function.override";
+    public static final String ALLOW_FUNCTION_OVERRIDE_ENV = "CITRUS_ALLOW_FUNCTION_OVERRIDE";
+    public static final String ALLOW_FUNCTION_OVERRIDE_DEFAULT = TRUE.toString();
+
+    /**
+     * Flag to allow override of default validation matcher in library.
+     */
+    public static final String ALLOW_VALIDATION_MATCHER_OVERRIDE_PROPERTY = "citrus.allow.validation.matcher.override";
+    public static final String ALLOW_VALIDATION_MATCHER_OVERRIDE_ENV = "CITRUS_ALLOW_VALIDATION_MATCHER_OVERRIDE";
+    public static final String ALLOW_VALIDATION_MATCHER_OVERRIDE_DEFAULT = TRUE.toString();
+
+    /**
      * Gets set of file name patterns for Groovy test files.
      */
     public static Set<String> getGroovyTestFileNamePattern() {
@@ -595,5 +609,31 @@ public final class CitrusSettings {
      */
     public static String getApplicationPropertiesFile() {
         return APPLICATION_PROPERTY_FILE;
+    }
+
+    /**
+     * Should user be able to override default functions in library with custom instances using the same name.
+     */
+    public static boolean isAllowFunctionOverride() {
+        return parseBoolean(
+                getPropertyEnvOrDefault(
+                        ALLOW_FUNCTION_OVERRIDE_PROPERTY,
+                        ALLOW_FUNCTION_OVERRIDE_ENV,
+                        ALLOW_FUNCTION_OVERRIDE_DEFAULT
+                )
+        );
+    }
+
+    /**
+     * Should user be able to override default validation matchers in library with custom instances using the same name.
+     */
+    public static boolean isAllowValidationMatcherOverride() {
+        return parseBoolean(
+                getPropertyEnvOrDefault(
+                        ALLOW_VALIDATION_MATCHER_OVERRIDE_PROPERTY,
+                        ALLOW_VALIDATION_MATCHER_OVERRIDE_ENV,
+                        ALLOW_VALIDATION_MATCHER_OVERRIDE_DEFAULT
+                )
+        );
     }
 }

--- a/core/citrus-api/src/main/java/org/citrusframework/functions/FunctionLibrary.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/functions/FunctionLibrary.java
@@ -16,10 +16,11 @@
 
 package org.citrusframework.functions;
 
-import org.citrusframework.exceptions.NoSuchFunctionException;
-
 import java.util.HashMap;
 import java.util.Map;
+
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.exceptions.NoSuchFunctionException;
 
 /**
  * Library holding a set of functions. Each library defines a function prefix as namespace, so
@@ -27,14 +28,14 @@ import java.util.Map;
  *
  */
 public class FunctionLibrary {
+    /** Default function prefix */
+    static final String DEFAULT_PREFIX = "citrus:";
+
     /** Map of functions in this library */
     private Map<String, Function> members = new HashMap<>();
 
-    /** Default function prefix */
-    private static final String DEFAULT_PREFIX = "citrus:";
-
     /** Name of function library */
-    private String name = DEFAULT_PREFIX;
+    private String name = "standard";
 
     /** Function library prefix */
     private String prefix = DEFAULT_PREFIX;
@@ -71,8 +72,18 @@ public class FunctionLibrary {
     }
 
     /**
+     * Adds new member in this library.
+     */
+    public void addMember(String name, Function function) {
+        if (members.containsKey(name)) {
+            throw new CitrusRuntimeException(String.format("Failed to add function. " +
+                    "Duplicate function with name '%s' in library '%s'", name, getName()));
+        }
+        members.put(name, function);
+    }
+
+    /**
      * Set the function library content.
-     * @param members
      */
     public void setMembers(Map<String, Function> members) {
         this.members = members;
@@ -80,7 +91,6 @@ public class FunctionLibrary {
 
     /**
      * Gets the function library members.
-     * @return
      */
     public Map<String, Function> getMembers() {
         return members;
@@ -88,7 +98,6 @@ public class FunctionLibrary {
 
     /**
      * Get the library prefix.
-     * @return
      */
     public String getPrefix() {
         return prefix;
@@ -96,7 +105,6 @@ public class FunctionLibrary {
 
     /**
      * Set the library prefix.
-     * @param prefix
      */
     public void setPrefix(String prefix) {
         this.prefix = prefix;
@@ -104,7 +112,6 @@ public class FunctionLibrary {
 
     /**
      * Get the function library name.
-     * @return
      */
     public String getName() {
         return name;
@@ -112,7 +119,6 @@ public class FunctionLibrary {
 
     /**
      * Get the name of the function library.
-     * @param name
      */
     public void setName(String name) {
         this.name = name;

--- a/core/citrus-api/src/main/java/org/citrusframework/functions/FunctionRegistry.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/functions/FunctionRegistry.java
@@ -17,6 +17,7 @@
 package org.citrusframework.functions;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.citrusframework.exceptions.CitrusRuntimeException;
@@ -67,6 +68,23 @@ public class FunctionRegistry {
     }
 
     /**
+     * Get the library that is using the default prefix so it is operating as the default library in this registry.
+     * If this is not present fallback to the only exclusive library known to this registry.
+     */
+    public FunctionLibrary getDefaultLibrary() {
+        try {
+            return getLibraryForPrefix(FunctionLibrary.DEFAULT_PREFIX);
+        } catch (NoSuchFunctionLibraryException e) {
+            // fallback to the only available library in this registry
+            if (functionLibraries.size() == 1) {
+                return functionLibraries.get(0);
+            }
+
+            throw e;
+        }
+    }
+
+    /**
      * Adds given function library to this registry.
      */
     public void addFunctionLibrary(FunctionLibrary functionLibrary) {
@@ -81,17 +99,11 @@ public class FunctionRegistry {
         this.functionLibraries.add(functionLibrary);
     }
 
-    /**
-     * @param functionLibraries
-     */
     public void setFunctionLibraries(List<FunctionLibrary> functionLibraries) {
         this.functionLibraries = functionLibraries;
     }
 
-    /**
-     * @return the functionLibraries
-     */
     public List<FunctionLibrary> getFunctionLibraries() {
-        return functionLibraries;
+        return Collections.unmodifiableList(functionLibraries);
     }
 }

--- a/core/citrus-api/src/main/java/org/citrusframework/validation/matcher/ValidationMatcherLibrary.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/validation/matcher/ValidationMatcherLibrary.java
@@ -19,6 +19,7 @@ package org.citrusframework.validation.matcher;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.exceptions.NoSuchValidationMatcherException;
 
 /**
@@ -70,6 +71,17 @@ public class ValidationMatcherLibrary {
             // standard citrus-library without prefix:
             return members.containsKey(validationMatcherName.substring(0, validationMatcherName.indexOf('(')));
         }
+    }
+
+    /**
+     * Adds new member in this library.
+     */
+    public void addMember(String name, ValidationMatcher validationMatcher) {
+        if (members.containsKey(name)) {
+            throw new CitrusRuntimeException(String.format("Failed to add validation matcher. " +
+                    "Duplicate validation matcher with name '%s' in library '%s'", name, getName()));
+        }
+        members.put(name, validationMatcher);
     }
 
     /**

--- a/core/citrus-api/src/main/java/org/citrusframework/validation/matcher/ValidationMatcherRegistry.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/validation/matcher/ValidationMatcherRegistry.java
@@ -17,6 +17,7 @@
 package org.citrusframework.validation.matcher;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.citrusframework.exceptions.CitrusRuntimeException;
@@ -24,7 +25,6 @@ import org.citrusframework.exceptions.NoSuchValidationMatcherLibraryException;
 
 /**
  * ValidationMatcher registry holding all available validation matcher libraries.
- *
  */
 public class ValidationMatcherRegistry {
     /** list of libraries providing custom validation matchers */
@@ -48,6 +48,23 @@ public class ValidationMatcherRegistry {
     }
 
     /**
+     * Get the library that is not having a prefix so it is operating as the default library in this registry.
+     * If this is not present fallback to the only exclusive library known to this registry.
+     */
+    public ValidationMatcherLibrary getDefaultLibrary() {
+        try {
+            return getLibraryForPrefix("");
+        } catch (NoSuchValidationMatcherLibraryException e) {
+            // fallback to the only available library in this registry
+            if (validationMatcherLibraries.size() == 1) {
+                return validationMatcherLibraries.get(0);
+            }
+
+            throw e;
+        }
+    }
+
+    /**
      * Adds given validation matcher library to this registry.
      */
     public void addValidationMatcherLibrary(ValidationMatcherLibrary validationMatcherLibrary) {
@@ -62,17 +79,11 @@ public class ValidationMatcherRegistry {
         this.validationMatcherLibraries.add(validationMatcherLibrary);
     }
 
-    /**
-     * @param validationMatcherLibraries
-     */
     public void setValidationMatcherLibraries(List<ValidationMatcherLibrary> validationMatcherLibraries) {
         this.validationMatcherLibraries = validationMatcherLibraries;
     }
 
-    /**
-     * @return the validationMatcherLibraries
-     */
     public List<ValidationMatcherLibrary> getValidationMatcherLibraries() {
-        return validationMatcherLibraries;
+        return Collections.unmodifiableList(validationMatcherLibraries);
     }
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/CitrusContext.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/CitrusContext.java
@@ -35,6 +35,7 @@ import org.citrusframework.endpoint.DefaultEndpointFactory;
 import org.citrusframework.endpoint.EndpointFactory;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.functions.DefaultFunctionRegistry;
+import org.citrusframework.functions.Function;
 import org.citrusframework.functions.FunctionLibrary;
 import org.citrusframework.functions.FunctionRegistry;
 import org.citrusframework.log.DefaultLogModifier;
@@ -55,6 +56,7 @@ import org.citrusframework.validation.MessageValidator;
 import org.citrusframework.validation.MessageValidatorRegistry;
 import org.citrusframework.validation.context.ValidationContext;
 import org.citrusframework.validation.matcher.DefaultValidationMatcherRegistry;
+import org.citrusframework.validation.matcher.ValidationMatcher;
 import org.citrusframework.validation.matcher.ValidationMatcherLibrary;
 import org.citrusframework.validation.matcher.ValidationMatcherRegistry;
 import org.citrusframework.variable.GlobalVariables;
@@ -390,12 +392,16 @@ public class CitrusContext implements TestListenerAware, TestActionListenerAware
         synchronized (this) {
             if (component instanceof MessageValidator<?> messageValidator) {
                 messageValidatorRegistry.addMessageValidator(name, messageValidator);
-                testContextFactory.getMessageValidatorRegistry().addMessageValidator(name, messageValidator);
+                if (!messageValidatorRegistry.equals(testContextFactory.getMessageValidatorRegistry())) {
+                    testContextFactory.getMessageValidatorRegistry().addMessageValidator(name, messageValidator);
+                }
             }
 
             if (component instanceof MessageProcessor messageProcessor) {
                 messageProcessors.addMessageProcessor(messageProcessor);
-                testContextFactory.getMessageProcessors().addMessageProcessor(messageProcessor);
+                if (!messageProcessors.equals(testContextFactory.getMessageProcessors())) {
+                    testContextFactory.getMessageProcessors().addMessageProcessor(messageProcessor);
+                }
             }
 
             if (component instanceof TestSuiteListener suiteListener) {
@@ -404,7 +410,9 @@ public class CitrusContext implements TestListenerAware, TestActionListenerAware
 
             if (component instanceof TestListener testListener) {
                 testListeners.addTestListener(testListener);
-                testContextFactory.getTestListeners().addTestListener(testListener);
+                if (!testListeners.equals(testContextFactory.getTestListeners())) {
+                    testContextFactory.getTestListeners().addTestListener(testListener);
+                }
             }
 
             if (component instanceof TestReporter testReporter) {
@@ -413,12 +421,16 @@ public class CitrusContext implements TestListenerAware, TestActionListenerAware
 
             if (component instanceof TestActionListener testActionListener) {
                 testActionListeners.addTestActionListener(testActionListener);
-                testContextFactory.getTestActionListeners().addTestActionListener(testActionListener);
+                if (!testActionListeners.equals(testContextFactory.getTestActionListeners())) {
+                    testContextFactory.getTestActionListeners().addTestActionListener(testActionListener);
+                }
             }
 
             if (component instanceof MessageListener messageListener) {
                 messageListeners.addMessageListener(messageListener);
-                testContextFactory.getMessageListeners().addMessageListener(messageListener);
+                if (!messageListeners.equals(testContextFactory.getMessageListeners())) {
+                    testContextFactory.getMessageListeners().addMessageListener(messageListener);
+                }
             }
 
             if (component instanceof BeforeTest beforeTest) {
@@ -439,17 +451,37 @@ public class CitrusContext implements TestListenerAware, TestActionListenerAware
 
             if (component instanceof FunctionLibrary library) {
                 functionRegistry.addFunctionLibrary(library);
-                testContextFactory.getFunctionRegistry().addFunctionLibrary(library);
+                if (!functionRegistry.equals(testContextFactory.getFunctionRegistry())) {
+                    testContextFactory.getFunctionRegistry().addFunctionLibrary(library);
+                }
+            }
+
+            if (component instanceof Function function) {
+                functionRegistry.getDefaultLibrary().addMember(name, function);
+                if (!functionRegistry.equals(testContextFactory.getFunctionRegistry())) {
+                    testContextFactory.getFunctionRegistry().getDefaultLibrary().addMember(name, function);
+                }
             }
 
             if (component instanceof ValidationMatcherLibrary library) {
                 validationMatcherRegistry.addValidationMatcherLibrary(library);
-                testContextFactory.getValidationMatcherRegistry().addValidationMatcherLibrary(library);
+                if (!validationMatcherRegistry.equals(testContextFactory.getValidationMatcherRegistry())) {
+                    testContextFactory.getValidationMatcherRegistry().addValidationMatcherLibrary(library);
+                }
+            }
+
+            if (component instanceof ValidationMatcher validationMatcher) {
+                validationMatcherRegistry.getDefaultLibrary().addMember(name, validationMatcher);
+                if (!validationMatcherRegistry.equals(testContextFactory.getValidationMatcherRegistry())) {
+                    testContextFactory.getValidationMatcherRegistry().getDefaultLibrary().addMember(name, validationMatcher);
+                }
             }
 
             if (component instanceof GlobalVariables vars) {
                 globalVariables.getVariables().putAll(vars.getVariables());
-                testContextFactory.getGlobalVariables().getVariables().putAll(vars.getVariables());
+                if (!globalVariables.equals(testContextFactory.getGlobalVariables())) {
+                    testContextFactory.getGlobalVariables().getVariables().putAll(vars.getVariables());
+                }
             }
         }
     }

--- a/core/citrus-base/src/main/java/org/citrusframework/functions/DefaultFunctionLibrary.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/functions/DefaultFunctionLibrary.java
@@ -16,6 +16,7 @@
 
 package org.citrusframework.functions;
 
+import org.citrusframework.CitrusSettings;
 import org.citrusframework.functions.core.AbsoluteFunction;
 import org.citrusframework.functions.core.AdvancedRandomNumberFunction;
 import org.citrusframework.functions.core.AvgFunction;
@@ -65,41 +66,41 @@ public class DefaultFunctionLibrary extends FunctionLibrary {
     public DefaultFunctionLibrary() {
         setName("citrusFunctionLibrary");
 
-        getMembers().put("randomNumber", new RandomNumberFunction());
-        getMembers().put("randomNumberGenerator", new AdvancedRandomNumberFunction());
-        getMembers().put("randomString", new RandomStringFunction());
-        getMembers().put("randomPattern", new RandomPatternFunction());
-        getMembers().put("concat", new ConcatFunction());
-        getMembers().put("currentDate", new CurrentDateFunction());
-        getMembers().put("substring", new SubstringFunction());
-        getMembers().put("stringLength", new StringLengthFunction());
-        getMembers().put("translate", new TranslateFunction());
-        getMembers().put("substringBefore", new SubstringBeforeFunction());
-        getMembers().put("substringAfter", new SubstringAfterFunction());
-        getMembers().put("round", new RoundFunction());
-        getMembers().put("floor", new FloorFunction());
-        getMembers().put("ceiling", new CeilingFunction());
-        getMembers().put("upperCase", new UpperCaseFunction());
-        getMembers().put("lowerCase", new LowerCaseFunction());
-        getMembers().put("average", new AvgFunction());
-        getMembers().put("minimum", new MinFunction());
-        getMembers().put("maximum", new MaxFunction());
-        getMembers().put("sum", new SumFunction());
-        getMembers().put("absolute", new AbsoluteFunction());
-        getMembers().put("randomEnumValue", new RandomEnumValueFunction());
-        getMembers().put("randomUUID", new RandomUUIDFunction());
-        getMembers().put("encodeBase64", new EncodeBase64Function());
-        getMembers().put("decodeBase64", new DecodeBase64Function());
-        getMembers().put("urlEncode", new UrlEncodeFunction());
-        getMembers().put("urlDecode", new UrlDecodeFunction());
-        getMembers().put("digestAuthHeader", new DigestAuthHeaderFunction());
-        getMembers().put("localHostAddress", new LocalHostAddressFunction());
-        getMembers().put("changeDate", new ChangeDateFunction());
-        getMembers().put("readFile", new ReadFileResourceFunction());
-        getMembers().put("message", new LoadMessageFunction());
-        getMembers().put("systemProperty", new SystemPropertyFunction());
-        getMembers().put("unixTimestamp", new UnixTimestampFunction());
-        getMembers().put("escapeJson", new EscapeJsonFunction());
+        addMember("randomNumber", new RandomNumberFunction());
+        addMember("randomNumberGenerator", new AdvancedRandomNumberFunction());
+        addMember("randomString", new RandomStringFunction());
+        addMember("randomPattern", new RandomPatternFunction());
+        addMember("concat", new ConcatFunction());
+        addMember("currentDate", new CurrentDateFunction());
+        addMember("substring", new SubstringFunction());
+        addMember("stringLength", new StringLengthFunction());
+        addMember("translate", new TranslateFunction());
+        addMember("substringBefore", new SubstringBeforeFunction());
+        addMember("substringAfter", new SubstringAfterFunction());
+        addMember("round", new RoundFunction());
+        addMember("floor", new FloorFunction());
+        addMember("ceiling", new CeilingFunction());
+        addMember("upperCase", new UpperCaseFunction());
+        addMember("lowerCase", new LowerCaseFunction());
+        addMember("average", new AvgFunction());
+        addMember("minimum", new MinFunction());
+        addMember("maximum", new MaxFunction());
+        addMember("sum", new SumFunction());
+        addMember("absolute", new AbsoluteFunction());
+        addMember("randomEnumValue", new RandomEnumValueFunction());
+        addMember("randomUUID", new RandomUUIDFunction());
+        addMember("encodeBase64", new EncodeBase64Function());
+        addMember("decodeBase64", new DecodeBase64Function());
+        addMember("urlEncode", new UrlEncodeFunction());
+        addMember("urlDecode", new UrlDecodeFunction());
+        addMember("digestAuthHeader", new DigestAuthHeaderFunction());
+        addMember("localHostAddress", new LocalHostAddressFunction());
+        addMember("changeDate", new ChangeDateFunction());
+        addMember("readFile", new ReadFileResourceFunction());
+        addMember("message", new LoadMessageFunction());
+        addMember("systemProperty", new SystemPropertyFunction());
+        addMember("unixTimestamp", new UnixTimestampFunction());
+        addMember("escapeJson", new EscapeJsonFunction());
 
         lookupFunctions();
     }
@@ -108,8 +109,14 @@ public class DefaultFunctionLibrary extends FunctionLibrary {
      * Add custom function implementations loaded from resource path lookup.
      */
     private void lookupFunctions() {
+        boolean allowOverride = CitrusSettings.isAllowFunctionOverride();
+
         Function.lookup().forEach((k, m) -> {
-            getMembers().put(k, m);
+            if (allowOverride) {
+                getMembers().put(k, m);
+            } else {
+                addMember(k, m);
+            }
             logger.debug("Register function '{}' as {}", k, m.getClass());
         });
     }

--- a/core/citrus-base/src/main/java/org/citrusframework/validation/matcher/DefaultValidationMatcherLibrary.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/validation/matcher/DefaultValidationMatcherLibrary.java
@@ -16,6 +16,7 @@
 
 package org.citrusframework.validation.matcher;
 
+import org.citrusframework.CitrusSettings;
 import org.citrusframework.validation.matcher.core.ContainsIgnoreCaseValidationMatcher;
 import org.citrusframework.validation.matcher.core.ContainsValidationMatcher;
 import org.citrusframework.validation.matcher.core.CreateVariableValidationMatcher;
@@ -55,29 +56,29 @@ public class DefaultValidationMatcherLibrary extends ValidationMatcherLibrary {
     public DefaultValidationMatcherLibrary() {
         setName("citrusValidationMatcherLibrary");
 
-        getMembers().put("equalsIgnoreCase", new EqualsIgnoreCaseValidationMatcher());
-        getMembers().put("ignoreNewLine", new IgnoreNewLineValidationMatcher());
-        getMembers().put("trim", new TrimValidationMatcher());
-        getMembers().put("trimAllWhitespaces", new TrimAllWhitespacesValidationMatcher());
-        getMembers().put("contains", new ContainsValidationMatcher());
-        getMembers().put("containsIgnoreCase", new ContainsIgnoreCaseValidationMatcher());
-        getMembers().put("greaterThan", new GreaterThanValidationMatcher());
-        getMembers().put("lowerThan", new LowerThanValidationMatcher());
-        getMembers().put("startsWith", new StartsWithValidationMatcher());
-        getMembers().put("endsWith", new EndsWithValidationMatcher());
-        getMembers().put("isNumber", new IsNumberValidationMatcher());
-        getMembers().put("matches", new MatchesValidationMatcher());
-        getMembers().put("matchesDatePattern", new DatePatternValidationMatcher());
-        getMembers().put("isWeekday", new WeekdayValidationMatcher());
-        getMembers().put("variable", new CreateVariableValidationMatcher());
-        getMembers().put("dateRange", new DateRangeValidationMatcher());
-        getMembers().put("empty", new EmptyValidationMatcher());
-        getMembers().put("notEmpty", new NotEmptyValidationMatcher());
-        getMembers().put("null", new NullValidationMatcher());
-        getMembers().put("notNull", new NotNullValidationMatcher());
-        getMembers().put("ignore", new IgnoreValidationMatcher());
-        getMembers().put("hasLength", new StringLengthValidationMatcher());
-        getMembers().put("isUUIDv4", new UuidV4ValidationMatcher());
+        addMember("equalsIgnoreCase", new EqualsIgnoreCaseValidationMatcher());
+        addMember("ignoreNewLine", new IgnoreNewLineValidationMatcher());
+        addMember("trim", new TrimValidationMatcher());
+        addMember("trimAllWhitespaces", new TrimAllWhitespacesValidationMatcher());
+        addMember("contains", new ContainsValidationMatcher());
+        addMember("containsIgnoreCase", new ContainsIgnoreCaseValidationMatcher());
+        addMember("greaterThan", new GreaterThanValidationMatcher());
+        addMember("lowerThan", new LowerThanValidationMatcher());
+        addMember("startsWith", new StartsWithValidationMatcher());
+        addMember("endsWith", new EndsWithValidationMatcher());
+        addMember("isNumber", new IsNumberValidationMatcher());
+        addMember("matches", new MatchesValidationMatcher());
+        addMember("matchesDatePattern", new DatePatternValidationMatcher());
+        addMember("isWeekday", new WeekdayValidationMatcher());
+        addMember("variable", new CreateVariableValidationMatcher());
+        addMember("dateRange", new DateRangeValidationMatcher());
+        addMember("empty", new EmptyValidationMatcher());
+        addMember("notEmpty", new NotEmptyValidationMatcher());
+        addMember("null", new NullValidationMatcher());
+        addMember("notNull", new NotNullValidationMatcher());
+        addMember("ignore", new IgnoreValidationMatcher());
+        addMember("hasLength", new StringLengthValidationMatcher());
+        addMember("isUUIDv4", new UuidV4ValidationMatcher());
 
         lookupValidationMatchers();
     }
@@ -86,9 +87,16 @@ public class DefaultValidationMatcherLibrary extends ValidationMatcherLibrary {
      * Add custom matcher implementations loaded from resource path lookup.
      */
     private void lookupValidationMatchers() {
+        boolean allowOverride = CitrusSettings.isAllowValidationMatcherOverride();
+
         ValidationMatcher.lookup().forEach((k, m) -> {
-            getMembers().put(k, m);
-            logger.debug("Register message matcher '{}' as {}", k, m.getClass());
+            if (allowOverride) {
+                getMembers().put(k, m);
+            } else {
+                addMember(k, m);
+            }
+
+            logger.debug("Register validation matcher '{}' as {}", k, m.getClass());
         });
     }
 }

--- a/core/citrus-spring/src/main/java/org/citrusframework/validation/matcher/DefaultValidationMatcherLibraryFactory.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/validation/matcher/DefaultValidationMatcherLibraryFactory.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.citrusframework.functions;
+package org.citrusframework.validation.matcher;
 
 import org.citrusframework.CitrusSettings;
 import org.springframework.beans.BeansException;
@@ -24,15 +24,15 @@ import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.EnvironmentAware;
 import org.springframework.core.env.Environment;
 
-public class DefaultFunctionLibraryFactory implements FactoryBean<DefaultFunctionLibrary>, ApplicationContextAware, EnvironmentAware {
+public class DefaultValidationMatcherLibraryFactory implements FactoryBean<DefaultValidationMatcherLibrary>, ApplicationContextAware, EnvironmentAware {
 
     private ApplicationContext applicationContext;
     private Environment environment;
 
-    private final DefaultFunctionLibrary library = new DefaultFunctionLibrary();
+    private final DefaultValidationMatcherLibrary library = new DefaultValidationMatcherLibrary();
 
     @Override
-    public DefaultFunctionLibrary getObject() {
+    public DefaultValidationMatcherLibrary getObject() {
         library.getMembers().forEach((key, member) -> {
             if (member instanceof ApplicationContextAware applicationContextAware) {
                 applicationContextAware.setApplicationContext(applicationContext);
@@ -43,8 +43,8 @@ public class DefaultFunctionLibraryFactory implements FactoryBean<DefaultFunctio
             }
         });
 
-        boolean allowOverride = CitrusSettings.isAllowFunctionOverride();
-        applicationContext.getBeansOfType(Function.class)
+        boolean allowOverride = CitrusSettings.isAllowValidationMatcherOverride();
+        applicationContext.getBeansOfType(ValidationMatcher.class)
                 .forEach((key, value) -> {
                     if (allowOverride) {
                         library.getMembers().put(key, value);
@@ -58,7 +58,7 @@ public class DefaultFunctionLibraryFactory implements FactoryBean<DefaultFunctio
 
     @Override
     public Class<?> getObjectType() {
-        return DefaultFunctionLibrary.class;
+        return DefaultValidationMatcherLibrary.class;
     }
 
     @Override

--- a/core/citrus-spring/src/main/java/org/citrusframework/validation/matcher/ValidationMatcherConfig.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/validation/matcher/ValidationMatcherConfig.java
@@ -25,15 +25,13 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class ValidationMatcherConfig {
 
-    private ValidationMatcherLibrary validationMatcherLibrary = new DefaultValidationMatcherLibrary();
-
     @Bean(name = "citrusValidationMatcherRegistry")
     public ValidationMatcherRegistryFactory validationMatcherRegistry() {
         return new ValidationMatcherRegistryFactory();
     }
 
     @Bean(name = "citrusValidationMatcherLibrary")
-    public ValidationMatcherLibrary validationMatcherLibrary() {
-        return validationMatcherLibrary;
+    public DefaultValidationMatcherLibraryFactory validationMatcherLibrary() {
+        return new DefaultValidationMatcherLibraryFactory();
     }
 }


### PR DESCRIPTION
## Summary
- The default `FunctionLibrary` and `ValidationMatcherLibrary` now support injection of individual `Function` and `ValidationMatcher` beans via `@BindToRegistry` (and Spring `@Bean` configuration)
- Adds `addMember()` methods with duplicate detection to prevent silent overwrites of built-in functions/matchers
- Introduces configurable override settings (`citrus.allow.function.override` / `citrus.allow.validation.matcher.override`) to control override behavior
- Creates `DefaultValidationMatcherLibraryFactory` mirroring the existing `DefaultFunctionLibraryFactory` pattern

Fixes #1578

## Test plan
- [x] Verify `core/citrus-api` builds: `./mvnw clean install -pl core/citrus-api -DskipTests`
- [x] Verify `core/citrus-base` builds: `./mvnw clean install -pl core/citrus-base -am`
- [x] Verify `core/citrus-spring` builds: `./mvnw clean install -pl core/citrus-spring -am`
- [x] Run existing function and validation matcher tests
- [x] Verify duplicate detection throws when override is disabled
- [x] Verify override settings allow replacing built-in functions/matchers when enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)