### PR TITLE
fix(#1583): Support JBang command arguments via system property or envVars

### DIFF
--- a/connectors/citrus-jbang-connector/src/main/java/org/citrusframework/jbang/JBangSettings.java
+++ b/connectors/citrus-jbang-connector/src/main/java/org/citrusframework/jbang/JBangSettings.java
@@ -20,7 +20,10 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public final class JBangSettings {
@@ -58,6 +61,9 @@ public final class JBangSettings {
     private static final String APP_PROPERTY = JBANG_PROPERTY_PREFIX + "app";
     private static final String APP_ENV = JBANG_ENV_PREFIX + "APP";
     private static final String APP_DEFAULT = "citrus@citrusframework/citrus";
+
+    private static final String ARGS_PROPERTY = JBANG_PROPERTY_PREFIX + "args";
+    private static final String ARGS_ENV = JBANG_ENV_PREFIX + "ARGS";
 
     private static final String JBANG_EXECUTABLE_PROPERTY = JBANG_PROPERTY_PREFIX + "executable";
     private static final String JBANG_EXECUTABLE_ENV = JBANG_ENV_PREFIX + "EXECUTABLE";
@@ -157,5 +163,65 @@ public final class JBangSettings {
         return Optional.ofNullable(System.getenv(JBANG_LAUNCH_CMD))
                 .or(() -> Optional.ofNullable(System.getProperty(JBANG_EXECUTABLE_PROPERTY, System.getenv(JBANG_EXECUTABLE_ENV))))
                 .orElse(JBANG_EXECUTABLE_DEFAULT);
+    }
+
+    /**
+     * JBang command arguments resolved from system property or environment variable.
+     * Arguments are specified as comma-delimited key=value pairs. Repeated argument names
+     * are merged into a single argument with comma-separated values.
+     */
+    public static List<String> getArgs() {
+        return parseArgs(System.getProperty(ARGS_PROPERTY, System.getenv(ARGS_ENV)));
+    }
+
+    /**
+     * Parses comma-delimited key=value argument pairs into a list of JBang command arguments.
+     * Adds the "--" prefix to argument names when not already present.
+     * Merges repeated argument names into a single "--arg=value1,value2" argument.
+     * Empty values produce flag-only arguments (e.g., "fresh=" becomes "--fresh").
+     */
+    static List<String> parseArgs(String argsValue) {
+        if (argsValue == null || argsValue.isBlank()) {
+            return Collections.emptyList();
+        }
+
+        LinkedHashMap<String, List<String>> argMap = new LinkedHashMap<>();
+        for (String part : argsValue.split(",")) {
+            String trimmed = part.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+
+            int eqIndex = trimmed.indexOf('=');
+            String name;
+            String value;
+            if (eqIndex >= 0) {
+                name = trimmed.substring(0, eqIndex).trim();
+                value = trimmed.substring(eqIndex + 1).trim();
+            } else {
+                name = trimmed;
+                value = "";
+            }
+
+            if (!name.startsWith("--")) {
+                name = "--" + name;
+            }
+
+            argMap.computeIfAbsent(name, k -> new ArrayList<>());
+            if (!value.isEmpty()) {
+                argMap.get(name).add(value);
+            }
+        }
+
+        List<String> result = new ArrayList<>();
+        for (Map.Entry<String, List<String>> entry : argMap.entrySet()) {
+            if (entry.getValue().isEmpty()) {
+                result.add(entry.getKey());
+            } else {
+                result.add(entry.getKey() + "=" + String.join(",", entry.getValue()));
+            }
+        }
+
+        return result;
     }
 }

--- a/connectors/citrus-jbang-connector/src/main/java/org/citrusframework/jbang/JBangSupport.java
+++ b/connectors/citrus-jbang-connector/src/main/java/org/citrusframework/jbang/JBangSupport.java
@@ -246,7 +246,8 @@ public class JBangSupport {
     private List<String> constructAllArgs(String command, List<String> args) {
         List<String> allArgs = new ArrayList<>();
 
-        // JBang app name
+        allArgs.addAll(JBangSettings.getArgs());
+
         if (app != null) {
             allArgs.add(app);
         }

--- a/connectors/citrus-jbang-connector/src/test/java/org/citrusframework/jbang/JBangSettingsTest.java
+++ b/connectors/citrus-jbang-connector/src/test/java/org/citrusframework/jbang/JBangSettingsTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.jbang;
+
+import java.util.List;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class JBangSettingsTest {
+
+    @Test
+    public void shouldReturnEmptyListForNullInput() {
+        Assert.assertTrue(JBangSettings.parseArgs(null).isEmpty());
+    }
+
+    @Test
+    public void shouldReturnEmptyListForEmptyInput() {
+        Assert.assertTrue(JBangSettings.parseArgs("").isEmpty());
+    }
+
+    @Test
+    public void shouldReturnEmptyListForBlankInput() {
+        Assert.assertTrue(JBangSettings.parseArgs("   ").isEmpty());
+    }
+
+    @Test
+    public void shouldParseSingleArgWithValue() {
+        List<String> result = JBangSettings.parseArgs("deps=org.foo:bar:1.0");
+        Assert.assertEquals(result, List.of("--deps=org.foo:bar:1.0"));
+    }
+
+    @Test
+    public void shouldParseMultipleArgs() {
+        List<String> result = JBangSettings.parseArgs("deps=org.foo:bar:1.0,fresh=");
+        Assert.assertEquals(result, List.of("--deps=org.foo:bar:1.0", "--fresh"));
+    }
+
+    @Test
+    public void shouldMergeRepeatedArgNames() {
+        List<String> result = JBangSettings.parseArgs("deps=org.foo:bar:1.0,deps=org.baz:qux:2.0");
+        Assert.assertEquals(result, List.of("--deps=org.foo:bar:1.0,org.baz:qux:2.0"));
+    }
+
+    @Test
+    public void shouldHandleEmptyValueAsFlag() {
+        List<String> result = JBangSettings.parseArgs("fresh=");
+        Assert.assertEquals(result, List.of("--fresh"));
+    }
+
+    @Test
+    public void shouldHandleArgWithoutEqualsAsFlag() {
+        List<String> result = JBangSettings.parseArgs("fresh");
+        Assert.assertEquals(result, List.of("--fresh"));
+    }
+
+    @Test
+    public void shouldNotAddDoubleDashPrefix() {
+        List<String> result = JBangSettings.parseArgs("--deps=org.foo:bar:1.0");
+        Assert.assertEquals(result, List.of("--deps=org.foo:bar:1.0"));
+    }
+
+    @Test
+    public void shouldHandleFullExampleFromIssue() {
+        List<String> result = JBangSettings.parseArgs("deps=org.foo:bar:1.0,deps=org.baz:qux:2.0,fresh=");
+        Assert.assertEquals(result, List.of("--deps=org.foo:bar:1.0,org.baz:qux:2.0", "--fresh"));
+    }
+
+    @Test
+    public void shouldPreserveArgOrder() {
+        List<String> result = JBangSettings.parseArgs("fresh=,deps=org.foo:bar:1.0,verbose=");
+        Assert.assertEquals(result, List.of("--fresh", "--deps=org.foo:bar:1.0", "--verbose"));
+    }
+
+    @Test
+    public void shouldTrimWhitespace() {
+        List<String> result = JBangSettings.parseArgs(" deps = org.foo:bar:1.0 , fresh = ");
+        Assert.assertEquals(result, List.of("--deps=org.foo:bar:1.0", "--fresh"));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `citrus.jbang.args` system property / `CITRUS_JBANG_ARGS` environment variable to `JBangSettings` for specifying arbitrary JBang CLI arguments (e.g. `--deps`, `--fresh`)
- Arguments are parsed from comma-delimited `key=value` format with automatic `--` prefix and repeated-key merging (e.g. `deps=org.foo:bar:1.0,deps=org.baz:qux:2.0` → `--deps=org.foo:bar:1.0,org.baz:qux:2.0`)
- Resolved arguments are prepended to the JBang command invocation in `JBangSupport`

Fixes #1583

## Test plan

- [x] Unit tests for `JBangSettings.parseArgs()` covering: null/empty/blank input, single arg, multiple args, repeated arg merging, flag-only args, `--` prefix handling, ordering, whitespace trimming

Generated with [Claude Code](https://claude.ai/code)