### PR TITLE
feat(citrus-openapi-codegen): code generation with model builders

### DIFF
--- a/tools/test-api-generator/citrus-openapi-codegen/pom.xml
+++ b/tools/test-api-generator/citrus-openapi-codegen/pom.xml
@@ -166,7 +166,7 @@
               <artifactId>openapi-generator</artifactId>
               <version>${org.openapitools.version}</version>
               <includes>
-                Java/*Annotation*.mustache,Java/*Model*.mustache,Java/model*.mustache,Java/pojo*.mustache,Java/additional_properties.mustache,Java/enum_outer_doc.mustache,Java/nullable_var_annotations.mustache
+                Java/*Annotation*.mustache,Java/*Model*.mustache,Java/model*.mustache,Java/pojo*.mustache,Java/additional_properties.mustache,Java/enum_outer_doc.mustache,Java/javaBuilder.mustache,Java/nullable_var_annotations.mustache
               </includes>
             </artifactItem>
           </artifactItems>
@@ -291,6 +291,26 @@
                 </modelPackage>
                 <prefix>BookService</prefix>
                 <apiEndpoint>bookstore.endpoint</apiEndpoint>
+              </configOptions>
+            </configuration>
+          </execution>
+          <execution>
+            <id>generate-openapi-builder-files</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+            <configuration>
+              <inputSpec>${project.basedir}/src/test/resources/apis/petstore-v3.yaml</inputSpec>
+              <configOptions>
+                <invokerPackage>org.citrusframework.openapi.generator.builder.petstore</invokerPackage>
+                <apiPackage>org.citrusframework.openapi.generator.builder.petstore.request</apiPackage>
+                <modelPackage>
+                  org.citrusframework.openapi.generator.builder.petstore.model
+                </modelPackage>
+                <prefix>BuilderPetStore</prefix>
+                <apiEndpoint>builderpetstore.endpoint</apiEndpoint>
+                <generateBuilders>true</generateBuilders>
               </configOptions>
             </configuration>
           </execution>

--- a/tools/test-api-generator/citrus-openapi-codegen/src/test/java/org/citrusframework/openapi/generator/GeneratedModelBuilderTest.java
+++ b/tools/test-api-generator/citrus-openapi-codegen/src/test/java/org/citrusframework/openapi/generator/GeneratedModelBuilderTest.java
@@ -1,0 +1,35 @@
+package org.citrusframework.openapi.generator;
+
+import org.citrusframework.openapi.generator.builder.petstore.model.Pet;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that model classes are generated with a builder when the codegen option
+ * {@code generateBuilders} is enabled, see execution 'generate-openapi-builder-files' in pom.xml.
+ */
+class GeneratedModelBuilderTest {
+
+    @Test
+    void buildsModelViaGeneratedBuilder() {
+        Pet pet = Pet.builder()
+            .id(1L)
+            .build();
+
+        assertThat(pet.getId()).isEqualTo(1L);
+    }
+
+    @Test
+    void toBuilderCopiesExistingValues() {
+        Pet pet = Pet.builder()
+            .id(1L)
+            .build();
+
+        Pet copy = pet.toBuilder()
+            .id(2L)
+            .build();
+
+        assertThat(copy.getId()).isEqualTo(2L);
+    }
+}


### PR DESCRIPTION
adding the `Java/javaBuilder.mustache` template,
so that `generateBuilders` is a valid option to
the `citrus-openapi-codegen` module.