### PR TITLE
fix(#1580): Support beans configuration in YAML and XML DSL

### DIFF
--- a/core/citrus-api/src/main/java/org/citrusframework/util/ClassLoaderHelper.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/util/ClassLoaderHelper.java
@@ -98,6 +98,13 @@ public final class ClassLoaderHelper {
     }
 
     /**
+     * Instantiate given type. Uses the current thread context class loader to instantiate.
+     */
+    public static <T> T instantiateType(Class<T> clazz, Object... initargs) {
+        return instantiateType(clazz, getContextClassLoader(), initargs);
+    }
+
+    /**
      * Instantiate a type by its name. Use the given caller to resolve the class loader.
      */
     public static <T> T instantiateType(String type, Class<?> caller, Object... initargs) {
@@ -105,40 +112,59 @@ public final class ClassLoaderHelper {
     }
 
     /**
+     * Instantiate given type. Use the given caller to resolve the class loader.
+     */
+    public static <T> T instantiateType(Class<T> clazz, Class<?> caller, Object... initargs) {
+        return instantiateType(clazz, getClassLoader(caller), initargs);
+    }
+
+    /**
      * Instantiate a type by its name. Uses given class loader to instantiate.
      */
     public static <T> T instantiateType(String type, ClassLoader cl, Object... initargs) {
         try {
+            return (T) instantiateType(Class.forName(type, true, cl), cl, initargs);
+        } catch (ClassNotFoundException e) {
+            throw new CitrusRuntimeException(
+                    format("Failed to resolve classpath resource of type '%s' - caused by: %s",
+                            type, Optional.ofNullable(e.getMessage()).orElse(e.getClass().getName())), e);
+        }
+    }
+
+    /**
+     * Instantiate given type. Uses given class loader to instantiate.
+     */
+    public static <T> T instantiateType(Class<T> clazz, ClassLoader cl, Object... initargs) {
+        try {
             if (initargs.length == 0) {
-                return (T) Class.forName(type, true, cl).getDeclaredConstructor().newInstance();
+                return clazz.getDeclaredConstructor().newInstance();
             } else {
-                return (T) getConstructor(Class.forName(type, true, cl), initargs).newInstance(initargs);
+                return (T) getConstructor(clazz, initargs).newInstance(initargs);
             }
-        } catch (ClassNotFoundException | IllegalAccessException | InstantiationException |
-                 NoSuchMethodException | InvocationTargetException e) {
+        } catch (IllegalAccessException | InstantiationException | NoSuchMethodException | InvocationTargetException e) {
             try {
                 if (
-                    Arrays.stream(Class.forName(type, true, cl).getFields())
+                    Arrays.stream(clazz.getFields())
                             .anyMatch(field -> field.getName().equals(INSTANCE)
                                     && Modifier.isStatic(field.getModifiers()))
                 ) {
-                    return (T) Class.forName(type, true, cl).getField(INSTANCE).get(null);
+                    return (T) clazz.getField(INSTANCE).get(null);
                 }
-            } catch (IllegalAccessException | NoSuchFieldException | ClassNotFoundException e1) {
+            } catch (IllegalAccessException | NoSuchFieldException e1) {
                 throw new CitrusRuntimeException(
                         format("Failed to resolve classpath resource of type '%s' - caused by: %s",
-                                type, Optional.ofNullable(e1.getMessage()).orElse(e1.getClass().getName())), e1);
+                                clazz.getName(), Optional.ofNullable(e1.getMessage()).orElse(e1.getClass().getName())), e1);
             }
 
             logger.warn(
                     "Neither static instance nor accessible default constructor ({}) is given on type '{}'",
                     Arrays.toString(getParameterTypes(initargs)),
-                    type
+                    clazz.getName()
             );
 
             throw new CitrusRuntimeException(
                     format("Failed to resolve classpath resource of type '%s' - caused by: %s",
-                            type, Optional.ofNullable(e.getMessage()).orElse(e.getClass().getName())), e);
+                            clazz.getName(), Optional.ofNullable(e.getMessage()).orElse(e.getClass().getName())), e);
         }
     }
 
@@ -196,12 +222,11 @@ public final class ClassLoaderHelper {
     /**
      * Gets the constructor best matching the given parameter types.
      */
-    private static Constructor<?> getConstructor(Class<?> type, Object[] initargs) {
+    private static <T> Constructor<?> getConstructor(Class<T> type, Object[] initargs) {
         final Class<?>[] parameterTypes = getParameterTypes(initargs);
 
         Optional<Constructor<?>> exactMatch = Arrays.stream(type.getDeclaredConstructors())
-                .filter(
-                        constructor -> Arrays.equals(replacePrimitiveTypes(constructor), parameterTypes))
+                .filter(constructor -> Arrays.equals(replacePrimitiveTypes(constructor), parameterTypes))
                 .findFirst();
 
         if (exactMatch.isPresent()) {

--- a/core/citrus-base/src/main/java/org/citrusframework/DefaultTestCase.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/DefaultTestCase.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.time.StopWatch;
+import org.citrusframework.bean.BeanDefinition;
 import org.citrusframework.common.InitializingPhase;
 import org.citrusframework.container.AbstractActionContainer;
 import org.citrusframework.container.AfterTest;
@@ -36,6 +37,9 @@ import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.exceptions.TestCaseFailedException;
 import org.citrusframework.spi.ReferenceResolver;
 import org.citrusframework.spi.ReferenceResolverAware;
+import org.citrusframework.util.ClassLoaderHelper;
+import org.citrusframework.util.PropertyUtils;
+import org.citrusframework.util.ReflectionHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,6 +82,11 @@ public class DefaultTestCase extends AbstractActionContainer implements TestCase
      * Adhoc endpoints that are port of the test.
      */
     private final List<EndpointBuilder<?>> endpoints = new ArrayList<>();
+
+    /**
+     * Adhoc bean definitions that are part of the test configuration.
+     */
+    private final List<BeanDefinition> beanDefinitions = new ArrayList<>();
 
     /**
      * Meta-Info
@@ -166,6 +175,7 @@ public class DefaultTestCase extends AbstractActionContainer implements TestCase
             initializeTestVariables(variableDefinitions, context);
             traceVariables("Test", context);
             initializeEndpoints(endpoints, endpointDefinitions, context);
+            initializeBeans(beanDefinitions, context);
 
             beforeTest(context);
         } catch (final Exception | Error e) {
@@ -490,6 +500,53 @@ public class DefaultTestCase extends AbstractActionContainer implements TestCase
     }
 
     /**
+     * Initialize beans with given definitions in the test context.
+     */
+    private void initializeBeans(List<BeanDefinition> beanDefinitions, TestContext context) {
+        for (final BeanDefinition beanDef : beanDefinitions) {
+            logger.debug("Initializing bean '{}' of type '{}'", beanDef.getName(), beanDef.getType());
+            try {
+                Class<?> clazz = Class.forName(beanDef.getType(), true, ClassLoaderHelper.getContextClassLoader());
+                Object bean = ClassLoaderHelper.instantiateType(clazz);
+
+                for (Map.Entry<String, String> property : beanDef.getProperties().entrySet()) {
+                    String setterName = "set" + property.getKey().substring(0, 1).toUpperCase() + property.getKey().substring(1);
+                    ReflectionHelper.doWithMethods(clazz, method -> {
+                        if (method.getName().equals(setterName) && method.getParameterTypes().length == 1) {
+                            Object convertedValue = context.getTypeConverter()
+                                    .convertIfNecessary(property.getValue(), method.getParameterTypes()[0]);
+                            ReflectionHelper.invokeMethod(method, bean, convertedValue);
+                        }
+                    });
+                }
+
+                if (bean instanceof ReferenceResolverAware resolverAware) {
+                    resolverAware.setReferenceResolver(context.getReferenceResolver());
+                }
+
+                PropertyUtils.configure(beanDef.getName(), bean, context.getReferenceResolver());
+
+                if (bean instanceof InitializingPhase initializingBean) {
+                    initializingBean.initialize();
+                }
+
+                if (context.getReferenceResolver().isResolvable(beanDef.getName())) {
+                    logger.warn("Skip binding bean to registry, because bean already exists: {}", beanDef.getName());
+                } else {
+                    logger.info("Binding bean {} to bean registry", beanDef.getName());
+                    context.getReferenceResolver().bind(beanDef.getName(), bean);
+                }
+            } catch (ClassNotFoundException e) {
+                throw new CitrusRuntimeException(
+                        "Failed to instantiate bean '%s' - class '%s' not found".formatted(beanDef.getName(), beanDef.getType()), e);
+            } catch (Exception e) {
+                throw new CitrusRuntimeException(
+                        "Failed to instantiate bean '%s' of type '%s'".formatted(beanDef.getName(), beanDef.getType()), e);
+            }
+        }
+    }
+
+    /**
      * Setter for variables.
      */
     public void setVariableDefinitions(final Map<String, Object> variableDefinitions) {
@@ -509,6 +566,10 @@ public class DefaultTestCase extends AbstractActionContainer implements TestCase
     @Override
     public List<EndpointBuilder<?>> getEndpoints() {
         return endpoints;
+    }
+
+    public List<BeanDefinition> getBeanDefinitions() {
+        return beanDefinitions;
     }
 
     /**

--- a/core/citrus-base/src/main/java/org/citrusframework/bean/BeanDefinition.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/bean/BeanDefinition.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.bean;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class BeanDefinition {
+
+    private String name;
+    private String type;
+    private final Map<String, String> properties = new LinkedHashMap<>();
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+}

--- a/runtime/citrus-xml/src/main/java/org/citrusframework/xml/XmlTestCase.java
+++ b/runtime/citrus-xml/src/main/java/org/citrusframework/xml/XmlTestCase.java
@@ -40,6 +40,7 @@ import org.citrusframework.CitrusSettings;
 import org.citrusframework.DefaultTestCase;
 import org.citrusframework.TestCase;
 import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.bean.BeanDefinition;
 import org.citrusframework.endpoint.EndpointBuilder;
 import org.citrusframework.endpoint.EndpointComponent;
 import org.citrusframework.exceptions.CitrusRuntimeException;
@@ -136,6 +137,20 @@ public class XmlTestCase {
 
         for (EndpointBuilder<?> endpointBuilder : endpoints.getEndpointBuilders()) {
             delegate.getEndpoints().add(endpointBuilder);
+        }
+    }
+
+    @XmlElement
+    public void setConfiguration(Configuration configuration) {
+        if (configuration.getBeans() != null) {
+            configuration.getBeans().getBeans().forEach(bean -> {
+                BeanDefinition beanDef = new BeanDefinition();
+                beanDef.setName(bean.getName());
+                beanDef.setType(bean.getType());
+                bean.getProperties().forEach(prop ->
+                        beanDef.getProperties().put(prop.getName(), prop.getValue()));
+                delegate.getBeanDefinitions().add(beanDef);
+            });
         }
     }
 
@@ -401,6 +416,113 @@ public class XmlTestCase {
 
                 public void setValue(String value) {
                     this.value = value;
+                }
+            }
+        }
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(name = "", propOrder = {
+            "beans"
+    })
+    public static class Configuration {
+
+        @XmlElement(name = "beans")
+        protected Beans beans;
+
+        public Beans getBeans() {
+            return beans;
+        }
+
+        public void setBeans(Beans beans) {
+            this.beans = beans;
+        }
+
+        @XmlAccessorType(XmlAccessType.FIELD)
+        @XmlType(name = "", propOrder = {
+                "beans"
+        })
+        public static class Beans {
+
+            @XmlElement(name = "bean", required = true)
+            protected List<Bean> beans;
+
+            public List<Bean> getBeans() {
+                if (beans == null) {
+                    beans = new ArrayList<>();
+                }
+                return this.beans;
+            }
+
+            public void setBeans(List<Bean> beans) {
+                this.beans = beans;
+            }
+
+            @XmlAccessorType(XmlAccessType.FIELD)
+            @XmlType(name = "", propOrder = {
+                    "properties"
+            })
+            public static class Bean {
+
+                @XmlAttribute(name = "name", required = true)
+                protected String name;
+                @XmlAttribute(name = "type", required = true)
+                protected String type;
+                @XmlElement(name = "property")
+                protected List<Property> properties;
+
+                public String getName() {
+                    return name;
+                }
+
+                public void setName(String name) {
+                    this.name = name;
+                }
+
+                public String getType() {
+                    return type;
+                }
+
+                public void setType(String type) {
+                    this.type = type;
+                }
+
+                public List<Property> getProperties() {
+                    if (properties == null) {
+                        properties = new ArrayList<>();
+                    }
+                    return properties;
+                }
+
+                public void setProperties(List<Property> properties) {
+                    this.properties = properties;
+                }
+
+                @XmlAccessorType(XmlAccessType.FIELD)
+                @XmlType(name = "", propOrder = {
+                })
+                public static class Property {
+
+                    @XmlAttribute(required = true)
+                    protected String name;
+                    @XmlAttribute(required = true)
+                    protected String value;
+
+                    public String getName() {
+                        return name;
+                    }
+
+                    public void setName(String name) {
+                        this.name = name;
+                    }
+
+                    public String getValue() {
+                        return value;
+                    }
+
+                    public void setValue(String value) {
+                        this.value = value;
+                    }
                 }
             }
         }

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-5.0.0-SNAPSHOT.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-5.0.0-SNAPSHOT.xsd
@@ -154,12 +154,33 @@
         </xs:complexType>
       </xs:element>
       <xs:element name="endpoints" type="tns:TestEndpoints" minOccurs="0"/>
+      <xs:element name="configuration" type="tns:TestConfiguration" minOccurs="0"/>
       <xs:element name="actions" type="tns:TestActions" minOccurs="0"/>
       <xs:element name="finally" type="tns:TestActions" minOccurs="0"/>
     </xs:sequence>
     <xs:attribute name="author" type="xs:string"/>
     <xs:attribute name="name" type="xs:string"/>
     <xs:attribute name="status" type="tns:StatusType"/>
+  </xs:complexType>
+
+  <xs:complexType name="TestConfiguration">
+    <xs:sequence>
+      <xs:element name="beans" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="bean" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="property" type="tns:PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:sequence>
+                <xs:attribute name="name" type="xs:string" use="required"/>
+                <xs:attribute name="type" type="xs:string" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
   </xs:complexType>
 
   <xs:complexType name="TestEndpoints">

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
@@ -154,12 +154,33 @@
         </xs:complexType>
       </xs:element>
       <xs:element name="endpoints" type="tns:TestEndpoints" minOccurs="0"/>
+      <xs:element name="configuration" type="tns:TestConfiguration" minOccurs="0"/>
       <xs:element name="actions" type="tns:TestActions" minOccurs="0"/>
       <xs:element name="finally" type="tns:TestActions" minOccurs="0"/>
     </xs:sequence>
     <xs:attribute name="author" type="xs:string"/>
     <xs:attribute name="name" type="xs:string"/>
     <xs:attribute name="status" type="tns:StatusType"/>
+  </xs:complexType>
+
+  <xs:complexType name="TestConfiguration">
+    <xs:sequence>
+      <xs:element name="beans" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="bean" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="property" type="tns:PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:sequence>
+                <xs:attribute name="name" type="xs:string" use="required"/>
+                <xs:attribute name="type" type="xs:string" use="required"/>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
   </xs:complexType>
 
   <xs:complexType name="TestEndpoints">

--- a/runtime/citrus-xml/src/test/java/org/citrusframework/xml/actions/BeansTest.java
+++ b/runtime/citrus-xml/src/test/java/org/citrusframework/xml/actions/BeansTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.xml.actions;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.validation.DefaultTextEqualsMessageValidator;
+import org.citrusframework.xml.XmlTestLoader;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class BeansTest extends AbstractXmlActionTest {
+
+    @Test
+    public void shouldLoadBeansConfiguration() {
+        XmlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/xml/actions/beans.citrus.it.xml");
+
+        testLoader.load();
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "BeansTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 1L);
+
+        Assert.assertTrue(context.getReferenceResolver().isResolvable("myValidator"));
+        Assert.assertTrue(context.getReferenceResolver().isResolvable("myValidator", DefaultTextEqualsMessageValidator.class));
+
+        Assert.assertTrue(context.getReferenceResolver().isResolvable("myBean"));
+        Assert.assertTrue(context.getReferenceResolver().isResolvable("myBean", FooBean.class));
+
+        FooBean fooBean = context.getReferenceResolver().resolve("myBean", FooBean.class);
+        Assert.assertEquals(fooBean.getMessage(), "Hello Citrus!");
+        Assert.assertEquals(fooBean.getCount(), 42);
+    }
+}

--- a/runtime/citrus-xml/src/test/java/org/citrusframework/xml/actions/FooBean.java
+++ b/runtime/citrus-xml/src/test/java/org/citrusframework/xml/actions/FooBean.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.xml.actions;
+
+public class FooBean {
+
+    private String message;
+    private int count;
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    public void setCount(int count) {
+        this.count = count;
+    }
+}

--- a/runtime/citrus-xml/src/test/resources/org/citrusframework/xml/actions/beans.citrus.it.xml
+++ b/runtime/citrus-xml/src/test/resources/org/citrusframework/xml/actions/beans.citrus.it.xml
@@ -1,0 +1,16 @@
+<test xmlns="http://citrusframework.org/schema/xml/testcase"
+      name="BeansTest" author="Christoph" status="FINAL">
+  <description>Bean definition test in XML</description>
+  <configuration>
+    <beans>
+      <bean name="myValidator" type="org.citrusframework.validation.DefaultTextEqualsMessageValidator"/>
+      <bean name="myBean" type="org.citrusframework.xml.actions.FooBean">
+        <property name="message" value="Hello Citrus!"/>
+        <property name="count" value="42"/>
+      </bean>
+    </beans>
+  </configuration>
+  <actions>
+    <echo message="Bean test"/>
+  </actions>
+</test>

--- a/runtime/citrus-yaml/src/main/java/org/citrusframework/yaml/YamlTestCase.java
+++ b/runtime/citrus-yaml/src/main/java/org/citrusframework/yaml/YamlTestCase.java
@@ -29,6 +29,7 @@ import org.citrusframework.CitrusSettings;
 import org.citrusframework.DefaultTestCase;
 import org.citrusframework.TestCase;
 import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.bean.BeanDefinition;
 import org.citrusframework.common.Named;
 import org.citrusframework.endpoint.EndpointBuilder;
 import org.citrusframework.endpoint.EndpointComponent;
@@ -124,6 +125,21 @@ public class YamlTestCase {
                 }
             }
         });
+    }
+
+    @SchemaProperty(advanced = true, description = "Test configuration section for beans and other resources.")
+    public void setConfiguration(Configuration configuration) {
+        if (configuration.getBeans() != null) {
+            configuration.getBeans().forEach(bean -> {
+                BeanDefinition beanDef = new BeanDefinition();
+                beanDef.setName(bean.getName());
+                beanDef.setType(bean.getType());
+                if (bean.getProperties() != null) {
+                    beanDef.getProperties().putAll(bean.getProperties());
+                }
+                delegate.getBeanDefinitions().add(beanDef);
+            });
+        }
     }
 
     @SchemaProperty(description = "The test actions.")
@@ -256,6 +272,54 @@ public class YamlTestCase {
                 description = "The endpoint properties.")
         public void setProperties(Map<String, String> properties) {
             this.properties.putAll(properties);
+        }
+    }
+
+    public static class Configuration {
+
+        protected List<Bean> beans;
+
+        public List<Bean> getBeans() {
+            return beans;
+        }
+
+        @SchemaProperty(description = "List of beans to register in the test context.")
+        public void setBeans(List<Bean> beans) {
+            this.beans = beans;
+        }
+    }
+
+    public static class Bean {
+
+        protected String name;
+        protected String type;
+        protected Map<String, String> properties;
+
+        public String getName() {
+            return name;
+        }
+
+        @SchemaProperty(required = true, description = "The bean name used for registration in the bean registry.")
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        @SchemaProperty(required = true, description = "The fully qualified bean class type.")
+        public void setType(String type) {
+            this.type = type;
+        }
+
+        public Map<String, String> getProperties() {
+            return properties;
+        }
+
+        @SchemaProperty(description = "The bean properties set via setter methods.")
+        public void setProperties(Map<String, String> properties) {
+            this.properties = properties;
         }
     }
 }

--- a/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/actions/BeansTest.java
+++ b/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/actions/BeansTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaml.actions;
+
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.validation.DefaultTextEqualsMessageValidator;
+import org.citrusframework.yaml.YamlTestLoader;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class BeansTest extends AbstractYamlActionTest {
+
+    @Test
+    public void shouldLoadBeansConfiguration() {
+        YamlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/yaml/actions/beans.citrus.it.yaml");
+
+        testLoader.load();
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "BeansTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 1L);
+
+        Assert.assertTrue(context.getReferenceResolver().isResolvable("myValidator"));
+        Assert.assertTrue(context.getReferenceResolver().isResolvable("myValidator", DefaultTextEqualsMessageValidator.class));
+
+        Assert.assertTrue(context.getReferenceResolver().isResolvable("myBean"));
+        Assert.assertTrue(context.getReferenceResolver().isResolvable("myBean", FooBean.class));
+
+        FooBean fooBean = context.getReferenceResolver().resolve("myBean", FooBean.class);
+        Assert.assertEquals(fooBean.getMessage(), "Hello Citrus!");
+        Assert.assertEquals(fooBean.getCount(), 42);
+    }
+}

--- a/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/actions/FooBean.java
+++ b/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/actions/FooBean.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaml.actions;
+
+public class FooBean {
+
+    private String message;
+    private int count;
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    public void setCount(int count) {
+        this.count = count;
+    }
+}

--- a/runtime/citrus-yaml/src/test/resources/org/citrusframework/yaml/actions/beans.citrus.it.yaml
+++ b/runtime/citrus-yaml/src/test/resources/org/citrusframework/yaml/actions/beans.citrus.it.yaml
@@ -1,0 +1,16 @@
+name: BeansTest
+author: Christoph
+status: FINAL
+description: "Bean definition test in YAML"
+configuration:
+  beans:
+    - name: myValidator
+      type: org.citrusframework.validation.DefaultTextEqualsMessageValidator
+    - name: myBean
+      type: org.citrusframework.yaml.actions.FooBean
+      properties:
+        message: "Hello Citrus!"
+        count: "42"
+actions:
+  - echo:
+      message: "Bean test"

--- a/src/manual/run-xml.adoc
+++ b/src/manual/run-xml.adoc
@@ -47,6 +47,52 @@ The test logic itself is defined in the XML file like this:
 </test>
 ----
 
+[[run-xml-bean-definitions]]
+=== Bean definitions
+
+The XML test is able to define custom beans as part of the test configuration.
+Beans are registered in the Citrus bean registry and can be referenced by test actions and other components.
+
+This does not require the `citrus-groovy` dependency.
+
+.my.citrus.it.xml
+[source,xml]
+----
+<test name="BeanTest" author="Christoph" status="FINAL"
+      xmlns="http://citrusframework.org/schema/xml/testcase"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://citrusframework.org/schema/xml/testcase
+            http://citrusframework.org/schema/xml/testcase/citrus-testcase.xsd">
+  <description>Sample test in XML</description>
+
+  <configuration>
+    <beans>
+      <bean name="myValidator" type="org.citrusframework.validation.DefaultTextEqualsMessageValidator"/>
+      <bean name="connectionFactory" type="org.example.jms.ActiveMQConnectionFactory">
+        <property name="brokerUrl" value="tcp://localhost:61616"/>
+        <property name="userName" value="admin"/>
+      </bean>
+    </beans>
+  </configuration>
+
+  <actions>
+    <echo message="Bean test"/>
+  </actions>
+</test>
+----
+
+The `<configuration>` element holds a `<beans>` section where each `<bean>` specifies:
+
+* `name` - the bean identifier used to register the instance in the Citrus bean registry
+* `type` - the fully qualified Java class name (must have a default constructor)
+* `<property>` - optional child elements with `name` and `value` attributes set via setter methods on the bean instance
+
+The bean type must have a default constructor.
+Property values are automatically converted to the target setter parameter type (e.g. String to int).
+
+Beans that implement `InitializingPhase` will have their `initialize()` method called after all properties are set.
+Beans that implement `ReferenceResolverAware` will receive the current reference resolver.
+
 [[run-xml-groovy-configuration]]
 === Configuration scripts
 

--- a/src/manual/run-yaml.adoc
+++ b/src/manual/run-yaml.adoc
@@ -42,6 +42,47 @@ actions:
       message: "${message}"
 ----
 
+[[run-yaml-bean-definitions]]
+=== Bean definitions
+
+The YAML test is able to define custom beans as part of the test configuration.
+Beans are registered in the Citrus bean registry and can be referenced by test actions and other components.
+
+This does not require the `citrus-groovy` dependency.
+
+.my.citrus.it.yaml
+[source,yaml]
+----
+name: BeanTest
+author: Christoph
+status: FINAL
+description: "Sample test in YAML"
+configuration:
+  beans:
+    - name: myValidator
+      type: org.citrusframework.validation.DefaultTextEqualsMessageValidator
+    - name: connectionFactory
+      type: org.example.jms.ActiveMQConnectionFactory
+      properties:
+        brokerUrl: "tcp://localhost:61616"
+        userName: "admin"
+actions:
+  - echo:
+      message: "Bean test"
+----
+
+The `configuration` section holds a `beans` list where each entry specifies:
+
+* `name` - the bean identifier used to register the instance in the Citrus bean registry
+* `type` - the fully qualified Java class name (must have a default constructor)
+* `properties` - optional map of property name-value pairs set via setter methods on the bean instance
+
+The bean type must have a default constructor.
+Property values are automatically converted to the target setter parameter type (e.g. String to int).
+
+Beans that implement `InitializingPhase` will have their `initialize()` method called after all properties are set.
+Beans that implement `ReferenceResolverAware` will receive the current reference resolver.
+
 [[run-yaml-groovy-configuration]]
 === Configuration scripts
 


### PR DESCRIPTION
## Summary

- Adds a `configuration` section with nested `beans` to YAML and XML test definitions, allowing users to register custom beans in the Citrus bean registry without requiring the `citrus-groovy` dependency
- Each bean definition specifies a name, fully qualified type, and optional properties set via reflection during test case initialization
- Includes documentation in the user manual for both YAML and XML DSL

Fixes #1580

## Test plan

- [x] YAML `BeansTest` verifies bean registration and property injection
- [x] XML `BeansTest` verifies bean registration and property injection
- [x] Full reactor build passes (`mvn clean install -DskipTests`)
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)