### PR TITLE
fix(#1586): Redesign logging concept for clearer test workflow output

### DIFF
--- a/connectors/citrus-agent-connector/src/main/java/org/citrusframework/agent/connector/actions/AgentConnectAction.java
+++ b/connectors/citrus-agent-connector/src/main/java/org/citrusframework/agent/connector/actions/AgentConnectAction.java
@@ -42,7 +42,7 @@ public class AgentConnectAction extends AbstractAgentAction {
     @Override
     public void doExecute(TestContext context) {
         String agent = context.replaceDynamicContentInString(agentName);
-        logger.info("Connecting to Citrus agent '%s'".formatted(agent));
+        logger.debug("Connecting to Citrus agent '%s'".formatted(agent));
 
         String clientName = agent + ".client";
         HttpClient httpClient = resolveHttpClient(clientName, context);

--- a/connectors/citrus-agent-connector/src/main/java/org/citrusframework/agent/connector/actions/AgentRunAction.java
+++ b/connectors/citrus-agent-connector/src/main/java/org/citrusframework/agent/connector/actions/AgentRunAction.java
@@ -147,7 +147,7 @@ public class AgentRunAction extends AbstractAgentAction {
                     "but was %d %s").formatted(response.getStatusCode().value(), response.getReasonPhrase()));
         }
 
-        logger.info("Verify Citrus agent response:%n%s".formatted(response.getPayload(String.class)));
+        logger.debug("Verify Citrus agent response:%n%s".formatted(response.getPayload(String.class)));
 
         JsonPathMessageValidator validator = new JsonPathMessageValidator();
         JsonPathMessageValidationContext validationContext = new JsonPathMessageValidationContext();

--- a/connectors/citrus-agent-connector/src/test/resources/log4j2.properties
+++ b/connectors/citrus-agent-connector/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/connectors/citrus-docker/src/main/java/org/citrusframework/docker/actions/DockerExecuteAction.java
+++ b/connectors/citrus-docker/src/main/java/org/citrusframework/docker/actions/DockerExecuteAction.java
@@ -109,7 +109,7 @@ public class DockerExecuteAction extends AbstractTestAction {
 
             validateCommandResult(command, context);
 
-            logger.info("Docker command execution successful: '{}'", command.getName());
+            logger.debug("Docker command execution successful: '{}'", command.getName());
         } catch (CitrusRuntimeException e) {
             throw e;
         } catch (Exception e) {

--- a/connectors/citrus-docker/src/main/java/org/citrusframework/docker/client/DockerClient.java
+++ b/connectors/citrus-docker/src/main/java/org/citrusframework/docker/client/DockerClient.java
@@ -80,7 +80,7 @@ public class DockerClient extends AbstractEndpoint implements Producer, ReplyCon
         DockerCommand command = message.getPayload(DockerCommand.class);
         command.execute(this, context);
 
-        logger.info("Docker request was sent to endpoint: '{}'", getEndpointConfiguration().getDockerClientConfig().getDockerHost());
+        logger.debug("Docker request was sent to endpoint: '{}'", getEndpointConfiguration().getDockerClientConfig().getDockerHost());
 
         correlationManager.store(correlationKey, command);
 

--- a/connectors/citrus-docker/src/test/resources/log4j2.properties
+++ b/connectors/citrus-docker/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/connectors/citrus-jbang-connector/src/main/java/org/citrusframework/jbang/actions/JBangAction.java
+++ b/connectors/citrus-jbang-connector/src/main/java/org/citrusframework/jbang/actions/JBangAction.java
@@ -76,7 +76,7 @@ public class JBangAction extends AbstractTestAction {
     @Override
     public void doExecute(TestContext context) {
         String scriptName = FileUtils.getFileName(context.replaceDynamicContentInString(scriptOrFile));
-        logger.info("Running JBang script '%s'".formatted(scriptName));
+        logger.debug("Running JBang script '%s'".formatted(scriptName));
 
         ProcessAndOutput result = JBangSupport.jbang()
                 .app(app)

--- a/connectors/citrus-jbang-connector/src/test/resources/log4j2.properties
+++ b/connectors/citrus-jbang-connector/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/connectors/citrus-knative/src/main/java/org/citrusframework/knative/actions/eventing/CreateBrokerAction.java
+++ b/connectors/citrus-knative/src/main/java/org/citrusframework/knative/actions/eventing/CreateBrokerAction.java
@@ -56,7 +56,7 @@ public class CreateBrokerAction extends AbstractKnativeAction {
     private void createLocalBroker(TestContext context) {
         String resolvedBrokerName = context.replaceDynamicContentInString(brokerName);
 
-        logger.info("Creating local Knative broker: {}", resolvedBrokerName);
+        logger.debug("Creating local Knative broker: {}", resolvedBrokerName);
 
         HttpServer brokerServer;
         if (!context.getReferenceResolver().isResolvable(resolvedBrokerName, HttpServer.class)) {
@@ -86,7 +86,7 @@ public class CreateBrokerAction extends AbstractKnativeAction {
         String resolvedBrokerName = context.replaceDynamicContentInString(brokerName);
         String brokerNamespace = namespace(context);
 
-        logger.info("Creating Knative broker '{}' in namespace {}", resolvedBrokerName, brokerNamespace);
+        logger.debug("Creating Knative broker '{}' in namespace {}", resolvedBrokerName, brokerNamespace);
 
         Broker broker = new BrokerBuilder()
                 .withApiVersion(String.format("%s/%s", KnativeSupport.knativeEventingGroup(), KnativeSupport.knativeApiVersion()))

--- a/connectors/citrus-knative/src/main/java/org/citrusframework/knative/actions/eventing/VerifyBrokerAction.java
+++ b/connectors/citrus-knative/src/main/java/org/citrusframework/knative/actions/eventing/VerifyBrokerAction.java
@@ -56,7 +56,7 @@ public class VerifyBrokerAction extends AbstractKnativeAction {
             throw new ValidationException(String.format("Knative broker '%s' is not ready", brokerName));
         }
 
-        logger.info("Knative broker {} is ready", brokerName);
+        logger.debug("Knative broker {} is ready", brokerName);
     }
 
     private void verifyBroker(TestContext context) {
@@ -71,7 +71,7 @@ public class VerifyBrokerAction extends AbstractKnativeAction {
                     broker.getStatus().getConditions().stream()
                             .anyMatch(condition -> condition.getType().equals("Ready") &&
                                     condition.getStatus().equalsIgnoreCase("True"))) {
-                logger.info("Knative broker {} is ready", brokerName);
+                logger.debug("Knative broker {} is ready", brokerName);
             } else {
                 throw new ValidationException(String.format("Knative broker '%s' is not ready", brokerName));
             }

--- a/connectors/citrus-knative/src/test/resources/log4j2.properties
+++ b/connectors/citrus-knative/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/actions/AgentConnectAction.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/actions/AgentConnectAction.java
@@ -91,7 +91,7 @@ public class AgentConnectAction extends ServiceConnectAction {
     @Override
     public void doExecute(TestContext context) {
         String agent = context.replaceDynamicContentInString(agentName);
-        logger.info("Creating Kubernetes agent '{}'", agent);
+        logger.debug("Creating Kubernetes agent '{}'", agent);
 
         Path testJarPath = null;
         if (testJar != null) {
@@ -111,7 +111,7 @@ public class AgentConnectAction extends ServiceConnectAction {
                         .inNamespace(namespace(context))
                         .create();
             } else {
-                logger.info("Connecting to Kubernetes agent '{}' in namespace {}", agent, namespace(context));
+                logger.debug("Connecting to Kubernetes agent '{}' in namespace {}", agent, namespace(context));
             }
 
             if (autoCreate && isAutoRemoveResources()) {
@@ -135,7 +135,7 @@ public class AgentConnectAction extends ServiceConnectAction {
             jbang.agent().start();
         }
 
-        logger.info("Citrus agent service '{}' created successfully", agent);
+        logger.debug("Citrus agent service '{}' created successfully", agent);
         super.doExecute(context);
 
         if (waitForRunningState) {

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/actions/AgentDisconnectAction.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/actions/AgentDisconnectAction.java
@@ -46,7 +46,7 @@ public class AgentDisconnectAction extends ServiceDisconnectAction {
 
     @Override
     public void doExecute(TestContext context) {
-        logger.info("Disconnect from Kubernetes agent '{}'", agentName);
+        logger.debug("Disconnect from Kubernetes agent '{}'", agentName);
 
         if (KubernetesSupport.isConnected(context)) {
             getKubernetesClient().resourceList(getAgentManifest())

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/actions/KubernetesDisconnectAction.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/actions/KubernetesDisconnectAction.java
@@ -35,11 +35,11 @@ public class KubernetesDisconnectAction extends AbstractKubernetesAction impleme
             return;
         }
 
-        logger.info("Disconnect from Kubernetes cluster");
+        logger.debug("Disconnect from Kubernetes cluster");
         context.setVariable(KubernetesVariableNames.CONNECTED.value(), false);
 
         if (isAutoRemoveResources()) {
-            logger.info("Remove resources from Kubernetes cluster");
+            logger.debug("Remove resources from Kubernetes cluster");
         }
     }
 

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/actions/ServiceConnectAction.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/actions/ServiceConnectAction.java
@@ -69,13 +69,13 @@ public class ServiceConnectAction extends AbstractKubernetesAction {
 
         LocalPortForward portForward;
         if (StringUtils.hasText(localPort)) {
-            logger.info("Using local port {} for Kubernetes service {}", localPort, serviceName);
+            logger.debug("Using local port {} for Kubernetes service {}", localPort, serviceName);
             portForward = getKubernetesClient().services()
                     .inNamespace(namespace(context))
                     .withName(serviceName)
                     .portForward(Integer.parseInt(context.replaceDynamicContentInString(port)), Integer.parseInt(context.replaceDynamicContentInString(localPort)));
         } else {
-            logger.info("Using random local port for Kubernetes service {}", serviceName);
+            logger.debug("Using random local port for Kubernetes service {}", serviceName);
             portForward = getKubernetesClient().services()
                     .inNamespace(namespace(context))
                     .withName(serviceName)

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/actions/ServiceDisconnectAction.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/actions/ServiceDisconnectAction.java
@@ -48,7 +48,7 @@ public class ServiceDisconnectAction extends AbstractKubernetesAction {
             return;
         }
 
-        logger.info("Disconnect from Kubernetes service '{}'", serviceName);
+        logger.debug("Disconnect from Kubernetes service '{}'", serviceName);
 
         if (context.getReferenceResolver().isResolvable(serviceName + ":port-forward", LocalPortForward.class)) {
             LocalPortForward portForward = context.getReferenceResolver().resolve(serviceName + ":port-forward", LocalPortForward.class);

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/actions/VerifyPodAction.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/actions/VerifyPodAction.java
@@ -99,7 +99,7 @@ public class VerifyPodAction extends AbstractKubernetesAction {
             }
 
             if (!printLogs) {
-                logger.info("Waiting for pod '{}' to log message - retry in {} ms", nameOrLabel, delayBetweenAttempts);
+                logger.debug("Waiting for pod '{}' to log message - retry in {} ms", nameOrLabel, delayBetweenAttempts);
             }
 
             try {
@@ -141,9 +141,9 @@ public class VerifyPodAction extends AbstractKubernetesAction {
      */
     private Pod verifyPod(String name, String labelExpression, String phase, String namespace) {
         if (StringUtils.hasText(name)) {
-            POD_STATUS_LOG.info("Waiting for pod '{}' to be in state '{}'", name, phase);
+            POD_STATUS_LOG.debug("Waiting for pod '{}' to be in state '{}'", name, phase);
         } else {
-            POD_STATUS_LOG.info("Waiting for pod with label '{}' to be in state '{}'", labelExpression, phase);
+            POD_STATUS_LOG.debug("Waiting for pod with label '{}' to be in state '{}'", labelExpression, phase);
         }
 
         for (int i = 0; i < maxAttempts; i++) {
@@ -155,11 +155,11 @@ public class VerifyPodAction extends AbstractKubernetesAction {
             }
 
             if (pod != null) {
-                logger.info("Verified pod '{}' state '{}'!", getNameOrLabel(name, labelExpression), phase);
+                logger.debug("Verified pod '{}' state '{}'!", getNameOrLabel(name, labelExpression), phase);
                 return pod;
             }
 
-            logger.info("Waiting for pod '{}' in state '{}' - retry in {} ms", getNameOrLabel(name, labelExpression), phase, delayBetweenAttempts);
+            logger.debug("Waiting for pod '{}' in state '{}' - retry in {} ms", getNameOrLabel(name, labelExpression), phase, delayBetweenAttempts);
             try {
                 Thread.sleep(delayBetweenAttempts);
             } catch (InterruptedException e) {
@@ -184,7 +184,7 @@ public class VerifyPodAction extends AbstractKubernetesAction {
         boolean verified = KubernetesSupport.verifyPodStatus(pod, phase);
 
         if (!verified) {
-            POD_STATUS_LOG.info("Pod '{}' not yet in state '{}'. Will keep checking ...", name, phase);
+            POD_STATUS_LOG.debug("Pod '{}' not yet in state '{}'. Will keep checking ...", name, phase);
         }
 
         return verified ? pod : null;
@@ -208,7 +208,7 @@ public class VerifyPodAction extends AbstractKubernetesAction {
                 .list();
 
         if (pods.getItems().isEmpty()) {
-            POD_STATUS_LOG.info("Integration with label '{}' not yet available. Will keep checking ...", labelExpression);
+            POD_STATUS_LOG.debug("Integration with label '{}' not yet available. Will keep checking ...", labelExpression);
         }
 
         return pods.getItems().stream()
@@ -216,7 +216,7 @@ public class VerifyPodAction extends AbstractKubernetesAction {
                     boolean verified = KubernetesSupport.verifyPodStatus(pod, phase);
 
                     if (!verified) {
-                        POD_STATUS_LOG.info("Pod with label '{}' not yet in state '{}'. Will keep checking ...", labelExpression, phase);
+                        POD_STATUS_LOG.debug("Pod with label '{}' not yet in state '{}'. Will keep checking ...", labelExpression, phase);
                     }
 
                     return verified;

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/client/KubernetesClient.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/client/KubernetesClient.java
@@ -76,7 +76,7 @@ public class KubernetesClient extends AbstractEndpoint implements Producer, Repl
         KubernetesCommand<?, ?> command = getEndpointConfiguration().getMessageConverter().convertOutbound(message, getEndpointConfiguration(), context);
         command.execute(this, context);
 
-        logger.info("Kubernetes request was sent to endpoint: '{}'", getEndpointConfiguration().getKubernetesClientConfig().getMasterUrl());
+        logger.debug("Kubernetes request was sent to endpoint: '{}'", getEndpointConfiguration().getKubernetesClientConfig().getMasterUrl());
 
         correlationManager.store(correlationKey, command);
     }

--- a/connectors/citrus-kubernetes/src/test/resources/log4j2.properties
+++ b/connectors/citrus-kubernetes/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/connectors/citrus-openapi/src/test/resources/log4j2.properties
+++ b/connectors/citrus-openapi/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/actions/AbstractSeleniumAction.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/actions/AbstractSeleniumAction.java
@@ -64,7 +64,7 @@ public abstract class AbstractSeleniumAction extends AbstractTestAction implemen
 
         execute(browserToUse, context);
 
-        logger.info("Selenium browser command execution successful: '{}'", getName());
+        logger.debug("Selenium browser command execution successful: '{}'", getName());
     }
 
     protected abstract void execute(SeleniumBrowser browser, TestContext context);

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/actions/AlertAction.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/actions/AlertAction.java
@@ -63,7 +63,7 @@ public class AlertAction extends AbstractSeleniumAction {
         }
 
         if (StringUtils.hasText(text)) {
-            logger.info("Validating alert text");
+            logger.debug("Validating alert text");
 
             String alertText = context.replaceDynamicContentInString(text);
 

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/actions/CloseWindowAction.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/actions/CloseWindowAction.java
@@ -59,13 +59,13 @@ public class CloseWindowAction extends AbstractSeleniumAction implements Seleniu
             throw new CitrusRuntimeException("Failed to find window for handle " + context.getVariable(windowName));
         }
 
-        logger.info("Current window: {}", browser.getWebDriver().getWindowHandle());
-        logger.info("Window to close: {}", context.getVariable(windowName));
+        logger.debug("Current window: {}", browser.getWebDriver().getWindowHandle());
+        logger.debug("Window to close: {}", context.getVariable(windowName));
 
         if (browser.getWebDriver().getWindowHandle().equals((context.getVariable(windowName)))) {
             browser.getWebDriver().close();
 
-            logger.info("Switch back to main window!");
+            logger.debug("Switch back to main window!");
             if (context.getVariables().containsKey(SeleniumHeaders.SELENIUM_LAST_WINDOW)) {
                 browser.getWebDriver().switchTo().window(context.getVariable(SeleniumHeaders.SELENIUM_LAST_WINDOW));
                 context.setVariable(SeleniumHeaders.SELENIUM_ACTIVE_WINDOW, context.getVariable(SeleniumHeaders.SELENIUM_LAST_WINDOW));

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/actions/OpenWindowAction.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/actions/OpenWindowAction.java
@@ -69,7 +69,7 @@ public class OpenWindowAction extends AbstractSeleniumAction {
 
         if (!StringUtils.isEmpty(newWindow)) {
             browser.getWebDriver().switchTo().window(newWindow);
-            logger.info("Open window: {}", newWindow);
+            logger.debug("Open window: {}", newWindow);
             context.setVariable(SeleniumHeaders.SELENIUM_ACTIVE_WINDOW, newWindow);
             context.setVariable(windowName, newWindow);
         } else {

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/actions/SwitchWindowAction.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/actions/SwitchWindowAction.java
@@ -63,11 +63,11 @@ public class SwitchWindowAction extends AbstractSeleniumAction implements Seleni
             context.setVariable(SeleniumHeaders.SELENIUM_LAST_WINDOW, lastWindow);
 
             browser.getWebDriver().switchTo().window(targetWindow);
-            logger.info("Switch window focus to {}", windowName);
+            logger.debug("Switch window focus to {}", windowName);
 
             context.setVariable(SeleniumHeaders.SELENIUM_ACTIVE_WINDOW, targetWindow);
         } else {
-            logger.info("Skip switch window action as window is already focused");
+            logger.debug("Skip switch window action as window is already focused");
         }
     }
 

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/endpoint/SeleniumBrowser.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/endpoint/SeleniumBrowser.java
@@ -100,7 +100,7 @@ public class SeleniumBrowser extends AbstractEndpoint implements Producer, Shutd
         SeleniumAction action = message.getPayload(SeleniumAction.class);
         action.execute(context);
 
-        logger.info("Selenium action successfully executed");
+        logger.debug("Selenium action successfully executed");
     }
 
     /**
@@ -118,7 +118,7 @@ public class SeleniumBrowser extends AbstractEndpoint implements Producer, Shutd
 
             if (getEndpointConfiguration().getEventListeners() != null &&
                     !getEndpointConfiguration().getEventListeners().isEmpty()) {
-                logger.info("Add event listeners to web driver: {}", getEndpointConfiguration().getEventListeners().size());
+                logger.debug("Add event listeners to web driver: {}", getEndpointConfiguration().getEventListeners().size());
                 webDriver = new EventFiringDecorator(getEndpointConfiguration().getEventListeners().toArray(new WebDriverListener[0])).decorate(webDriver);
             }
         } else {
@@ -134,7 +134,7 @@ public class SeleniumBrowser extends AbstractEndpoint implements Producer, Shutd
             logger.info("Stopping browser {}", webDriver.getCurrentUrl());
 
             try {
-                logger.info("Trying to close the browser {} ...", webDriver);
+                logger.debug("Trying to close the browser {} ...", webDriver);
                 webDriver.quit();
             } catch (UnreachableBrowserException e) {
                 // It happens for Firefox. It's ok: browser is already closed.
@@ -176,7 +176,7 @@ public class SeleniumBrowser extends AbstractEndpoint implements Producer, Shutd
         try {
             File newFile = new File(temporaryStorage.toFile(), FileUtils.getFileName(file.location()));
 
-            logger.info("Store file {} to {}", file, newFile);
+            logger.debug("Store file {} to {}", file, newFile);
 
             org.apache.commons.io.FileUtils.copyFile(file.file(), newFile);
 
@@ -296,7 +296,7 @@ public class SeleniumBrowser extends AbstractEndpoint implements Producer, Shutd
             Path tempDir = Files.createTempDirectory("selenium");
             tempDir.toFile().deleteOnExit();
 
-            logger.info("Download storage location is: {}", tempDir);
+            logger.debug("Download storage location is: {}", tempDir);
             return tempDir;
         } catch (IOException e) {
             throw new CitrusRuntimeException("Could not create temporary storage", e);

--- a/connectors/citrus-selenium/src/test/resources/log4j2.properties
+++ b/connectors/citrus-selenium/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/connectors/citrus-sql/src/main/java/org/citrusframework/actions/ExecutePLSQLAction.java
+++ b/connectors/citrus-sql/src/main/java/org/citrusframework/actions/ExecutePLSQLAction.java
@@ -117,7 +117,7 @@ public class ExecutePLSQLAction extends AbstractDatabaseConnectingTestAction {
 
                 getJdbcTemplate().execute(toExecute);
 
-                logger.info("PLSQL statement execution successful");
+                logger.debug("PLSQL statement execution successful");
             } catch (DataAccessException e) {
                 if (ignoreErrors) {
                     logger.warn("Ignoring error while executing PLSQL statement: " + e.getMessage());

--- a/connectors/citrus-sql/src/main/java/org/citrusframework/actions/ExecuteSQLAction.java
+++ b/connectors/citrus-sql/src/main/java/org/citrusframework/actions/ExecuteSQLAction.java
@@ -100,7 +100,7 @@ public class ExecuteSQLAction extends AbstractDatabaseConnectingTestAction {
 
                 getJdbcTemplate().execute(toExecute);
 
-                logger.info("SQL statement execution successful");
+                logger.debug("SQL statement execution successful");
             } catch (Exception e) {
                 if (ignoreErrors) {
                     logger.error("Ignoring error while executing SQL statement: " + e.getLocalizedMessage());

--- a/connectors/citrus-sql/src/test/resources/log4j2.properties
+++ b/connectors/citrus-sql/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/actions/StartTestcontainersAction.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/actions/StartTestcontainersAction.java
@@ -62,7 +62,7 @@ public class StartTestcontainersAction<C extends GenericContainer<?>> extends Ab
 
     @Override
     public void doExecute(TestContext context) {
-        logger.info("Starting Testcontainers container '{}'", containerName);
+        logger.debug("Starting Testcontainers container '{}'", containerName);
 
         // Give subclasses a chance to configure the container with the test context.
         configure(container, context);

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/actions/StopTestcontainersAction.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/actions/StopTestcontainersAction.java
@@ -60,7 +60,7 @@ public class StopTestcontainersAction extends AbstractTestcontainersAction {
             container.stop();
             logger.info("Successfully stopped Testcontainers container '{}' with id {}", containerName, containerId);
         } else {
-            logger.info("Testcontainers container '{}' is stopped", containerName);
+            logger.debug("Testcontainers container '{}' is stopped", containerName);
         }
     }
 

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/StartKafkaAction.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/StartKafkaAction.java
@@ -81,7 +81,7 @@ public class StartKafkaAction<T extends GenericContainer<?>> extends StartTestco
             result.all().get();
 
             for (String topic : topics) {
-                logger.info("Successfully created Kafka topic: {}", context.replaceDynamicContentInString(topic));
+                logger.debug("Successfully created Kafka topic: {}", context.replaceDynamicContentInString(topic));
             }
         } catch (ExecutionException | InterruptedException e) {
             throw new CitrusRuntimeException("Failed to create Kafka topics", e);

--- a/connectors/citrus-testcontainers/src/test/resources/log4j2.properties
+++ b/connectors/citrus-testcontainers/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/core/citrus-api/src/main/java/org/citrusframework/config/annotation/AnnotationConfigParser.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/config/annotation/AnnotationConfigParser.java
@@ -60,8 +60,8 @@ public interface AnnotationConfigParser<A extends Annotation, T extends Endpoint
         if (parsers.isEmpty()) {
             parsers.putAll(TYPE_RESOLVER.resolveAll("", TypeResolver.TYPE_PROPERTY_WILDCARD));
 
-            if (logger.isDebugEnabled()) {
-                parsers.forEach((k, v) -> logger.debug("Found annotation config parser '{}' as {}", k, v.getClass()));
+            if (logger.isTraceEnabled()) {
+                parsers.forEach((k, v) -> logger.trace("Found annotation config parser '{}' as {}", k, v.getClass()));
             }
         }
         return parsers;

--- a/core/citrus-api/src/main/java/org/citrusframework/functions/Function.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/functions/Function.java
@@ -47,8 +47,8 @@ public interface Function {
         if (functions.isEmpty()) {
             functions.putAll(new ResourcePathTypeResolver().resolveAll(RESOURCE_PATH));
 
-            if (logger.isDebugEnabled()) {
-                functions.forEach((k, v) -> logger.debug("Found function '{}' as {}", k, v.getClass()));
+            if (logger.isTraceEnabled()) {
+                functions.forEach((k, v) -> logger.trace("Found function '{}' as {}", k, v.getClass()));
             }
         }
 

--- a/core/citrus-api/src/main/java/org/citrusframework/log/CitrusLogSettings.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/log/CitrusLogSettings.java
@@ -85,6 +85,46 @@ public final class CitrusLogSettings {
     public static final String LOG_MASK_FORM_URL_ENCODED_ENV = CITRUS_LOGGER_ENV_PREFIX + "MASK_FORM_URL_ENCODED";
     public static final String LOG_MASK_FORM_URL_ENCODED_DEFAULT = Boolean.TRUE.toString();
 
+    /**
+     * Flag to enable/disable message content (headers + body) in log output
+     */
+    public static final String LOG_PRINT_MESSAGE_CONTENT_PROPERTY = CITRUS_LOGGER_PROPERTY_PREFIX + "print.message.content";
+    public static final String LOG_PRINT_MESSAGE_CONTENT_ENV = CITRUS_LOGGER_ENV_PREFIX + "PRINT_MESSAGE_CONTENT";
+    public static final String LOG_PRINT_MESSAGE_CONTENT_DEFAULT = Boolean.FALSE.toString();
+
+    /**
+     * Flag to enable/disable inbound message content (headers + body) in log output
+     */
+    public static final String LOG_PRINT_INBOUND_MESSAGE_CONTENT_PROPERTY = CITRUS_LOGGER_PROPERTY_PREFIX + "print.inbound.message.content";
+    public static final String LOG_PRINT_INBOUND_MESSAGE_CONTENT_ENV = CITRUS_LOGGER_ENV_PREFIX + "PRINT_INBOUND_MESSAGE_CONTENT";
+
+    /**
+     * Flag to enable/disable outbound message content (headers + body) in log output
+     */
+    public static final String LOG_PRINT_OUTBOUND_MESSAGE_CONTENT_PROPERTY = CITRUS_LOGGER_PROPERTY_PREFIX + "print.outbound.message.content";
+    public static final String LOG_PRINT_OUTBOUND_MESSAGE_CONTENT_ENV = CITRUS_LOGGER_ENV_PREFIX + "PRINT_OUTBOUND_MESSAGE_CONTENT";
+
+    /**
+     * Layout mode defines how message content gets printed to the log output (summary, verbose, compact, body)
+     */
+    public static final String LOG_PRINT_MESSAGE_LAYOUT_PROPERTY = CITRUS_LOGGER_PROPERTY_PREFIX + "print.message.layout";
+    public static final String LOG_PRINT_MESSAGE_LAYOUT_ENV = CITRUS_LOGGER_ENV_PREFIX + "PRINT_MESSAGE_LAYOUT";
+    public static final String LOG_PRINT_MESSAGE_LAYOUT_DEFAULT = "verbose";
+
+    /**
+     * Maximum length of message body in log output before truncation
+     */
+    public static final String LOG_MESSAGE_PAYLOAD_MAX_LENGTH_PROPERTY = CITRUS_LOGGER_PROPERTY_PREFIX + "message.payload.max.length";
+    public static final String LOG_MESSAGE_PAYLOAD_MAX_LENGTH_ENV = CITRUS_LOGGER_ENV_PREFIX + "MESSAGE_PAYLOAD_MAX_LENGTH";
+    public static final String LOG_MESSAGE_PAYLOAD_MAX_LENGTH_DEFAULT = "2048";
+
+    /**
+     * ANSI color mode for log output: auto, always, never
+     */
+    public static final String LOG_COLOR_PROPERTY = CITRUS_LOGGER_PROPERTY_PREFIX + "color";
+    public static final String LOG_COLOR_ENV = CITRUS_LOGGER_ENV_PREFIX + "COLOR";
+    public static final String LOG_COLOR_DEFAULT = "auto";
+
     private CitrusLogSettings() {
         //prevent instantiation of utility class
     }
@@ -170,5 +210,65 @@ public final class CitrusLogSettings {
                 LOG_MASK_FORM_URL_ENCODED_PROPERTY,
                 LOG_MASK_FORM_URL_ENCODED_ENV,
                 LOG_MASK_FORM_URL_ENCODED_DEFAULT));
+    }
+
+    /**
+     * Gets the print message content enabled/disabled setting.
+     */
+    public static boolean isPrintMessageContentEnabled() {
+        return parseBoolean(CitrusSettings.getPropertyEnvOrDefault(
+                LOG_PRINT_MESSAGE_CONTENT_PROPERTY,
+                LOG_PRINT_MESSAGE_CONTENT_ENV,
+                LOG_PRINT_MESSAGE_CONTENT_DEFAULT));
+    }
+
+    /**
+     * Gets the print inbound message content enabled/disabled setting.
+     */
+    public static boolean isPrintInboundMessageContentEnabled() {
+        return parseBoolean(CitrusSettings.getPropertyEnvOrDefault(
+                LOG_PRINT_INBOUND_MESSAGE_CONTENT_PROPERTY,
+                LOG_PRINT_INBOUND_MESSAGE_CONTENT_ENV,
+                String.valueOf(isPrintMessageContentEnabled())));
+    }
+
+    /**
+     * Gets the print inbound message content enabled/disabled setting.
+     */
+    public static boolean isPrintOutboundMessageContentEnabled() {
+        return parseBoolean(CitrusSettings.getPropertyEnvOrDefault(
+                LOG_PRINT_OUTBOUND_MESSAGE_CONTENT_PROPERTY,
+                LOG_PRINT_OUTBOUND_MESSAGE_CONTENT_ENV,
+                String.valueOf(isPrintMessageContentEnabled())));
+    }
+
+    /**
+     * Gets the maximum message body length for log output.
+     */
+    public static int getMessagePayloadMaxLength() {
+        return Integer.parseInt(CitrusSettings.getPropertyEnvOrDefault(
+                LOG_MESSAGE_PAYLOAD_MAX_LENGTH_PROPERTY,
+                LOG_MESSAGE_PAYLOAD_MAX_LENGTH_ENV,
+                LOG_MESSAGE_PAYLOAD_MAX_LENGTH_DEFAULT));
+    }
+
+    /**
+     * Gets layout mode (full, body, compact) for the message printer.
+     */
+    public static String getPrintMessageLayout() {
+        return CitrusSettings.getPropertyEnvOrDefault(
+                LOG_PRINT_MESSAGE_LAYOUT_PROPERTY,
+                LOG_PRINT_MESSAGE_LAYOUT_ENV,
+                LOG_PRINT_MESSAGE_LAYOUT_DEFAULT);
+    }
+
+    /**
+     * Gets the ANSI color mode (auto, always, never).
+     */
+    public static String getColorMode() {
+        return CitrusSettings.getPropertyEnvOrDefault(
+                LOG_COLOR_PROPERTY,
+                LOG_COLOR_ENV,
+                LOG_COLOR_DEFAULT);
     }
 }

--- a/core/citrus-api/src/main/java/org/citrusframework/log/LogColors.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/log/LogColors.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.log;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public final class LogColors {
+
+    public static final String RESET = "\033[0m";
+    public static final String BOLD = "\033[1m";
+    public static final String DIM = "\033[2m";
+    public static final String GREEN = "\033[32m";
+    public static final String RED = "\033[31m";
+    public static final String YELLOW = "\033[33m";
+    public static final String CYAN = "\033[36m";
+
+    private static final AtomicBoolean colorEnabled = new AtomicBoolean(resolveColorEnabled());
+
+    private LogColors() {
+    }
+
+    public static void setColorEnabled(boolean enabled) {
+        colorEnabled.set(enabled);
+    }
+
+    public static boolean isColorEnabled() {
+        return colorEnabled.get();
+    }
+
+    private static boolean resolveColorEnabled() {
+        String mode = CitrusLogSettings.getColorMode();
+        return switch (mode.toLowerCase()) {
+            case "always" -> true;
+            case "never" -> false;
+            case "auto" -> detectTerminalColor();
+            default -> throw new IllegalStateException("Unknown log color mode: " + mode);
+        };
+    }
+
+    private static boolean detectTerminalColor() {
+        String term = System.getenv("TERM");
+        return !"dumb".equals(term) || System.console() != null;
+    }
+
+    public static String colorize(String text, String ansiCode) {
+        if (isColorEnabled()) {
+            return ansiCode + text + RESET;
+        }
+        return text;
+    }
+
+    public static String success(String text) {
+        return colorize(text, GREEN);
+    }
+
+    public static String failed(String text) {
+        return colorize(text, RED);
+    }
+
+    public static String skipped(String text) {
+        return colorize(text, YELLOW);
+    }
+
+    public static String arrow(String text) {
+        return colorize(text, CYAN);
+    }
+
+    public static String start(String text) {
+        return colorize(text, CYAN);
+    }
+
+    public static String dim(String text) {
+        return colorize(text, DIM);
+    }
+
+    public static String bold(String text) {
+        return colorize(text, BOLD);
+    }
+
+    public static void resetColorsEnabled() {
+        colorEnabled.set(resolveColorEnabled());
+    }
+}

--- a/core/citrus-api/src/main/java/org/citrusframework/message/DefaultMessagePrinter.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/message/DefaultMessagePrinter.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.message;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.citrusframework.log.CitrusLogSettings;
+import org.citrusframework.log.LogColors;
+import org.citrusframework.log.LogMessageModifier;
+import org.citrusframework.log.LogModifier;
+
+public class DefaultMessagePrinter implements MessagePrinter {
+
+    private static final String BOX_TOP_LEFT = "┌─ ";
+    private static final String BOX_BOTTOM_LEFT = "└";
+    private static final String BOX_VERTICAL = "│ ";
+    private static final String BOX_SEPARATOR = "├─ ";
+    private static final String BOX_BOTTOM_LINE = "─".repeat(56);
+
+    private static MessagePrinterLayout defaultLayout = retrieveLayout();
+    private final MessagePrinterLayout layout;
+
+    private final LogModifier logModifier;
+
+    public DefaultMessagePrinter() {
+        this(defaultLayout);
+    }
+
+    DefaultMessagePrinter(LogModifier logModifier) {
+        this(defaultLayout, logModifier);
+    }
+
+    DefaultMessagePrinter(MessagePrinterLayout layout) {
+        this(layout, null);
+    }
+
+    DefaultMessagePrinter(MessagePrinterLayout layout, LogModifier logModifier) {
+        this.layout = layout;
+        this.logModifier = logModifier;
+    }
+
+    @Override
+    public String print(Message message) {
+        String normalizedPayload = normalize(message.getPayload(String.class));
+
+        Map<String, Object> headers;
+        List<String> headerData;
+        if (logModifier instanceof LogMessageModifier modifier) {
+            headers = modifier.maskHeaders(message);
+            headerData = modifier.maskHeaderData(message);
+        } else {
+            headers = Collections.unmodifiableMap(message.getHeaders());
+            headerData = Collections.unmodifiableList(message.getHeaderData());
+        }
+
+        return switch (layout) {
+            case BODY -> this.printBody(message.getId(), normalizedPayload);
+            case SUMMARY -> LogColors.dim(this.printSummary(message.getId(), MessagePayloadUtils.sizeInfo(message), headers, headerData));
+            case VERBOSE -> this.printVerbose(message.getId(), normalizedPayload, headers, headerData);
+            case COMPACT -> this.printCompact(message.getId(), normalizedPayload, headers, headerData);
+        };
+    }
+
+    protected String printBody(String id, String payload) {
+        return "[id: " + id + "][payload: " + payload + "]";
+    }
+
+    protected String printSummary(String id, String sizeInfo, Map<String, Object> headers, List<String> headerData) {
+        boolean hasHeaderData = headerData != null && !headerData.isEmpty();
+        if (hasHeaderData) {
+            return "[id: " + id + "][headers.size: " + headers.size() + "][header-data.size: " + headerData.size() + "][payload: " + sizeInfo + "]";
+        } else {
+            return "[id: " + id + "][headers.size: " + headers.size() + "][payload: " + sizeInfo + "]";
+        }
+    }
+
+    protected String printCompact(String id, String payload, Map<String, Object> headers, List<String> headerData) {
+        boolean hasHeaderData = headerData != null && !headerData.isEmpty();
+        if (hasHeaderData) {
+            return "[id: " + id + "][headers: " + headers + "][header-data: " + headerData + "][payload: " + payload + "]";
+        } else {
+            return "[id: " + id + "][headers: " + headers + "][payload: " + payload + "]";
+        }
+    }
+
+    protected String printVerbose(String id, String payload, Map<String, Object> headers, List<String> headerData) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("\n");
+
+        boolean hasHeaders = headers != null && !headers.isEmpty();
+        boolean hasHeaderData = headerData != null && !headerData.isEmpty();
+        boolean hasPayload = payload != null && !payload.isEmpty();
+
+        sb.append(LogColors.dim("    " + BOX_TOP_LEFT + "Id " + "─".repeat(53))).append("\n");
+        sb.append(LogColors.dim("    " + BOX_VERTICAL)).append(id).append("\n");
+
+        if (hasHeaders) {
+            sb.append(LogColors.dim("    " + BOX_SEPARATOR + "Headers " + "─".repeat(48))).append("\n");
+            for (Map.Entry<String, Object> entry : headers.entrySet()) {
+                if (!entry.getKey().startsWith("citrus_message_id")
+                        && !entry.getKey().startsWith("citrus_message_timestamp")) {
+                    sb.append(LogColors.dim("    " + BOX_VERTICAL)).append(entry.getKey()).append(": ").append(entry.getValue()).append("\n");
+                }
+            }
+        }
+
+        if (hasHeaderData) {
+            sb.append(LogColors.dim("    " + BOX_SEPARATOR + "Header Data " + "─".repeat(44))).append("\n");
+            for (String entry : headerData) {
+                sb.append(LogColors.dim("    " + BOX_VERTICAL)).append(entry).append("\n");
+            }
+        }
+
+        if (hasPayload) {
+            sb.append(LogColors.dim("    " + BOX_SEPARATOR + "Body " + "─".repeat(51))).append("\n");
+            for (String line : payload.split("\n")) {
+                sb.append(LogColors.dim("    " + BOX_VERTICAL)).append(line).append("\n");
+            }
+        }
+
+        sb.append(LogColors.dim("    " + BOX_BOTTOM_LEFT + BOX_BOTTOM_LINE)).append("\n");
+
+        return sb.toString();
+    }
+
+    public static void setDefaultLayout(MessagePrinterLayout layout) {
+        DefaultMessagePrinter.defaultLayout = layout;
+    }
+
+    public static void resetDefaultLayout() {
+        defaultLayout = retrieveLayout();
+    }
+
+    private static MessagePrinterLayout retrieveLayout() {
+        String layoutName = CitrusLogSettings.getPrintMessageLayout();
+        return Arrays.stream(MessagePrinterLayout.values())
+                .filter(layout -> layoutName.toUpperCase().equals(layout.name()))
+                .findFirst()
+                .orElse(MessagePrinterLayout.VERBOSE);
+    }
+
+    private String normalize(String payload) {
+        if (payload == null) {
+            return "";
+        }
+
+        String printable = MessagePayloadUtils.prettyPrint(payload.trim());
+        int maxLength = CitrusLogSettings.getMessagePayloadMaxLength();
+        if (printable.length() > maxLength) {
+            printable = printable.substring(0, maxLength) + "\n ... (truncated at " + maxLength + " chars)";
+        }
+
+        if (logModifier != null) {
+            return logModifier.mask(printable);
+        }
+
+        return printable;
+    }
+}

--- a/core/citrus-api/src/main/java/org/citrusframework/message/DefaultMessageStore.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/message/DefaultMessageStore.java
@@ -48,7 +48,7 @@ public class DefaultMessageStore extends ConcurrentHashMap<String, Message> impl
     @Override
     public void storeMessage(String name, Message message) {
         if (registeredNames.containsKey(name)) {
-            logger.warn("Message with name '{}' already exists in message store - will overwrite the name mapping", name);
+            logger.debug("Message with name '{}' already exists in message store - will overwrite the name mapping", name);
         }
 
         registeredNames.put(name, message.getId());

--- a/core/citrus-api/src/main/java/org/citrusframework/message/MediaTypeMapper.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/message/MediaTypeMapper.java
@@ -25,6 +25,7 @@ final class MediaTypeMapper {
         m.put("application/yaml",         MessageType.YAML);
         // Plain text
         m.put("text/plain",               MessageType.PLAINTEXT);
+        m.put("text/html",                MessageType.PLAINTEXT);
         // Binary
         m.put("application/octet-stream", MessageType.BINARY);
         // GZIP

--- a/core/citrus-api/src/main/java/org/citrusframework/message/Message.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/message/Message.java
@@ -17,12 +17,10 @@
 package org.citrusframework.message;
 
 import java.io.Serializable;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 import org.citrusframework.context.TestContext;
-import org.citrusframework.log.LogMessageModifier;
 
 /**
  * @since 2.0
@@ -33,18 +31,14 @@ public interface Message extends Serializable {
      * Prints message content to String representation.
      */
     default String print() {
-        return print(getPayload(String.class).trim(), getHeaders(), getHeaderData());
+        return new DefaultMessagePrinter().print(this);
     }
 
     /**
-     * Prints given message content (body, headers, headerData) to String representation.
+     * Prints message content to String representation.
      */
-    default String print(String body, Map<String, Object> headers, List<String> headerData) {
-        if (headerData == null || headerData.isEmpty()) {
-            return getClass().getSimpleName().toUpperCase() + " [id: " + getId() + "]\n[headers: " + Collections.unmodifiableMap(headers) + "]\n[payload: " + MessagePayloadUtils.prettyPrint(body) + "]";
-        } else {
-            return getClass().getSimpleName().toUpperCase() + " [id: " + getId() + "]\n[headers: " + Collections.unmodifiableMap(headers) + "]\n[header-data: " + Collections.unmodifiableList(headerData) + "]\n[payload: " + MessagePayloadUtils.prettyPrint(body) + "]";
-        }
+    default String print(MessagePrinterLayout layout) {
+        return new DefaultMessagePrinter(layout).print(this);
     }
 
     /**
@@ -55,12 +49,7 @@ public interface Message extends Serializable {
             return print();
         }
 
-        String payload = getPayload(String.class).trim();
-        if (context.getLogModifier() instanceof LogMessageModifier modifier) {
-            return print(modifier.mask(payload), modifier.maskHeaders(this), modifier.maskHeaderData(this));
-        }
-
-        return print(context.getLogModifier().mask(payload), getHeaders(), getHeaderData());
+        return new DefaultMessagePrinter(context.getLogModifier()).print(this);
     }
 
     /**

--- a/core/citrus-api/src/main/java/org/citrusframework/message/MessagePayloadUtils.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/message/MessagePayloadUtils.java
@@ -147,6 +147,11 @@ public class MessagePayloadUtils {
             return payload.trim();
         }
 
+        if (payload.trim().startsWith("[") && payload.trim().endsWith("]") && !payload.contains("\"")) {
+            // Array of numbers e.g. bytes array - do not pretty print
+            return payload.trim();
+        }
+
         int indentNum = 2;
         int indent = 0;
         boolean inQuote = false;
@@ -227,5 +232,23 @@ public class MessagePayloadUtils {
             }
         }
         return sb.toString();
+    }
+
+    public static String sizeInfo(Message message) {
+        String sizeInfo;
+        if (message.getHeader("Content-Length") != null) {
+            sizeInfo = message.getHeader("Content-Length") + " bytes";
+        } else if (message.getPayload() != null) {
+            try {
+                byte[] bytes = message.getPayload(byte[].class);
+                sizeInfo = bytes.length + " bytes";
+            } catch (Exception e) {
+                sizeInfo = "-1 bytes";
+            }
+        } else {
+            sizeInfo = "empty";
+        }
+
+        return sizeInfo;
     }
 }

--- a/core/citrus-api/src/main/java/org/citrusframework/message/MessagePrinter.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/message/MessagePrinter.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.message;
+
+@FunctionalInterface
+public interface MessagePrinter {
+
+    /**
+     * Builds a String of the message content in a printable way for logging.
+     */
+    String print(Message message);
+
+}

--- a/core/citrus-api/src/main/java/org/citrusframework/message/MessagePrinterLayout.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/message/MessagePrinterLayout.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.message;
+
+/**
+ * Layout defines how the message printer prints the message content (summary, body and header, body, compact, verbose).
+ */
+public enum MessagePrinterLayout {
+    SUMMARY,
+    VERBOSE,
+    BODY,
+    COMPACT
+}

--- a/core/citrus-api/src/main/java/org/citrusframework/spi/ClasspathResourceResolver.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/spi/ClasspathResourceResolver.java
@@ -145,7 +145,7 @@ public class ClasspathResourceResolver {
                     continue;
                 }
 
-                logger.debug("Scanning for resources in: {}", urlPath);
+                logger.trace("Scanning for resources in: {}", urlPath);
 
                 File file = new File(urlPath);
                 if (file.isDirectory()) {

--- a/core/citrus-api/src/main/java/org/citrusframework/util/DefaultTypeConverter.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/util/DefaultTypeConverter.java
@@ -16,15 +16,6 @@
 
 package org.citrusframework.util;
 
-import org.citrusframework.CitrusSettings;
-import org.citrusframework.exceptions.CitrusRuntimeException;
-import org.citrusframework.xml.StringSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.w3c.dom.Node;
-
-import javax.xml.transform.Source;
-import javax.xml.transform.dom.DOMSource;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -37,6 +28,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import javax.xml.transform.Source;
+import javax.xml.transform.dom.DOMSource;
+
+import org.citrusframework.CitrusSettings;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.xml.StringSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Node;
 
 public class DefaultTypeConverter implements TypeConverter {
 
@@ -100,9 +100,8 @@ public class DefaultTypeConverter implements TypeConverter {
                 }
             } else if (target instanceof ByteBuffer) {
                 return (T) ((ByteBuffer) target).array();
-            } else if (target instanceof ByteArrayInputStream) {
+            } else if (target instanceof InputStream is) {
                 try {
-                    InputStream is = ((ByteArrayInputStream) target);
                     ByteBuffer byteBuffer = ByteBuffer.allocate(is.available());
                     while (is.available() > 0) {
                         byteBuffer.put((byte) is.read());
@@ -134,7 +133,7 @@ public class DefaultTypeConverter implements TypeConverter {
             }
         }
 
-        if (type.equals(String.class)) {
+        if (String.class.equals(type)) {
             if (target == null) {
                 return (T) "null";
             } else if (ByteBuffer.class.isAssignableFrom(target.getClass())) {
@@ -192,7 +191,7 @@ public class DefaultTypeConverter implements TypeConverter {
             return convertAfter(target, type);
         } catch (Exception e) {
             if (String.class.equals(type)) {
-                logger.warn("Using default toString representation because object type conversion failed with: {}", e.getMessage());
+                logger.debug("Using default toString representation because object type conversion failed with: {}", e.getMessage());
                 return (T) target.toString();
             }
 
@@ -245,7 +244,7 @@ public class DefaultTypeConverter implements TypeConverter {
                 }
             }
 
-            logger.warn("Using default toString representation for object type {}", target.getClass());
+            logger.debug("Using default toString representation for object type {}", target.getClass());
             return (T) target.toString();
         }
 

--- a/core/citrus-api/src/main/java/org/citrusframework/util/TypeConverter.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/util/TypeConverter.java
@@ -52,8 +52,8 @@ public interface TypeConverter {
                 converters.put(DEFAULT, DefaultTypeConverter.INSTANCE);
             }
 
-            if (logger.isDebugEnabled()) {
-                converters.forEach((k, v) -> logger.debug("Found type converter '{}' as {}", k, v.getClass()));
+            if (logger.isTraceEnabled()) {
+                converters.forEach((k, v) -> logger.trace("Found type converter '{}' as {}", k, v.getClass()));
             }
         }
 

--- a/core/citrus-api/src/main/java/org/citrusframework/validation/HeaderValidator.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/validation/HeaderValidator.java
@@ -53,8 +53,8 @@ public interface HeaderValidator {
         if (validators.isEmpty()) {
             validators.putAll(TYPE_RESOLVER.resolveAll("", TypeResolver.DEFAULT_TYPE_PROPERTY, "name"));
 
-            if (logger.isDebugEnabled()) {
-                validators.forEach((k, v) -> logger.debug("Found header validator '{}' as {}", k, v.getClass()));
+            if (logger.isTraceEnabled()) {
+                validators.forEach((k, v) -> logger.trace("Found header validator '{}' as {}", k, v.getClass()));
             }
         }
         return validators;

--- a/core/citrus-api/src/main/java/org/citrusframework/validation/MessageValidator.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/validation/MessageValidator.java
@@ -56,8 +56,8 @@ public interface MessageValidator<T extends ValidationContext> {
     static Map<String, MessageValidator<? extends ValidationContext>> lookup() {
         Map<String, MessageValidator<?>> validators = TYPE_RESOLVER.resolveAll("", TypeResolver.DEFAULT_TYPE_PROPERTY, "name");
 
-        if (logger.isDebugEnabled()) {
-            validators.forEach((k, v) -> logger.debug("Found message validator '{}' as {}", k, v.getClass()));
+        if (logger.isTraceEnabled()) {
+            validators.forEach((k, v) -> logger.trace("Found message validator '{}' as {}", k, v.getClass()));
         }
 
         return validators;

--- a/core/citrus-api/src/main/java/org/citrusframework/validation/SchemaValidator.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/validation/SchemaValidator.java
@@ -48,8 +48,8 @@ public interface SchemaValidator<T extends SchemaValidationContext> {
     static Map<String, SchemaValidator<? extends SchemaValidationContext>> lookup() {
         Map<String, SchemaValidator<?>> validators = TYPE_RESOLVER.resolveAll("", TypeResolver.DEFAULT_TYPE_PROPERTY, "name");
 
-        if (logger.isDebugEnabled()) {
-            validators.forEach((k, v) -> logger.debug("Found message validator '{}' as {}", k, v.getClass()));
+        if (logger.isTraceEnabled()) {
+            validators.forEach((k, v) -> logger.trace("Found message validator '{}' as {}", k, v.getClass()));
         }
 
         return validators;

--- a/core/citrus-api/src/main/java/org/citrusframework/validation/matcher/ValidationMatcher.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/validation/matcher/ValidationMatcher.java
@@ -50,8 +50,8 @@ public interface ValidationMatcher {
         if (matcher.isEmpty()) {
             matcher.putAll(new ResourcePathTypeResolver().resolveAll(RESOURCE_PATH));
 
-            if (logger.isDebugEnabled()) {
-                matcher.forEach((k, v) -> logger.debug("Found validation matcher '{}' as {}", k, v.getClass()));
+            if (logger.isTraceEnabled()) {
+                matcher.forEach((k, v) -> logger.trace("Found validation matcher '{}' as {}", k, v.getClass()));
             }
         }
         return matcher;

--- a/core/citrus-api/src/test/java/org/citrusframework/message/MessagePayloadUtilsTest.java
+++ b/core/citrus-api/src/test/java/org/citrusframework/message/MessagePayloadUtilsTest.java
@@ -35,8 +35,7 @@ public class MessagePayloadUtilsTest {
                 String.format("{%n  \"user\": \"citrus\"%n}"));
         assertEquals(MessagePayloadUtils.prettyPrint("{\"user\":\"citrus\",\"age\": 32}"),
                 String.format("{%n  \"user\": \"citrus\",%n  \"age\": 32%n}"));
-        assertEquals(MessagePayloadUtils.prettyPrint("[22, 32]"),
-                String.format("[%n22,%n32%n]"));
+        assertEquals(MessagePayloadUtils.prettyPrint("[22, 32]"), "[22, 32]");
         assertEquals(MessagePayloadUtils.prettyPrint("[{\"user\":\"citrus\",\"age\": 32}]"),
                 String.format("[%n  {%n    \"user\": \"citrus\",%n    \"age\": 32%n  }%n]"));
         assertEquals(MessagePayloadUtils.prettyPrint("[{\"user\":\"citrus\",\"age\": 32}, {\"user\":\"foo\",\"age\": 99}]"),

--- a/core/citrus-api/src/test/java/org/citrusframework/util/DefaultTypeConverterTest.java
+++ b/core/citrus-api/src/test/java/org/citrusframework/util/DefaultTypeConverterTest.java
@@ -17,12 +17,16 @@
 package org.citrusframework.util;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
 import javax.xml.transform.Source;
 
 import org.citrusframework.xml.StringSource;
@@ -37,7 +41,7 @@ public class DefaultTypeConverterTest {
     private final DefaultTypeConverter converter = DefaultTypeConverter.INSTANCE;
 
     @Test
-    public void testConvertIfNecessary() {
+    public void testConvertIfNecessary() throws IOException {
         String payload = "Hello Citrus!";
 
         Assert.assertEquals(converter.convertIfNecessary("1", Byte.class), Byte.valueOf((byte) 1));
@@ -75,5 +79,17 @@ public class DefaultTypeConverterTest {
         Assert.assertEquals(converter.convertIfNecessary(payload, byte[].class), payload.getBytes());
         Assert.assertEquals(converter.convertIfNecessary(payload.getBytes(), String.class), Arrays.toString(payload.getBytes()));
         Assert.assertEquals(converter.convertIfNecessary(ByteBuffer.wrap(payload.getBytes()), String.class), payload);
+        Assert.assertEquals(converter.convertIfNecessary(new ByteArrayInputStream(payload.getBytes()), String.class), Arrays.toString(payload.getBytes()));
+        Assert.assertEquals(converter.convertIfNecessary(new GZIPInputStream(new ByteArrayInputStream(getZipped(payload.getBytes()))), String.class), Arrays.toString(payload.getBytes()));
+    }
+
+    private byte[] getZipped(byte[] in) throws IOException {
+        try (ByteArrayOutputStream zipped = new ByteArrayOutputStream()) {
+            try (GZIPOutputStream gzipOutputStream = new GZIPOutputStream(zipped)) {
+                gzipOutputStream.write(in);
+                gzipOutputStream.flush();
+            }
+            return zipped.toByteArray();
+        }
     }
 }

--- a/core/citrus-api/src/test/resources/log4j2.properties
+++ b/core/citrus-api/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/core/citrus-base/src/main/java/org/citrusframework/actions/AntRunAction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/actions/AntRunAction.java
@@ -109,20 +109,20 @@ public class AntRunAction extends AbstractTestAction {
 
             project.addBuildListener(consoleLogger);
 
-            logger.info("Executing ANT build: {}", buildFileResource);
+            logger.debug("Executing ANT build: {}", buildFileResource);
 
             if (StringUtils.hasText(targets)) {
-                logger.info("Executing ANT targets: {}", targets);
+                logger.debug("Executing ANT targets: {}", targets);
                 project.executeTargets(parseTargets());
             } else {
-                logger.info("Executing ANT target: {}", target);
+                logger.debug("Executing ANT target: {}", target);
                 project.executeTarget(target);
             }
         } catch (BuildException e) {
             throw new CitrusRuntimeException("Failed to run ANT build file", e);
         }
 
-        logger.info("Executed ANT build: {}", buildFileResource);
+        logger.debug("Executed ANT build: {}", buildFileResource);
     }
 
     private static DefaultLogger getDefaultConsoleLogger() {
@@ -132,7 +132,7 @@ public class AntRunAction extends AbstractTestAction {
                 if (stream.equals(System.err)) {
                     logger.error(message);
                 } else {
-                    logger.info(message);
+                    logger.debug(message);
                 }
             }
         };
@@ -166,7 +166,7 @@ public class AntRunAction extends AbstractTestAction {
     private void loadBuildPropertyFile(Project project, TestContext context) {
         if (StringUtils.hasText(propertyFilePath)) {
             String propertyFileResource = context.replaceDynamicContentInString(propertyFilePath);
-            logger.info("Reading build property file: {}", propertyFileResource);
+            logger.debug("Reading build property file: {}", propertyFileResource);
             Properties fileProperties = new Properties();
             try {
                 Resource propertyResource = Resources.fromClasspath(propertyFileResource);

--- a/core/citrus-base/src/main/java/org/citrusframework/actions/CreateEndpointAction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/actions/CreateEndpointAction.java
@@ -87,7 +87,7 @@ public class CreateEndpointAction extends AbstractTestAction {
             if (context.getReferenceResolver().isResolvable(resolvedEndpointName)) {
                 logger.warn("Skip binding endpoint to bean registry, because endpoint already exists: {}", resolvedEndpointName);
             } else {
-                logger.info("Binding endpoint {} to bean registry", resolvedEndpointName);
+                logger.debug("Binding endpoint {} to bean registry", resolvedEndpointName);
                 context.getReferenceResolver().bind(resolvedEndpointName, endpoint);
 
                 if (endpoint instanceof InitializingPhase initializingPhase) {

--- a/core/citrus-base/src/main/java/org/citrusframework/actions/JavaAction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/actions/JavaAction.java
@@ -126,7 +126,7 @@ public class JavaAction extends AbstractTestAction {
                     Arrays.stream(methodTypes).map(Class::getSimpleName).collect(Collectors.joining(",")) + ")' for class '" + instance.getClass() + "'");
         }
 
-        logger.info("Invoking method '{}' on instance '{}'", methodToRun, instance.getClass());
+        logger.debug("Invoking method '{}' on instance '{}'", methodToRun, instance.getClass());
 
         methodToRun.invoke(instance, methodObjects);
     }
@@ -153,7 +153,7 @@ public class JavaAction extends AbstractTestAction {
                 "is set for Java reflection call");
         }
 
-        logger.info("Instantiating class for name '{}'", className);
+        logger.debug("Instantiating class for name '{}'", className);
 
         Class<?> classToRun = Class.forName(className, true, ClassLoaderHelper.getClassLoader());
 

--- a/core/citrus-base/src/main/java/org/citrusframework/actions/PurgeEndpointAction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/actions/PurgeEndpointAction.java
@@ -95,7 +95,7 @@ public class PurgeEndpointAction extends AbstractTestAction {
             purgeEndpoint(resolveEndpointName(endpointName), context);
         }
 
-        logger.info("Purged message endpoints");
+        logger.debug("Purged message endpoints");
     }
 
     /**

--- a/core/citrus-base/src/main/java/org/citrusframework/actions/ReceiveTimeoutAction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/actions/ReceiveTimeoutAction.java
@@ -92,7 +92,7 @@ public class ReceiveTimeoutAction extends AbstractTestAction {
             }
         } catch (ActionTimeoutException e) {
             logger.info("No messages received on destination. Message timeout validation OK!");
-            logger.info(e.getMessage());
+            logger.debug(e.getMessage());
         }
     }
 

--- a/core/citrus-base/src/main/java/org/citrusframework/actions/SleepAction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/actions/SleepAction.java
@@ -67,11 +67,11 @@ public class SleepAction extends AbstractTestAction {
                 parsedDuration = Duration.ofMillis(TimeUnit.MILLISECONDS.convert(Long.parseLong(duration), timeUnit));
             }
 
-            logger.info("Sleeping {} {}", duration, timeUnit);
+            logger.debug("Sleeping {} {}", duration, timeUnit);
 
             TimeUnit.MILLISECONDS.sleep(parsedDuration.toMillis());
 
-            logger.info("Returning after {} {}", duration, timeUnit);
+            logger.debug("Returning after {} {}", duration, timeUnit);
         } catch (InterruptedException e) {
             throw new CitrusRuntimeException(e);
         }

--- a/core/citrus-base/src/main/java/org/citrusframework/actions/TraceVariablesAction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/actions/TraceVariablesAction.java
@@ -50,7 +50,7 @@ public class TraceVariablesAction extends AbstractTestAction {
 
     @Override
     public void doExecute(TestContext context) {
-        logger.info("Trace variables");
+        logger.debug("Trace variables");
 
         Iterator<String> it;
         if (variableNames != null && !variableNames.isEmpty()) {

--- a/core/citrus-base/src/main/java/org/citrusframework/actions/TransformAction.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/actions/TransformAction.java
@@ -120,7 +120,7 @@ public class TransformAction extends AbstractTestAction {
             transformer.transform(xmlSource, result);
 
             context.setVariable(targetVariable, result.toString());
-            logger.info("Finished XSLT transformation");
+            logger.debug("Finished XSLT transformation");
         } catch (IOException | TransformerException e) {
             throw new CitrusRuntimeException(e);
         }

--- a/core/citrus-base/src/main/java/org/citrusframework/container/Async.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/container/Async.java
@@ -62,7 +62,7 @@ public class Async extends AbstractActionContainer {
 
             @Override
             public void onError(TestContext context, Throwable error) {
-                logger.info("Apply error actions after async container ...");
+                logger.debug("Apply error actions after async container ...");
                 for (TestActionBuilder<?> actionBuilder : errorActions) {
                     TestAction action = actionBuilder.build();
                     action.execute(context);
@@ -71,7 +71,7 @@ public class Async extends AbstractActionContainer {
 
             @Override
             public void onSuccess(TestContext context) {
-                logger.info("Apply success actions after async container ...");
+                logger.debug("Apply success actions after async container ...");
                 for (TestActionBuilder<?> actionBuilder : successActions) {
                     TestAction action = actionBuilder.build();
                     action.execute(context);

--- a/core/citrus-base/src/main/java/org/citrusframework/container/RepeatOnErrorUntilTrue.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/container/RepeatOnErrorUntilTrue.java
@@ -87,7 +87,7 @@ public class RepeatOnErrorUntilTrue extends AbstractIteratingActionContainer {
                 Thread.currentThread().interrupt();
             }
 
-            logger.info("Returning after {}", autoSleep);
+            logger.debug("Returning after {}", autoSleep);
         }
     }
 

--- a/core/citrus-base/src/main/java/org/citrusframework/container/SequenceAfterSuite.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/container/SequenceAfterSuite.java
@@ -47,7 +47,7 @@ public class SequenceAfterSuite extends AbstractSuiteActionContainer implements 
     public void doExecute(TestContext context) {
         boolean success = true;
 
-        logger.info("Entering after suite block");
+        logger.debug("Entering after suite block");
 
         if (logger.isDebugEnabled()) {
             logger.debug("Executing {} actions after suite", actions.size());

--- a/core/citrus-base/src/main/java/org/citrusframework/container/SequenceAfterTest.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/container/SequenceAfterTest.java
@@ -48,7 +48,7 @@ public class SequenceAfterTest extends AbstractTestBoundaryActionContainer imple
             return;
         }
 
-        logger.info("Entering after test block");
+        logger.debug("Entering after test block");
 
         if (logger.isDebugEnabled()) {
             logger.debug("Executing {} actions after test", actions.size());

--- a/core/citrus-base/src/main/java/org/citrusframework/container/SequenceBeforeSuite.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/container/SequenceBeforeSuite.java
@@ -45,7 +45,7 @@ public class SequenceBeforeSuite extends AbstractSuiteActionContainer implements
 
     @Override
     public void doExecute(TestContext context) {
-        logger.info("Entering before suite block");
+        logger.debug("Entering before suite block");
 
         if (logger.isDebugEnabled()) {
             logger.debug("Executing {} actions before suite", actions.size());

--- a/core/citrus-base/src/main/java/org/citrusframework/container/SequenceBeforeTest.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/container/SequenceBeforeTest.java
@@ -48,7 +48,7 @@ public class SequenceBeforeTest extends AbstractTestBoundaryActionContainer impl
             return;
         }
 
-        logger.info("Entering before test block");
+        logger.debug("Entering before test block");
 
         if (logger.isDebugEnabled()) {
             logger.debug("Executing {} actions before test", actions.size());

--- a/core/citrus-base/src/main/java/org/citrusframework/endpoint/AbstractEndpointAdapter.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/endpoint/AbstractEndpointAdapter.java
@@ -112,7 +112,7 @@ public abstract class AbstractEndpointAdapter implements EndpointAdapter {
      */
     public TestContextFactory getTestContextFactory() {
         if (testContextFactory == null) {
-            logger.warn("Could not identify proper test context factory from Spring bean application context - constructing own test context factory. " +
+            logger.debug("Could not identify proper test context factory from Spring bean application context - constructing own test context factory. " +
                     "This restricts test context capabilities to an absolute minimum! You could do better when enabling the root application context for this server instance.");
 
             testContextFactory = TestContextFactory.newInstance();

--- a/core/citrus-base/src/main/java/org/citrusframework/endpoint/direct/DirectConsumer.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/endpoint/direct/DirectConsumer.java
@@ -80,7 +80,7 @@ public class DirectConsumer extends AbstractSelectiveMessageConsumer {
             throw new MessageTimeoutException(timeout, destinationQueueName);
         }
 
-        logger.info("Received message from queue: '{}'", destinationQueueName);
+        logger.debug("Received message from queue: '{}'", destinationQueueName);
         return message;
     }
 

--- a/core/citrus-base/src/main/java/org/citrusframework/endpoint/direct/DirectProducer.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/endpoint/direct/DirectProducer.java
@@ -59,7 +59,7 @@ public class DirectProducer implements Producer {
             throw new CitrusRuntimeException(String.format("Failed to send message to queue: '%s'", destinationQueueName), e);
         }
 
-        logger.info("Message was sent to queue: '{}'", destinationQueueName);
+        logger.debug("Message was sent to queue: '{}'", destinationQueueName);
     }
 
     /**

--- a/core/citrus-base/src/main/java/org/citrusframework/endpoint/direct/DirectSyncConsumer.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/endpoint/direct/DirectSyncConsumer.java
@@ -72,7 +72,7 @@ public class DirectSyncConsumer extends DirectConsumer implements ReplyProducer 
         }
 
         replyQueue.send(message);
-        logger.info("Message was sent to reply channel: '{}'", replyQueue);
+        logger.debug("Message was sent to reply channel: '{}'", replyQueue);
     }
 
     /**

--- a/core/citrus-base/src/main/java/org/citrusframework/endpoint/direct/DirectSyncProducer.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/endpoint/direct/DirectSyncProducer.java
@@ -66,7 +66,7 @@ public class DirectSyncProducer extends DirectProducer implements ReplyConsumer 
             logger.debug("Message to send is:\n{}", message.toString());
         }
 
-        logger.info("Message was sent to queue: '{}'", destinationQueueName);
+        logger.debug("Message was sent to queue: '{}'", destinationQueueName);
 
         MessageQueue replyQueue = getReplyQueue(message, context);
         getDestinationQueue(context).send(message);
@@ -75,7 +75,7 @@ public class DirectSyncProducer extends DirectProducer implements ReplyConsumer 
         if (replyMessage == null) {
             throw new ReplyMessageTimeoutException(endpointConfiguration.getTimeout(), destinationQueueName);
         } else {
-            logger.info("Received synchronous response from reply queue");
+            logger.debug("Received synchronous response from reply queue");
         }
 
         correlationManager.store(correlationKey, replyMessage);

--- a/core/citrus-base/src/main/java/org/citrusframework/functions/DefaultFunctionLibrary.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/functions/DefaultFunctionLibrary.java
@@ -117,7 +117,7 @@ public class DefaultFunctionLibrary extends FunctionLibrary {
             } else {
                 addMember(k, m);
             }
-            logger.debug("Register function '{}' as {}", k, m.getClass());
+            logger.trace("Register function '{}' as {}", k, m.getClass());
         });
     }
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/message/DefaultMessage.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/message/DefaultMessage.java
@@ -146,7 +146,7 @@ public class DefaultMessage implements Message {
 
     @Override
     public String toString() {
-        return print();
+        return print(MessagePrinterLayout.COMPACT);
     }
 
     @Override

--- a/core/citrus-base/src/main/java/org/citrusframework/report/AbstractOutputFileReporter.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/report/AbstractOutputFileReporter.java
@@ -64,7 +64,7 @@ public abstract class AbstractOutputFileReporter extends AbstractTestReporter {
         try (Writer fileWriter = new FileWriter(new File(targetDirectory, reportFileName))) {
             fileWriter.append(content);
             fileWriter.flush();
-            logger.info("Generated test report: {}{}{}", targetDirectory, File.separator, reportFileName);
+            logger.debug("Generated test report: {}{}{}", targetDirectory, File.separator, reportFileName);
         } catch (IOException e) {
             logger.error("Failed to create test report", e);
         }

--- a/core/citrus-base/src/main/java/org/citrusframework/report/LoggingReporter.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/report/LoggingReporter.java
@@ -29,7 +29,11 @@ import org.citrusframework.common.Described;
 import org.citrusframework.common.ShutdownPhase;
 import org.citrusframework.container.TestActionContainer;
 import org.citrusframework.context.TestContext;
+import org.citrusframework.log.CitrusLogSettings;
+import org.citrusframework.log.LogColors;
 import org.citrusframework.message.Message;
+import org.citrusframework.message.MessageDirection;
+import org.citrusframework.message.MessagePayloadUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.helpers.NOPLoggerFactory;
@@ -53,52 +57,41 @@ import static org.citrusframework.util.StringUtils.hasText;
 public class LoggingReporter extends AbstractTestReporter implements MessageListener, TestSuiteListener,
         TestListener, TestActionListener, ShutdownPhase {
 
-    /**
-     * Logger
-     */
     private static Logger logger = LoggerFactory.getLogger(LoggingReporter.class);
 
-    /**
-     * Inbound message logger
-     */
-    private static Logger inboundMessageLogger = LoggerFactory.getLogger("Logger.Message_IN");
+    private static Logger inboundMessageLogger = LoggerFactory.getLogger(LoggingReporter.class.getName() + ".Message_IN");
+    private static Logger outboundMessageLogger = LoggerFactory.getLogger(LoggingReporter.class.getName() + ".Message_OUT");
 
-    /**
-     * The inbound message logger used when the reporter is enabled
-     */
-    private static final Logger enabledInboundMessageLogger = inboundMessageLogger;
-
-    /**
-     * Outbound message logger
-     */
-    private static Logger outboundMessageLogger = LoggerFactory.getLogger("Logger.Message_OUT");
-
-    /**
-     * The inbound message logger used when the reporter is enabled
-     */
-    private static final Logger enabledOutboundMessageLogger = outboundMessageLogger;
-
-    /**
-     * The standard logger used when the reporter is enabled
-     */
-    private static final Logger enabledLog = logger;
-
-    /**
-     * A {@link org.slf4j.helpers.NOPLogger} used in case the reporter is not enabled.
-     */
     private static final Logger noOpLogger = new NOPLoggerFactory().getLogger(LoggingReporter.class.getName());
 
     private static final AtomicBoolean initialized = new AtomicBoolean(false);
+
+    private static final String DOUBLE_SEPARATOR = "═".repeat(68);
+    private static final String SINGLE_SEPARATOR = "─".repeat(68);
+
+    private static final String INDICATOR_START = "➤";
+    private static final String INDICATOR_SUCCESS = "✔";
+    private static final String INDICATOR_FAILED = "✘";
+    private static final String INDICATOR_SKIPPED = "⊘";
+    private static final String ARROW_OUTBOUND = "→";
+    private static final String ARROW_INBOUND = "←";
+
+    private final boolean stackTraceOutputEnabled;
 
     protected static void initialized(boolean value) {
         LoggingReporter.initialized.set(value);
     }
 
-    private static String formatDurationString(TestCase test) {
-        return nonNull(test.getTestResult()) && nonNull(test.getTestResult().getDuration()) ? " (" + test.getTestResult().getDuration().toString() + ") " : "";
+    private static String resolveActionName(TestAction testAction) {
+        return hasText(testAction.getName()) ? testAction.getName() : testAction.getClass().getSimpleName();
     }
 
-    private final boolean stackTraceOutputEnabled;
+    private static String formatDuration(TestCase test) {
+        if (nonNull(test.getTestResult()) && nonNull(test.getTestResult().getDuration())) {
+            return test.getTestResult().getDuration().toMillis() + "ms";
+        }
+        return "";
+    }
 
     public LoggingReporter() {
         this(CitrusSettings.isStackTraceOutputEnabled());
@@ -115,42 +108,53 @@ public class LoggingReporter extends AbstractTestReporter implements MessageList
     @Override
     public void generate(TestResults testResults) {
         newLine();
-        info("CITRUS TEST RESULTS");
+        info(LogColors.bold((testResults.getFailed() > 0 ? LogColors.failed(INDICATOR_FAILED) : LogColors.success(INDICATOR_SUCCESS)) + " CITRUS TEST RESULTS"));
         newLine();
 
         testResults.doWithResults(testResult -> {
             info(toFormattedTestResult(testResult));
 
             if (testResult.isFailed()) {
-                info(
+                info(LogColors.failed(
                         Optional.ofNullable(testResult.getCause())
                                 .filter(cause -> hasText(cause.getMessage()))
                                 .map(ExceptionUtils::getRootCause)
-                                .map(cause -> "\tCaused by: " + cause.getClass().getSimpleName() + ": " + cause.getMessage())
-                                .orElse("\tCaused by: " + Optional.ofNullable(testResult.getErrorMessage()).orElse("Unknown error")));
+                                .map(cause -> "    Caused by: " + cause.getClass().getSimpleName() + ": " + cause.getMessage())
+                                .orElse("    Caused by: " + Optional.ofNullable(testResult.getErrorMessage()).orElse("Unknown error")))
+                );
             }
         });
 
         newLine();
 
-        info(format("TOTAL:\t\t%s", testResults.getSize()));
-        info(format("PASSED:\t\t%s (%s%%)", testResults.getSuccess(), testResults.getSuccessPercentageFormatted()));
-        info(format("FAILED:\t\t%s (%s%%)", testResults.getFailed(), testResults.getFailedPercentageFormatted()));
-
+        info(format("  TOTAL:    %s", testResults.getSize()));
+        info(format("  PASSED:   %s (%s%%)", testResults.getSuccess(), testResults.getSuccessPercentageFormatted()));
+        if (testResults.getFailed() > 0) {
+            info(LogColors.failed(format("  FAILED:   %s (%s%%)", testResults.getFailed(), testResults.getFailedPercentageFormatted())));
+        } else {
+            info(format("  FAILED:   %s (%s%%)", testResults.getFailed(), testResults.getFailedPercentageFormatted()));
+        }
         if (testResults.getSkipped() > 0) {
-            info(format("SKIP:\t\t%s (%s%%)", testResults.getSkipped(), testResults.getSkippedPercentageFormatted()));
+            info(LogColors.skipped(format("  SKIPPED:  %s (%s%%)", testResults.getSkipped(), testResults.getSkippedPercentageFormatted())));
         }
 
-        info(format("TIME:\t\t%s ms", testResults.getTotalDuration().toMillis()));
+        info(format("  TIME:     %s ms", testResults.getTotalDuration().toMillis()));
 
         newLine();
-
-        separator();
+        info(LogColors.bold(DOUBLE_SEPARATOR));
     }
 
     private String toFormattedTestResult(TestResult testResult) {
-        return format("%s (%6d ms) %s",
-                testResult.getResult(),
+        String resultText;
+        if (testResult.isSuccess()) {
+            resultText = LogColors.success(INDICATOR_SUCCESS) + " SUCCESS";
+        } else if (testResult.isFailed()) {
+            resultText = LogColors.failed(INDICATOR_FAILED + " FAILED ");
+        } else {
+            resultText = LogColors.skipped(INDICATOR_SKIPPED + " SKIPPED");
+        }
+        return format("  %s (%4dms) %s",
+                resultText,
                 Optional.ofNullable(testResult.getDuration()).orElse(ZERO).toMillis(),
                 testResult.getTestName());
     }
@@ -159,36 +163,40 @@ public class LoggingReporter extends AbstractTestReporter implements MessageList
     public void onTestFailure(TestCase testCase, Throwable cause) {
         newLine();
 
-        var duration = formatDurationString(testCase);
+        info(SINGLE_SEPARATOR);
+        var duration = formatDuration(testCase);
+        String line = LogColors.failed(INDICATOR_FAILED) + " TEST FAILED: " + testCase.getName();
+        if (hasText(duration)) {
+            line += LogColors.dim("  " + duration);
+        }
+        info(line);
 
         if (stackTraceOutputEnabled) {
-            error("TEST FAILED " + testCase.getName() + " <" + testCase.getPackageName() + ">" + duration + " Nested exception is: ", cause);
+            error("    " + LogColors.failed(cause.getClass().getSimpleName() + ": " + cause.getMessage()), cause);
         } else {
-            error("TEST FAILED " + testCase.getName() + " <" + testCase.getPackageName() + ">" + duration + " Nested exception is: " + cause.getMessage());
+            info(LogColors.failed("    " + cause.getClass().getSimpleName() + ": " + cause.getMessage()));
         }
 
-        separator();
+        info(SINGLE_SEPARATOR);
         newLine();
     }
 
     @Override
     public void onTestSkipped(TestCase test) {
-        if (isDebugEnabled()) {
-            newLine();
-            separator();
-            debug("SKIPPING TEST: " + test.getName());
-            newLine();
-        }
+        newLine();
+        info(SINGLE_SEPARATOR);
+        info(LogColors.skipped(INDICATOR_SKIPPED) + " TEST SKIPPED: " + test.getName());
+        info(SINGLE_SEPARATOR);
+        newLine();
     }
 
     @Override
     public void onTestStart(TestCase test) {
-        if (isDebugEnabled()) {
-            newLine();
-            separator();
-            debug("STARTING TEST " + test.getName() + " <" + test.getPackageName() + ">");
-            newLine();
-        }
+        newLine();
+        info(SINGLE_SEPARATOR);
+        info(LogColors.start(INDICATOR_START) + " TEST START: " + test.getName() + " (" + test.getPackageName() + ")");
+        info(SINGLE_SEPARATOR);
+        newLine();
     }
 
     @Override
@@ -199,20 +207,25 @@ public class LoggingReporter extends AbstractTestReporter implements MessageList
     @Override
     public void onTestSuccess(TestCase test) {
         newLine();
+        info(SINGLE_SEPARATOR);
 
-        var duration = formatDurationString(test);
-        info("TEST SUCCESS " + test.getName() + " (" + test.getPackageName() + ")" + duration);
+        var duration = formatDuration(test);
+        String line = LogColors.success(INDICATOR_SUCCESS) + " TEST SUCCESS: " + test.getName();
+        if (hasText(duration)) {
+            line += LogColors.dim("  " + duration);
+        }
+        info(line);
 
-        separator();
+        info(SINGLE_SEPARATOR);
         newLine();
     }
 
     @Override
     public void onFinish() {
         if (isDebugEnabled()) {
-            newLine();
-            separator();
-            debug("AFTER TEST SUITE");
+            debug(SINGLE_SEPARATOR);
+            debug(LogColors.start(INDICATOR_START) + " TEST SUITE FINISH");
+            debug(SINGLE_SEPARATOR);
             newLine();
         }
     }
@@ -226,8 +239,10 @@ public class LoggingReporter extends AbstractTestReporter implements MessageList
         separator();
 
         if (isDebugEnabled()) {
-            debug("BEFORE TEST SUITE");
             newLine();
+            debug(SINGLE_SEPARATOR);
+            debug(LogColors.start(INDICATOR_START) + " TEST SUITE START");
+            debug(SINGLE_SEPARATOR);
         }
     }
 
@@ -250,178 +265,174 @@ public class LoggingReporter extends AbstractTestReporter implements MessageList
 
     @Override
     public void onFinishFailure(Throwable cause) {
-        newLine();
-        error("AFTER TEST SUITE: FAILED");
-        separator();
+        info(SINGLE_SEPARATOR);
+        info(LogColors.failed(INDICATOR_FAILED) + " TEST SUITE FINISH: FAILED");
+
+        if (stackTraceOutputEnabled) {
+            error("    " + LogColors.failed(cause.getClass().getSimpleName() + ": " + cause.getMessage()), cause);
+        } else {
+            info(LogColors.failed("    " + cause.getClass().getSimpleName() + ": " + cause.getMessage()));
+        }
+
+        info(SINGLE_SEPARATOR);
         newLine();
     }
 
     @Override
     public void onFinishSuccess() {
-        if (isDebugEnabled()) {
-            newLine();
-            debug("AFTER TEST SUITE: SUCCESS");
-            separator();
-            newLine();
-        }
+        debug(SINGLE_SEPARATOR);
+        debug(LogColors.success(INDICATOR_SUCCESS) + " TEST SUITE FINISHED");
+        debug(SINGLE_SEPARATOR);
+        newLine();
     }
 
     @Override
     public void onStartFailure(Throwable cause) {
         newLine();
-        error("BEFORE TEST SUITE: FAILED");
-        separator();
-        newLine();
+        info(SINGLE_SEPARATOR);
+        info(LogColors.failed(INDICATOR_FAILED) + " TEST SUITE START: FAILED");
+
+        if (stackTraceOutputEnabled) {
+            error("    " + LogColors.failed(cause.getClass().getSimpleName() + ": " + cause.getMessage()), cause);
+        } else {
+            info(LogColors.failed("    " + cause.getClass().getSimpleName() + ": " + cause.getMessage()));
+        }
+
+        info(SINGLE_SEPARATOR);
     }
 
     @Override
     public void onStartSuccess() {
-        if (isDebugEnabled()) {
-            newLine();
-            debug("BEFORE TEST SUITE: SUCCESS");
-            separator();
-            newLine();
-        }
+        newLine();
+        debug(SINGLE_SEPARATOR);
+        debug(LogColors.success(INDICATOR_SUCCESS) + " TEST SUITE STARTED");
+        debug(SINGLE_SEPARATOR);
     }
 
     @Override
     public void onTestActionStart(TestCase testCase, TestAction testAction) {
-        if (isDebugEnabled()) {
-            newLine();
-            if (testCase.isIncremental()) {
-                debug("TEST STEP " + (testCase.getNumberOfExecutedActions() + 1) + ": " + (testAction.getName() != null ? testAction.getName() : testAction.getClass().getName()));
-            } else {
-                debug("TEST STEP " + (testCase.getActionIndex(testAction) + 1) + "/" + testCase.getActionCount() + ": " + (testAction.getName() != null ? testAction.getName() : testAction.getClass().getName()));
-            }
+        String actionName = resolveActionName(testAction);
 
-            if (testAction instanceof TestActionContainer container) {
-                debug("TEST ACTION CONTAINER with " + container.getActionCount() + " embedded actions");
-            }
+        if (testAction instanceof TestActionContainer container) {
+            info(LogColors.start(INDICATOR_START) + " " + actionName + " - container with (" + container.getActionCount() + ") embedded actions");
+        } else {
+            debug(LogColors.start(INDICATOR_START) + " " + actionName);
+        }
 
-            if (testAction instanceof Described described && hasText(described.getDescription())) {
-                debug("");
-                debug(described.getDescription());
-                debug("");
-            }
+        if (testAction instanceof Described described && hasText(described.getDescription())) {
+            debug("    " + LogColors.dim(described.getDescription()));
         }
     }
 
     @Override
     public void onTestActionFinish(TestCase testCase, TestAction testAction) {
-        if (isDebugEnabled()) {
-            newLine();
+        String actionName = resolveActionName(testAction);
 
-            var duration = formatDurationString(testCase);
-            if (testCase.isIncremental()) {
-                debug("TEST STEP " + (testCase.getNumberOfExecutedActions() + 1) + " SUCCESS" + duration);
-            } else {
-                debug("TEST STEP " + (testCase.getActionIndex(testAction) + 1) + "/" + testCase.getActionCount() + " SUCCESS" + duration);
-            }
+        var duration = formatDuration(testCase);
+        String line = LogColors.success(INDICATOR_SUCCESS) + " " + actionName;
+        if (hasText(duration)) {
+            line += LogColors.dim("  " + duration);
         }
+        info(line);
     }
 
     @Override
     public void onTestActionFailed(TestCase testCase, TestAction testAction, Throwable cause) {
-        if (isDebugEnabled()) {
-            newLine();
+        String actionName = resolveActionName(testAction);
 
-            var duration = formatDurationString(testCase);
-            if (testCase.isIncremental()) {
-                debug("TEST STEP " + (testCase.getNumberOfExecutedActions() + 1) + " FAILED" + duration + " Nested exception is: " + cause.getMessage());
-            } else {
-                debug("TEST STEP " + (testCase.getActionIndex(testAction) + 1) + "/" + testCase.getActionCount() + " FAILED" + duration + " Nested exception is: " + cause.getMessage());
-            }
+        var duration = formatDuration(testCase);
+        String line = LogColors.failed(INDICATOR_FAILED) + " " + actionName;
+        if (hasText(duration)) {
+            line += LogColors.dim("  " + duration);
         }
+        info(line);
+        info("    " + LogColors.failed(cause.getClass().getSimpleName() + ": " + cause.getMessage()));
     }
 
     @Override
     public void onTestActionSkipped(TestCase testCase, TestAction testAction) {
-        if (isDebugEnabled()) {
-            newLine();
-
-            if (testCase.isIncremental()) {
-                debug("TEST STEP " + (testCase.getNumberOfExecutedActions() + 1) + " SKIPPED");
-            } else {
-                debug("TEST STEP " + (testCase.getActionIndex(testAction) + 1) + "/" + testCase.getActionCount() + " SKIPPED");
-            }
-
-            debug("TEST ACTION " + (testAction.getName() != null ? testAction.getName() : testAction.getClass().getName()) + " SKIPPED");
-        }
+        String actionName = resolveActionName(testAction);
+        debug(LogColors.skipped(INDICATOR_SKIPPED) + " " + actionName);
     }
 
     @Override
     public void onInboundMessage(Message message, TestContext context) {
-        if (outboundMessageLogger.isDebugEnabled()) {
-            inboundMessageLogger.debug(message.print(context));
+        if (inboundMessageLogger.isDebugEnabled() || CitrusLogSettings.isPrintInboundMessageContentEnabled()) {
+            logMessage(message, context, MessageDirection.INBOUND);
+        } else {
+            logMessageSummary(message, MessageDirection.INBOUND);
         }
     }
 
     @Override
     public void onOutboundMessage(Message message, TestContext context) {
-        if (outboundMessageLogger.isDebugEnabled()) {
-            outboundMessageLogger.debug(message.print(context));
+        if (outboundMessageLogger.isDebugEnabled() || CitrusLogSettings.isPrintOutboundMessageContentEnabled()) {
+            logMessage(message, context, MessageDirection.OUTBOUND);
+        } else {
+            logMessageSummary(message, MessageDirection.OUTBOUND);
         }
     }
 
-    /**
-     * Helper method to build consistent separators
-     */
-    protected void separator() {
-        info("------------------------------------------------------------------------");
+    private void logMessage(Message message, TestContext context, MessageDirection direction) {
+        String messageContent = message.print(context);
+        String directionArrow = direction == MessageDirection.OUTBOUND
+                ? LogColors.arrow(ARROW_OUTBOUND)
+                : LogColors.arrow(ARROW_INBOUND);
+
+        messageLogger(direction).info("{} {} MESSAGE {}", directionArrow, direction.name(), messageContent);
     }
 
-    /**
-     * Adds new line to console logging output.
-     */
+    private void logMessageSummary(Message message, MessageDirection direction) {
+        String directionArrow = direction == MessageDirection.OUTBOUND
+                ? LogColors.arrow(ARROW_OUTBOUND)
+                : LogColors.arrow(ARROW_INBOUND);
+
+        messageLogger(direction).info("{} {} MESSAGE {}", directionArrow, direction.name(), LogColors.dim("(" + MessagePayloadUtils.sizeInfo(message) + ")"));
+    }
+
+    protected Logger messageLogger(MessageDirection direction) {
+        return switch (direction) {
+            case INBOUND -> inboundMessageLogger;
+            case OUTBOUND -> outboundMessageLogger;
+            case UNBOUND -> logger;
+        };
+    }
+
+    protected void separator() {
+        info(DOUBLE_SEPARATOR);
+    }
+
     protected void newLine() {
         info("");
     }
 
-    /**
-     * Write info level output.
-     */
     protected void info(String line) {
         logger.info(line);
     }
 
-    /**
-     * Write error level output.
-     */
     protected void error(String line) {
         logger.error(line);
     }
 
-    /**
-     * Write error level output.
-     */
     protected void error(String line, Throwable cause) {
         logger.error(line, cause);
     }
 
-    /**
-     * Write debug level output.
-     */
     protected void debug(String line) {
         if (isDebugEnabled()) {
             logger.debug(line);
         }
     }
 
-    /**
-     * Is debug level enabled.
-     */
     protected boolean isDebugEnabled() {
         return logger.isDebugEnabled();
     }
 
-    /**
-     * Sets the enablement state of the reporter.
-     */
     public void setEnabled(boolean enabled) {
         if (enabled) {
-            logger = enabledLog;
-            inboundMessageLogger = enabledInboundMessageLogger;
-            outboundMessageLogger = enabledOutboundMessageLogger;
+            logger = LoggerFactory.getLogger(LoggingReporter.class);
+            inboundMessageLogger = LoggerFactory.getLogger(LoggingReporter.class.getName() + ".Message_IN");
+            outboundMessageLogger = LoggerFactory.getLogger(LoggingReporter.class.getName() + ".Message_OUT");
         } else {
             logger = noOpLogger;
             inboundMessageLogger = noOpLogger;
@@ -437,4 +448,5 @@ public class LoggingReporter extends AbstractTestReporter implements MessageList
     public void destroy() {
         initialized(false);
     }
+
 }

--- a/core/citrus-base/src/main/java/org/citrusframework/report/TestFlowReporter.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/report/TestFlowReporter.java
@@ -90,7 +90,7 @@ public class TestFlowReporter extends AbstractTestReporter implements TestListen
         try (Writer fileWriter = new FileWriter(new File(targetDirectory, fileName))) {
             fileWriter.append(content);
             fileWriter.flush();
-            logger.info("Generated test report: {}{}{}", targetDirectory, File.separator, fileName);
+            logger.debug("Generated test report: {}{}{}", targetDirectory, File.separator, fileName);
         } catch (IOException e) {
             logger.error("Failed to create test report", e);
         }

--- a/core/citrus-base/src/main/java/org/citrusframework/validation/matcher/DefaultValidationMatcherLibrary.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/validation/matcher/DefaultValidationMatcherLibrary.java
@@ -96,7 +96,7 @@ public class DefaultValidationMatcherLibrary extends ValidationMatcherLibrary {
                 addMember(k, m);
             }
 
-            logger.debug("Register validation matcher '{}' as {}", k, m.getClass());
+            logger.trace("Register validation matcher '{}' as {}", k, m.getClass());
         });
     }
 }

--- a/core/citrus-base/src/test/java/org/citrusframework/message/DefaultMessageTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/message/DefaultMessageTest.java
@@ -16,15 +16,28 @@
 
 package org.citrusframework.message;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotEquals;
 import java.util.Map;
 
 import org.citrusframework.UnitTestSupport;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+
 public class DefaultMessageTest extends UnitTestSupport {
+
+    @BeforeClass
+    public void setup() {
+        DefaultMessagePrinter.setDefaultLayout(MessagePrinterLayout.COMPACT);
+    }
+
+    @AfterClass
+    public void teardown() {
+        DefaultMessagePrinter.resetDefaultLayout();
+    }
 
     @Test
     public void testPrint() {
@@ -34,11 +47,11 @@ public class DefaultMessageTest extends UnitTestSupport {
         message.setHeader("password", "foo");
 
         String output = message.print();
-        assertThat(output).isEqualToIgnoringNewLines(String.format("DEFAULTMESSAGE " +
-                    "[id: %s]%n" +
+        assertThat(output).isEqualToIgnoringNewLines(String.format(
+                    "[id: %s]" +
                     "[headers: {" +
                         "citrus_message_id=%s, citrus_message_timestamp=%s, operation=getCredentials, password=foo" +
-                    "}]%n" +
+                    "}]" +
                     "[payload: <credentials>%n  <password>foo</password>%n</credentials>%n]", message.getId(), message.getId(), message.getTimestamp()));
     }
 
@@ -51,11 +64,11 @@ public class DefaultMessageTest extends UnitTestSupport {
         message.setHeader("secret", "bar");
 
         String output = message.print(context);
-        assertThat(output).isEqualToIgnoringNewLines(String.format("DEFAULTMESSAGE " +
-                    "[id: %s]%n" +
+        assertThat(output).isEqualToIgnoringNewLines(String.format(
+                    "[id: %s]" +
                     "[headers: {" +
                         "citrus_message_id=%s, citrus_message_timestamp=%s, operation=getCredentials, password=****, secret=****" +
-                    "}]%n" +
+                    "}]" +
                     "[payload: password=****,secret=****]", message.getId(), message.getId(), message.getTimestamp()));
     }
 
@@ -68,11 +81,11 @@ public class DefaultMessageTest extends UnitTestSupport {
         message.setHeader("secret", "bar");
 
         String output = message.print(context);
-        assertThat(output).isEqualToIgnoringNewLines(String.format("DEFAULTMESSAGE " +
-                    "[id: %s]%n" +
+        assertThat(output).isEqualToIgnoringNewLines(String.format(
+                    "[id: %s]" +
                     "[headers: {" +
                         "citrus_message_id=%s, citrus_message_timestamp=%s, operation=getCredentials, password=****, secret=****" +
-                    "}]%n" +
+                    "}]" +
                     "[payload: password=****&secret=****]", message.getId(), message.getId(), message.getTimestamp()));
     }
 
@@ -84,11 +97,11 @@ public class DefaultMessageTest extends UnitTestSupport {
         message.setHeader("password", "foo");
 
         String output = message.print(context);
-        assertThat(output).isEqualToIgnoringNewLines(String.format("DEFAULTMESSAGE " +
-                    "[id: %s]%n" +
+        assertThat(output).isEqualToIgnoringNewLines(String.format(
+                    "[id: %s]" +
                     "[headers: {" +
                         "citrus_message_id=%s, citrus_message_timestamp=%s, operation=getCredentials, password=****" +
-                    "}]%n" +
+                    "}]" +
                     "[payload: <credentials>%n  <password>****</password>%n</credentials>%n]", message.getId(), message.getId(), message.getTimestamp()));
     }
 
@@ -101,11 +114,11 @@ public class DefaultMessageTest extends UnitTestSupport {
         message.setHeader("secretKey", "bar");
 
         String output = message.print(context);
-        assertThat(output).isEqualToIgnoringNewLines(String.format("DEFAULTMESSAGE " +
-                    "[id: %s]%n" +
+        assertThat(output).isEqualToIgnoringNewLines(String.format(
+                    "[id: %s]" +
                     "[headers: {" +
                         "citrus_message_id=%s, citrus_message_timestamp=%s, operation=getCredentials, password=****, secretKey=****" +
-                    "}]%n" +
+                    "}]" +
                     "[payload: {%n  \"credentials\": {%n    \"password\": \"****\",%n    \"secretKey\": \"****\"%n  }%n}]", message.getId(), message.getId(), message.getTimestamp()));
     }
 

--- a/core/citrus-base/src/test/java/org/citrusframework/report/LoggingReporterTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/report/LoggingReporterTest.java
@@ -16,18 +16,19 @@
 
 package org.citrusframework.report;
 
+import java.time.Duration;
+import java.util.Locale;
+import java.util.function.Consumer;
+
 import org.citrusframework.DefaultTestCase;
 import org.citrusframework.actions.EchoAction;
 import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.log.LogColors;
 import org.mockito.Mock;
 import org.slf4j.Logger;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-import java.time.Duration;
-import java.util.Locale;
-import java.util.function.Consumer;
 
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -60,6 +61,8 @@ public class LoggingReporterTest {
     @BeforeMethod
     public void beforeMethod() {
         mocks = openMocks(this);
+
+        LogColors.setColorEnabled(false);
 
         test = new DefaultTestCase();
         test.setName("SampleIT");
@@ -101,7 +104,7 @@ public class LoggingReporterTest {
         fixture.onFinish();
         fixture.onFinishSuccess();
 
-        verify(logger).info("TEST SUCCESS SampleIT (org.citrusframework.sample)");
+        verify(logger).info("✔ TEST SUCCESS: SampleIT");
 
         TestResults testResults = new TestResults();
         testResults.addResult(success("testLoggingReporterSuccess-1", getClass().getSimpleName()).withDuration(Duration.ofMillis(111)));
@@ -109,17 +112,18 @@ public class LoggingReporterTest {
 
         fixture.generate(testResults);
 
-        verify(logger).info("SUCCESS (   111 ms) testLoggingReporterSuccess-1");
-        verify(logger).info("SUCCESS (   222 ms) testLoggingReporterSuccess-2");
+        verify(logger).info("  ✔ SUCCESS ( 111ms) testLoggingReporterSuccess-1");
+        verify(logger).info("  ✔ SUCCESS ( 222ms) testLoggingReporterSuccess-2");
 
-        verifyResultSummaryLog(2, 2, 0, 333);
+        verifyResultSummaryLog(2, 2, 0, 0, 333);
 
         verify(logger, never()).debug(anyString());
     }
 
     @Test
     public void testLoggingReporterFailed() {
-        testLoggingReporterFailed((cause) -> verify(logger).error("TEST FAILED SampleIT <org.citrusframework.sample> Nested exception is: Failed!"));
+        testLoggingReporterFailed(
+                (cause) -> verify(logger).info("    CitrusRuntimeException: Failed!"));
     }
 
     @Test
@@ -127,12 +131,16 @@ public class LoggingReporterTest {
         // Override fixture, enable stacktrace output
         fixture = new LoggingReporter(true);
 
-        testLoggingReporterFailed((cause) -> verify(logger).error("TEST FAILED SampleIT <org.citrusframework.sample> Nested exception is: ", cause));
+        testLoggingReporterFailed(
+                (cause) -> verify(logger).error("    CitrusRuntimeException: Failed!", cause));
     }
 
     public void testLoggingReporterFailed(Consumer<Throwable> verifyErrorLogInvocation) {
         var nestedException = new CitrusRuntimeException("I am the final boss.");
         var cause = new CitrusRuntimeException("Failed!", nestedException);
+
+        // Re-inject mock logger in case fixture was replaced
+        setField(requireNonNull(findField(LoggingReporter.class, "logger")), null, logger);
 
         fixture.onStart();
         fixture.onStartSuccess();
@@ -143,6 +151,7 @@ public class LoggingReporterTest {
         fixture.onFinish();
         fixture.onFinishSuccess();
 
+        verify(logger).info("✘ TEST FAILED: SampleIT");
         verifyErrorLogInvocation.accept(cause);
 
         TestResults testResults = new TestResults();
@@ -153,13 +162,13 @@ public class LoggingReporterTest {
 
         fixture.generate(testResults);
 
-        verify(logger).info("FAILURE (  1234 ms) testLoggingReporterFailed-1");
-        verify(logger).info("FAILURE (  2345 ms) testLoggingReporterFailed-2");
-        verify(logger, times(2)).info("\tCaused by: %s: %s".formatted(nestedException.getClass().getSimpleName(), nestedException.getMessage()));
-        verify(logger).info("FAILURE (  3456 ms) testLoggingReporterFailed-3");
-        verify(logger).info("\tCaused by: %s".formatted(customErrorMessage));
+        verify(logger).info("  ✘ FAILED  (1234ms) testLoggingReporterFailed-1");
+        verify(logger).info("  ✘ FAILED  (2345ms) testLoggingReporterFailed-2");
+        verify(logger, times(2)).info("    Caused by: CitrusRuntimeException: I am the final boss.");
+        verify(logger).info("  ✘ FAILED  (3456ms) testLoggingReporterFailed-3");
+        verify(logger).info("    Caused by: custom error message");
 
-        verifyResultSummaryLog(3, 0, 3, 7035);
+        verifyResultSummaryLog(3, 0, 3, 0, 7035);
 
         verify(logger, never()).debug(anyString());
     }
@@ -172,11 +181,11 @@ public class LoggingReporterTest {
 
         fixture.generate(testResults);
 
-        verify(logger).info("SUCCESS (  1000 ms) testLoggingReporterMiscellaneous-1");
-        verify(logger).info("FAILURE (    22 ms) testLoggingReporterMiscellaneous-2");
-        verify(logger).info("\tCaused by: Unknown error");
+        verify(logger).info("  ✔ SUCCESS (1000ms) testLoggingReporterMiscellaneous-1");
+        verify(logger).info("  ✘ FAILED  (  22ms) testLoggingReporterMiscellaneous-2");
+        verify(logger).info("    Caused by: Unknown error");
 
-        verifyResultSummaryLog(2, 1, 1, 1022);
+        verifyResultSummaryLog(2, 1, 1, 0, 1022);
 
         verify(logger, never()).debug(anyString());
     }
@@ -197,9 +206,9 @@ public class LoggingReporterTest {
 
         fixture.generate(testResults);
 
-        verify(logger).info("SKIP (     0 ms) testLoggingReporterSkipped");
+        verify(logger).info("  ⊘ SKIPPED (   0ms) testLoggingReporterSkipped");
 
-        verifyResultSummaryLog(1, 0, 0, 0);
+        verifyResultSummaryLog(1, 0, 0, 1, 0);
 
         verify(logger, never()).debug(anyString());
     }
@@ -233,22 +242,26 @@ public class LoggingReporterTest {
 
     @AfterMethod
     void afterMethodTeardown() throws Exception {
+        LogColors.resetColorsEnabled();
         mocks.close();
     }
 
-    private void verifyResultSummaryLog(int total, int success, int failed, long performance) {
-        verify(logger).info("TOTAL:\t\t" + total);
-        verify(logger).info("PASSED:\t\t" + success + " (" + calculatePercentage(total, success) + "%)");
-        verify(logger).info("FAILED:\t\t" + failed + " (" + calculatePercentage(total, failed) + "%)");
-        verify(logger).info("TIME:\t\t" + performance + " ms");
+    private void verifyResultSummaryLog(int total, int success, int failed, int skipped, long performance) {
+        verify(logger).info("  TOTAL:    " + total);
+        verify(logger).info("  PASSED:   " + success + " (" + calculatePercentage(total, success) + "%)");
+        verify(logger).info("  FAILED:   " + failed + " (" + calculatePercentage(total, failed) + "%)");
+        if (skipped > 0) {
+            verify(logger).info("  SKIPPED:  " + skipped + " (" + calculatePercentage(total, skipped) + "%)");
+        }
+        verify(logger).info("  TIME:     " + performance + " ms");
     }
 
-    private String calculatePercentage(int total, int success) {
-        if (total == 0) {
+    private String calculatePercentage(int total, int count) {
+        if (total == 0 || count == 0) {
             return "0.0";
         }
 
-        double percentage = (double) success / total * 100;
-        return format(Locale.US, "%3.1f", percentage);
+        double percentage = (double) count / total * 100;
+        return format(Locale.US, "%.1f", percentage);
     }
 }

--- a/core/citrus-base/src/test/resources/log4j2.properties
+++ b/core/citrus-base/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/core/citrus-spring/src/test/resources/log4j2.properties
+++ b/core/citrus-spring/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/endpoint/CamelConsumer.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/endpoint/CamelConsumer.java
@@ -86,7 +86,7 @@ public class CamelConsumer implements Consumer {
             throw new MessageTimeoutException(timeout, endpointUri);
         }
 
-        logger.info("Received message from camel endpoint: '{}'", endpointUri);
+        logger.debug("Received message from camel endpoint: '{}'", endpointUri);
 
         Message message = endpointConfiguration.getMessageConverter().convertInbound(exchange, endpointConfiguration, context);
         context.onInboundMessage(message);

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/endpoint/CamelProducer.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/endpoint/CamelProducer.java
@@ -79,7 +79,7 @@ public class CamelProducer implements Producer {
             throw new CitrusRuntimeException("Sending message to camel endpoint resulted in exception", camelExchange.getException());
         }
 
-        logger.info("Message was sent to camel endpoint '{}'", endpointUri);
+        logger.debug("Message was sent to camel endpoint '{}'", endpointUri);
     }
 
     /**

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/endpoint/CamelSyncConsumer.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/endpoint/CamelSyncConsumer.java
@@ -85,7 +85,7 @@ public class CamelSyncConsumer extends CamelConsumer implements ReplyProducer {
             throw new MessageTimeoutException(timeout, endpointUri);
         }
 
-        logger.info("Received message from camel endpoint: '{}'", endpointUri);
+        logger.debug("Received message from camel endpoint: '{}'", endpointUri);
 
         Message message = endpointConfiguration.getMessageConverter().convertInbound(exchange, endpointConfiguration, context);
         context.onInboundMessage(message);
@@ -117,7 +117,7 @@ public class CamelSyncConsumer extends CamelConsumer implements ReplyProducer {
 
         context.onOutboundMessage(message);
 
-        logger.info("Message was sent to camel endpoint: '{}'", exchange.getFromEndpoint());
+        logger.debug("Message was sent to camel endpoint: '{}'", exchange.getFromEndpoint());
     }
 
     /**

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/endpoint/CamelSyncProducer.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/endpoint/CamelSyncProducer.java
@@ -76,10 +76,10 @@ public class CamelSyncProducer extends CamelProducer implements ReplyConsumer {
         Exchange response = getProducerTemplate(context)
                 .request(endpointUri, exchange -> {
                     endpointConfiguration.getMessageConverter().convertOutbound(exchange, message, endpointConfiguration, context);
-                    logger.info("Message was sent to camel endpoint: '{}'", endpointUri);
+                    logger.debug("Message was sent to camel endpoint: '{}'", endpointUri);
                 });
 
-        logger.info("Received synchronous reply message on camel endpoint: '{}'", endpointUri);
+        logger.debug("Received synchronous reply message on camel endpoint: '{}'", endpointUri);
         Message replyMessage = endpointConfiguration.getMessageConverter().convertInbound(response, endpointConfiguration, context);
         context.onInboundMessage(replyMessage);
         correlationManager.store(correlationKey, replyMessage);

--- a/endpoints/citrus-camel/src/test/resources/log4j2.properties
+++ b/endpoints/citrus-camel/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/endpoints/citrus-ftp/src/main/java/org/citrusframework/ftp/client/FtpClient.java
+++ b/endpoints/citrus-ftp/src/main/java/org/citrusframework/ftp/client/FtpClient.java
@@ -150,7 +150,7 @@ public class FtpClient extends AbstractEndpoint implements Producer, ReplyConsum
                 }
             }
 
-            logger.info("FTP message was sent to: '{}:{}'", getEndpointConfiguration().getHost(), getEndpointConfiguration().getPort());
+            logger.debug("FTP message was sent to: '{}:{}'", getEndpointConfiguration().getHost(), getEndpointConfiguration().getPort());
 
             correlationManager.store(correlationKey, response);
         } catch (IOException e) {
@@ -423,7 +423,7 @@ public class FtpClient extends AbstractEndpoint implements Producer, ReplyConsum
                 throw new CitrusRuntimeException("FTP server refused connection.");
             }
 
-            logger.info("Opened connection to FTP server");
+            logger.debug("Opened connection to FTP server");
 
             if (getEndpointConfiguration().getUser() != null) {
                 if (logger.isDebugEnabled()) {
@@ -509,7 +509,7 @@ public class FtpClient extends AbstractEndpoint implements Producer, ReplyConsum
                     logger.warn("Failed to disconnect from FTP server", e);
                 }
 
-                logger.info("Closed connection to FTP server");
+                logger.debug("Closed connection to FTP server");
             }
         } catch (IOException e) {
             throw new CitrusRuntimeException("Failed to logout from FTP server", e);

--- a/endpoints/citrus-ftp/src/main/java/org/citrusframework/ftp/client/SftpClient.java
+++ b/endpoints/citrus-ftp/src/main/java/org/citrusframework/ftp/client/SftpClient.java
@@ -277,7 +277,7 @@ public class SftpClient extends FtpClient {
 
                 getEndpointConfiguration().getSessionConfigs().entrySet()
                         .stream()
-                        .peek(entry -> logger.info("Setting session configuration: {}='{}'", entry.getKey(), entry.getValue()))
+                        .peek(entry -> logger.debug("Setting session configuration: {}='{}'", entry.getKey(), entry.getValue()))
                         .forEach(entry -> session.setConfig(entry.getKey(), entry.getValue()));
 
                 session.connect((int) getEndpointConfiguration().getTimeout());
@@ -286,7 +286,7 @@ public class SftpClient extends FtpClient {
                 channel.connect((int) getEndpointConfiguration().getTimeout());
                 sftp = (ChannelSftp) channel;
 
-                logger.info("Opened secure connection to FTP server");
+                logger.debug("Opened secure connection to FTP server");
             } catch (JSchException e) {
                 throw new CitrusRuntimeException(String.format("Failed to login to FTP server using credentials: %s:%s", getEndpointConfiguration().getUser(), getEndpointConfiguration().getPassword()), e);
             }
@@ -366,7 +366,7 @@ public class SftpClient extends FtpClient {
     public void destroy() {
         if (session != null && session.isConnected()) {
             session.disconnect();
-            logger.info("Closed connection to FTP server");
+            logger.debug("Closed connection to FTP server");
         }
 
         sftp.disconnect();

--- a/endpoints/citrus-ftp/src/test/resources/log4j2.properties
+++ b/endpoints/citrus-ftp/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/client/HttpClient.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/client/HttpClient.java
@@ -101,7 +101,7 @@ public class HttpClient extends AbstractEndpoint implements Producer, ReplyConsu
         final String endpointUri = getEndpointUri(httpMessage);
         context.setVariable(MessageHeaders.MESSAGE_REPLY_TO + "_" + correlationKeyName, endpointUri);
 
-        logger.info("Sending HTTP message to: '{}'", endpointUri);
+        logger.debug("Sending HTTP message to: '{}'", endpointUri);
         if (logger.isDebugEnabled()) {
             logger.debug("Message to send:\n{}", httpMessage.getPayload(String.class));
         }

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/interceptor/LoggingClientInterceptor.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/interceptor/LoggingClientInterceptor.java
@@ -19,7 +19,6 @@ package org.citrusframework.http.interceptor;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.util.List;
 import java.util.Map.Entry;
 
@@ -38,7 +37,6 @@ import org.springframework.http.client.ClientHttpResponse;
 
 import static java.lang.String.join;
 import static java.lang.System.lineSeparator;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Simple logging interceptor writes Http request and response messages to the console.
@@ -114,25 +112,8 @@ public class LoggingClientInterceptor implements ClientHttpRequestInterceptor {
      */
     private String getRequestContent(HttpRequest request, byte[] body) {
         String contentType = request.getHeaders().getFirst(HttpHeaders.CONTENT_TYPE);
-        String requestBody = null;
-        if (contentType != null) {
-            String[] contentTypeParts = contentType.split(";");
-            for (String contentTypePart : contentTypeParts) {
-                if (contentTypePart.startsWith("charset=") && !contentTypePart.endsWith("charset=")) {
-                    String charset = contentTypePart.split("=")[1];
-                    try {
-                        requestBody = new String(body, charset);
-                    } catch (UnsupportedEncodingException e) {
-                        requestBody = new String(body, UTF_8);
-                    }
-                }
-                break;
-            }
-        }
-
-        if (requestBody == null) {
-            requestBody = new String(body, UTF_8);
-        }
+        String contentEncoding = request.getHeaders().getFirst(HttpHeaders.CONTENT_ENCODING);
+        String requestBody = LoggingInterceptorUtils.getBodyContent(body, contentType, contentEncoding);
 
         StringBuilder builder = new StringBuilder();
 
@@ -169,7 +150,10 @@ public class LoggingClientInterceptor implements ClientHttpRequestInterceptor {
             appendHeaders(response.getHeaders(), builder);
 
             builder.append(NEWLINE);
-            builder.append(response.getBodyContent());
+
+            String contentType = response.getHeaders().getFirst(HttpHeaders.CONTENT_TYPE);
+            String contentEncoding = response.getHeaders().getFirst(HttpHeaders.CONTENT_ENCODING);
+            builder.append(LoggingInterceptorUtils.getBodyContent(response.getBodyContent(), contentType, contentEncoding));
 
             return builder.toString();
         } else {
@@ -229,12 +213,12 @@ public class LoggingClientInterceptor implements ClientHttpRequestInterceptor {
             return new ByteArrayInputStream(this.body);
         }
 
-        public String getBodyContent() throws IOException {
+        public byte[] getBodyContent() throws IOException {
             if (this.body == null) {
                 getBody();
             }
 
-            return new String(body, UTF_8);
+            return body;
         }
 
         @Override

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/interceptor/LoggingHandlerInterceptor.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/interceptor/LoggingHandlerInterceptor.java
@@ -17,6 +17,7 @@
 package org.citrusframework.http.interceptor;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Enumeration;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -28,6 +29,8 @@ import org.citrusframework.report.MessageListeners;
 import org.citrusframework.util.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
@@ -121,14 +124,14 @@ public class LoggingHandlerInterceptor implements HandlerInterceptor {
         builder.append(request.getRequestURI());
         builder.append(NEWLINE);
 
-        Enumeration<?> headerNames = request.getHeaderNames();
+        Enumeration<String> headerNames = request.getHeaderNames();
         while (headerNames.hasMoreElements()) {
-            String headerName = headerNames.nextElement().toString();
+            String headerName = headerNames.nextElement();
 
             builder.append(headerName);
             builder.append(":");
 
-            Enumeration<?> headerValues = request.getHeaders(headerName);
+            Enumeration<String> headerValues = request.getHeaders(headerName);
             if (headerValues.hasMoreElements()) {
                 builder.append(headerValues.nextElement());
             }
@@ -142,7 +145,10 @@ public class LoggingHandlerInterceptor implements HandlerInterceptor {
         }
 
         builder.append(NEWLINE);
-        builder.append(FileUtils.readToString(request.getInputStream()));
+
+        String contentType = request.getHeader(HttpHeaders.CONTENT_TYPE);
+        String contentEncoding = request.getHeader(HttpHeaders.CONTENT_ENCODING);
+        builder.append(LoggingInterceptorUtils.getBodyContent(FileUtils.copyToByteArray(request.getInputStream()), contentType, contentEncoding));
 
         return builder.toString();
     }
@@ -161,14 +167,42 @@ public class LoggingHandlerInterceptor implements HandlerInterceptor {
     private String getResponseContent(HttpServletRequest request, HttpServletResponse response, Object handler) {
         var builder = new StringBuilder();
 
-        builder.append(response);
+        builder.append(request.getProtocol());
+        builder.append(" ");
+        builder.append(HttpStatus.valueOf(response.getStatus()));
+        builder.append(NEWLINE);
+
+        Collection<String> headerNames = response.getHeaderNames();
+        for (String headerName : headerNames) {
+            builder.append(headerName);
+            builder.append(":");
+
+            Collection<String> headerValues = response.getHeaders(headerName);
+            builder.append(String.join(",", headerValues));
+
+            builder.append(NEWLINE);
+        }
+
+        builder.append(NEWLINE);
 
         if (handler instanceof HandlerMethod handlerMethod) {
             if (handlerMethod.getBean() instanceof HttpMessageController httpMessageController) {
                 ResponseEntity<?> responseEntity = httpMessageController.getResponseCache(request);
                 if (responseEntity != null) {
+                    String contentType = responseEntity.getHeaders().getFirst(HttpHeaders.CONTENT_TYPE);
+                    String contentEncoding = responseEntity.getHeaders().getFirst(HttpHeaders.CONTENT_ENCODING);
+
                     builder.append(NEWLINE);
-                    builder.append(responseEntity.getBody());
+                    byte[] body;
+                    if (responseEntity.getBody() == null) {
+                        body = new byte[0];
+                    } else if (responseEntity.getBody() instanceof byte[] bytes) {
+                        body = bytes;
+                    } else {
+                        body = contextFactory.getObject().getTypeConverter().convertIfNecessary(responseEntity.getBody(), byte[].class);
+                    }
+
+                    builder.append(LoggingInterceptorUtils.getBodyContent(body, contentType, contentEncoding));
                 }
             }
         }

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/interceptor/LoggingInterceptorUtils.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/interceptor/LoggingInterceptorUtils.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.http.interceptor;
+
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import org.citrusframework.message.MessagePayloadUtils;
+import org.citrusframework.message.MessageType;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+class LoggingInterceptorUtils {
+
+    private LoggingInterceptorUtils() {
+        // prevent instantiation of utility class
+    }
+
+    public static String getBodyContent(byte[] body, String contentType, String contentEncoding) {
+        if (isBinaryEncoding(contentEncoding)) {
+            return Arrays.toString(body);
+        }
+
+        MessageType messageType = MessageType.mapToMessageType(contentType, contentEncoding);
+        if (messageType != null && MessageType.isBinary(messageType.name())) {
+            return Arrays.toString(body);
+        }
+
+        return MessagePayloadUtils.prettyPrint(new String(body, getCharset(contentType)).trim());
+    }
+
+    private static Charset getCharset(String contentType) {
+        if (contentType == null) {
+            return UTF_8;
+        }
+
+        String[] contentTypeParts = contentType.split(";");
+        for (String contentTypePart : contentTypeParts) {
+            if (contentTypePart.startsWith("charset=") && !contentTypePart.endsWith("charset=")) {
+                String charset = contentTypePart.split("=")[1];
+                try {
+                    return Charset.forName(charset);
+                } catch (IllegalArgumentException e) {
+                    return UTF_8;
+                }
+            }
+            break;
+        }
+
+        return UTF_8;
+    }
+
+    private static boolean isBinaryEncoding(String contentEncoding) {
+        if (contentEncoding == null) {
+            return false;
+        }
+
+        return Stream.of("zstd", "gzip", "deflate")
+                .anyMatch(encoding -> encoding.equalsIgnoreCase(contentEncoding));
+    }
+}

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/servlet/CitrusDispatcherServlet.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/servlet/CitrusDispatcherServlet.java
@@ -55,7 +55,7 @@ public class CitrusDispatcherServlet extends DispatcherServlet {
     /**
      * Http server hosting the servlet
      */
-    private HttpServer httpServer;
+    private final HttpServer httpServer;
 
     /**
      * Default bean names used in default configuration

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/validation/FormUrlEncodedMessageValidator.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/validation/FormUrlEncodedMessageValidator.java
@@ -71,7 +71,7 @@ public class FormUrlEncodedMessageValidator implements MessageValidator<Validati
     @Override
     public void validateMessage(Message receivedMessage, Message controlMessage,
                                 TestContext context, List<ValidationContext> validationContexts) throws ValidationException {
-        logger.info("Start " + MessageType.FORM_URL_ENCODED + " message validation");
+        logger.debug("Start " + MessageType.FORM_URL_ENCODED + " message validation");
 
         try {
             Message formMessage = new DefaultMessage(receivedMessage);
@@ -85,7 +85,7 @@ public class FormUrlEncodedMessageValidator implements MessageValidator<Validati
             throw new ValidationException("Failed to validate " + MessageType.FORM_URL_ENCODED + " message", e);
         }
 
-        logger.info("Validation of " + MessageType.FORM_URL_ENCODED + " message finished successfully: All values OK");
+        logger.debug("Validation of " + MessageType.FORM_URL_ENCODED + " message finished successfully: All values OK");
     }
 
     /**

--- a/endpoints/citrus-http/src/test/resources/log4j2.properties
+++ b/endpoints/citrus-http/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/endpoints/citrus-http/src/test/resources/org/citrusframework/http/integration/HttpClientIT.xml
+++ b/endpoints/citrus-http/src/test/resources/org/citrusframework/http/integration/HttpClientIT.xml
@@ -19,9 +19,9 @@
     <description>Test send messages to some Http server instance that automatically responds with static message data.</description>
 
     <variables>
-      <variable name="correlationId" value="1000000001"></variable>
-      <variable name="messageId" value="1234567890"></variable>
-      <variable name="user" value="User"></variable>
+      <variable name="correlationId" value="1000000001"/>
+      <variable name="messageId" value="1234567890"/>
+      <variable name="user" value="User"/>
     </variables>
 
     <actions>

--- a/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/actions/PurgeJmsQueuesAction.java
+++ b/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/actions/PurgeJmsQueuesAction.java
@@ -113,7 +113,7 @@ public class PurgeJmsQueuesAction extends AbstractTestAction {
             JmsUtils.closeConnection(connection, true);
         }
 
-        logger.info("Purged JMS queues");
+        logger.debug("Purged JMS queues");
     }
 
     /**

--- a/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/endpoint/JmsConsumer.java
+++ b/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/endpoint/JmsConsumer.java
@@ -88,7 +88,7 @@ public class JmsConsumer extends AbstractSelectiveMessageConsumer {
             throw new MessageTimeoutException(endpointConfiguration.getTimeout(), getDestinationNameWithSelector(destinationName, selector));
         }
 
-        logger.info("Received JMS message on destination: '{}'", getDestinationNameWithSelector(destinationName, selector));
+        logger.debug("Received JMS message on destination: '{}'", getDestinationNameWithSelector(destinationName, selector));
 
         return receivedJmsMessage;
     }
@@ -113,7 +113,7 @@ public class JmsConsumer extends AbstractSelectiveMessageConsumer {
             throw new MessageTimeoutException(endpointConfiguration.getTimeout(), getDestinationNameWithSelector(endpointConfiguration.getDestinationName(destination), selector));
         }
 
-        logger.info("Received JMS message on destination: '{}'", getDestinationNameWithSelector(endpointConfiguration.getDestinationName(destination), selector));
+        logger.debug("Received JMS message on destination: '{}'", getDestinationNameWithSelector(endpointConfiguration.getDestinationName(destination), selector));
 
         return receivedJmsMessage;
     }

--- a/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/endpoint/JmsProducer.java
+++ b/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/endpoint/JmsProducer.java
@@ -85,7 +85,7 @@ public class JmsProducer implements Producer {
             return jmsMessage;
         });
 
-        logger.info("Message was sent to JMS destination: '{}'", destinationName);
+        logger.debug("Message was sent to JMS destination: '{}'", destinationName);
     }
 
     /**
@@ -102,10 +102,8 @@ public class JmsProducer implements Producer {
             return jmsMessage;
         });
 
-        if (logger.isInfoEnabled()) {
-            logger.info("Message was sent to JMS destination: '{}'",
-                endpointConfiguration.getDestinationName(destination));
-        }
+        logger.debug("Message was sent to JMS destination: '{}'",
+            endpointConfiguration.getDestinationName(destination));
     }
 
     @Override

--- a/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/endpoint/JmsSyncConsumer.java
+++ b/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/endpoint/JmsSyncConsumer.java
@@ -88,7 +88,7 @@ public class JmsSyncConsumer extends JmsConsumer implements ReplyProducer {
 
         context.onOutboundMessage(message);
 
-        logger.info("Message was sent to JMS destination: '{}'", endpointConfiguration.getDestinationName(replyDestination));
+        logger.debug("Message was sent to JMS destination: '{}'", endpointConfiguration.getDestinationName(replyDestination));
     }
 
     /**

--- a/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/endpoint/JmsSyncProducer.java
+++ b/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/endpoint/JmsSyncProducer.java
@@ -142,7 +142,7 @@ public class JmsSyncProducer extends JmsProducer implements ReplyConsumer {
                 messageConsumer = createMessageConsumer(replyToDestination, jmsRequest.getJMSMessageID());
             }
 
-            logger.info("Message was sent to JMS destination: '{}'", endpointConfiguration.getDestinationName(destination));
+            logger.debug("Message was sent to JMS destination: '{}'", endpointConfiguration.getDestinationName(destination));
             logger.debug("Receiving reply message on destination: '{}'", replyToDestination);
 
             jakarta.jms.Message jmsReplyMessage = (endpointConfiguration.getTimeout() >= 0) ? messageConsumer.receive(endpointConfiguration.getTimeout()) : messageConsumer.receive();
@@ -153,7 +153,7 @@ public class JmsSyncProducer extends JmsProducer implements ReplyConsumer {
 
             Message responseMessage = endpointConfiguration.getMessageConverter().convertInbound(jmsReplyMessage, endpointConfiguration, context);
 
-            logger.info("Received reply message on JMS destination: '{}'", replyToDestination);
+            logger.debug("Received reply message on JMS destination: '{}'", replyToDestination);
 
             context.onInboundMessage(responseMessage);
 

--- a/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/endpoint/JmsTopicSubscriber.java
+++ b/endpoints/citrus-jms/src/main/java/org/citrusframework/jms/endpoint/JmsTopicSubscriber.java
@@ -175,7 +175,7 @@ public class JmsTopicSubscriber extends JmsConsumer implements Runnable {
 
         try {
             if (started.get()) {
-                logger.info("Started JMS topic subscription");
+                logger.debug("Started JMS topic subscription");
             }
         } catch (InterruptedException | ExecutionException e) {
             logger.warn("Failed to wait for topic subscriber to start subscription", e);

--- a/endpoints/citrus-jms/src/test/resources/log4j2.properties
+++ b/endpoints/citrus-jms/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/endpoints/citrus-jmx/src/main/java/org/citrusframework/jmx/client/JmxClient.java
+++ b/endpoints/citrus-jmx/src/main/java/org/citrusframework/jmx/client/JmxClient.java
@@ -257,7 +257,7 @@ public class JmxClient extends AbstractEndpoint implements Producer, ReplyConsum
                 scheduleReconnect();
             }
         };
-        logger.info("Reconnecting to MBean server {} in {} milliseconds.", getEndpointConfiguration().getServerUrl(), getEndpointConfiguration().getDelayOnReconnect());
+        logger.debug("Reconnecting to MBean server {} in {} milliseconds.", getEndpointConfiguration().getServerUrl(), getEndpointConfiguration().getDelayOnReconnect());
         scheduledExecutor.schedule(startRunnable, getEndpointConfiguration().getDelayOnReconnect(), TimeUnit.MILLISECONDS);
     }
 

--- a/endpoints/citrus-jmx/src/test/resources/log4j2.properties
+++ b/endpoints/citrus-jmx/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaMessageFilteringConsumer.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaMessageFilteringConsumer.java
@@ -141,11 +141,7 @@ class KafkaMessageFilteringConsumer extends AbstractSelectiveMessageConsumer {
                 getEndpointConfiguration(),
                 testContext);
 
-        if (logger.isDebugEnabled()) {
-            logger.info("Received Kafka message on topic '{}': {}", topic, received);
-        } else {
-            logger.info("Received Kafka message on topic '{}'", topic);
-        }
+        logger.debug("Received Kafka message on topic '{}'", topic);
 
         return received;
     }

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaMessageSingleConsumer.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaMessageSingleConsumer.java
@@ -72,11 +72,7 @@ class KafkaMessageSingleConsumer extends AbstractMessageConsumer {
 
         consumer.commitSync(Duration.ofMillis(getEndpointConfiguration().getTimeout()));
 
-        if (logger.isDebugEnabled()) {
-            logger.info("Received Kafka message on topic '{}': {}", topic, received);
-        } else {
-            logger.info("Received Kafka message on topic '{}'", topic);
-        }
+        logger.debug("Received Kafka message on topic '{}'", topic);
 
         return received;
     }

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaProducer.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaProducer.java
@@ -104,7 +104,7 @@ public class KafkaProducer implements Producer {
         try {
             ProducerRecord<Object, Object> producerRecord = endpointConfiguration.getMessageConverter().convertOutbound(message, endpointConfiguration, context);
             producer.send(producerRecord).get(endpointConfiguration.getTimeout(), MILLISECONDS);
-            logger.info("Message was sent to Kafka stream topic: '{}'", topic);
+            logger.debug("Message was sent to Kafka stream topic: '{}'", topic);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new CitrusRuntimeException("Thread was interrupted while publishing Kafka message", e);

--- a/endpoints/citrus-kafka/src/test/resources/log4j2.properties
+++ b/endpoints/citrus-kafka/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/endpoints/citrus-mail/src/main/java/org/citrusframework/mail/client/MailClient.java
+++ b/endpoints/citrus-mail/src/main/java/org/citrusframework/mail/client/MailClient.java
@@ -94,7 +94,7 @@ public class MailClient extends AbstractEndpoint implements Producer, Initializi
 
         context.onOutboundMessage(mailMessage);
 
-        logger.info("Mail message was sent to host: '{}://{}:{}'", getEndpointConfiguration().getProtocol(), getEndpointConfiguration().getHost(), getEndpointConfiguration().getPort());
+        logger.debug("Mail message was sent to host: '{}://{}:{}'", getEndpointConfiguration().getProtocol(), getEndpointConfiguration().getHost(), getEndpointConfiguration().getPort());
     }
 
     /**

--- a/endpoints/citrus-mail/src/test/resources/log4j2.properties
+++ b/endpoints/citrus-mail/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/endpoints/citrus-rmi/src/main/java/org/citrusframework/rmi/client/RmiClient.java
+++ b/endpoints/citrus-rmi/src/main/java/org/citrusframework/rmi/client/RmiClient.java
@@ -132,7 +132,7 @@ public class RmiClient extends AbstractEndpoint implements Producer, ReplyConsum
             Message response = new DefaultMessage(payload.toString());
             correlationManager.store(correlationKey, response);
 
-            logger.info("Message was sent to RMI server: '{}'", binding);
+            logger.debug("Message was sent to RMI server: '{}'", binding);
             if (result != null) {
                 context.onInboundMessage(response);
             }
@@ -146,7 +146,7 @@ public class RmiClient extends AbstractEndpoint implements Producer, ReplyConsum
             throw new CitrusRuntimeException("Failed to invoke method on remote target, because remote method not accessible", e);
         }
 
-        logger.info("Message was sent to RMI server: '{}'", binding);
+        logger.debug("Message was sent to RMI server: '{}'", binding);
     }
 
     @Override

--- a/endpoints/citrus-rmi/src/test/resources/log4j2.properties
+++ b/endpoints/citrus-rmi/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/channel/ChannelProducer.java
+++ b/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/channel/ChannelProducer.java
@@ -72,7 +72,7 @@ public class ChannelProducer implements Producer {
             throw new CitrusRuntimeException("Failed to send message to channel: '" + destinationChannelName + "'", e);
         }
 
-        logger.info("Message was sent to channel: '{}'", destinationChannelName);
+        logger.debug("Message was sent to channel: '{}'", destinationChannelName);
     }
 
     /**

--- a/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/channel/ChannelSyncConsumer.java
+++ b/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/channel/ChannelSyncConsumer.java
@@ -83,7 +83,7 @@ public class ChannelSyncConsumer extends ChannelConsumer implements ReplyProduce
             throw new CitrusRuntimeException("Failed to send message to channel: '" + replyChannel + "'", e);
         }
 
-        logger.info("Message was sent to reply channel: '{}'", replyChannel);
+        logger.debug("Message was sent to reply channel: '{}'", replyChannel);
     }
 
     /**

--- a/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/channel/ChannelSyncProducer.java
+++ b/endpoints/citrus-spring-integration/src/main/java/org/citrusframework/channel/ChannelSyncProducer.java
@@ -71,7 +71,7 @@ public class ChannelSyncProducer extends ChannelProducer implements ReplyConsume
 
         endpointConfiguration.getMessagingTemplate().setReceiveTimeout(endpointConfiguration.getTimeout());
 
-        logger.info("Message was sent to channel: '{}'", destinationChannelName);
+        logger.debug("Message was sent to channel: '{}'", destinationChannelName);
 
         org.springframework.messaging.Message<?> replyMessage = endpointConfiguration.getMessagingTemplate().sendAndReceive(getDestinationChannel(context),
                 endpointConfiguration.getMessageConverter().convertOutbound(message, endpointConfiguration, context));
@@ -79,7 +79,7 @@ public class ChannelSyncProducer extends ChannelProducer implements ReplyConsume
         if (replyMessage == null) {
             throw new ReplyMessageTimeoutException(endpointConfiguration.getTimeout(), destinationChannelName);
         } else {
-            logger.info("Received synchronous response from reply channel '{}'", destinationChannelName);
+            logger.debug("Received synchronous response from reply channel '{}'", destinationChannelName);
         }
 
         correlationManager.store(correlationKey, endpointConfiguration.getMessageConverter().convertInbound(replyMessage, endpointConfiguration, context));

--- a/endpoints/citrus-spring-integration/src/test/resources/log4j2.properties
+++ b/endpoints/citrus-spring-integration/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/endpoints/citrus-ssh/src/test/resources/log4j2.properties
+++ b/endpoints/citrus-ssh/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/endpoints/citrus-vertx/src/main/java/org/citrusframework/vertx/endpoint/VertxConsumer.java
+++ b/endpoints/citrus-vertx/src/main/java/org/citrusframework/vertx/endpoint/VertxConsumer.java
@@ -88,7 +88,7 @@ public class VertxConsumer extends AbstractMessageConsumer {
                 throw new MessageTimeoutException(timeout, endpointConfiguration.getAddress());
             }
 
-            logger.info("Received message on Vert.x event bus address: '{}'", endpointConfiguration.getAddress());
+            logger.debug("Received message on Vert.x event bus address: '{}'", endpointConfiguration.getAddress());
 
             context.onInboundMessage(message);
 

--- a/endpoints/citrus-vertx/src/main/java/org/citrusframework/vertx/endpoint/VertxProducer.java
+++ b/endpoints/citrus-vertx/src/main/java/org/citrusframework/vertx/endpoint/VertxProducer.java
@@ -74,7 +74,7 @@ public class VertxProducer implements Producer {
 
         context.onOutboundMessage(message);
 
-        logger.info("Message was sent to Vert.x event bus address: '{}'", endpointConfiguration.getAddress());
+        logger.debug("Message was sent to Vert.x event bus address: '{}'", endpointConfiguration.getAddress());
     }
 
     /**

--- a/endpoints/citrus-vertx/src/main/java/org/citrusframework/vertx/endpoint/VertxSyncConsumer.java
+++ b/endpoints/citrus-vertx/src/main/java/org/citrusframework/vertx/endpoint/VertxSyncConsumer.java
@@ -83,7 +83,7 @@ public class VertxSyncConsumer extends VertxConsumer implements ReplyProducer {
 
         context.onOutboundMessage(message);
 
-        logger.info("Message was sent to Vert.x event bus address: '{}'", replyAddress);
+        logger.debug("Message was sent to Vert.x event bus address: '{}'", replyAddress);
     }
 
     /**

--- a/endpoints/citrus-vertx/src/main/java/org/citrusframework/vertx/endpoint/VertxSyncProducer.java
+++ b/endpoints/citrus-vertx/src/main/java/org/citrusframework/vertx/endpoint/VertxSyncProducer.java
@@ -70,13 +70,13 @@ public class VertxSyncProducer extends VertxProducer implements ReplyConsumer {
         correlationManager.saveCorrelationKey(correlationKeyName, correlationKey, context);
         context.onOutboundMessage(message);
 
-        logger.info("Message was sent to Vert.x event bus address: '{}'", endpointConfiguration.getAddress());
+        logger.debug("Message was sent to Vert.x event bus address: '{}'", endpointConfiguration.getAddress());
 
         DeliveryOptions deliveryOptions = new DeliveryOptions();
         deliveryOptions.setSendTimeout(endpointConfiguration.getTimeout());
         vertx.eventBus().request(endpointConfiguration.getAddress(), message.getPayload(), deliveryOptions,
             event -> {
-                logger.info("Received synchronous response on Vert.x event bus reply address");
+                logger.debug("Received synchronous response on Vert.x event bus reply address");
 
                 Message responseMessage = endpointConfiguration.getMessageConverter().convertInbound(event.result(), endpointConfiguration, context);
 

--- a/endpoints/citrus-vertx/src/test/resources/log4j2.properties
+++ b/endpoints/citrus-vertx/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/endpoints/citrus-websocket/src/main/java/org/citrusframework/websocket/endpoint/WebSocketConsumer.java
+++ b/endpoints/citrus-websocket/src/main/java/org/citrusframework/websocket/endpoint/WebSocketConsumer.java
@@ -51,12 +51,12 @@ public class WebSocketConsumer extends AbstractSelectiveMessageConsumer {
 
     @Override
     public Message receive(String selector, TestContext context, long timeout) {
-        logger.info("Waiting {} ms for Web Socket message ...", timeout);
+        logger.debug("Waiting {} ms for Web Socket message ...", timeout);
 
         WebSocketMessage<?> message = receive(endpointConfiguration, timeout);
         Message receivedMessage = endpointConfiguration.getMessageConverter().convertInbound(message, endpointConfiguration, context);
 
-        logger.info("Received Web Socket message");
+        logger.debug("Received Web Socket message");
         context.onInboundMessage(receivedMessage);
 
         return receivedMessage;

--- a/endpoints/citrus-websocket/src/main/java/org/citrusframework/websocket/endpoint/WebSocketProducer.java
+++ b/endpoints/citrus-websocket/src/main/java/org/citrusframework/websocket/endpoint/WebSocketProducer.java
@@ -52,13 +52,13 @@ public class WebSocketProducer implements Producer {
     public void send(Message message, TestContext context) {
         ObjectHelper.assertNotNull(message, "Message is empty - unable to send empty message");
 
-        logger.info("Sending WebSocket message ...");
+        logger.debug("Sending WebSocket message ...");
 
         context.onOutboundMessage(message);
 
         WebSocketMessage wsMessage = endpointConfiguration.getMessageConverter().convertOutbound(message, endpointConfiguration, context);
         if (endpointConfiguration.getHandler().sendMessage(wsMessage)) {
-            logger.info("WebSocket Message was successfully sent");
+            logger.debug("WebSocket Message was successfully sent");
         }
     }
 

--- a/endpoints/citrus-websocket/src/main/java/org/citrusframework/websocket/servlet/CitrusWebSocketDispatcherServlet.java
+++ b/endpoints/citrus-websocket/src/main/java/org/citrusframework/websocket/servlet/CitrusWebSocketDispatcherServlet.java
@@ -42,7 +42,7 @@ import org.springframework.web.socket.server.support.WebSocketHttpRequestHandler
 public class CitrusWebSocketDispatcherServlet extends CitrusDispatcherServlet {
 
     /** Http server hosting the servlet */
-    private WebSocketServer webSocketServer;
+    private final WebSocketServer webSocketServer;
 
     /** Default bean names used in default configuration for supporting WebSocket endpoints */
     protected static final String URL_HANDLER_MAPPING_BEAN_NAME = "citrusUrlHandlerMapping";

--- a/endpoints/citrus-websocket/src/test/resources/log4j2.properties
+++ b/endpoints/citrus-websocket/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/client/WebServiceClient.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/client/WebServiceClient.java
@@ -134,13 +134,13 @@ public class WebServiceClient extends AbstractEndpoint implements Producer, Repl
             result = getEndpointConfiguration().getWebServiceTemplate().sendAndReceive(requestCallback, responseCallback);
         }
 
-        logger.info("SOAP message was sent to endpoint: '{}'", endpointUri);
+        logger.debug("SOAP message was sent to endpoint: '{}'", endpointUri);
 
         if (result) {
-            logger.info("Received SOAP response on endpoint: '{}'", endpointUri);
+            logger.debug("Received SOAP response on endpoint: '{}'", endpointUri);
             correlationManager.store(correlationKey, responseCallback.getResponse());
         } else {
-            logger.info("Received no SOAP response from endpoint: '{}'", endpointUri);
+            logger.debug("Received no SOAP response from endpoint: '{}'", endpointUri);
         }
     }
 
@@ -246,7 +246,7 @@ public class WebServiceClient extends AbstractEndpoint implements Producer, Repl
                         responseMessage.setPayload(faultPayload.toString());
                     }
 
-                    logger.info("Received SOAP fault response on endpoint: '{}'", endpointUri);
+                    logger.debug("Received SOAP fault response on endpoint: '{}'", endpointUri);
                     correlationManager.store(correlationKey, responseMessage);
                 } catch (TransformerException e) {
                     throw new CitrusRuntimeException("Failed to handle fault response message", e);

--- a/endpoints/citrus-ws/src/test/resources/log4j2.properties
+++ b/endpoints/citrus-ws/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/endpoints/citrus-zookeeper/src/test/resources/log4j2.properties
+++ b/endpoints/citrus-zookeeper/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/runtime/citrus-cucumber/src/main/java/org/citrusframework/cucumber/backend/spring/CitrusSpringBackend.java
+++ b/runtime/citrus-cucumber/src/main/java/org/citrusframework/cucumber/backend/spring/CitrusSpringBackend.java
@@ -16,6 +16,10 @@
 
 package org.citrusframework.cucumber.backend.spring;
 
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
 import io.cucumber.core.backend.Container;
 import io.cucumber.core.backend.Glue;
 import io.cucumber.core.backend.Lookup;
@@ -31,10 +35,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
-
-import java.net.URI;
-import java.util.List;
-import java.util.Map;
 
 public class CitrusSpringBackend extends CitrusBackend {
 
@@ -69,7 +69,7 @@ public class CitrusSpringBackend extends CitrusBackend {
         public void process(Citrus instance) {
             for (URI gluePath : gluePaths) {
                 String xmlStepConfigLocation = "classpath*:" + ClasspathSupport.resourceNameOfPackageName(ClasspathSupport.packageName(gluePath)) + "/**/*Steps.xml";
-                logger.info("Loading XML step definitions {}", xmlStepConfigLocation);
+                logger.debug("Loading XML step definitions {}", xmlStepConfigLocation);
 
                 ApplicationContext ctx;
                 if (instance.getCitrusContext() instanceof CitrusSpringContext) {
@@ -81,9 +81,7 @@ public class CitrusSpringBackend extends CitrusBackend {
                 Map<String, StepTemplate> xmlSteps = ctx.getBeansOfType(StepTemplate.class);
 
                 for (StepTemplate stepTemplate : xmlSteps.values()) {
-                    if (logger.isDebugEnabled()) {
-                        logger.info("Loading XML step definitions {}", xmlStepConfigLocation);
-                    }
+                    logger.debug("Loading XML step definition: {}", stepTemplate.getName());
                     glue.addStepDefinition(new XmlStepDefinition(stepTemplate, lookup));
                 }
             }

--- a/runtime/citrus-cucumber/src/test/resources/log4j2.properties
+++ b/runtime/citrus-cucumber/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/runtime/citrus-groovy/src/main/java/org/citrusframework/script/CreateEndpointsAction.java
+++ b/runtime/citrus-groovy/src/main/java/org/citrusframework/script/CreateEndpointsAction.java
@@ -67,7 +67,7 @@ public class CreateEndpointsAction extends AbstractTestAction {
             new EndpointConfigurationScript(resolvedScript, context.getReferenceResolver()) {
                 @Override
                 protected void onCreate(Endpoint endpoint) {
-                    logger.info("Creating endpoint from script configuration: %s".formatted(endpoint.getName()));
+                    logger.debug("Creating endpoint from script configuration: %s".formatted(endpoint.getName()));
                 }
             }.execute(context);
         } catch (IOException e) {

--- a/runtime/citrus-groovy/src/main/java/org/citrusframework/script/GroovyAction.java
+++ b/runtime/citrus-groovy/src/main/java/org/citrusframework/script/GroovyAction.java
@@ -132,7 +132,7 @@ public class GroovyAction extends AbstractTestAction {
                 groovyObject.invokeMethod("run", new Object[]{});
             }
 
-            logger.info("Groovy script execution successful");
+            logger.debug("Groovy script execution successful");
         } catch (CitrusRuntimeException e) {
             throw e;
         } catch (Exception e) {

--- a/runtime/citrus-groovy/src/test/resources/log4j2.properties
+++ b/runtime/citrus-groovy/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/runtime/citrus-junit-jupiter/src/test/resources/log4j2.properties
+++ b/runtime/citrus-junit-jupiter/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/runtime/citrus-junit/src/test/resources/log4j2.properties
+++ b/runtime/citrus-junit/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/runtime/citrus-main/src/test/resources/log4j2.properties
+++ b/runtime/citrus-main/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/runtime/citrus-testng/src/test/resources/log4j2.properties
+++ b/runtime/citrus-testng/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/runtime/citrus-xml/src/test/resources/log4j2.properties
+++ b/runtime/citrus-xml/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/runtime/citrus-yaml/src/test/resources/log4j2.properties
+++ b/runtime/citrus-yaml/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/tools/agent/src/main/java/org/citrusframework/agent/listener/AgentTestListener.java
+++ b/tools/agent/src/main/java/org/citrusframework/agent/listener/AgentTestListener.java
@@ -20,10 +20,8 @@ import java.io.StringWriter;
 
 import org.citrusframework.TestAction;
 import org.citrusframework.TestCase;
-import org.citrusframework.context.TestContext;
-import org.citrusframework.message.Message;
-import org.citrusframework.report.TestFlowReporter;
 import org.citrusframework.report.OutputStreamReporter;
+import org.citrusframework.report.TestFlowReporter;
 import org.citrusframework.report.TestResults;
 
 public class AgentTestListener extends OutputStreamReporter {
@@ -129,22 +127,6 @@ public class AgentTestListener extends OutputStreamReporter {
         pending.addResult(test.getTestResult());
         testFlowReporter.onTestSkipped(test);
         super.onTestSkipped(test);
-    }
-
-    @Override
-    public void onInboundMessage(Message message, TestContext context) {
-        info("INBOUND_MESSAGE");
-        separator();
-        info(message.print(context));
-        separator();
-    }
-
-    @Override
-    public void onOutboundMessage(Message message, TestContext context) {
-        info("OUTBOUND_MESSAGE");
-        separator();
-        info(message.print(context));
-        separator();
     }
 
     public void reset() {

--- a/tools/archetypes/jms/src/main/resources/archetype-resources/src/test/resources/log4j2.properties
+++ b/tools/archetypes/jms/src/main/resources/archetype-resources/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/tools/archetypes/quickstart/src/main/resources/archetype-resources/src/test/resources/log4j2.properties
+++ b/tools/archetypes/quickstart/src/main/resources/archetype-resources/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/tools/archetypes/soap/src/main/resources/archetype-resources/src/test/resources/log4j2.properties
+++ b/tools/archetypes/soap/src/main/resources/archetype-resources/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/tools/docs-generator/src/test/resources/log4j2.properties
+++ b/tools/docs-generator/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/tools/maven/citrus-agent-maven-plugin/src/main/resources/log4j2.xml
+++ b/tools/maven/citrus-agent-maven-plugin/src/main/resources/log4j2.xml
@@ -32,11 +32,11 @@
       <AppenderRef ref="STDOUT"/>
     </Logger>
 
-    <Logger name="Logger.Message_IN" additivity="false" level="DEBUG">
+    <Logger name="org.citrusframework.report.LoggingReporter.Message_IN" additivity="false" level="DEBUG">
       <AppenderRef ref="STDOUT"/>
     </Logger>
 
-    <Logger name="Logger.Message_OUT" additivity="false" level="DEBUG">
+    <Logger name="org.citrusframework.report.LoggingReporter.Message_OUT" additivity="false" level="DEBUG">
       <AppenderRef ref="STDOUT"/>
     </Logger>
 

--- a/tools/maven/citrus-maven-plugin-integration/src/test/resources/log4j2.properties
+++ b/tools/maven/citrus-maven-plugin-integration/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/tools/maven/citrus-maven-plugin/src/test/resources/log4j2.properties
+++ b/tools/maven/citrus-maven-plugin/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/tools/restdocs/src/test/resources/log4j2.properties
+++ b/tools/restdocs/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/tools/test-generator/src/test/resources/log4j2.properties
+++ b/tools/test-generator/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/validation/citrus-validation-binary/src/main/java/org/citrusframework/validation/binary/BinaryMessageValidator.java
+++ b/validation/citrus-validation-binary/src/main/java/org/citrusframework/validation/binary/BinaryMessageValidator.java
@@ -86,7 +86,7 @@ public class BinaryMessageValidator extends DefaultMessageValidator {
                     controlResult.write((char)control);
 
                     if (received != control) {
-                        logger.info("Received input stream is not equal - expected '%s', but was '%s'".formatted(controlResult.toString(), receivedResult.toString()));
+                        logger.debug("Received input stream is not equal - expected '%s', but was '%s'".formatted(controlResult.toString(), receivedResult.toString()));
                         throw new ValidationException(("Received input stream is not equal to given control, " +
                                 "expected '%s', but was '%s'").formatted(
                                         controlResult.toString().substring(controlResult.toString().length() - Math.min(25, controlResult.size())),

--- a/validation/citrus-validation-binary/src/test/resources/log4j2.properties
+++ b/validation/citrus-validation-binary/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/validation/citrus-validation-groovy/src/test/resources/log4j2.properties
+++ b/validation/citrus-validation-groovy/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/validation/citrus-validation-hamcrest/src/test/resources/log4j2.properties
+++ b/validation/citrus-validation-hamcrest/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/validation/citrus-validation-json/src/test/resources/log4j2.properties
+++ b/validation/citrus-validation-json/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/validation/citrus-validation-text/src/test/resources/log4j2.properties
+++ b/validation/citrus-validation-text/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/validation/citrus-validation-xml/src/test/resources/log4j2.properties
+++ b/validation/citrus-validation-xml/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false

--- a/validation/citrus-validation-yaml/src/test/resources/log4j2.properties
+++ b/validation/citrus-validation-yaml/src/test/resources/log4j2.properties
@@ -37,12 +37,12 @@ logger.citrus.appenderRef.stdout.ref = STDOUT
 logger.citrus.additivity = false
 
 # Message loggers
-logger.messageIn.name = Logger.Message_IN
+logger.messageIn.name = org.citrusframework.report.LoggingReporter.Message_IN
 logger.messageIn.level = DEBUG
 logger.messageIn.appenderRef.stdout.ref = STDOUT
 logger.messageIn.additivity = false
 
-logger.messageOut.name = Logger.Message_OUT
+logger.messageOut.name = org.citrusframework.report.LoggingReporter.Message_OUT
 logger.messageOut.level = DEBUG
 logger.messageOut.appenderRef.stdout.ref = STDOUT
 logger.messageOut.additivity = false


### PR DESCRIPTION
## Summary

- Restructure log levels across the framework so **INFO** reflects the test workflow with action outcome indicators (✔/✘/⊘), **DEBUG** provides diagnostics (message content, connection details), and **TRACE** absorbs SPI registration noise
- Add ANSI color support (`LogColors`) and configurable settings (`CitrusLogSettings`) for controlling colored output and message content logging
- Introduce `MessagePrinter` abstraction with box-drawing formatted output (`DefaultMessagePrinter`) for structured message display
- Refactor `LoggingReporter` to use the new log level hierarchy and color-coded test lifecycle output
- Consolidate HTTP interceptor logging into shared `LoggingInterceptorUtils`
- Update all `log4j2.properties` test configurations to use the new `citrus` logger category

## Test plan
- [x] Verify existing unit tests pass (`./mvnw test -pl core/citrus-base`)
- [x] Verify `LoggingReporterTest` covers the redesigned reporter output
- [x] Run integration tests to confirm log output at INFO level shows clean test workflow
- [x] Verify ANSI colors render correctly in terminal and can be disabled via `CitrusLogSettings`
- [x] Confirm DEBUG level shows message content and connection diagnostics
- [x] Confirm TRACE level shows SPI registration details

Closes #1586

🤖 Generated with [Claude Code](https://claude.com/claude-code)