### PR TITLE
fix(#1549): Reinstall Camel plugin when version or GAV args change

### DIFF
--- a/core/citrus-api/src/main/java/org/citrusframework/actions/camel/CamelJBangPluginAddActionBuilder.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/actions/camel/CamelJBangPluginAddActionBuilder.java
@@ -40,4 +40,9 @@ public interface CamelJBangPluginAddActionBuilder<T extends TestAction, B extend
      * Adds command arguments.
      */
     B withArgs(String... args);
+
+    /**
+     * Automatically removes the plugin after the test.
+     */
+    B autoRemove(boolean enabled);
 }

--- a/core/citrus-api/src/main/java/org/citrusframework/actions/camel/CamelJBangPluginDeleteActionBuilder.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/actions/camel/CamelJBangPluginDeleteActionBuilder.java
@@ -17,19 +17,12 @@
 package org.citrusframework.actions.camel;
 
 import org.citrusframework.TestAction;
-import org.citrusframework.TestActionBuilder;
-import org.citrusframework.actions.ReferenceResolverAwareBuilder;
 
-public interface CamelJBangPluginActionBuilder<T extends TestAction, B extends CamelJBangPluginActionBuilder<T, B>>
-        extends ReferenceResolverAwareBuilder<T, B>, TestActionBuilder<T> {
+public interface CamelJBangPluginDeleteActionBuilder<T extends TestAction, B extends CamelJBangPluginDeleteActionBuilder<T, B>>
+        extends CamelJBangActionBuilderBase<T, B> {
 
     /**
-     * Adds a plugin to the Camel JBang installation.
+     * Sets the plugin name.
      */
-    CamelJBangPluginAddActionBuilder<?, ?> add();
-
-    /**
-     * Deletes a plugin from the Camel JBang installation.
-     */
-    CamelJBangPluginDeleteActionBuilder<?, ?> delete();
+    B pluginName(String name);
 }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/AddCamelPluginAction.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/AddCamelPluginAction.java
@@ -50,16 +50,26 @@ public class AddCamelPluginAction extends AbstractCamelJBangAction {
     @Override
     public void doExecute(TestContext context) {
         String pluginName = context.replaceDynamicContentInString(name);
+        List<String> resolvedArgs = context.resolveDynamicValuesInList(args);
         List<String> installedPlugins = camelJBang().getPlugins();
 
-        if (!installedPlugins.contains(pluginName)) {
-            logger.info("Adding Camel plugin '%s' ...".formatted(pluginName));
-            camelJBang().addPlugin(pluginName, context.resolveDynamicValuesInList(args).toArray(String[]::new));
-            logger.info("Camel plugin '%s' successfully installed".formatted(pluginName));
-        } else {
-            logger.info("Camel plugin '%s' already installed".formatted(pluginName));
+        if (installedPlugins.contains(pluginName)) {
+            if (hasVersionArgs(resolvedArgs)) {
+                logger.info("Reinstalling Camel plugin '{}' with updated version ...", pluginName);
+                camelJBang().deletePlugin(pluginName);
+            } else {
+                logger.info("Camel plugin '{}' already installed", pluginName);
+                return;
+            }
         }
 
+        logger.info("Adding Camel plugin '{}' ...", pluginName);
+        camelJBang().addPlugin(pluginName, resolvedArgs.toArray(String[]::new));
+        logger.info("Camel plugin '{}' successfully installed", pluginName);
+    }
+
+    private boolean hasVersionArgs(List<String> args) {
+        return args.stream().anyMatch(arg -> arg.equals("--version") || arg.equals("--gav"));
     }
 
     /**

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/AddCamelPluginAction.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/AddCamelPluginAction.java
@@ -16,11 +16,14 @@
 
 package org.citrusframework.camel.actions;
 
+import static org.citrusframework.camel.dsl.CamelSupport.camel;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import org.citrusframework.actions.camel.CamelJBangPluginAddActionBuilder;
+import org.citrusframework.camel.jbang.CamelJBangSettings;
 import org.citrusframework.context.TestContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,18 +36,15 @@ public class AddCamelPluginAction extends AbstractCamelJBangAction {
     /** Logger */
     private static final Logger logger = LoggerFactory.getLogger(AddCamelPluginAction.class);
 
-    /** Camel Jbang plugin name */
     private final String name;
-    /** Camel Jbang command arguments */
     private final List<String> args;
+    private final boolean autoRemove;
 
-    /**
-     * Default constructor.
-     */
     public AddCamelPluginAction(AddCamelPluginAction.Builder builder) {
         super("plugin-add", builder);
         this.name = builder.name;
         this.args = builder.args;
+        this.autoRemove = builder.autoRemove;
     }
 
     @Override
@@ -66,6 +66,14 @@ public class AddCamelPluginAction extends AbstractCamelJBangAction {
         logger.info("Adding Camel plugin '{}' ...", pluginName);
         camelJBang().addPlugin(pluginName, resolvedArgs.toArray(String[]::new));
         logger.info("Camel plugin '{}' successfully installed", pluginName);
+
+        if (autoRemove) {
+            context.doFinally(camel()
+                    .jbang()
+                    .plugin()
+                    .delete()
+                    .pluginName(pluginName));
+        }
     }
 
     private boolean hasVersionArgs(List<String> args) {
@@ -80,6 +88,7 @@ public class AddCamelPluginAction extends AbstractCamelJBangAction {
 
         private String name;
         private final List<String> args = new ArrayList<>();
+        private boolean autoRemove = CamelJBangSettings.isAutoRemovePlugins();
 
         @Override
         public Builder pluginName(String name) {
@@ -103,6 +112,12 @@ public class AddCamelPluginAction extends AbstractCamelJBangAction {
         @Override
         public Builder withArgs(String... args) {
             this.args.addAll(Arrays.asList(args));
+            return this;
+        }
+
+        @Override
+        public Builder autoRemove(boolean enabled) {
+            this.autoRemove = enabled;
             return this;
         }
 

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelPluginActionBuilder.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelPluginActionBuilder.java
@@ -32,6 +32,13 @@ public class CamelPluginActionBuilder extends AbstractReferenceResolverAwareTest
     }
 
     @Override
+    public DeleteCamelPluginAction.Builder delete() {
+        DeleteCamelPluginAction.Builder builder = new DeleteCamelPluginAction.Builder();
+        this.delegate = builder;
+        return builder;
+    }
+
+    @Override
     public CamelPluginActionBuilder withReferenceResolver(ReferenceResolver referenceResolver) {
         this.referenceResolver = referenceResolver;
         return this;

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/DeleteCamelPluginAction.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/DeleteCamelPluginAction.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.actions;
+
+import org.citrusframework.actions.camel.CamelJBangPluginDeleteActionBuilder;
+import org.citrusframework.context.TestContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Delete a specific plugin from a Camel JBang tooling.
+ */
+public class DeleteCamelPluginAction extends AbstractCamelJBangAction {
+
+    private static final Logger logger = LoggerFactory.getLogger(DeleteCamelPluginAction.class);
+
+    private final String name;
+
+    public DeleteCamelPluginAction(Builder builder) {
+        super("plugin-delete", builder);
+        this.name = builder.name;
+    }
+
+    @Override
+    public void doExecute(TestContext context) {
+        String pluginName = context.replaceDynamicContentInString(name);
+        logger.info("Deleting Camel plugin '{}' ...", pluginName);
+        camelJBang().deletePlugin(pluginName);
+        logger.info("Camel plugin '{}' successfully deleted", pluginName);
+    }
+
+    /**
+     * Action builder.
+     */
+    public static final class Builder extends AbstractCamelJBangAction.Builder<DeleteCamelPluginAction, Builder>
+            implements CamelJBangPluginDeleteActionBuilder<DeleteCamelPluginAction, Builder> {
+
+        private String name;
+
+        @Override
+        public Builder pluginName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        @Override
+        public DeleteCamelPluginAction doBuild() {
+            return new DeleteCamelPluginAction(this);
+        }
+    }
+}

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/jbang/CamelJBang.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/jbang/CamelJBang.java
@@ -386,6 +386,18 @@ public class CamelJBang {
         }
     }
 
+    public void deletePlugin(String pluginName) {
+        List<String> fullArgs = new ArrayList<>();
+        fullArgs.add("delete");
+        fullArgs.add(pluginName);
+
+        ProcessAndOutput pao = app.run("plugin", fullArgs);
+        int exitValue = pao.getProcess().exitValue();
+        if (exitValue != OK_EXIT_CODE && exitValue != 1) {
+            throw new CitrusRuntimeException("Error while deleting Camel JBang plugin. Exit code: " + exitValue);
+        }
+    }
+
     public ProcessAndOutput send(String ... args) {
         List<String> fullArgs = new ArrayList<>();
         fullArgs.add("send");

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/jbang/CamelJBangSettings.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/jbang/CamelJBangSettings.java
@@ -62,6 +62,10 @@ public final class CamelJBangSettings {
     private static final String AUTO_REMOVE_RESOURCES_ENV = JBANG_ENV_PREFIX + "AUTO_REMOVE_RESOURCES";
     private static final String AUTO_REMOVE_RESOURCES_DEFAULT = "true";
 
+    private static final String AUTO_REMOVE_PLUGINS_PROPERTY = JBANG_PROPERTY_PREFIX + "auto.remove.plugins";
+    private static final String AUTO_REMOVE_PLUGINS_ENV = JBANG_ENV_PREFIX + "AUTO_REMOVE_PLUGINS";
+    private static final String AUTO_REMOVE_PLUGINS_DEFAULT = "false";
+
     private static final String WAIT_FOR_RUNNING_STATE_PROPERTY = JBANG_PROPERTY_PREFIX + "wait.for.running.state";
     private static final String WAIT_FOR_RUNNING_STATE_ENV = JBANG_ENV_PREFIX + "WAIT_FOR_RUNNING_STATE";
     private static final String WAIT_FOR_RUNNING_STATE_DEFAULT = "true";
@@ -168,6 +172,16 @@ public final class CamelJBangSettings {
     public static boolean isAutoRemoveResources() {
         return Boolean.parseBoolean(System.getProperty(AUTO_REMOVE_RESOURCES_PROPERTY,
                 System.getenv(AUTO_REMOVE_RESOURCES_ENV) != null ? System.getenv(AUTO_REMOVE_RESOURCES_ENV) : AUTO_REMOVE_RESOURCES_DEFAULT));
+    }
+
+    /**
+     * When set to true Camel JBang plugins added during the test are
+     * automatically removed after the test.
+     * @return
+     */
+    public static boolean isAutoRemovePlugins() {
+        return Boolean.parseBoolean(System.getProperty(AUTO_REMOVE_PLUGINS_PROPERTY,
+                System.getenv(AUTO_REMOVE_PLUGINS_ENV) != null ? System.getenv(AUTO_REMOVE_PLUGINS_ENV) : AUTO_REMOVE_PLUGINS_DEFAULT));
     }
 
     /**

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/Camel.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/Camel.java
@@ -326,6 +326,10 @@ public class Camel implements TestActionBuilder<TestAction>, ReferenceResolverAw
                     builder.withArgs(jbang.getPlugin().getAdd().getArgLine().split(" "));
                 }
                 this.builder = builder;
+            } else if (jbang.getPlugin().getDelete() != null) {
+                DeleteCamelPluginAction.Builder builder = new DeleteCamelPluginAction.Builder();
+                builder.pluginName(jbang.getPlugin().getDelete().getName());
+                this.builder = builder;
             }
         } else if (jbang.getCmd() != null) {
             if (jbang.getCmd().getSend() != null) {

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/Camel.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/Camel.java
@@ -325,6 +325,7 @@ public class Camel implements TestActionBuilder<TestAction>, ReferenceResolverAw
                 if (jbang.getPlugin().getAdd().getArgLine() != null) {
                     builder.withArgs(jbang.getPlugin().getAdd().getArgLine().split(" "));
                 }
+                builder.autoRemove(jbang.getPlugin().getAdd().isAutoRemove());
                 this.builder = builder;
             } else if (jbang.getPlugin().getDelete() != null) {
                 DeleteCamelPluginAction.Builder builder = new DeleteCamelPluginAction.Builder();

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/JBang.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/JBang.java
@@ -929,12 +929,16 @@ public class JBang {
 
     @XmlAccessorType(XmlAccessType.FIELD)
     @XmlType(name = "", propOrder = {
-            "add"
+            "add",
+            "delete"
     })
     public static class Plugin {
 
         @XmlElement
         protected Add add;
+
+        @XmlElement
+        protected Delete delete;
 
         public void setAdd(Add add) {
             this.add = add;
@@ -942,6 +946,14 @@ public class JBang {
 
         public Add getAdd() {
             return this.add;
+        }
+
+        public void setDelete(Delete delete) {
+            this.delete = delete;
+        }
+
+        public Delete getDelete() {
+            return this.delete;
         }
 
         @XmlAccessorType(XmlAccessType.FIELD)
@@ -967,6 +979,22 @@ public class JBang {
 
             public void setArgLine(String argLine) {
                 this.argLine = argLine;
+            }
+        }
+
+        @XmlAccessorType(XmlAccessType.FIELD)
+        @XmlType(name = "")
+        public static class Delete {
+
+            @XmlAttribute(name = "name", required = true)
+            protected String name;
+
+            public String getName() {
+                return name;
+            }
+
+            public void setName(String value) {
+                this.name = value;
             }
         }
     }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/JBang.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/JBang.java
@@ -964,6 +964,8 @@ public class JBang {
             protected String name;
             @XmlAttribute(name = "args")
             protected String argLine;
+            @XmlAttribute(name = "auto-remove")
+            protected boolean autoRemove;
 
             public String getName() {
                 return name;
@@ -979,6 +981,14 @@ public class JBang {
 
             public void setArgLine(String argLine) {
                 this.argLine = argLine;
+            }
+
+            public boolean isAutoRemove() {
+                return autoRemove;
+            }
+
+            public void setAutoRemove(boolean autoRemove) {
+                this.autoRemove = autoRemove;
             }
         }
 

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/JBang.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/JBang.java
@@ -657,6 +657,7 @@ public class JBang implements CamelActionBuilderWrapper<AbstractCamelJBangAction
             if (add.getArgs() != null) {
                 add.getArgs().forEach(builder::withArg);
             }
+            builder.autoRemove(add.isAutoRemove());
             this.builder = builder;
         }
 
@@ -677,6 +678,8 @@ public class JBang implements CamelActionBuilderWrapper<AbstractCamelJBangAction
 
             protected List<String> args;
 
+            protected boolean autoRemove = CamelJBangSettings.isAutoRemovePlugins();
+
             public String getName() {
                 return name;
             }
@@ -696,6 +699,15 @@ public class JBang implements CamelActionBuilderWrapper<AbstractCamelJBangAction
             @SchemaProperty(advanced = true, description = "Plugin arguments.")
             public void setArgs(List<String> args) {
                 this.args = args;
+            }
+
+            public boolean isAutoRemove() {
+                return autoRemove;
+            }
+
+            @SchemaProperty(advanced = true, description = "When enabled the Camel plugin is automatically removed after the test.", defaultValue = "false")
+            public void setAutoRemove(boolean autoRemove) {
+                this.autoRemove = autoRemove;
             }
         }
 

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/JBang.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/JBang.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import org.citrusframework.camel.CamelSettings;
 import org.citrusframework.camel.actions.AbstractCamelJBangAction;
 import org.citrusframework.camel.actions.AddCamelPluginAction;
+import org.citrusframework.camel.actions.DeleteCamelPluginAction;
 import org.citrusframework.camel.actions.CamelCmdReceiveAction;
 import org.citrusframework.camel.actions.CamelCmdSendAction;
 import org.citrusframework.camel.actions.CamelCustomizedRunIntegrationAction;
@@ -659,6 +660,13 @@ public class JBang implements CamelActionBuilderWrapper<AbstractCamelJBangAction
             this.builder = builder;
         }
 
+        @SchemaProperty(kind = ACTION, group = CAMEL_JBANG_PLUGIN_GROUP, description = "Deletes a plugin from the Camel Jbang installation.")
+        public void setDelete(Delete delete) {
+            DeleteCamelPluginAction.Builder builder = new DeleteCamelPluginAction.Builder();
+            builder.pluginName(delete.getName());
+            this.builder = builder;
+        }
+
         @Override
         public AbstractCamelJBangAction.Builder<?, ?> getBuilder() {
             return builder;
@@ -688,6 +696,19 @@ public class JBang implements CamelActionBuilderWrapper<AbstractCamelJBangAction
             @SchemaProperty(advanced = true, description = "Plugin arguments.")
             public void setArgs(List<String> args) {
                 this.args = args;
+            }
+        }
+
+        public static class Delete {
+            protected String name;
+
+            public String getName() {
+                return name;
+            }
+
+            @SchemaProperty(required = true, description = "The plugin name.")
+            public void setName(String name) {
+                this.name = name;
             }
         }
     }

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/actions/AddCamelPluginActionTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/actions/AddCamelPluginActionTest.java
@@ -19,11 +19,13 @@ package org.citrusframework.camel.actions;
 import java.util.Collections;
 import java.util.List;
 
+import org.citrusframework.TestActionBuilder;
 import org.citrusframework.camel.UnitTestSupport;
 import org.citrusframework.camel.jbang.CamelJBang;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -123,5 +125,40 @@ public class AddCamelPluginActionTest extends UnitTestSupport {
 
         verify(camelJBang).addPlugin("my-plugin", "--version", "1.5.0-SNAPSHOT");
         verify(camelJBang, never()).deletePlugin("my-plugin");
+    }
+
+    @Test
+    public void shouldRegisterFinallyActionWhenAutoRemoveEnabled() {
+        when(camelJBang.getPlugins()).thenReturn(Collections.emptyList());
+
+        AddCamelPluginAction action = new AddCamelPluginAction.Builder()
+                .pluginName("my-plugin")
+                .autoRemove(true)
+                .withReferenceResolver(context.getReferenceResolver())
+                .build();
+
+        action.execute(context);
+
+        verify(camelJBang).addPlugin("my-plugin");
+
+        List<TestActionBuilder<?>> finalActions = context.getFinalActions();
+        Assert.assertEquals(finalActions.size(), 1);
+        Assert.assertEquals(finalActions.get(0).build().getClass(), DeleteCamelPluginAction.class);
+    }
+
+    @Test
+    public void shouldNotRegisterFinallyActionWhenAutoRemoveDisabled() {
+        when(camelJBang.getPlugins()).thenReturn(Collections.emptyList());
+
+        AddCamelPluginAction action = new AddCamelPluginAction.Builder()
+                .pluginName("my-plugin")
+                .autoRemove(false)
+                .withReferenceResolver(context.getReferenceResolver())
+                .build();
+
+        action.execute(context);
+
+        verify(camelJBang).addPlugin("my-plugin");
+        Assert.assertTrue(context.getFinalActions().isEmpty());
     }
 }

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/actions/AddCamelPluginActionTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/actions/AddCamelPluginActionTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.actions;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.citrusframework.camel.UnitTestSupport;
+import org.citrusframework.camel.jbang.CamelJBang;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class AddCamelPluginActionTest extends UnitTestSupport {
+
+    @Mock
+    private CamelJBang camelJBang;
+
+    @BeforeMethod
+    @Override
+    public void prepareTest() {
+        super.prepareTest();
+        MockitoAnnotations.openMocks(this);
+        context.getReferenceResolver().bind("camelJBang", camelJBang);
+    }
+
+    @Test
+    public void shouldInstallPluginWhenNotInstalled() {
+        when(camelJBang.getPlugins()).thenReturn(Collections.emptyList());
+
+        AddCamelPluginAction action = new AddCamelPluginAction.Builder()
+                .pluginName("my-plugin")
+                .withReferenceResolver(context.getReferenceResolver())
+                .build();
+
+        action.execute(context);
+
+        verify(camelJBang).addPlugin("my-plugin");
+        verify(camelJBang, never()).deletePlugin("my-plugin");
+    }
+
+    @Test
+    public void shouldSkipWhenAlreadyInstalledWithoutVersionArgs() {
+        when(camelJBang.getPlugins()).thenReturn(List.of("my-plugin"));
+
+        AddCamelPluginAction action = new AddCamelPluginAction.Builder()
+                .pluginName("my-plugin")
+                .withReferenceResolver(context.getReferenceResolver())
+                .build();
+
+        action.execute(context);
+
+        verify(camelJBang, never()).addPlugin("my-plugin");
+        verify(camelJBang, never()).deletePlugin("my-plugin");
+    }
+
+    @Test
+    public void shouldReinstallWhenAlreadyInstalledWithVersionArg() {
+        when(camelJBang.getPlugins()).thenReturn(List.of("my-plugin"));
+
+        AddCamelPluginAction action = new AddCamelPluginAction.Builder()
+                .pluginName("my-plugin")
+                .withArg("--version", "1.5.0-SNAPSHOT")
+                .withReferenceResolver(context.getReferenceResolver())
+                .build();
+
+        action.execute(context);
+
+        InOrder order = inOrder(camelJBang);
+        order.verify(camelJBang).deletePlugin("my-plugin");
+        order.verify(camelJBang).addPlugin("my-plugin", "--version", "1.5.0-SNAPSHOT");
+    }
+
+    @Test
+    public void shouldReinstallWhenAlreadyInstalledWithGavArg() {
+        when(camelJBang.getPlugins()).thenReturn(List.of("my-plugin"));
+
+        AddCamelPluginAction action = new AddCamelPluginAction.Builder()
+                .pluginName("my-plugin")
+                .withArg("--gav", "com.example:my-plugin:2.0.0")
+                .withReferenceResolver(context.getReferenceResolver())
+                .build();
+
+        action.execute(context);
+
+        InOrder order = inOrder(camelJBang);
+        order.verify(camelJBang).deletePlugin("my-plugin");
+        order.verify(camelJBang).addPlugin("my-plugin", "--gav", "com.example:my-plugin:2.0.0");
+    }
+
+    @Test
+    public void shouldInstallWithVersionWhenNotInstalled() {
+        when(camelJBang.getPlugins()).thenReturn(Collections.emptyList());
+
+        AddCamelPluginAction action = new AddCamelPluginAction.Builder()
+                .pluginName("my-plugin")
+                .withArg("--version", "1.5.0-SNAPSHOT")
+                .withReferenceResolver(context.getReferenceResolver())
+                .build();
+
+        action.execute(context);
+
+        verify(camelJBang).addPlugin("my-plugin", "--version", "1.5.0-SNAPSHOT");
+        verify(camelJBang, never()).deletePlugin("my-plugin");
+    }
+}

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/actions/DeleteCamelPluginActionTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/actions/DeleteCamelPluginActionTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.actions;
+
+import org.citrusframework.camel.UnitTestSupport;
+import org.citrusframework.camel.jbang.CamelJBang;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.verify;
+
+public class DeleteCamelPluginActionTest extends UnitTestSupport {
+
+    @Mock
+    private CamelJBang camelJBang;
+
+    @BeforeMethod
+    @Override
+    public void prepareTest() {
+        super.prepareTest();
+        MockitoAnnotations.openMocks(this);
+        context.getReferenceResolver().bind("camelJBang", camelJBang);
+    }
+
+    @Test
+    public void shouldDeletePlugin() {
+        DeleteCamelPluginAction action = new DeleteCamelPluginAction.Builder()
+                .pluginName("my-plugin")
+                .withReferenceResolver(context.getReferenceResolver())
+                .build();
+
+        action.execute(context);
+
+        verify(camelJBang).deletePlugin("my-plugin");
+    }
+
+    @Test
+    public void shouldDeletePluginWithVariableExpression() {
+        context.setVariable("pluginName", "my-plugin");
+
+        DeleteCamelPluginAction action = new DeleteCamelPluginAction.Builder()
+                .pluginName("${pluginName}")
+                .withReferenceResolver(context.getReferenceResolver())
+                .build();
+
+        action.execute(context);
+
+        verify(camelJBang).deletePlugin("my-plugin");
+    }
+}

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/xml/CamelDeletePluginTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/xml/CamelDeletePluginTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.xml;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.camel.CamelSettings;
+import org.citrusframework.camel.actions.DeleteCamelPluginAction;
+import org.citrusframework.camel.jbang.CamelJBang;
+import org.citrusframework.xml.XmlTestLoader;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.verify;
+
+public class CamelDeletePluginTest extends AbstractXmlActionTest {
+
+    @Mock
+    private CamelJBang camelJBang;
+
+    @BeforeClass
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void shouldLoadCamelActions() {
+        XmlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/camel/xml/camel-jbang-delete-plugin.citrus.it.xml");
+
+        CamelContext citrusCamelContext = new DefaultCamelContext();
+        citrusCamelContext.start();
+
+        context.getReferenceResolver().bind(CamelSettings.getContextName(), citrusCamelContext);
+        context.getReferenceResolver().bind("camelContext", citrusCamelContext);
+
+        context.getReferenceResolver().bind("camel-jbang", camelJBang);
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "CamelDeletePluginTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 1L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), DeleteCamelPluginAction.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "camel:jbang:plugin-delete");
+
+        verify(camelJBang).deletePlugin("my-plugin");
+    }
+}

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/yaml/CamelDeletePluginTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/yaml/CamelDeletePluginTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.yaml;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.camel.CamelSettings;
+import org.citrusframework.camel.actions.DeleteCamelPluginAction;
+import org.citrusframework.camel.jbang.CamelJBang;
+import org.citrusframework.yaml.YamlTestLoader;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.verify;
+
+public class CamelDeletePluginTest extends AbstractYamlActionTest {
+
+    @Mock
+    private CamelJBang camelJBang;
+
+    @BeforeClass
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void shouldLoadCamelActions() {
+        YamlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/camel/yaml/camel-jbang-delete-plugin.citrus.it.yaml");
+
+        CamelContext citrusCamelContext = new DefaultCamelContext();
+        citrusCamelContext.start();
+
+        context.getReferenceResolver().bind(CamelSettings.getContextName(), citrusCamelContext);
+        context.getReferenceResolver().bind("camelContext", citrusCamelContext);
+
+        context.getReferenceResolver().bind("camel-jbang", camelJBang);
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "CamelDeletePluginTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 1L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), DeleteCamelPluginAction.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "camel:jbang:plugin-delete");
+
+        verify(camelJBang).deletePlugin("my-plugin");
+    }
+}

--- a/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/xml/camel-jbang-delete-plugin.citrus.it.xml
+++ b/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/xml/camel-jbang-delete-plugin.citrus.it.xml
@@ -1,0 +1,31 @@
+<!--
+  ~ Copyright the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<test name="CamelDeletePluginTest" author="Christoph" status="FINAL" xmlns="http://citrusframework.org/schema/xml/testcase"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://citrusframework.org/schema/xml/testcase http://citrusframework.org/schema/xml/testcase/citrus-testcase.xsd
+                          http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
+  <description>Sample test in XML</description>
+  <actions>
+    <camel>
+      <jbang>
+        <plugin>
+          <delete name="my-plugin"/>
+        </plugin>
+      </jbang>
+    </camel>
+  </actions>
+</test>

--- a/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/yaml/camel-jbang-delete-plugin.citrus.it.yaml
+++ b/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/yaml/camel-jbang-delete-plugin.citrus.it.yaml
@@ -1,0 +1,9 @@
+name: "CamelDeletePluginTest"
+author: "Christoph"
+status: "FINAL"
+actions:
+  - camel:
+      jbang:
+        plugin:
+          delete:
+            name: "my-plugin"

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-5.0.0-SNAPSHOT.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-5.0.0-SNAPSHOT.xsd
@@ -2545,7 +2545,16 @@
                           <xs:documentation>Add a Camel JBang plugin.</xs:documentation>
                         </xs:annotation>
                         <xs:attribute name="name" type="xs:string" use="required"/>
+                        <xs:attribute name="auto-remove" type="xs:boolean"/>
                         <xs:attribute name="args" type="xs:string"/>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="delete">
+                      <xs:complexType>
+                        <xs:annotation>
+                          <xs:documentation>Delete a Camel JBang plugin.</xs:documentation>
+                        </xs:annotation>
+                        <xs:attribute name="name" type="xs:string" use="required"/>
                       </xs:complexType>
                     </xs:element>
                   </xs:choice>

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
@@ -2545,7 +2545,16 @@
                           <xs:documentation>Add a Camel JBang plugin.</xs:documentation>
                         </xs:annotation>
                         <xs:attribute name="name" type="xs:string" use="required"/>
+                        <xs:attribute name="auto-remove" type="xs:boolean"/>
                         <xs:attribute name="args" type="xs:string"/>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="delete">
+                      <xs:complexType>
+                        <xs:annotation>
+                          <xs:documentation>Delete a Camel JBang plugin.</xs:documentation>
+                        </xs:annotation>
+                        <xs:attribute name="name" type="xs:string" use="required"/>
                       </xs:complexType>
                     </xs:element>
                   </xs:choice>

--- a/src/manual/endpoint-camel.adoc
+++ b/src/manual/endpoint-camel.adoc
@@ -1541,6 +1541,91 @@ Please see the Camel JBang receive command help for more configuration options.
 camel cmd receive --help
 ----
 
+[[camel-jbang-plugins]]
+=== Manage Camel plugins
+
+Camel JBang supports plugins that extend the CLI with additional commands and capabilities.
+Citrus provides test actions to add and delete plugins as part of a test.
+
+==== Add a plugin
+
+.Java
+[source,java,indent=0,role="primary"]
+----
+when(camel().jbang()
+    .plugin()
+    .add()
+    .pluginName("my-plugin")
+    .withArg("--version", "1.0.0"));
+----
+
+.YAML
+[source,yaml,indent=0,role="secondary"]
+----
+- camel:
+    jbang:
+      plugin:
+        add:
+          name: "my-plugin"
+          args:
+            - "--version"
+            - "1.0.0"
+----
+
+.XML
+[source,xml,indent=0,role="secondary"]
+----
+<camel>
+  <jbang>
+    <plugin>
+      <add name="my-plugin" args="--version 1.0.0"/>
+    </plugin>
+  </jbang>
+</camel>
+----
+
+The action checks if the plugin is already installed by name.
+When the plugin is already installed and no `--version` or `--gav` arguments are provided, the action skips the installation.
+When `--version` or `--gav` arguments are present, the action removes the existing plugin and reinstalls it with the new arguments.
+
+TIP: The test action has an `autoRemove` option that is disabled by default. When enabled, the test will automatically delete the plugin after the test using the `context.doFinally()` mechanism. You can enable it globally via the `citrus.camel.jbang.auto.remove.plugins` system property or `CITRUS_CAMEL_JBANG_AUTO_REMOVE_PLUGINS` environment variable.
+
+==== Delete a plugin
+
+You can explicitly delete a plugin in your test.
+This is useful in `finally` blocks to clean up plugins that were installed during the test.
+
+.Java
+[source,java,indent=0,role="primary"]
+----
+when(camel().jbang()
+    .plugin()
+    .delete()
+    .pluginName("my-plugin"));
+----
+
+.YAML
+[source,yaml,indent=0,role="secondary"]
+----
+- camel:
+    jbang:
+      plugin:
+        delete:
+          name: "my-plugin"
+----
+
+.XML
+[source,xml,indent=0,role="secondary"]
+----
+<camel>
+  <jbang>
+    <plugin>
+      <delete name="my-plugin"/>
+    </plugin>
+  </jbang>
+</camel>
+----
+
 [[camel-jbang-kubernetes]]
 == Camel JBang Kubernetes support
 

--- a/tools/schema-generator/src/test/resources/control/citrus-catalog-aggregate-test-actions.json
+++ b/tools/schema-generator/src/test/resources/control/citrus-catalog-aggregate-test-actions.json
@@ -1272,6 +1272,35 @@
             "$comment": "group:advanced"
           }
         },
+        "autoRemove": {
+          "type": "boolean",
+          "title": "AutoRemove",
+          "description": "When enabled the Camel plugin is automatically removed after the test.",
+          "default": "false",
+          "$comment": "group:advanced"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The plugin name."
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false    }
+  },
+  "camel-jbang-plugin-delete": {
+    "kind": "testAction",
+    "version": "${citrus.version}",
+    "name": "camel-jbang-plugin-delete",
+    "group": "camel-jbang-plugin",
+    "title": "Delete",
+    "description": "Deletes a plugin from the Camel Jbang installation.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
         "name": {
           "type": "string",
           "title": "Name",


### PR DESCRIPTION
## Summary

- `AddCamelPluginAction` now detects `--version` or `--gav` arguments when a plugin is already installed and performs a delete+reinstall instead of skipping
- Added `CamelJBang.deletePlugin()` method to support removing plugins via `camel plugin delete`
- Added new `DeleteCamelPluginAction` test action so users can explicitly delete plugins (e.g. in `finally` blocks for cleanup)
- Full integration across Java API, XML DSL, and YAML DSL for the delete plugin action
- Added `autoRemove` option to `AddCamelPluginAction` — when enabled, automatically registers a `DeleteCamelPluginAction` in the test's finally block via `context.doFinally()` (same pattern as `CamelRunIntegrationAction`)
- New setting `citrus.camel.jbang.auto.remove.plugins` / env `CITRUS_CAMEL_JBANG_AUTO_REMOVE_PLUGINS` (default: `false`) controls the default

Fixes #1549

## Test plan

- [x] `AddCamelPluginActionTest` — 7 scenarios (fresh install, skip, reinstall with `--version`/`--gav`, fresh install with `--version`, auto-remove enabled, auto-remove disabled)
- [x] `DeleteCamelPluginActionTest` — 2 scenarios (delete, delete with variable expression)
- [x] `CamelDeletePluginTest` (XML) — XML DSL parsing and execution
- [x] `CamelDeletePluginTest` (YAML) — YAML DSL parsing and execution
- [x] Module tests pass (`mvn test -pl endpoints/citrus-camel`)
- [x] Full reactor build passes (`mvn clean install -DskipTests`)

Generated with [Claude Code](https://claude.ai/code)