### PR TITLE
feat(#1588): Add fixed port configuration for Camel infra services

### DIFF
--- a/core/citrus-api/src/main/java/org/citrusframework/actions/camel/CamelInfraRunActionBuilder.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/actions/camel/CamelInfraRunActionBuilder.java
@@ -27,6 +27,10 @@ public interface CamelInfraRunActionBuilder<T extends TestAction, B extends Came
 
     B implementation(String implementation);
 
+    B port(int port);
+
+    B fixedPort(boolean fixedPort);
+
     B autoRemove(boolean autoRemove);
 
     B dumpServiceOutput(boolean dumpServiceOutput);

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/infra/CamelInfraSettings.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/infra/CamelInfraSettings.java
@@ -29,13 +29,26 @@ public final class CamelInfraSettings {
     private static final String CAMEL_DUMP_SERVICE_OUTPUT_ENV = CAMEL_INFRA_ENV_PREFIX + "DUMP_SERVICE_OUTPUT";
     private static final String CAMEL_DUMP_SERVICE_OUTPUT_DEFAULT = "false";
 
+    private static final String PORT_PROPERTY = CAMEL_INFRA_PROPERTY_PREFIX + "port";
+    private static final String PORT_ENV = CAMEL_INFRA_ENV_PREFIX + "PORT";
+    private static final String PORT_DEFAULT = "-1";
+
+    private static final String SERVICE_PORT_PROPERTY = CAMEL_INFRA_PROPERTY_PREFIX + "%s.port";
+    private static final String SERVICE_PORT_ENV = CAMEL_INFRA_ENV_PREFIX + "%s_PORT";
+
+    private static final String FIXED_PORT_PROPERTY = CAMEL_INFRA_PROPERTY_PREFIX + "fixedPort";
+    private static final String FIXED_PORT_ENV = CAMEL_INFRA_ENV_PREFIX + "FIXED_PORT";
+    private static final String FIXED_PORT_DEFAULT = "false";
+
+    public static final String CAMEL_INFRA_PORT_PROPERTY = "camel.infra.port";
+    public static final String CAMEL_INFRA_FIXED_PORT_PROPERTY = "camel.infra.fixedPort";
+
     private CamelInfraSettings() {
         //prevent instantiation of utility class
     }
 
     /**
      * When set to true test will automatically stop and remove Camel infra services that have been started.
-     * @return
      */
     public static boolean isAutoRemoveServices() {
         return Boolean.parseBoolean(System.getProperty(AUTO_REMOVE_SERVICES_PROPERTY,
@@ -44,10 +57,36 @@ public final class CamelInfraSettings {
 
     /**
      * When set to true infra service output will be redirected to a file in the current working directory.
-     * @return
      */
     public static boolean isDumpServiceOutput() {
         return Boolean.parseBoolean(System.getProperty(CAMEL_DUMP_SERVICE_OUTPUT_PROPERTY,
                 System.getenv(CAMEL_DUMP_SERVICE_OUTPUT_ENV) != null ? System.getenv(CAMEL_DUMP_SERVICE_OUTPUT_ENV) : CAMEL_DUMP_SERVICE_OUTPUT_DEFAULT));
+    }
+
+    /**
+     * When set infra services use this port as a fixed port.
+     */
+    public static int port() {
+        return Integer.parseInt(System.getProperty(PORT_PROPERTY,
+                System.getenv(PORT_ENV) != null ? System.getenv(PORT_ENV) : PORT_DEFAULT));
+    }
+
+    /**
+     * When set to true infra service uses fixed ports. Otherwise, services use random ports for better isolation.
+     */
+    public static boolean isFixedPort() {
+        return Boolean.parseBoolean(System.getProperty(FIXED_PORT_PROPERTY,
+                System.getenv(FIXED_PORT_ENV) != null ? System.getenv(FIXED_PORT_ENV) : FIXED_PORT_DEFAULT));
+    }
+
+    /**
+     * Retrieve the service port from environment settings for given full service name.
+     * Full service name must be specified as system property or environment variable.
+     */
+    public static int getServicePort(String fullServiceName) {
+        String serviceEnvVarName = SERVICE_PORT_ENV.formatted(
+                fullServiceName.replaceAll("[^a-zA-Z0-9]", "_").toUpperCase());
+        return Integer.parseInt(System.getProperty(SERVICE_PORT_PROPERTY.formatted(fullServiceName),
+                System.getenv(serviceEnvVarName) != null ? System.getenv(serviceEnvVarName) : PORT_DEFAULT));
     }
 }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/infra/CamelRunInfraAction.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/infra/CamelRunInfraAction.java
@@ -60,6 +60,9 @@ public class CamelRunInfraAction extends AbstractCamelAction {
     private final String serviceName;
     private final String implementation;
 
+    private final int port;
+    private final boolean fixedPort;
+
     private final boolean autoRemove;
     private final boolean dumpServiceOutput;
 
@@ -69,6 +72,8 @@ public class CamelRunInfraAction extends AbstractCamelAction {
         this.catalog = builder.catalog;
         this.serviceName = builder.serviceName;
         this.implementation = builder.implementation;
+        this.fixedPort = builder.fixedPort;
+        this.port = builder.port;
         this.autoRemove = builder.autoRemove;
         this.dumpServiceOutput = builder.dumpServiceOutput;
     }
@@ -83,10 +88,23 @@ public class CamelRunInfraAction extends AbstractCamelAction {
             Optional<InfraService> infraService = resolveInfraService(catalog, resolvedServiceName, resolvedImplementation);
 
             if (infraService.isEmpty()) {
-                throw new CitrusRuntimeException("No Camel infra service found for '%s'".formatted(fullServiceName));
+                throw new CitrusRuntimeException("Failed to resolve Camel infra service for '%s'".formatted(fullServiceName));
             }
 
             logger.info("Starting Camel infra service '{}' ...", fullServiceName);
+
+            int servicePort = port;
+            if (servicePort < 0) {
+                servicePort = CamelInfraSettings.getServicePort(fullServiceName);
+            }
+
+            // Set the fixed port property BEFORE instantiating the service so it uses fixed ports
+            boolean useFixedPort = fixedPort || servicePort > 0;
+            System.setProperty(CamelInfraSettings.CAMEL_INFRA_FIXED_PORT_PROPERTY, String.valueOf(useFixedPort));
+            // Set the port property if a specific port was requested
+            if (servicePort > 0) {
+                System.setProperty(CamelInfraSettings.CAMEL_INFRA_PORT_PROPERTY, String.valueOf(servicePort));
+            }
 
             ClassLoader classLoader = ClassLoaderHelper.getClassLoader();
             Class<?> serviceType = Class.forName(infraService.get().service(), true, classLoader);
@@ -222,6 +240,9 @@ public class CamelRunInfraAction extends AbstractCamelAction {
         private String serviceName;
         private String implementation;
 
+        private int port = CamelInfraSettings.port();
+        private boolean fixedPort = CamelInfraSettings.isFixedPort();
+
         private String catalogName;
         private CamelCatalog catalog;
 
@@ -249,6 +270,18 @@ public class CamelRunInfraAction extends AbstractCamelAction {
         @Override
         public Builder implementation(String implementation) {
             this.implementation = implementation;
+            return this;
+        }
+
+        @Override
+        public Builder port(int port) {
+            this.port = port;
+            return this;
+        }
+
+        @Override
+        public Builder fixedPort(boolean fixedPort) {
+            this.fixedPort = fixedPort;
             return this;
         }
 

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/infra/CamelStopInfraAction.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/infra/CamelStopInfraAction.java
@@ -70,6 +70,9 @@ public class CamelStopInfraAction extends AbstractCamelAction {
             logger.info("Stopped Camel infra service '{}'", fullServiceName);
         } catch (IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
             throw new CitrusRuntimeException("Failed to stop Camel infra service '%s'".formatted(fullServiceName), e);
+        } finally {
+            System.clearProperty(CamelInfraSettings.CAMEL_INFRA_FIXED_PORT_PROPERTY);
+            System.clearProperty(CamelInfraSettings.CAMEL_INFRA_PORT_PROPERTY);
         }
     }
 

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/infra/InfraService.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/infra/InfraService.java
@@ -17,7 +17,6 @@
 package org.citrusframework.camel.actions.infra;
 
 import java.util.List;
-
 /**
  * Camel infra service metadata as stored in the Camel catalog.
  */
@@ -29,5 +28,6 @@ public record InfraService(
             List<String> aliasImplementation,
             String groupId,
             String artifactId,
-            String version) {
+            String version,
+            String serviceVersion) {
 }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/infra/InfraServiceUtils.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/infra/InfraServiceUtils.java
@@ -19,14 +19,18 @@ package org.citrusframework.camel.actions.infra;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.apache.camel.catalog.CamelCatalog;
+import org.apache.camel.catalog.DefaultCamelCatalog;
 
 /**
  * Utility class provides access to Camel infra services metadata.
@@ -38,6 +42,7 @@ public final class InfraServiceUtils {
             .enable(SerializationFeature.INDENT_OUTPUT)
             .configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true)
             .configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true)
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
             .build();
 
     private InfraServiceUtils() {
@@ -54,8 +59,7 @@ public final class InfraServiceUtils {
                      = catalog.loadResource("test-infra", "metadata.json")) {
             String json = new String(is.readAllBytes(), StandardCharsets.UTF_8);
 
-            metadata = jsonMapper.readValue(json, new TypeReference<List<InfraService>>() {
-            });
+            metadata = jsonMapper.readValue(json, new TypeReference<>() {});
         }
 
         return metadata;

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/Camel.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/Camel.java
@@ -161,7 +161,9 @@ public class Camel implements TestActionBuilder<TestAction>, ReferenceResolverAw
         if (infra.getRun() != null) {
             CamelRunInfraAction.Builder builder = new CamelRunInfraAction.Builder()
                     .service(infra.getRun().getService())
-                    .implementation(infra.getRun().getImplementation());
+                    .implementation(infra.getRun().getImplementation())
+                    .port(infra.getRun().getPort())
+                    .fixedPort(infra.getRun().isFixedPort());
 
             builder.autoRemove(infra.getRun().isAutoRemove());
             builder.dumpServiceOutput(infra.getRun().isDumpServiceOutput());

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/Infra.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/Infra.java
@@ -63,6 +63,10 @@ public class Infra {
         private String implementation;
         @XmlAttribute(name = "auto-remove")
         private boolean autoRemove = CamelInfraSettings.isAutoRemoveServices();
+        @XmlAttribute(name = "port")
+        private int port = CamelInfraSettings.port();
+        @XmlAttribute(name = "fixed-port")
+        private boolean fixedPort = CamelInfraSettings.isFixedPort();
 
         @XmlAttribute(name = "dump-service-output")
         private boolean dumpServiceOutput = CamelInfraSettings.isDumpServiceOutput();
@@ -105,6 +109,22 @@ public class Infra {
 
         public void setDumpServiceOutput(boolean dumpServiceOutput) {
             this.dumpServiceOutput = dumpServiceOutput;
+        }
+
+        public int getPort() {
+            return port;
+        }
+
+        public void setPort(int port) {
+            this.port = port;
+        }
+
+        public boolean isFixedPort() {
+            return fixedPort;
+        }
+
+        public void setFixedPort(boolean fixedPort) {
+            this.fixedPort = fixedPort;
         }
     }
 

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/Infra.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/Infra.java
@@ -73,6 +73,16 @@ public class Infra implements CamelActionBuilderWrapper<AbstractCamelAction.Buil
             builder.autoRemove(autoRemove);
         }
 
+        @SchemaProperty(description = "When set the infra service uses this port as a fixed port.")
+        public void setPort(int port) {
+            builder.port(port);
+        }
+
+        @SchemaProperty(description = "When enabled the infra service uses fixed ports.")
+        public void setFixedPort(boolean fixedPort) {
+            builder.fixedPort(fixedPort);
+        }
+
         @SchemaProperty(advanced = true, description = "When enabled the service output is saved into a log file.")
         public void setDumpServiceOutput(boolean enabled) {
             builder.dumpServiceOutput(enabled);

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/actions/infra/CamelRunInfraActionTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/actions/infra/CamelRunInfraActionTest.java
@@ -47,7 +47,8 @@ public class CamelRunInfraActionTest extends AbstractTestNGUnitTest {
         "aliasImplementation": [ "bar" ],
         "groupId": "org.citrusframework",
         "artifactId": "camel-infra-foo",
-        "version": "1.0"
+        "version": "1.0",
+        "serviceVersion": "1.0"
       },
       {
         "service": "%s",
@@ -57,7 +58,8 @@ public class CamelRunInfraActionTest extends AbstractTestNGUnitTest {
         "aliasImplementation": [],
         "groupId": "org.citrusframework",
         "artifactId": "camel-infra-service",
-        "version": "1.0"
+        "version": "1.0",
+        "serviceVersion": "1.0"
       },
       {
         "service": "%s",
@@ -157,7 +159,7 @@ public class CamelRunInfraActionTest extends AbstractTestNGUnitTest {
         verify(modifier).mask("CITRUS_CAMEL_INFRA_MY_SERVICE_PASSWORD='secret'");
     }
 
-    @Test(expectedExceptions = CitrusRuntimeException.class, expectedExceptionsMessageRegExp = "No Camel infra service found for 'unknown'")
+    @Test(expectedExceptions = CitrusRuntimeException.class, expectedExceptionsMessageRegExp = "Failed to resolve Camel infra service for 'unknown'")
     public void testRunInfraNotFound() {
         CamelRunInfraAction action = new CamelRunInfraAction.Builder()
                 .service("unknown")
@@ -167,7 +169,7 @@ public class CamelRunInfraActionTest extends AbstractTestNGUnitTest {
         action.execute(context);
     }
 
-    @Test(expectedExceptions = CitrusRuntimeException.class, expectedExceptionsMessageRegExp = "No Camel infra service found for 'service.unknown'")
+    @Test(expectedExceptions = CitrusRuntimeException.class, expectedExceptionsMessageRegExp = "Failed to resolve Camel infra service for 'service.unknown'")
     public void testRunInfraImplementationNotFound() {
         CamelRunInfraAction action = new CamelRunInfraAction.Builder()
                 .service("service", "unknown")

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/actions/infra/CamelStopInfraActionTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/actions/infra/CamelStopInfraActionTest.java
@@ -36,6 +36,7 @@ public class CamelStopInfraActionTest extends AbstractTestNGUnitTest {
                 Collections.emptyList(),
                 "org.citrusframework",
                 "camel-infra-service",
+                "1.0",
                 "1.0");
         context.setVariable("citrus.camel.infra.my-service:meta", meta);
 
@@ -62,6 +63,7 @@ public class CamelStopInfraActionTest extends AbstractTestNGUnitTest {
                 Arrays.asList("one", "two", "three"),
                 "org.citrusframework",
                 "camel-infra-service",
+                "1.0",
                 "1.0");
         context.setVariable("citrus.camel.infra.my-service.one:meta", meta);
 

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/xml/infra/CamelStopInfraTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/xml/infra/CamelStopInfraTest.java
@@ -50,6 +50,7 @@ public class CamelStopInfraTest extends AbstractXmlActionTest {
                 Collections.emptyList(),
                 "org.citrusframework",
                 "camel-infra-service",
+                "1.0",
                 "1.0");
         context.setVariable("citrus.camel.infra.my-service:meta", meta);
 

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/yaml/infra/CamelStopInfraTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/yaml/infra/CamelStopInfraTest.java
@@ -50,6 +50,7 @@ public class CamelStopInfraTest extends AbstractYamlActionTest {
                 Collections.emptyList(),
                 "org.citrusframework",
                 "camel-infra-service",
+                "1.0",
                 "1.0");
         context.setVariable("citrus.camel.infra.my-service:meta", meta);
 

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-5.0.0-SNAPSHOT.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-5.0.0-SNAPSHOT.xsd
@@ -2352,6 +2352,8 @@
                   <xs:attribute name="service" use="required" type="xs:string"/>
                   <xs:attribute name="implementation" type="xs:string"/>
                   <xs:attribute name="catalog" type="xs:string"/>
+                  <xs:attribute name="port" type="xs:int"/>
+                  <xs:attribute name="fixed-port" type="xs:boolean"/>
                   <xs:attribute name="auto-remove" type="xs:boolean"/>
                 </xs:complexType>
               </xs:element>

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
@@ -2352,6 +2352,8 @@
                   <xs:attribute name="service" use="required" type="xs:string"/>
                   <xs:attribute name="implementation" type="xs:string"/>
                   <xs:attribute name="catalog" type="xs:string"/>
+                  <xs:attribute name="port" type="xs:int"/>
+                  <xs:attribute name="fixed-port" type="xs:boolean"/>
                   <xs:attribute name="auto-remove" type="xs:boolean"/>
                 </xs:complexType>
               </xs:element>

--- a/src/manual/endpoint-camel.adoc
+++ b/src/manual/endpoint-camel.adoc
@@ -1785,7 +1785,6 @@ The Camel infra services usually start Docker/Podman containers and/or use Testc
 
 See this list of supported infrastructure services in Apache Camel:
 
-
 |===
 |Service |Service |Service
 
@@ -1810,7 +1809,7 @@ See this list of supported infrastructure services in Apache Camel:
 | hazelcast
 
 | hive-mq (sparkplug)
-| kafka (redpanda, strimzi)
+| kafka (confluent, redpanda, strimzi)
 | microprofile (lra)
 
 | milvus
@@ -1844,6 +1843,9 @@ See this list of supported infrastructure services in Apache Camel:
 |===
 
 You can start/stop such an infra service via test actions in Citrus.
+
+[[camel-infra-run]]
+=== Run Camel infra services
 
 .Java
 [source,java,indent=0,role="primary"]
@@ -1979,6 +1981,72 @@ actions:
 
 By default, the infrastructure services get automatically removed after the test. You can disable the auto removal when running the service (`auto-remove` setting).
 
+=== Fixed port configuration
+
+By default, Camel infra services use random ports for better test isolation.
+In some cases you may want to use a fixed port instead (e.g. when an external tool expects a service on a well-known port, or when debugging locally).
+
+You can configure a fixed port directly on the run action:
+
+.Java
+[source,java,indent=0,role="primary"]
+----
+public class CamelInfraIT extends TestNGCitrusSpringSupport {
+
+    @Test
+    @CitrusTest
+    public void createInfraService() {
+        $(camel()
+            .infra()
+            .run()
+            .service("postgres")
+            .port(5432));
+    }
+}
+----
+
+.YAML
+[source,yaml,indent=0,role="secondary"]
+----
+name: "CamelInfraTest"
+actions:
+  - camel:
+      infra:
+        run:
+          service: postgres
+          port: 5432
+----
+
+Setting a specific port automatically enables fixed port mode.
+You can also enable fixed port mode without specifying a concrete port number — this tells the service to use its own default port rather than a random one:
+
+.Java
+[source,java,indent=0,role="primary"]
+----
+$(camel()
+    .infra()
+    .run()
+    .service("postgres")
+    .fixedPort(true));
+----
+
+.YAML
+[source,yaml,indent=0,role="secondary"]
+----
+name: "CamelInfraTest"
+actions:
+  - camel:
+      infra:
+        run:
+          service: postgres
+          fixedPort: true
+----
+
+The fixed port settings can also be configured globally via system properties or environment variables (see <<camel-infra-settings>>).
+
+[[camel-infra-stop]]
+=== Stop Camel infra services
+
 To explicitly stop a running infrastructure service use the following test action.
 
 .Java
@@ -2033,6 +2101,53 @@ actions:
     <!-- NOT SUPPORTED -->
 </spring:beans>
 ----
+
+[[camel-infra-settings]]
+=== Camel infra settings
+
+The Camel infrastructure services support the following environment settings.
+
+.System properties
+|===
+|System property |Description
+
+| citrus.camel.infra.auto.remove.services
+| When set to true the test will automatically stop and remove Camel infra services that have been started. (default="true")
+
+| citrus.camel.infra.dump.service.output
+| When set to true infra service output will be redirected to a file in the current working directory. (default="false")
+
+| citrus.camel.infra.port
+| When set infra services use this port as a fixed port. (default="-1", meaning random port)
+
+| citrus.camel.infra.fixedPort
+| When set to true infra services use fixed ports. Otherwise, services use random ports for better isolation. (default="false")
+
+| citrus.camel.infra.<service>.port
+| Sets a fixed port for a specific service. The service name is the full service name (e.g. `citrus.camel.infra.postgres.port=5432`).
+
+|===
+
+.Environment variables
+|===
+|Environment variable |Description
+
+| CITRUS_CAMEL_INFRA_AUTO_REMOVE_SERVICES
+| When set to true the test will automatically stop and remove Camel infra services that have been started. (default="true")
+
+| CITRUS_CAMEL_INFRA_DUMP_SERVICE_OUTPUT
+| When set to true infra service output will be redirected to a file in the current working directory. (default="false")
+
+| CITRUS_CAMEL_INFRA_PORT
+| When set infra services use this port as a fixed port. (default="-1", meaning random port)
+
+| CITRUS_CAMEL_INFRA_FIXED_PORT
+| When set to true infra services use fixed ports. Otherwise, services use random ports for better isolation. (default="false")
+
+| CITRUS_CAMEL_INFRA_<SERVICE>_PORT
+| Sets a fixed port for a specific service. The service name uses upper case and non-alphanumeric characters are replaced with underscores (e.g. `CITRUS_CAMEL_INFRA_POSTGRES_PORT=5432`).
+
+|===
 
 [[camel-endpoint-dsl]]
 == Camel endpoint DSL


### PR DESCRIPTION
## Summary

- Add `port(int)` and `fixedPort(boolean)` builder methods to configure fixed ports on Camel infra services, with support in Java, YAML, and XML DSLs
- Introduce `CamelInfraSettings` for global port configuration via system properties (`citrus.camel.infra.port`, `citrus.camel.infra.fixedPort`) and environment variables, including per-service port overrides
- Add `serviceVersion` field to `InfraService` record and configure Jackson to ignore unknown properties for forward compatibility with catalog changes
- Document the new fixed port settings and all Camel infra environment variables

Closes #1588

## Test plan

- [ ] Verify `port(5432)` on the run action starts the infra service on the specified fixed port
- [ ] Verify `fixedPort(true)` enables fixed port mode using the service's default port
- [ ] Verify global settings via `CITRUS_CAMEL_INFRA_PORT` and `CITRUS_CAMEL_INFRA_FIXED_PORT` environment variables
- [ ] Verify per-service port override via `CITRUS_CAMEL_INFRA_<SERVICE>_PORT`
- [ ] Verify system properties are cleared on service stop
- [ ] Verify XML DSL `port` and `fixed-port` attributes work correctly
- [ ] Verify YAML DSL `port` and `fixedPort` properties work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)