### PR TITLE
fix(#1581): Fix misleading log output when waitForRunningState is false

### DIFF
--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelRunIntegrationAction.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelRunIntegrationAction.java
@@ -145,14 +145,15 @@ public class CamelRunIntegrationAction extends AbstractCamelJBangAction {
                         .integration(name));
             }
 
-            logger.info("Waiting for the Camel integration '%s' (%s) to be running ...".formatted(name, pid));
-
             if (waitForRunningState) {
+                logger.info("Waiting for the Camel integration '%s' (%s) to be running ...".formatted(name, pid));
                 new CamelVerifyIntegrationAction.Builder()
                         .integrationName(name)
                         .isRunning()
                         .build()
                         .execute(context);
+            } else {
+                logger.info("Started Camel integration '%s' (%s) — not waiting for running state".formatted(name, pid));
             }
         } catch (IOException e) {
             throw new CitrusRuntimeException("Failed to create temporary file from Camel integration source", e);


### PR DESCRIPTION
## Summary

- Moves the "Waiting for the Camel integration to be running" log message inside the `waitForRunningState` conditional so it only appears when the action actually waits
- Adds a distinct log message when `waitForRunningState` is `false`: "Started Camel integration — not waiting for running state"

Fixes #1581

## Test plan

- [x] Module builds successfully (`mvn -DskipTests install` in `endpoints/citrus-camel`)
- [x] Full reactor build passes (`mvn clean install -DskipTests`)
- [x] Manual verification: run a Camel integration with `waitForRunningState: false` and confirm the new log message appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)