### PR TITLE
fix(#1594): Add auto dependency resolving for Camel infra services in JBang

### DIFF
--- a/tools/jbang/src/main/java/org/citrusframework/jbang/util/CodeAnalyzer.java
+++ b/tools/jbang/src/main/java/org/citrusframework/jbang/util/CodeAnalyzer.java
@@ -17,14 +17,17 @@
 package org.citrusframework.jbang.util;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
 import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.jbang.CitrusJBangMain;
 import org.citrusframework.jbang.JsonSupport;
 import org.citrusframework.spi.Resource;
 import org.citrusframework.util.ClassLoaderHelper;
@@ -162,6 +165,65 @@ public interface CodeAnalyzer {
             return components;
         } catch (JacksonException e) {
             throw new CitrusRuntimeException("Failed to read component aggregate schema definitions of kind '%s'".formatted(kind), e);
+        }
+    }
+
+    /**
+     * Specialized implementations add logic to extract Camel endpoint component names used in the code.
+     */
+    default Set<String> extractCamelEndpointComponents(String code) {
+        return Collections.emptySet();
+    }
+
+    default Set<String> resolveCamelEndpointDependencies(String code) {
+        Set<String> dependencies = new HashSet<>();
+        String camelVersion = CitrusJBangMain.Settings.getCamelVersion();
+        Set<String> components = extractCamelEndpointComponents(code);
+        for (String componentName : components) {
+            dependencies.add("org.apache.camel:camel-%s:%s".formatted(componentName, camelVersion));
+        }
+        return dependencies;
+    }
+
+    /**
+     * Specialized implementations add logic to extract Camel infra service names used in the code.
+     */
+    default Set<String> extractCamelInfraServiceNames(String code) {
+        return Collections.emptySet();
+    }
+
+    default Set<String> resolveCamelInfraServiceDependencies(String code) {
+        Set<String> dependencies = new HashSet<>();
+        Set<String> serviceNames = extractCamelInfraServiceNames(code);
+        Map<String, String> catalog = getKnownInfraServices();
+        String camelVersion = CitrusJBangMain.Settings.getCamelVersion();
+
+        for (String serviceName : serviceNames) {
+            String baseName = serviceName.contains(".") ? serviceName.substring(0, serviceName.indexOf(".")) : serviceName;
+            if (catalog.containsKey(serviceName)) {
+                dependencies.add("%s:%s".formatted(catalog.get(serviceName), camelVersion));
+            } else if (catalog.containsKey(baseName)) {
+                dependencies.add("%s:%s".formatted(catalog.get(baseName), camelVersion));
+            } else {
+                dependencies.add("org.apache.camel:camel-test-infra-%s:%s".formatted(baseName, camelVersion));
+            }
+        }
+
+        return dependencies;
+    }
+
+    default Map<String, String> getKnownInfraServices() {
+        try {
+            InputStream is = ClassLoaderHelper.getClassLoader().getResourceAsStream("citrus-catalog/citrus/citrus-catalog-aggregate-infra-services.json");
+            if (is == null) {
+                return Collections.emptyMap();
+            }
+            JsonNode raw = JsonSupport.json().readTree(is);
+            Map<String, String> services = new HashMap<>();
+            raw.propertyNames().forEach(name -> services.put(name, raw.get(name).asString()));
+            return services;
+        } catch (JacksonException e) {
+            return Collections.emptyMap();
         }
     }
 

--- a/tools/jbang/src/main/java/org/citrusframework/jbang/util/GroovyCodeAnalyzer.java
+++ b/tools/jbang/src/main/java/org/citrusframework/jbang/util/GroovyCodeAnalyzer.java
@@ -24,7 +24,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import org.citrusframework.jbang.CitrusJBangMain;
 import org.citrusframework.util.StringUtils;
 
 public class GroovyCodeAnalyzer implements CodeAnalyzer {
@@ -33,6 +32,8 @@ public class GroovyCodeAnalyzer implements CodeAnalyzer {
     private static final Pattern MODULES_MODELINE_PATTERN = Pattern.compile("^//\\s*modules:\\s+(.+)\\s*$", Pattern.MULTILINE);
 
     private static final Pattern CAMEL_ENDPOINT_PATTERN = Pattern.compile("^\\s*(\\$\\(send\\(\\))?\\.endpoint\\(\"?'?camel:([^\\s:?]+).*$", Pattern.MULTILINE);
+
+    private static final Pattern CAMEL_INFRA_SERVICE_PATTERN = Pattern.compile("\\.service\\(\\s*[\"']([a-zA-Z][a-zA-Z0-9._-]*)[\"']\\s*\\)", Pattern.MULTILINE);
 
     @Override
     public Set<String> scanModules(String code) {
@@ -70,11 +71,10 @@ public class GroovyCodeAnalyzer implements CodeAnalyzer {
         }
 
         // Special handling of Camel endpoint URIs
-        matcher = CAMEL_ENDPOINT_PATTERN.matcher(code);
-        while (matcher.find()) {
-            String componentName = matcher.group(2);
-            items.add("org.apache.camel:camel-%s:%s".formatted(componentName, CitrusJBangMain.Settings.getCamelVersion()));
-        }
+        items.addAll(resolveCamelEndpointDependencies(code));
+
+        // Special handling of Camel infra services
+        items.addAll(resolveCamelInfraServiceDependencies(code));
 
         return items;
     }
@@ -137,6 +137,26 @@ public class GroovyCodeAnalyzer implements CodeAnalyzer {
         }
 
         return items;
+    }
+
+    @Override
+    public Set<String> extractCamelEndpointComponents(String code) {
+        Set<String> names = new HashSet<>();
+        Matcher matcher = CAMEL_ENDPOINT_PATTERN.matcher(code);
+        while (matcher.find()) {
+            names.add(matcher.group(2));
+        }
+        return names;
+    }
+
+    @Override
+    public Set<String> extractCamelInfraServiceNames(String code) {
+        Set<String> names = new HashSet<>();
+        Matcher matcher = CAMEL_INFRA_SERVICE_PATTERN.matcher(code);
+        while (matcher.find()) {
+            names.add(matcher.group(1));
+        }
+        return names;
     }
 
     @Override

--- a/tools/jbang/src/main/java/org/citrusframework/jbang/util/XmlCodeAnalyzer.java
+++ b/tools/jbang/src/main/java/org/citrusframework/jbang/util/XmlCodeAnalyzer.java
@@ -24,7 +24,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import org.citrusframework.jbang.CitrusJBangMain;
 import org.citrusframework.util.StringUtils;
 
 public class XmlCodeAnalyzer implements CodeAnalyzer {
@@ -33,6 +32,8 @@ public class XmlCodeAnalyzer implements CodeAnalyzer {
     private static final Pattern MODULES_MODELINE_PATTERN = Pattern.compile("^<!--\\s*modules:\\s+(.+)\\s*-->$", Pattern.MULTILINE);
 
     private static final Pattern CAMEL_ENDPOINT_PATTERN = Pattern.compile("^\\s*<(send|receive) endpoint=\"camel:([^\\s:?]+).*$", Pattern.MULTILINE);
+
+    private static final Pattern CAMEL_INFRA_SERVICE_PATTERN = Pattern.compile("<service>([a-zA-Z][a-zA-Z0-9._-]*)</service>", Pattern.MULTILINE);
 
     @Override
     public Set<String> scanModules(String code) {
@@ -70,11 +71,10 @@ public class XmlCodeAnalyzer implements CodeAnalyzer {
         }
 
         // Special handling of Camel endpoint URIs
-        matcher = CAMEL_ENDPOINT_PATTERN.matcher(code);
-        while (matcher.find()) {
-            String componentName = matcher.group(2);
-            items.add("org.apache.camel:camel-%s:%s".formatted(componentName, CitrusJBangMain.Settings.getCamelVersion()));
-        }
+        items.addAll(resolveCamelEndpointDependencies(code));
+
+        // Special handling of Camel infra services
+        items.addAll(resolveCamelInfraServiceDependencies(code));
 
         return items;
     }
@@ -137,6 +137,26 @@ public class XmlCodeAnalyzer implements CodeAnalyzer {
         }
 
         return items;
+    }
+
+    @Override
+    public Set<String> extractCamelEndpointComponents(String code) {
+        Set<String> names = new HashSet<>();
+        Matcher matcher = CAMEL_ENDPOINT_PATTERN.matcher(code);
+        while (matcher.find()) {
+            names.add(matcher.group(2));
+        }
+        return names;
+    }
+
+    @Override
+    public Set<String> extractCamelInfraServiceNames(String code) {
+        Set<String> names = new HashSet<>();
+        Matcher matcher = CAMEL_INFRA_SERVICE_PATTERN.matcher(code);
+        while (matcher.find()) {
+            names.add(matcher.group(1));
+        }
+        return names;
     }
 
     @Override

--- a/tools/jbang/src/main/java/org/citrusframework/jbang/util/YamlCodeAnalyzer.java
+++ b/tools/jbang/src/main/java/org/citrusframework/jbang/util/YamlCodeAnalyzer.java
@@ -24,7 +24,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import org.citrusframework.jbang.CitrusJBangMain;
 import org.citrusframework.util.StringUtils;
 
 public class YamlCodeAnalyzer implements CodeAnalyzer {
@@ -33,6 +32,8 @@ public class YamlCodeAnalyzer implements CodeAnalyzer {
     private static final Pattern MODULES_MODELINE_PATTERN = Pattern.compile("^#\\s*modules:\\s*(.+)\\s*$", Pattern.MULTILINE);
 
     private static final Pattern CAMEL_ENDPOINT_PATTERN = Pattern.compile("^\\s+endpoint:\\s+\"?'?camel:([^\\s:?]+)\"?'?.*$", Pattern.MULTILINE);
+
+    private static final Pattern CAMEL_INFRA_SERVICE_PATTERN = Pattern.compile("^\\s+service:\\s*\"?'?([a-zA-Z][a-zA-Z0-9._-]*)\"?'?\\s*$", Pattern.MULTILINE);
 
     @Override
     public Set<String> scanModules(String code) {
@@ -70,11 +71,10 @@ public class YamlCodeAnalyzer implements CodeAnalyzer {
         }
 
         // Special handling of Camel endpoint URIs
-        matcher = CAMEL_ENDPOINT_PATTERN.matcher(code.replaceAll("endpoint:\\s*[|>]\\s*\n", "endpoint: "));
-        while (matcher.find()) {
-            String componentName = matcher.group(1);
-            items.add("org.apache.camel:camel-%s:%s".formatted(componentName, CitrusJBangMain.Settings.getCamelVersion()));
-        }
+        items.addAll(resolveCamelEndpointDependencies(code));
+
+        // Special handling of Camel infra services
+        items.addAll(resolveCamelInfraServiceDependencies(code));
 
         return items;
     }
@@ -141,6 +141,26 @@ public class YamlCodeAnalyzer implements CodeAnalyzer {
         }
 
         return items;
+    }
+
+    @Override
+    public Set<String> extractCamelEndpointComponents(String code) {
+        Set<String> names = new HashSet<>();
+        Matcher matcher = CAMEL_ENDPOINT_PATTERN.matcher(code.replaceAll("endpoint:\\s*[|>]\\s*\n", "endpoint: "));
+        while (matcher.find()) {
+            names.add(matcher.group(1));
+        }
+        return names;
+    }
+
+    @Override
+    public Set<String> extractCamelInfraServiceNames(String code) {
+        Set<String> names = new HashSet<>();
+        Matcher matcher = CAMEL_INFRA_SERVICE_PATTERN.matcher(code);
+        while (matcher.find()) {
+            names.add(matcher.group(1));
+        }
+        return names;
     }
 
     @Override

--- a/tools/jbang/src/test/java/org/citrusframework/jbang/commands/InspectTest.java
+++ b/tools/jbang/src/test/java/org/citrusframework/jbang/commands/InspectTest.java
@@ -43,12 +43,9 @@ public class InspectTest extends CommandTest {
                 "citrus-jms"
               ],
             """));
-        Assertions.assertTrue(printer.getOutput().contains("""
-           "actions": [
-               "receive",
-               "print",
-               "send"
-             ],
-           """));
+        Assertions.assertTrue(printer.getOutput().contains("\"receive\""));
+        Assertions.assertTrue(printer.getOutput().contains("\"print\""));
+        Assertions.assertTrue(printer.getOutput().contains("\"send\""));
+        Assertions.assertTrue(printer.getOutput().contains("\"camel-infra-run\""));
     }
 }

--- a/tools/jbang/src/test/java/org/citrusframework/jbang/util/GroovyCodeAnalyzerTest.java
+++ b/tools/jbang/src/test/java/org/citrusframework/jbang/util/GroovyCodeAnalyzerTest.java
@@ -43,16 +43,18 @@ public class GroovyCodeAnalyzerTest {
         Assert.assertEquals(foundModules[4], "citrus-kafka");
         Assert.assertEquals(foundModules[5], "citrus-testcontainers");
 
-        Assert.assertEquals(scanResult.dependencies().length, 2L);
+        Assert.assertEquals(scanResult.dependencies().length, 3L);
         String[] foundDeps = Arrays.stream(scanResult.dependencies()).sorted().toArray(String[]::new);
         Assert.assertEquals(foundDeps[0], "org.apache.camel:camel-aws2-s3:" + CAMEL_VERSION_DEFAULT);
         Assert.assertEquals(foundDeps[1], "org.apache.camel:camel-paho-mqtt5:" + CAMEL_VERSION_DEFAULT);
+        Assert.assertEquals(foundDeps[2], "org.apache.camel:camel-test-infra-kafka:" + CAMEL_VERSION_DEFAULT);
 
-        Assert.assertEquals(scanResult.actions().length, 3L);
+        Assert.assertEquals(scanResult.actions().length, 4L);
         String[] foundActions = Arrays.stream(scanResult.actions()).sorted().toArray(String[]::new);
-        Assert.assertEquals(foundActions[0], "print");
-        Assert.assertEquals(foundActions[1], "receive");
-        Assert.assertEquals(foundActions[2], "send");
+        Assert.assertEquals(foundActions[0], "camel-infra-run");
+        Assert.assertEquals(foundActions[1], "print");
+        Assert.assertEquals(foundActions[2], "receive");
+        Assert.assertEquals(foundActions[3], "send");
 
         Assert.assertEquals(scanResult.containers().length, 1L);
         Assert.assertEquals(scanResult.containers()[0], "iterate");

--- a/tools/jbang/src/test/java/org/citrusframework/jbang/util/XmlCodeAnalyzerTest.java
+++ b/tools/jbang/src/test/java/org/citrusframework/jbang/util/XmlCodeAnalyzerTest.java
@@ -43,16 +43,18 @@ public class XmlCodeAnalyzerTest {
         Assert.assertEquals(foundModules[4], "citrus-kafka");
         Assert.assertEquals(foundModules[5], "citrus-testcontainers");
 
-        Assert.assertEquals(scanResult.dependencies().length, 2L);
+        Assert.assertEquals(scanResult.dependencies().length, 3L);
         String[] foundDeps = Arrays.stream(scanResult.dependencies()).sorted().toArray(String[]::new);
         Assert.assertEquals(foundDeps[0], "org.apache.camel:camel-aws2-s3:" + CAMEL_VERSION_DEFAULT);
         Assert.assertEquals(foundDeps[1], "org.apache.camel:camel-paho-mqtt5:" + CAMEL_VERSION_DEFAULT);
+        Assert.assertEquals(foundDeps[2], "org.apache.camel:camel-test-infra-kafka:" + CAMEL_VERSION_DEFAULT);
 
-        Assert.assertEquals(scanResult.actions().length, 3L);
+        Assert.assertEquals(scanResult.actions().length, 4L);
         String[] foundActions = Arrays.stream(scanResult.actions()).sorted().toArray(String[]::new);
-        Assert.assertEquals(foundActions[0], "print");
-        Assert.assertEquals(foundActions[1], "receive");
-        Assert.assertEquals(foundActions[2], "send");
+        Assert.assertEquals(foundActions[0], "camel-infra-run");
+        Assert.assertEquals(foundActions[1], "print");
+        Assert.assertEquals(foundActions[2], "receive");
+        Assert.assertEquals(foundActions[3], "send");
 
         Assert.assertEquals(scanResult.containers().length, 1L);
         Assert.assertEquals(scanResult.containers()[0], "iterate");

--- a/tools/jbang/src/test/java/org/citrusframework/jbang/util/YamlCodeAnalyzerTest.java
+++ b/tools/jbang/src/test/java/org/citrusframework/jbang/util/YamlCodeAnalyzerTest.java
@@ -43,16 +43,18 @@ public class YamlCodeAnalyzerTest {
         Assert.assertEquals(foundModules[4], "citrus-kafka");
         Assert.assertEquals(foundModules[5], "citrus-testcontainers");
 
-        Assert.assertEquals(scanResult.dependencies().length, 2L);
+        Assert.assertEquals(scanResult.dependencies().length, 3L);
         String[] foundDeps = Arrays.stream(scanResult.dependencies()).sorted().toArray(String[]::new);
         Assert.assertEquals(foundDeps[0], "org.apache.camel:camel-aws2-s3:" + CAMEL_VERSION_DEFAULT);
         Assert.assertEquals(foundDeps[1], "org.apache.camel:camel-paho-mqtt5:" + CAMEL_VERSION_DEFAULT);
+        Assert.assertEquals(foundDeps[2], "org.apache.camel:camel-test-infra-kafka:" + CAMEL_VERSION_DEFAULT);
 
-        Assert.assertEquals(scanResult.actions().length, 3L);
+        Assert.assertEquals(scanResult.actions().length, 4L);
         String[] foundActions = Arrays.stream(scanResult.actions()).sorted().toArray(String[]::new);
-        Assert.assertEquals(foundActions[0], "print");
-        Assert.assertEquals(foundActions[1], "receive");
-        Assert.assertEquals(foundActions[2], "send");
+        Assert.assertEquals(foundActions[0], "camel-infra-run");
+        Assert.assertEquals(foundActions[1], "print");
+        Assert.assertEquals(foundActions[2], "receive");
+        Assert.assertEquals(foundActions[3], "send");
 
         Assert.assertEquals(scanResult.containers().length, 1L);
         Assert.assertEquals(scanResult.containers()[0], "iterate");

--- a/tools/jbang/src/test/resources/sample.citrus.it.groovy
+++ b/tools/jbang/src/test/resources/sample.citrus.it.groovy
@@ -58,6 +58,10 @@ actions {
       .message()
         .body("@ignore@ @isNumber()@"))
 
+    $(camel().infra().run()
+      .service("kafka")
+      .autoRemove(true))
+
     $(iterate()
       .condition("i < 10")
       .actions(

--- a/tools/jbang/src/test/resources/sample.citrus.it.xml
+++ b/tools/jbang/src/test/resources/sample.citrus.it.xml
@@ -68,6 +68,14 @@
         </body>
       </message>
     </receive>
+    <camel>
+      <infra>
+        <run>
+          <service>kafka</service>
+          <autoRemove>true</autoRemove>
+        </run>
+      </infra>
+    </camel>
     <iterate condition="i &lt; 10">
       <actions>
         <print>

--- a/tools/jbang/src/test/resources/sample.citrus.it.yaml
+++ b/tools/jbang/src/test/resources/sample.citrus.it.yaml
@@ -34,6 +34,11 @@ actions:
       message:
         body:
           data: @ignore@ @isNumber()@
+  - camel:
+      infra:
+        run:
+          service: kafka
+          autoRemove: true
   - iterate:
       condition: i < 10
       actions:

--- a/tools/schema-generator/src/main/java/org/citrusframework/dsl/schema/Catalog.java
+++ b/tools/schema-generator/src/main/java/org/citrusframework/dsl/schema/Catalog.java
@@ -16,13 +16,18 @@
 
 package org.citrusframework.dsl.schema;
 
+import java.io.IOException;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
 import com.github.victools.jsonschema.generator.Option;
+import org.apache.camel.catalog.DefaultCamelCatalog;
 import org.citrusframework.CitrusVersion;
+import org.citrusframework.camel.actions.infra.InfraService;
+import org.citrusframework.camel.actions.infra.InfraServiceUtils;
 import org.citrusframework.dsl.schema.generator.CitrusModule;
 import org.citrusframework.dsl.schema.generator.CitrusSchemaGenerator;
 import org.citrusframework.endpoint.EndpointBuilder;
@@ -198,6 +203,28 @@ public class Catalog {
                             jsonSchema));
         }
 
+        return catalog;
+    }
+
+    public Map<String, String> getInfraServiceCatalog() {
+        Map<String, String> catalog = new LinkedHashMap<>();
+        try {
+            List<InfraService> services = InfraServiceUtils.getInfraServiceMetadata(new DefaultCamelCatalog());
+            for (InfraService service : services) {
+                String artifact = "%s:%s".formatted(service.groupId(), service.artifactId());
+                for (String alias : service.alias()) {
+                    if (service.aliasImplementation() != null && !service.aliasImplementation().isEmpty()) {
+                        for (String impl : service.aliasImplementation()) {
+                            catalog.put("%s.%s".formatted(alias, impl), artifact);
+                        }
+                    } else {
+                        catalog.put(alias, artifact);
+                    }
+                }
+            }
+        } catch (IOException e) {
+            System.err.println("Failed to load infra service metadata: " + e.getMessage());
+        }
         return catalog;
     }
 

--- a/tools/schema-generator/src/main/java/org/citrusframework/dsl/schema/generator/CitrusSchemaGenerator.java
+++ b/tools/schema-generator/src/main/java/org/citrusframework/dsl/schema/generator/CitrusSchemaGenerator.java
@@ -99,6 +99,10 @@ public class CitrusSchemaGenerator {
             String validationMatcherCatalog = MessagePayloadUtils.prettyPrintJson(JsonSupport.json().writeValueAsString(catalog.getValidationMatcherCatalog()));
             writeFile(workingDir, "citrus-catalog-aggregate-validation-matcher.json", validationMatcherCatalog + "\n");
             writeFile(versionWorkingDir, "citrus-catalog-aggregate-validation-matcher.json", validationMatcherCatalog + "\n");
+
+            String infraServiceCatalog = MessagePayloadUtils.prettyPrintJson(JsonSupport.json().writeValueAsString(catalog.getInfraServiceCatalog()));
+            writeFile(workingDir, "citrus-catalog-aggregate-infra-services.json", infraServiceCatalog + "\n");
+            writeFile(versionWorkingDir, "citrus-catalog-aggregate-infra-services.json", infraServiceCatalog + "\n");
         } catch (IOException e) {
             throw new RuntimeException("Failed to generate Citrus DSL schema", e);
         }


### PR DESCRIPTION
## Summary

- Extends the JBang code inspection mechanism to automatically detect and resolve `camel-test-infra-*` Maven dependencies when Camel infra services are used in test files
- Generates a camel infra services catalog at build time (via `CitrusSchemaGenerator`) that maps service names to their corresponding Maven artifact coordinates
- Adds service name extraction in all three format-specific code analyzers (YAML, XML, Groovy)

Fixes #1594

## How It Works

1. **Schema Generator** (`Catalog.getlInfraServiceCatalog()`) reads `InfraService` metadata from the Camel catalog at build time and generates `citrus-catalog-aggregate-infra-services.json` - a mapping of service names to `groupId:artifactId` coordinates
2. **CodeAnalyzer** loads the generated catalog at analysis time and resolves service names to full Maven GAV dependencies (appending the configured Camel version)
3. Service name extraction uses format-specific regex patterns:
   - YAML: `service: kafka`
   - XML: `<service>kafka</service>`
   - Groovy: `.service("kafka")`

The resolution handles the `serviceName.implementationAlias` convention - e.g. `kafka.confluent` resolves to `camel-test-infra-kafka`, while `google.pub-sub` resolves to `camel-test-infra-google-pubsub`.

## Test plan
- [x] Updated `YamlCodeAnalyzerTest` with camel-infra-run action in sample YAML test
- [x] Updated `InspectTest` to verify new action detection
- [x] Full reactor build passes

Generated with [Claude Code](https://claude.ai/code)