### PR TITLE
fix(#1591): Fix ConcurrentModificationException in HttpEndpointConfiguration

### DIFF
--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/client/HttpEndpointConfiguration.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/client/HttpEndpointConfiguration.java
@@ -154,7 +154,7 @@ public class HttpEndpointConfiguration extends AbstractPollableEndpointConfigura
      */
     public void setRestTemplate(RestTemplate restTemplate) {
         clientInterceptors.addAll(restTemplate.getInterceptors());
-        restTemplate.setInterceptors(clientInterceptors);
+        restTemplate.setInterceptors(new ArrayList<>(clientInterceptors));
         this.restTemplate = restTemplate;
     }
 
@@ -237,7 +237,7 @@ public class HttpEndpointConfiguration extends AbstractPollableEndpointConfigura
     public RestTemplate getRestTemplate() {
         if (restTemplate == null) {
             restTemplate = new RestTemplate();
-            restTemplate.setInterceptors(clientInterceptors);
+            restTemplate.setInterceptors(new ArrayList<>(clientInterceptors));
         }
 
         restTemplate.setRequestFactory(getRequestFactory());
@@ -283,7 +283,12 @@ public class HttpEndpointConfiguration extends AbstractPollableEndpointConfigura
      */
     public void setClientInterceptors(List<ClientHttpRequestInterceptor> clientInterceptors) {
         this.clientInterceptors = clientInterceptors;
-        getRestTemplate().setInterceptors(clientInterceptors);
+
+        if (restTemplate == null) {
+            getRestTemplate();
+        } else {
+            restTemplate.setInterceptors(new ArrayList<>(clientInterceptors));
+        }
     }
 
     /**

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/client/HttpClientTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/client/HttpClientTest.java
@@ -18,10 +18,17 @@ package org.citrusframework.http.client;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import org.citrusframework.endpoint.resolver.EndpointUriResolver;
 import org.citrusframework.http.message.HttpMessage;
+import org.citrusframework.http.interceptor.LoggingClientInterceptor;
 import org.citrusframework.http.message.HttpMessageHeaders;
 import org.citrusframework.message.DefaultMessage;
 import org.citrusframework.message.ErrorHandlingStrategy;
@@ -516,6 +523,35 @@ public class HttpClientTest extends AbstractTestNGUnitTest {
         Assert.assertEquals(responseMessage.getReasonPhrase(), "OK");
 
         verify(restTemplate).setInterceptors(anyList());
+    }
+
+    @Test
+    public void testConcurrentGetRestTemplate() throws Exception {
+        HttpEndpointConfiguration endpointConfiguration = new HttpEndpointConfiguration();
+
+        int threadCount = 10;
+        CyclicBarrier barrier = new CyclicBarrier(threadCount);
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        try {
+            List<Future<RestTemplate>> futures = new ArrayList<>();
+            for (int i = 0; i < threadCount; i++) {
+                futures.add(executor.submit(() -> {
+                    barrier.await();
+                    return endpointConfiguration.getRestTemplate();
+                }));
+            }
+
+            for (Future<RestTemplate> future : futures) {
+                RestTemplate template = future.get();
+                Assert.assertNotNull(template);
+                Assert.assertFalse(template.getInterceptors().isEmpty());
+                Assert.assertTrue(template.getInterceptors().stream()
+                        .anyMatch(LoggingClientInterceptor.class::isInstance));
+            }
+        } finally {
+            executor.shutdown();
+        }
+
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Pass defensive copies of the `clientInterceptors` list to `RestTemplate.setInterceptors()` in all call sites (`getRestTemplate()`, `setRestTemplate()`, `setClientInterceptors()`) to prevent `ConcurrentModificationException` when multiple threads concurrently access the shared `HttpClient`
- Spring's `setInterceptors()` sorts the list in-place via `AnnotationAwareOrderComparator.sort()` — when two threads race through `getRestTemplate()`'s lazy init, both can end up calling `setInterceptors` on the same `RestTemplate` instance, causing the concurrent sort to throw
- Added concurrent access test for `getRestTemplate()` using `CyclicBarrier` to verify thread safety

Fixes #1591

## Test plan

- [x] New `testConcurrentGetRestTemplate` test with 10 threads calling `getRestTemplate()` simultaneously
- [x] All existing `HttpClientTest` tests pass (20 tests)
- [x] Full module `mvn verify` passes (40 tests including integration tests)
- [x] Full reactor build succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)