### PR TITLE
fix(#1593): Add schema examples and autocompletion for Camel infra service names

### DIFF
--- a/core/citrus-api/src/main/java/org/citrusframework/yaml/ExamplesProvider.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/yaml/ExamplesProvider.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaml;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.function.Supplier;
+
+@FunctionalInterface
+public interface ExamplesProvider extends Supplier<Set<String>> {
+
+    class EmptyExamplesProvider implements ExamplesProvider {
+        @Override
+        public Set<String> get() {
+            return Collections.emptySet();
+        }
+    }
+}

--- a/core/citrus-api/src/main/java/org/citrusframework/yaml/SchemaProperty.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/yaml/SchemaProperty.java
@@ -109,6 +109,16 @@ public @interface SchemaProperty {
     String pattern() default "";
 
     /**
+     * List of examples for String properties
+     */
+    String[] examples() default {};
+
+    /**
+     * Provider generating examples for String properties
+     */
+    Class<? extends ExamplesProvider> examplesProvider() default ExamplesProvider.EmptyExamplesProvider.class;
+
+    /**
      * Required properties
      */
     boolean required() default false;

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/infra/CamelRunInfraAction.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/infra/CamelRunInfraAction.java
@@ -21,7 +21,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -85,7 +84,7 @@ public class CamelRunInfraAction extends AbstractCamelAction {
         String fullServiceName = StringUtils.hasText(resolvedImplementation) ? resolvedServiceName + "." + resolvedImplementation : resolvedServiceName;
 
         try {
-            Optional<InfraService> infraService = resolveInfraService(catalog, resolvedServiceName, resolvedImplementation);
+            Optional<InfraService> infraService = InfraServiceUtils.resolveInfraService(catalog, resolvedServiceName, resolvedImplementation);
 
             if (infraService.isEmpty()) {
                 throw new CitrusRuntimeException("Failed to resolve Camel infra service for '%s'".formatted(fullServiceName));
@@ -187,25 +186,6 @@ public class CamelRunInfraAction extends AbstractCamelAction {
         });
     }
 
-    private static Optional<InfraService> resolveInfraService(CamelCatalog catalog, String serviceName, String implementation) throws IOException {
-        List<InfraService> services = InfraServiceUtils.getInfraServiceMetadata(catalog);
-        return services
-                .stream()
-                .filter(service -> {
-                    if (implementation != null && !implementation.isEmpty()
-                            && service.aliasImplementation() != null) {
-                        return service.alias().contains(serviceName)
-                                && service.aliasImplementation().contains(implementation);
-                    } else if (implementation == null) {
-                        return service.alias().contains(serviceName)
-                                && (service.aliasImplementation() == null || service.aliasImplementation().isEmpty());
-                    }
-
-                    return false;
-                })
-                .findFirst();
-    }
-
     private static String normalizeKey(String key) {
         String result =  key.replaceAll("([A-Z])", "_$1");
 
@@ -263,7 +243,14 @@ public class CamelRunInfraAction extends AbstractCamelAction {
 
         @Override
         public Builder service(String serviceName) {
-            this.serviceName = serviceName;
+            if (serviceName.contains(".")) {
+                String[] tokens = serviceName.split(".", 2);
+                this.serviceName = tokens[0];
+                this.implementation = tokens[1];
+            } else {
+                this.serviceName = serviceName;
+            }
+
             return this;
         }
 

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/infra/InfraServiceUtils.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/infra/InfraServiceUtils.java
@@ -20,7 +20,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -31,11 +34,15 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.apache.camel.catalog.CamelCatalog;
 import org.apache.camel.catalog.DefaultCamelCatalog;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Utility class provides access to Camel infra services metadata.
  */
 public final class InfraServiceUtils {
+
+    private static final Logger logger = LoggerFactory.getLogger(InfraServiceUtils.class);
 
     private static final ObjectMapper jsonMapper = JsonMapper.builder()
             .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
@@ -63,5 +70,59 @@ public final class InfraServiceUtils {
         }
 
         return metadata;
+    }
+
+    /**
+     * Search for infra service in given Camel catalog metadata that matches the given service name and implementation combination.
+     * The implementation alias is optional.
+     */
+    public static Optional<InfraService> resolveInfraService(CamelCatalog catalog, String serviceName, String implementation) throws IOException {
+        return resolveInfraService(getInfraServiceMetadata(catalog), serviceName, implementation);
+    }
+
+    /**
+     * Find infra service in the given list of services that matches the given service name and implementation combination.
+     * The implementation alias is optional. If not present the method returns the infra service that matches the service name only.
+     */
+    public static Optional<InfraService> resolveInfraService(List<InfraService> services, String serviceName, String implementation) {
+        return services
+                .stream()
+                .filter(service -> {
+                    if (implementation != null && !implementation.isEmpty()
+                            && service.aliasImplementation() != null) {
+                        return service.alias().contains(serviceName)
+                                && service.aliasImplementation().contains(implementation);
+                    } else if (implementation == null) {
+                        return service.alias().contains(serviceName)
+                                && (service.aliasImplementation() == null || service.aliasImplementation().isEmpty());
+                    }
+
+                    return false;
+                })
+                .findFirst();
+    }
+
+    /**
+     * Provide a list of available Camel infra services names.
+     * When an infra service has multiple aliases and multiple implementation aliases the list of names contains a combination of these values using
+     * "service_alias.implementation_alias".
+     */
+    public static Set<String> getInfraServiceNames() {
+        try {
+            return InfraServiceUtils.getInfraServiceMetadata(new DefaultCamelCatalog())
+                    .stream()
+                    .map(is -> {
+                        if (is.aliasImplementation() != null && !is.aliasImplementation().isEmpty()) {
+                            return is.aliasImplementation().stream().map(impl -> is.alias().get(0) + "." + impl).collect(Collectors.toList());
+                        } else {
+                            return is.alias();
+                        }
+                    })
+                    .flatMap(Collection::stream)
+                    .collect(Collectors.toSet());
+        } catch (IOException e) {
+            logger.warn("Failed to load Infra service names from Camel catalog meta data", e);
+            return Collections.emptySet();
+        }
     }
 }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/Infra.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/Infra.java
@@ -16,10 +16,14 @@
 
 package org.citrusframework.camel.yaml;
 
+import java.util.Set;
+
 import org.citrusframework.camel.actions.AbstractCamelAction;
 import org.citrusframework.camel.actions.infra.CamelRunInfraAction;
 import org.citrusframework.camel.actions.infra.CamelStopInfraAction;
+import org.citrusframework.camel.actions.infra.InfraServiceUtils;
 import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.yaml.ExamplesProvider;
 import org.citrusframework.yaml.SchemaProperty;
 
 import static org.citrusframework.yaml.SchemaProperty.Kind.ACTION;
@@ -53,12 +57,19 @@ public class Infra implements CamelActionBuilderWrapper<AbstractCamelAction.Buil
 
         private final CamelRunInfraAction.Builder builder = new CamelRunInfraAction.Builder();
 
+        public static class InfraServiceNamesProvider implements ExamplesProvider {
+            @Override
+            public Set<String> get() {
+                return InfraServiceUtils.getInfraServiceNames();
+            }
+        }
+
         @SchemaProperty(advanced = true, description = "The Camel catalog that holds the infra service definitions.")
         public void setCatalog(String camelCatalog) {
             builder.catalog(camelCatalog);
         }
 
-        @SchemaProperty(description = "The Camel infra service name.")
+        @SchemaProperty(description = "The Camel infra service name.", examplesProvider = InfraServiceNamesProvider.class)
         public void setService(String serviceName) {
             builder.service(serviceName);
         }

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/actions/infra/InfraServiceUtilsTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/actions/infra/InfraServiceUtilsTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.actions.infra;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class InfraServiceUtilsTest {
+
+    private static InfraService infraService(String service, String impl, List<String> alias, List<String> aliasImpl) {
+        return new InfraService(service, impl, "Sample infra service", alias, aliasImpl,
+                "org.acme", "test-infra-services", "0.1", "0.1");
+    }
+
+    @Test
+    public void shouldResolveByServiceNameOnly() {
+        InfraService kafka = infraService("org.acme.InfraService", "org.acme.InfraServiceImpl", List.of("kafka"), null);
+        List<InfraService> services = List.of(kafka);
+
+        Optional<InfraService> result = InfraServiceUtils.resolveInfraService(services, "kafka", null);
+        Assert.assertTrue(result.isPresent());
+        Assert.assertEquals(result.get(), kafka);
+    }
+
+    @Test
+    public void shouldResolveByServiceNameWithEmptyAliasImplementation() {
+        InfraService kafka = infraService("org.acme.InfraService", "org.acme.InfraServiceImpl", List.of("kafka"), Collections.emptyList());
+        List<InfraService> services = List.of(kafka);
+
+        Optional<InfraService> result = InfraServiceUtils.resolveInfraService(services, "kafka", null);
+        Assert.assertTrue(result.isPresent());
+        Assert.assertEquals(result.get(), kafka);
+    }
+
+    @Test
+    public void shouldResolveByServiceNameAndImplementation() {
+        InfraService redpanda = infraService("org.acme.InfraService", "org.acme.InfraServiceImpl", List.of("kafka"), List.of("redpanda"));
+        List<InfraService> services = List.of(redpanda);
+
+        Optional<InfraService> result = InfraServiceUtils.resolveInfraService(services, "kafka", "redpanda");
+        Assert.assertTrue(result.isPresent());
+        Assert.assertEquals(result.get(), redpanda);
+    }
+
+    @Test
+    public void shouldReturnEmptyWhenServiceNameDoesNotMatch() {
+        InfraService kafka = infraService("org.acme.InfraService", "org.acme.InfraServiceImpl", List.of("kafka"), null);
+        List<InfraService> services = List.of(kafka);
+
+        Optional<InfraService> result = InfraServiceUtils.resolveInfraService(services, "redis", null);
+        Assert.assertFalse(result.isPresent());
+    }
+
+    @Test
+    public void shouldReturnEmptyWhenImplementationDoesNotMatch() {
+        InfraService redpanda = infraService("org.acme.InfraService", "org.acme.InfraServiceImpl", List.of("kafka"), List.of("redpanda"));
+        List<InfraService> services = List.of(redpanda);
+
+        Optional<InfraService> result = InfraServiceUtils.resolveInfraService(services, "kafka", "strimzi");
+        Assert.assertFalse(result.isPresent());
+    }
+
+    @Test
+    public void shouldReturnEmptyWhenImplementationGivenButServiceHasNone() {
+        InfraService kafka = infraService("org.acme.InfraService", "org.acme.InfraServiceImpl", List.of("kafka"), null);
+        List<InfraService> services = List.of(kafka);
+
+        Optional<InfraService> result = InfraServiceUtils.resolveInfraService(services, "kafka", "redpanda");
+        Assert.assertFalse(result.isPresent());
+    }
+
+    @Test
+    public void shouldNotMatchServiceWithImplementationWhenNullRequested() {
+        InfraService redpanda = infraService("org.acme.InfraService", "org.acme.InfraServiceImpl", List.of("kafka"), List.of("redpanda"));
+        List<InfraService> services = List.of(redpanda);
+
+        Optional<InfraService> result = InfraServiceUtils.resolveInfraService(services, "kafka", null);
+        Assert.assertFalse(result.isPresent());
+    }
+
+    @Test
+    public void shouldReturnEmptyForEmptyServiceList() {
+        Optional<InfraService> result = InfraServiceUtils.resolveInfraService(Collections.emptyList(), "kafka", null);
+        Assert.assertFalse(result.isPresent());
+    }
+
+    @Test
+    public void shouldResolveFirstMatchWhenMultipleServicesMatch() {
+        InfraService first = infraService("org.acme.InfraService1", "org.acme.InfraServiceImpl1", List.of("kafka"), null);
+        InfraService second = infraService("org.acme.InfraService2", "org.acme.InfraServiceImpl2", List.of("kafka"), null);
+        List<InfraService> services = List.of(first, second);
+
+        Optional<InfraService> result = InfraServiceUtils.resolveInfraService(services, "kafka", null);
+        Assert.assertTrue(result.isPresent());
+        Assert.assertEquals(result.get(), first);
+    }
+
+    @Test
+    public void shouldMatchAnyAliasInList() {
+        InfraService service = infraService("org.acme.InfraService", "org.acme.InfraServiceImpl", List.of("dynamodb", "dynamo-db"), null);
+        List<InfraService> services = List.of(service);
+
+        Assert.assertTrue(InfraServiceUtils.resolveInfraService(services, "dynamodb", null).isPresent());
+        Assert.assertTrue(InfraServiceUtils.resolveInfraService(services, "dynamo-db", null).isPresent());
+    }
+
+    @Test
+    public void shouldReturnEmptyWhenImplementationIsEmptyString() {
+        InfraService kafka = infraService("org.acme.InfraService", "org.acme.InfraServiceImpl", List.of("kafka"), null);
+        List<InfraService> services = List.of(kafka);
+
+        Optional<InfraService> result = InfraServiceUtils.resolveInfraService(services, "kafka", "");
+        Assert.assertFalse(result.isPresent());
+    }
+
+    @Test
+    public void shouldListInfraServices() {
+        Assert.assertEquals(InfraServiceUtils.getInfraServiceNames().stream().sorted().collect(Collectors.joining("\n")), """
+               arangodb
+               artemis
+               artemis.amqp
+               aws.cloud-watch
+               aws.config
+               aws.dynamo-db
+               aws.dynamodb
+               aws.ec2
+               aws.event-bridge
+               aws.iam
+               aws.kinesis
+               aws.kms
+               aws.lambda
+               aws.s3
+               aws.secrets-manager
+               aws.sns
+               aws.sqs
+               aws.ssm
+               aws.sts
+               aws.transcribe
+               azure.storage-blob
+               azure.storage-queue
+               cassandra
+               chat-script
+               consul
+               couchbase
+               couchdb
+               docling
+               elasticsearch
+               fhir
+               ftp
+               ftps
+               google.pub-sub
+               hashicorp.vault
+               hazelcast
+               hive-mq
+               hive-mq.sparkplug
+               ibmmq
+               iggy
+               ignite
+               infinispan
+               kafka
+               kafka.confluent
+               kafka.redpanda
+               kafka.strimzi
+               keycloak
+               microprofile.lra
+               milvus
+               minio
+               mongodb
+               mosquitto
+               nats
+               neo4j
+               ollama
+               openldap
+               pgvector
+               pinecone
+               postgres
+               postgres-vector
+               pulsar
+               qdrant
+               rabbitmq
+               redis
+               rocketmq
+               sftp
+               smb
+               solr
+               weaviate
+               xmpp
+               zookeeper""");
+    }
+
+}

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-5.0.0-SNAPSHOT.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-5.0.0-SNAPSHOT.xsd
@@ -2197,6 +2197,81 @@
     <xs:attribute name="actor" type="xs:string"/>
   </xs:complexType>
 
+  <xs:simpleType name="CamelInfraServiceType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="arangodb"/>
+      <xs:enumeration value="artemis"/>
+      <xs:enumeration value="artemis.amqp"/>
+      <xs:enumeration value="aws.cloud-watch"/>
+      <xs:enumeration value="aws.config"/>
+      <xs:enumeration value="aws.dynamo-db"/>
+      <xs:enumeration value="aws.dynamodb"/>
+      <xs:enumeration value="aws.ec2"/>
+      <xs:enumeration value="aws.event-bridge"/>
+      <xs:enumeration value="aws.iam"/>
+      <xs:enumeration value="aws.kinesis"/>
+      <xs:enumeration value="aws.kms"/>
+      <xs:enumeration value="aws.lambda"/>
+      <xs:enumeration value="aws.s3"/>
+      <xs:enumeration value="aws.secrets-manager"/>
+      <xs:enumeration value="aws.sns"/>
+      <xs:enumeration value="aws.sqs"/>
+      <xs:enumeration value="aws.ssm"/>
+      <xs:enumeration value="aws.sts"/>
+      <xs:enumeration value="aws.transcribe"/>
+      <xs:enumeration value="azure.storage-blob"/>
+      <xs:enumeration value="azure.storage-queue"/>
+      <xs:enumeration value="cassandra"/>
+      <xs:enumeration value="chat-script"/>
+      <xs:enumeration value="consul"/>
+      <xs:enumeration value="couchbase"/>
+      <xs:enumeration value="couchdb"/>
+      <xs:enumeration value="docling"/>
+      <xs:enumeration value="elasticsearch"/>
+      <xs:enumeration value="fhir"/>
+      <xs:enumeration value="ftp"/>
+      <xs:enumeration value="ftps"/>
+      <xs:enumeration value="google.pub-sub"/>
+      <xs:enumeration value="hashicorp.vault"/>
+      <xs:enumeration value="hazelcast"/>
+      <xs:enumeration value="hive-mq"/>
+      <xs:enumeration value="hive-mq.sparkplug"/>
+      <xs:enumeration value="ibmmq"/>
+      <xs:enumeration value="iggy"/>
+      <xs:enumeration value="ignite"/>
+      <xs:enumeration value="infinispan"/>
+      <xs:enumeration value="kafka"/>
+      <xs:enumeration value="kafka.confluent"/>
+      <xs:enumeration value="kafka.redpanda"/>
+      <xs:enumeration value="kafka.strimzi"/>
+      <xs:enumeration value="keycloak"/>
+      <xs:enumeration value="microprofile.lra"/>
+      <xs:enumeration value="milvus"/>
+      <xs:enumeration value="minio"/>
+      <xs:enumeration value="mongodb"/>
+      <xs:enumeration value="mosquitto"/>
+      <xs:enumeration value="nats"/>
+      <xs:enumeration value="neo4j"/>
+      <xs:enumeration value="ollama"/>
+      <xs:enumeration value="openldap"/>
+      <xs:enumeration value="pgvector"/>
+      <xs:enumeration value="pinecone"/>
+      <xs:enumeration value="postgres"/>
+      <xs:enumeration value="postgres-vector"/>
+      <xs:enumeration value="pulsar"/>
+      <xs:enumeration value="qdrant"/>
+      <xs:enumeration value="rabbitmq"/>
+      <xs:enumeration value="redis"/>
+      <xs:enumeration value="rocketmq"/>
+      <xs:enumeration value="sftp"/>
+      <xs:enumeration value="smb"/>
+      <xs:enumeration value="solr"/>
+      <xs:enumeration value="weaviate"/>
+      <xs:enumeration value="xmpp"/>
+      <xs:enumeration value="zookeeper"/>
+    </xs:restriction>
+  </xs:simpleType>
+
   <xs:complexType name="Camel">
     <xs:sequence>
       <xs:element name="description" type="xs:string" minOccurs="0"/>
@@ -2349,7 +2424,11 @@
             <xs:choice>
               <xs:element name="run">
                 <xs:complexType>
-                  <xs:attribute name="service" use="required" type="xs:string"/>
+                  <xs:attribute name="service" use="required">
+                    <xs:simpleType>
+                      <xs:union memberTypes="xs:string tns:CamelInfraServiceType"/>
+                    </xs:simpleType>
+                  </xs:attribute>
                   <xs:attribute name="implementation" type="xs:string"/>
                   <xs:attribute name="catalog" type="xs:string"/>
                   <xs:attribute name="port" type="xs:int"/>
@@ -2359,7 +2438,11 @@
               </xs:element>
               <xs:element name="stop">
                 <xs:complexType>
-                  <xs:attribute name="service" use="required" type="xs:string"/>
+                  <xs:attribute name="service" use="required">
+                    <xs:simpleType>
+                      <xs:union memberTypes="xs:string tns:CamelInfraServiceType"/>
+                    </xs:simpleType>
+                  </xs:attribute>
                   <xs:attribute name="implementation" type="xs:string"/>
                 </xs:complexType>
               </xs:element>

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
@@ -2197,6 +2197,81 @@
     <xs:attribute name="actor" type="xs:string"/>
   </xs:complexType>
 
+  <xs:simpleType name="CamelInfraServiceType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="arangodb"/>
+      <xs:enumeration value="artemis"/>
+      <xs:enumeration value="artemis.amqp"/>
+      <xs:enumeration value="aws.cloud-watch"/>
+      <xs:enumeration value="aws.config"/>
+      <xs:enumeration value="aws.dynamo-db"/>
+      <xs:enumeration value="aws.dynamodb"/>
+      <xs:enumeration value="aws.ec2"/>
+      <xs:enumeration value="aws.event-bridge"/>
+      <xs:enumeration value="aws.iam"/>
+      <xs:enumeration value="aws.kinesis"/>
+      <xs:enumeration value="aws.kms"/>
+      <xs:enumeration value="aws.lambda"/>
+      <xs:enumeration value="aws.s3"/>
+      <xs:enumeration value="aws.secrets-manager"/>
+      <xs:enumeration value="aws.sns"/>
+      <xs:enumeration value="aws.sqs"/>
+      <xs:enumeration value="aws.ssm"/>
+      <xs:enumeration value="aws.sts"/>
+      <xs:enumeration value="aws.transcribe"/>
+      <xs:enumeration value="azure.storage-blob"/>
+      <xs:enumeration value="azure.storage-queue"/>
+      <xs:enumeration value="cassandra"/>
+      <xs:enumeration value="chat-script"/>
+      <xs:enumeration value="consul"/>
+      <xs:enumeration value="couchbase"/>
+      <xs:enumeration value="couchdb"/>
+      <xs:enumeration value="docling"/>
+      <xs:enumeration value="elasticsearch"/>
+      <xs:enumeration value="fhir"/>
+      <xs:enumeration value="ftp"/>
+      <xs:enumeration value="ftps"/>
+      <xs:enumeration value="google.pub-sub"/>
+      <xs:enumeration value="hashicorp.vault"/>
+      <xs:enumeration value="hazelcast"/>
+      <xs:enumeration value="hive-mq"/>
+      <xs:enumeration value="hive-mq.sparkplug"/>
+      <xs:enumeration value="ibmmq"/>
+      <xs:enumeration value="iggy"/>
+      <xs:enumeration value="ignite"/>
+      <xs:enumeration value="infinispan"/>
+      <xs:enumeration value="kafka"/>
+      <xs:enumeration value="kafka.confluent"/>
+      <xs:enumeration value="kafka.redpanda"/>
+      <xs:enumeration value="kafka.strimzi"/>
+      <xs:enumeration value="keycloak"/>
+      <xs:enumeration value="microprofile.lra"/>
+      <xs:enumeration value="milvus"/>
+      <xs:enumeration value="minio"/>
+      <xs:enumeration value="mongodb"/>
+      <xs:enumeration value="mosquitto"/>
+      <xs:enumeration value="nats"/>
+      <xs:enumeration value="neo4j"/>
+      <xs:enumeration value="ollama"/>
+      <xs:enumeration value="openldap"/>
+      <xs:enumeration value="pgvector"/>
+      <xs:enumeration value="pinecone"/>
+      <xs:enumeration value="postgres"/>
+      <xs:enumeration value="postgres-vector"/>
+      <xs:enumeration value="pulsar"/>
+      <xs:enumeration value="qdrant"/>
+      <xs:enumeration value="rabbitmq"/>
+      <xs:enumeration value="redis"/>
+      <xs:enumeration value="rocketmq"/>
+      <xs:enumeration value="sftp"/>
+      <xs:enumeration value="smb"/>
+      <xs:enumeration value="solr"/>
+      <xs:enumeration value="weaviate"/>
+      <xs:enumeration value="xmpp"/>
+      <xs:enumeration value="zookeeper"/>
+    </xs:restriction>
+  </xs:simpleType>
+
   <xs:complexType name="Camel">
     <xs:sequence>
       <xs:element name="description" type="xs:string" minOccurs="0"/>
@@ -2349,7 +2424,11 @@
             <xs:choice>
               <xs:element name="run">
                 <xs:complexType>
-                  <xs:attribute name="service" use="required" type="xs:string"/>
+                  <xs:attribute name="service" use="required">
+                    <xs:simpleType>
+                      <xs:union memberTypes="xs:string tns:CamelInfraServiceType"/>
+                    </xs:simpleType>
+                  </xs:attribute>
                   <xs:attribute name="implementation" type="xs:string"/>
                   <xs:attribute name="catalog" type="xs:string"/>
                   <xs:attribute name="port" type="xs:int"/>
@@ -2359,7 +2438,11 @@
               </xs:element>
               <xs:element name="stop">
                 <xs:complexType>
-                  <xs:attribute name="service" use="required" type="xs:string"/>
+                  <xs:attribute name="service" use="required">
+                    <xs:simpleType>
+                      <xs:union memberTypes="xs:string tns:CamelInfraServiceType"/>
+                    </xs:simpleType>
+                  </xs:attribute>
                   <xs:attribute name="implementation" type="xs:string"/>
                 </xs:complexType>
               </xs:element>

--- a/tools/schema-generator/pom.xml
+++ b/tools/schema-generator/pom.xml
@@ -152,5 +152,17 @@
       <artifactId>citrus-validation-hamcrest</artifactId>
       <version>${project.version}</version>
     </dependency>
+
+    <!-- Logging -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/tools/schema-generator/src/main/java/org/citrusframework/dsl/schema/generator/CitrusModule.java
+++ b/tools/schema-generator/src/main/java/org/citrusframework/dsl/schema/generator/CitrusModule.java
@@ -17,10 +17,14 @@
 package org.citrusframework.dsl.schema.generator;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -46,6 +50,7 @@ import com.github.victools.jsonschema.generator.naming.DefaultSchemaDefinitionNa
 import org.citrusframework.TestActionBuilder;
 import org.citrusframework.dsl.schema.Catalog;
 import org.citrusframework.util.StringUtils;
+import org.citrusframework.yaml.ExamplesProvider;
 import org.citrusframework.yaml.SchemaProperty;
 import org.citrusframework.yaml.SchemaType;
 import tools.jackson.databind.JsonNode;
@@ -232,6 +237,28 @@ public class CitrusModule implements Module {
             if (!comments.isEmpty()) {
                 jsonSchemaAttributesNode.put("$comment", String.join(",", comments));
             }
+        }
+
+        Set<String> examples = new HashSet<>();
+        this.getSchemaPropertyAnnotation(member)
+                .map(SchemaProperty::examples)
+                .map(Arrays::asList)
+                .ifPresent(examples::addAll);
+
+        this.getSchemaPropertyAnnotation(member)
+                .map(SchemaProperty::examplesProvider)
+                .ifPresent(providerType -> {
+                    try {
+                        ExamplesProvider provider = providerType.getDeclaredConstructor().newInstance();
+                        examples.addAll(provider.get());
+                    } catch (InstantiationException | IllegalAccessException | InvocationTargetException |
+                             NoSuchMethodException ignored) {
+                    }
+                });
+
+        if (!examples.isEmpty()) {
+            ArrayNode examplesNode = jsonSchemaAttributesNode.putArray("examples");
+            examples.stream().sorted().forEach(examplesNode::add);
         }
     }
 


### PR DESCRIPTION
## Summary
- Add `ExamplesProvider` interface and `examples`/`examplesProvider` attributes to `@SchemaProperty` annotation for dynamic schema autocompletion
- Extract `resolveInfraService()` logic from `CamelRunInfraAction` into `InfraServiceUtils` for reuse
- Wire `InfraServiceNamesProvider` into the YAML DSL `Infra.Run` to provide Camel infra service name suggestions in schema-aware editors
- Update schema generator (`CitrusModule`) to process `examples` and `examplesProvider` annotations
- Add unit tests for `InfraServiceUtils#resolveInfraService`

## Test plan
- [x] All 12 `InfraServiceUtilsTest` tests pass (service name resolution with/without implementation, edge cases)
- [ ] Verify generated YAML/JSON schema includes `examples` for the infra service name property
- [ ] Verify schema autocompletion works in a schema-aware editor (e.g. VS Code with YAML extension)

Fixes #1593

🤖 Generated with [Claude Code](https://claude.com/claude-code)