### PR TITLE
fix(#1609): Fix oneOf schema generation and remove duplicate HTTP method entries

### DIFF
--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/yaml/Http.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/yaml/Http.java
@@ -425,7 +425,6 @@ public class Http implements TestActionBuilder<TestAction>, ReferenceResolverAwa
        "GET",
        "POST",
        "PUT",
-       "PUT",
        "DELETE",
        "HEAD",
        "OPTIONS",
@@ -550,7 +549,6 @@ public class Http implements TestActionBuilder<TestAction>, ReferenceResolverAwa
     @SchemaType(oneOf = {
         "GET",
         "POST",
-        "PUT",
         "PUT",
         "DELETE",
         "HEAD",

--- a/tools/schema-generator/src/main/java/org/citrusframework/dsl/schema/generator/CitrusModule.java
+++ b/tools/schema-generator/src/main/java/org/citrusframework/dsl/schema/generator/CitrusModule.java
@@ -49,6 +49,7 @@ import com.github.victools.jsonschema.generator.naming.CleanSchemaDefinitionNami
 import com.github.victools.jsonschema.generator.naming.DefaultSchemaDefinitionNamingStrategy;
 import org.citrusframework.TestActionBuilder;
 import org.citrusframework.dsl.schema.Catalog;
+import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.util.StringUtils;
 import org.citrusframework.yaml.ExamplesProvider;
 import org.citrusframework.yaml.SchemaProperty;
@@ -98,17 +99,39 @@ public class CitrusModule implements Module {
             if (anyOf.isEmpty()) {
                 ArrayNode oneOf = anyOf.addObject().withArray(schemaGenerationContext.getKeyword(SchemaKeyword.TAG_ONEOF));
                 for (String oneOfItem : schemaType.oneOf()) {
+                    JsonNode original = schemaNode.get(schemaGenerationContext.getKeyword(SchemaKeyword.TAG_PROPERTIES)).get(oneOfItem);
+
+                    if (original == null) {
+                        throw new CitrusRuntimeException("Missing declared one of item " + oneOfItem + " in properties for " + schemaNode.asString());
+                    }
+
                     ObjectNode itemNode = oneOf.addObject();
-                    itemNode.put(schemaGenerationContext.getKeyword(SchemaKeyword.TAG_TYPE), "object");
-                    ObjectNode propertyNode = itemNode.withObject(schemaGenerationContext.getKeyword(SchemaKeyword.TAG_PROPERTIES));
-                    propertyNode.set(oneOfItem, schemaNode.get(schemaGenerationContext.getKeyword(SchemaKeyword.TAG_PROPERTIES)).get(oneOfItem));
+                    String type = Optional.ofNullable(original.findValue(schemaGenerationContext.getKeyword(SchemaKeyword.TAG_TYPE)))
+                            .map(JsonNode::asString)
+                            .orElse("object");
+                    if (type.equals("object")) {
+                        itemNode.put(schemaGenerationContext.getKeyword(SchemaKeyword.TAG_TYPE), "object");
+                        ObjectNode propertyNode = itemNode.withObject(schemaGenerationContext.getKeyword(SchemaKeyword.TAG_PROPERTIES));
+                        propertyNode.set(oneOfItem, original);
 
-                    // remove all properties from old item node
-                    ((ObjectNode) schemaNode.get(schemaGenerationContext.getKeyword(SchemaKeyword.TAG_PROPERTIES))).putObject(oneOfItem);
-
-                    if (requireOneOfItem) {
+                        // remove all properties from old item node, but keep the property as an empty element.
+                        // This is required to pass the additionalProperties=false check
+                        ((ObjectNode) schemaNode.get(schemaGenerationContext.getKeyword(SchemaKeyword.TAG_PROPERTIES))).putObject(oneOfItem);
+                        if (requireOneOfItem) {
+                            itemNode.withArray(schemaGenerationContext.getKeyword(SchemaKeyword.TAG_REQUIRED)).add(oneOfItem);
+                        }
+                    } else {
                         itemNode.withArray(schemaGenerationContext.getKeyword(SchemaKeyword.TAG_REQUIRED)).add(oneOfItem);
                     }
+
+                }
+
+                // Add the inversion of the required oneOf elements, allows users to not specify any of the oneOf listed elements
+                ObjectNode not = oneOf.addObject().withObject(schemaGenerationContext.getKeyword(SchemaKeyword.TAG_NOT));
+                ArrayNode notAnyOf = not.withArray(schemaGenerationContext.getKeyword(SchemaKeyword.TAG_ANYOF));
+                for (String oneOfItem : schemaType.oneOf()) {
+                    ObjectNode itemNode = notAnyOf.addObject();
+                    itemNode.withArray(schemaGenerationContext.getKeyword(SchemaKeyword.TAG_REQUIRED)).add(oneOfItem);
                 }
             }
         }

--- a/tools/schema-generator/src/test/resources/control/citrus-catalog-aggregate-test-actions.json
+++ b/tools/schema-generator/src/test/resources/control/citrus-catalog-aggregate-test-actions.json
@@ -2277,6 +2277,22 @@
                               "description": "Sets the Http server endpoint."
                             }
                           }
+                        },
+                        {
+                          "not": {
+                            "anyOf": [
+                              {
+                                "required": [
+                                  "client"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "server"
+                                ]
+                              }
+                            ]
+                          }
                         }
                       ]
                     }
@@ -2571,6 +2587,22 @@
                               "title": "Server",
                               "description": "Sets the SOAP WebService server endpoint."
                             }
+                          }
+                        },
+                        {
+                          "not": {
+                            "anyOf": [
+                              {
+                                "required": [
+                                  "client"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "server"
+                                ]
+                              }
+                            ]
                           }
                         }
                       ]
@@ -2950,6 +2982,22 @@
                               "description": "Sets the WebSocket server endpoint."
                             }
                           }
+                        },
+                        {
+                          "not": {
+                            "anyOf": [
+                              {
+                                "required": [
+                                  "client"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "server"
+                                ]
+                              }
+                            ]
+                          }
                         }
                       ]
                     }
@@ -3177,6 +3225,22 @@
                               "description": "Sets the mail server endpoint."
                             }
                           }
+                        },
+                        {
+                          "not": {
+                            "anyOf": [
+                              {
+                                "required": [
+                                  "client"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "server"
+                                ]
+                              }
+                            ]
+                          }
                         }
                       ]
                     }
@@ -3400,6 +3464,22 @@
                               "title": "Server",
                               "description": "Sets the ftp server endpoint."
                             }
+                          }
+                        },
+                        {
+                          "not": {
+                            "anyOf": [
+                              {
+                                "required": [
+                                  "client"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "server"
+                                ]
+                              }
+                            ]
                           }
                         }
                       ]
@@ -3666,6 +3746,22 @@
                               "description": "Sets the sftp server endpoint."
                             }
                           }
+                        },
+                        {
+                          "not": {
+                            "anyOf": [
+                              {
+                                "required": [
+                                  "client"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "server"
+                                ]
+                              }
+                            ]
+                          }
                         }
                       ]
                     }
@@ -3915,6 +4011,22 @@
                               "title": "Server",
                               "description": "Sets the sftp server endpoint."
                             }
+                          }
+                        },
+                        {
+                          "not": {
+                            "anyOf": [
+                              {
+                                "required": [
+                                  "client"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "server"
+                                ]
+                              }
+                            ]
                           }
                         }
                       ]
@@ -4287,6 +4399,22 @@
                               "description": "Sets the synchronous Jms endpoint."
                             }
                           }
+                        },
+                        {
+                          "not": {
+                            "anyOf": [
+                              {
+                                "required": [
+                                  "asynchronous"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "synchronous"
+                                ]
+                              }
+                            ]
+                          }
                         }
                       ]
                     }
@@ -4438,6 +4566,22 @@
                               "description": "Sets the synchronous Vert.x endpoint."
                             }
                           }
+                        },
+                        {
+                          "not": {
+                            "anyOf": [
+                              {
+                                "required": [
+                                  "asynchronous"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "synchronous"
+                                ]
+                              }
+                            ]
+                          }
                         }
                       ]
                     }
@@ -4537,6 +4681,22 @@
                               "title": "Synchronous",
                               "description": "Sets the synchronous direct endpoint."
                             }
+                          }
+                        },
+                        {
+                          "not": {
+                            "anyOf": [
+                              {
+                                "required": [
+                                  "asynchronous"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "synchronous"
+                                ]
+                              }
+                            ]
                           }
                         }
                       ]
@@ -4807,6 +4967,22 @@
                               "description": "Sets the synchronous Kafka endpoint."
                             }
                           }
+                        },
+                        {
+                          "not": {
+                            "anyOf": [
+                              {
+                                "required": [
+                                  "asynchronous"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "synchronous"
+                                ]
+                              }
+                            ]
+                          }
                         }
                       ]
                     }
@@ -4918,6 +5094,22 @@
                               "title": "Synchronous",
                               "description": "Sets the synchronous Camel endpoint."
                             }
+                          }
+                        },
+                        {
+                          "not": {
+                            "anyOf": [
+                              {
+                                "required": [
+                                  "asynchronous"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "synchronous"
+                                ]
+                              }
+                            ]
                           }
                         }
                       ]
@@ -5072,6 +5264,22 @@
                               "description": "Sets the synchronous Spring message channel endpoint."
                             }
                           }
+                        },
+                        {
+                          "not": {
+                            "anyOf": [
+                              {
+                                "required": [
+                                  "asynchronous"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "synchronous"
+                                ]
+                              }
+                            ]
+                          }
                         }
                       ]
                     }
@@ -5161,6 +5369,97 @@
                   "title": "Selenium",
                   "description": "Selenium endpoint."
                 }
+              }
+            },
+            {
+              "not": {
+                "anyOf": [
+                  {
+                    "required": [
+                      "http"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "soap"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "webSocket"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "context"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "mail"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "ftp"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "sftp"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "scp"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "docker"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "kubernetes"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "jms"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "vertx"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "direct"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "kafka"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "camel"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "channel"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "selenium"
+                    ]
+                  }
+                ]
               }
             }
           ]
@@ -5890,6 +6189,9 @@
                       "type": "object",
                       "properties": {
                         "data": {
+                          "type": "string",
+                          "title": "Data",
+                          "description": "The message body content as inline data."
                         },
                         "resource": {
                         },
@@ -5901,14 +6203,9 @@
                         {
                           "oneOf": [
                             {
-                              "type": "object",
-                              "properties": {
-                                "data": {
-                                  "type": "string",
-                                  "title": "Data",
-                                  "description": "The message body content as inline data."
-                                }
-                              }
+                              "required": [
+                                "data"
+                              ]
                             },
                             {
                               "type": "object",
@@ -5965,6 +6262,27 @@
                                   "title": "Script",
                                   "description": "The message body set via script."
                                 }
+                              }
+                            },
+                            {
+                              "not": {
+                                "anyOf": [
+                                  {
+                                    "required": [
+                                      "data"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "resource"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "script"
+                                    ]
+                                  }
+                                ]
                               }
                             }
                           ]
@@ -6027,6 +6345,9 @@
                         "type": "object",
                         "properties": {
                           "data": {
+                            "type": "string",
+                            "title": "Data",
+                            "description": "The message header value as inline data."
                           },
                           "name": {
                             "type": "string",
@@ -6042,6 +6363,9 @@
                             "$comment": "group:advanced"
                           },
                           "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The message header value."
                           }
                         },
                         "additionalProperties": false,
@@ -6049,14 +6373,9 @@
                           {
                             "oneOf": [
                               {
-                                "type": "object",
-                                "properties": {
-                                  "value": {
-                                    "type": "string",
-                                    "title": "Value",
-                                    "description": "The message header value."
-                                  }
-                                }
+                                "required": [
+                                  "value"
+                                ]
                               },
                               {
                                 "type": "object",
@@ -6086,13 +6405,29 @@
                                 }
                               },
                               {
-                                "type": "object",
-                                "properties": {
-                                  "data": {
-                                    "type": "string",
-                                    "title": "Data",
-                                    "description": "The message header value as inline data."
-                                  }
+                                "required": [
+                                  "data"
+                                ]
+                              },
+                              {
+                                "not": {
+                                  "anyOf": [
+                                    {
+                                      "required": [
+                                        "value"
+                                      ]
+                                    },
+                                    {
+                                      "required": [
+                                        "resource"
+                                      ]
+                                    },
+                                    {
+                                      "required": [
+                                        "data"
+                                      ]
+                                    }
+                                  ]
                                 }
                               }
                             ]
@@ -6194,6 +6529,9 @@
                       "type": "object",
                       "properties": {
                         "data": {
+                          "type": "string",
+                          "title": "Data",
+                          "description": "The message body content as inline data."
                         },
                         "resource": {
                         },
@@ -6205,14 +6543,9 @@
                         {
                           "oneOf": [
                             {
-                              "type": "object",
-                              "properties": {
-                                "data": {
-                                  "type": "string",
-                                  "title": "Data",
-                                  "description": "The message body content as inline data."
-                                }
-                              }
+                              "required": [
+                                "data"
+                              ]
                             },
                             {
                               "type": "object",
@@ -6269,6 +6602,27 @@
                                   "title": "Script",
                                   "description": "The message body set via script."
                                 }
+                              }
+                            },
+                            {
+                              "not": {
+                                "anyOf": [
+                                  {
+                                    "required": [
+                                      "data"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "resource"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "script"
+                                    ]
+                                  }
+                                ]
                               }
                             }
                           ]
@@ -6331,6 +6685,9 @@
                         "type": "object",
                         "properties": {
                           "data": {
+                            "type": "string",
+                            "title": "Data",
+                            "description": "The message header value as inline data."
                           },
                           "name": {
                             "type": "string",
@@ -6346,6 +6703,9 @@
                             "$comment": "group:advanced"
                           },
                           "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The message header value."
                           }
                         },
                         "additionalProperties": false,
@@ -6353,14 +6713,9 @@
                           {
                             "oneOf": [
                               {
-                                "type": "object",
-                                "properties": {
-                                  "value": {
-                                    "type": "string",
-                                    "title": "Value",
-                                    "description": "The message header value."
-                                  }
-                                }
+                                "required": [
+                                  "value"
+                                ]
                               },
                               {
                                 "type": "object",
@@ -6390,13 +6745,29 @@
                                 }
                               },
                               {
-                                "type": "object",
-                                "properties": {
-                                  "data": {
-                                    "type": "string",
-                                    "title": "Data",
-                                    "description": "The message header value as inline data."
-                                  }
+                                "required": [
+                                  "data"
+                                ]
+                              },
+                              {
+                                "not": {
+                                  "anyOf": [
+                                    {
+                                      "required": [
+                                        "value"
+                                      ]
+                                    },
+                                    {
+                                      "required": [
+                                        "resource"
+                                      ]
+                                    },
+                                    {
+                                      "required": [
+                                        "data"
+                                      ]
+                                    }
+                                  ]
                                 }
                               }
                             ]
@@ -6498,6 +6869,9 @@
                       "type": "object",
                       "properties": {
                         "data": {
+                          "type": "string",
+                          "title": "Data",
+                          "description": "The message body content as inline data."
                         },
                         "resource": {
                         },
@@ -6509,14 +6883,9 @@
                         {
                           "oneOf": [
                             {
-                              "type": "object",
-                              "properties": {
-                                "data": {
-                                  "type": "string",
-                                  "title": "Data",
-                                  "description": "The message body content as inline data."
-                                }
-                              }
+                              "required": [
+                                "data"
+                              ]
                             },
                             {
                               "type": "object",
@@ -6573,6 +6942,27 @@
                                   "title": "Script",
                                   "description": "The message body set via script."
                                 }
+                              }
+                            },
+                            {
+                              "not": {
+                                "anyOf": [
+                                  {
+                                    "required": [
+                                      "data"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "resource"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "script"
+                                    ]
+                                  }
+                                ]
                               }
                             }
                           ]
@@ -6635,6 +7025,9 @@
                         "type": "object",
                         "properties": {
                           "data": {
+                            "type": "string",
+                            "title": "Data",
+                            "description": "The message header value as inline data."
                           },
                           "name": {
                             "type": "string",
@@ -6650,6 +7043,9 @@
                             "$comment": "group:advanced"
                           },
                           "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The message header value."
                           }
                         },
                         "additionalProperties": false,
@@ -6657,14 +7053,9 @@
                           {
                             "oneOf": [
                               {
-                                "type": "object",
-                                "properties": {
-                                  "value": {
-                                    "type": "string",
-                                    "title": "Value",
-                                    "description": "The message header value."
-                                  }
-                                }
+                                "required": [
+                                  "value"
+                                ]
                               },
                               {
                                 "type": "object",
@@ -6694,13 +7085,29 @@
                                 }
                               },
                               {
-                                "type": "object",
-                                "properties": {
-                                  "data": {
-                                    "type": "string",
-                                    "title": "Data",
-                                    "description": "The message header value as inline data."
-                                  }
+                                "required": [
+                                  "data"
+                                ]
+                              },
+                              {
+                                "not": {
+                                  "anyOf": [
+                                    {
+                                      "required": [
+                                        "value"
+                                      ]
+                                    },
+                                    {
+                                      "required": [
+                                        "resource"
+                                      ]
+                                    },
+                                    {
+                                      "required": [
+                                        "data"
+                                      ]
+                                    }
+                                  ]
                                 }
                               }
                             ]
@@ -6789,13 +7196,6 @@
             {
               "type": "object",
               "properties": {
-                "PUT": {
-                }
-              }
-            },
-            {
-              "type": "object",
-              "properties": {
                 "DELETE": {
                   "type": "object",
                   "properties": {
@@ -6809,6 +7209,9 @@
                       "type": "object",
                       "properties": {
                         "data": {
+                          "type": "string",
+                          "title": "Data",
+                          "description": "The message body content as inline data."
                         },
                         "resource": {
                         },
@@ -6820,14 +7223,9 @@
                         {
                           "oneOf": [
                             {
-                              "type": "object",
-                              "properties": {
-                                "data": {
-                                  "type": "string",
-                                  "title": "Data",
-                                  "description": "The message body content as inline data."
-                                }
-                              }
+                              "required": [
+                                "data"
+                              ]
                             },
                             {
                               "type": "object",
@@ -6884,6 +7282,27 @@
                                   "title": "Script",
                                   "description": "The message body set via script."
                                 }
+                              }
+                            },
+                            {
+                              "not": {
+                                "anyOf": [
+                                  {
+                                    "required": [
+                                      "data"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "resource"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "script"
+                                    ]
+                                  }
+                                ]
                               }
                             }
                           ]
@@ -6946,6 +7365,9 @@
                         "type": "object",
                         "properties": {
                           "data": {
+                            "type": "string",
+                            "title": "Data",
+                            "description": "The message header value as inline data."
                           },
                           "name": {
                             "type": "string",
@@ -6961,6 +7383,9 @@
                             "$comment": "group:advanced"
                           },
                           "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The message header value."
                           }
                         },
                         "additionalProperties": false,
@@ -6968,14 +7393,9 @@
                           {
                             "oneOf": [
                               {
-                                "type": "object",
-                                "properties": {
-                                  "value": {
-                                    "type": "string",
-                                    "title": "Value",
-                                    "description": "The message header value."
-                                  }
-                                }
+                                "required": [
+                                  "value"
+                                ]
                               },
                               {
                                 "type": "object",
@@ -7005,13 +7425,29 @@
                                 }
                               },
                               {
-                                "type": "object",
-                                "properties": {
-                                  "data": {
-                                    "type": "string",
-                                    "title": "Data",
-                                    "description": "The message header value as inline data."
-                                  }
+                                "required": [
+                                  "data"
+                                ]
+                              },
+                              {
+                                "not": {
+                                  "anyOf": [
+                                    {
+                                      "required": [
+                                        "value"
+                                      ]
+                                    },
+                                    {
+                                      "required": [
+                                        "resource"
+                                      ]
+                                    },
+                                    {
+                                      "required": [
+                                        "data"
+                                      ]
+                                    }
+                                  ]
                                 }
                               }
                             ]
@@ -7113,6 +7549,9 @@
                       "type": "object",
                       "properties": {
                         "data": {
+                          "type": "string",
+                          "title": "Data",
+                          "description": "The message body content as inline data."
                         },
                         "resource": {
                         },
@@ -7124,14 +7563,9 @@
                         {
                           "oneOf": [
                             {
-                              "type": "object",
-                              "properties": {
-                                "data": {
-                                  "type": "string",
-                                  "title": "Data",
-                                  "description": "The message body content as inline data."
-                                }
-                              }
+                              "required": [
+                                "data"
+                              ]
                             },
                             {
                               "type": "object",
@@ -7188,6 +7622,27 @@
                                   "title": "Script",
                                   "description": "The message body set via script."
                                 }
+                              }
+                            },
+                            {
+                              "not": {
+                                "anyOf": [
+                                  {
+                                    "required": [
+                                      "data"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "resource"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "script"
+                                    ]
+                                  }
+                                ]
                               }
                             }
                           ]
@@ -7250,6 +7705,9 @@
                         "type": "object",
                         "properties": {
                           "data": {
+                            "type": "string",
+                            "title": "Data",
+                            "description": "The message header value as inline data."
                           },
                           "name": {
                             "type": "string",
@@ -7265,6 +7723,9 @@
                             "$comment": "group:advanced"
                           },
                           "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The message header value."
                           }
                         },
                         "additionalProperties": false,
@@ -7272,14 +7733,9 @@
                           {
                             "oneOf": [
                               {
-                                "type": "object",
-                                "properties": {
-                                  "value": {
-                                    "type": "string",
-                                    "title": "Value",
-                                    "description": "The message header value."
-                                  }
-                                }
+                                "required": [
+                                  "value"
+                                ]
                               },
                               {
                                 "type": "object",
@@ -7309,13 +7765,29 @@
                                 }
                               },
                               {
-                                "type": "object",
-                                "properties": {
-                                  "data": {
-                                    "type": "string",
-                                    "title": "Data",
-                                    "description": "The message header value as inline data."
-                                  }
+                                "required": [
+                                  "data"
+                                ]
+                              },
+                              {
+                                "not": {
+                                  "anyOf": [
+                                    {
+                                      "required": [
+                                        "value"
+                                      ]
+                                    },
+                                    {
+                                      "required": [
+                                        "resource"
+                                      ]
+                                    },
+                                    {
+                                      "required": [
+                                        "data"
+                                      ]
+                                    }
+                                  ]
                                 }
                               }
                             ]
@@ -7417,6 +7889,9 @@
                       "type": "object",
                       "properties": {
                         "data": {
+                          "type": "string",
+                          "title": "Data",
+                          "description": "The message body content as inline data."
                         },
                         "resource": {
                         },
@@ -7428,14 +7903,9 @@
                         {
                           "oneOf": [
                             {
-                              "type": "object",
-                              "properties": {
-                                "data": {
-                                  "type": "string",
-                                  "title": "Data",
-                                  "description": "The message body content as inline data."
-                                }
-                              }
+                              "required": [
+                                "data"
+                              ]
                             },
                             {
                               "type": "object",
@@ -7492,6 +7962,27 @@
                                   "title": "Script",
                                   "description": "The message body set via script."
                                 }
+                              }
+                            },
+                            {
+                              "not": {
+                                "anyOf": [
+                                  {
+                                    "required": [
+                                      "data"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "resource"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "script"
+                                    ]
+                                  }
+                                ]
                               }
                             }
                           ]
@@ -7554,6 +8045,9 @@
                         "type": "object",
                         "properties": {
                           "data": {
+                            "type": "string",
+                            "title": "Data",
+                            "description": "The message header value as inline data."
                           },
                           "name": {
                             "type": "string",
@@ -7569,6 +8063,9 @@
                             "$comment": "group:advanced"
                           },
                           "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The message header value."
                           }
                         },
                         "additionalProperties": false,
@@ -7576,14 +8073,9 @@
                           {
                             "oneOf": [
                               {
-                                "type": "object",
-                                "properties": {
-                                  "value": {
-                                    "type": "string",
-                                    "title": "Value",
-                                    "description": "The message header value."
-                                  }
-                                }
+                                "required": [
+                                  "value"
+                                ]
                               },
                               {
                                 "type": "object",
@@ -7613,13 +8105,29 @@
                                 }
                               },
                               {
-                                "type": "object",
-                                "properties": {
-                                  "data": {
-                                    "type": "string",
-                                    "title": "Data",
-                                    "description": "The message header value as inline data."
-                                  }
+                                "required": [
+                                  "data"
+                                ]
+                              },
+                              {
+                                "not": {
+                                  "anyOf": [
+                                    {
+                                      "required": [
+                                        "value"
+                                      ]
+                                    },
+                                    {
+                                      "required": [
+                                        "resource"
+                                      ]
+                                    },
+                                    {
+                                      "required": [
+                                        "data"
+                                      ]
+                                    }
+                                  ]
                                 }
                               }
                             ]
@@ -7721,6 +8229,9 @@
                       "type": "object",
                       "properties": {
                         "data": {
+                          "type": "string",
+                          "title": "Data",
+                          "description": "The message body content as inline data."
                         },
                         "resource": {
                         },
@@ -7732,14 +8243,9 @@
                         {
                           "oneOf": [
                             {
-                              "type": "object",
-                              "properties": {
-                                "data": {
-                                  "type": "string",
-                                  "title": "Data",
-                                  "description": "The message body content as inline data."
-                                }
-                              }
+                              "required": [
+                                "data"
+                              ]
                             },
                             {
                               "type": "object",
@@ -7796,6 +8302,27 @@
                                   "title": "Script",
                                   "description": "The message body set via script."
                                 }
+                              }
+                            },
+                            {
+                              "not": {
+                                "anyOf": [
+                                  {
+                                    "required": [
+                                      "data"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "resource"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "script"
+                                    ]
+                                  }
+                                ]
                               }
                             }
                           ]
@@ -7858,6 +8385,9 @@
                         "type": "object",
                         "properties": {
                           "data": {
+                            "type": "string",
+                            "title": "Data",
+                            "description": "The message header value as inline data."
                           },
                           "name": {
                             "type": "string",
@@ -7873,6 +8403,9 @@
                             "$comment": "group:advanced"
                           },
                           "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The message header value."
                           }
                         },
                         "additionalProperties": false,
@@ -7880,14 +8413,9 @@
                           {
                             "oneOf": [
                               {
-                                "type": "object",
-                                "properties": {
-                                  "value": {
-                                    "type": "string",
-                                    "title": "Value",
-                                    "description": "The message header value."
-                                  }
-                                }
+                                "required": [
+                                  "value"
+                                ]
                               },
                               {
                                 "type": "object",
@@ -7917,13 +8445,29 @@
                                 }
                               },
                               {
-                                "type": "object",
-                                "properties": {
-                                  "data": {
-                                    "type": "string",
-                                    "title": "Data",
-                                    "description": "The message header value as inline data."
-                                  }
+                                "required": [
+                                  "data"
+                                ]
+                              },
+                              {
+                                "not": {
+                                  "anyOf": [
+                                    {
+                                      "required": [
+                                        "value"
+                                      ]
+                                    },
+                                    {
+                                      "required": [
+                                        "resource"
+                                      ]
+                                    },
+                                    {
+                                      "required": [
+                                        "data"
+                                      ]
+                                    }
+                                  ]
                                 }
                               }
                             ]
@@ -8025,6 +8569,9 @@
                       "type": "object",
                       "properties": {
                         "data": {
+                          "type": "string",
+                          "title": "Data",
+                          "description": "The message body content as inline data."
                         },
                         "resource": {
                         },
@@ -8036,14 +8583,9 @@
                         {
                           "oneOf": [
                             {
-                              "type": "object",
-                              "properties": {
-                                "data": {
-                                  "type": "string",
-                                  "title": "Data",
-                                  "description": "The message body content as inline data."
-                                }
-                              }
+                              "required": [
+                                "data"
+                              ]
                             },
                             {
                               "type": "object",
@@ -8100,6 +8642,27 @@
                                   "title": "Script",
                                   "description": "The message body set via script."
                                 }
+                              }
+                            },
+                            {
+                              "not": {
+                                "anyOf": [
+                                  {
+                                    "required": [
+                                      "data"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "resource"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "script"
+                                    ]
+                                  }
+                                ]
                               }
                             }
                           ]
@@ -8162,6 +8725,9 @@
                         "type": "object",
                         "properties": {
                           "data": {
+                            "type": "string",
+                            "title": "Data",
+                            "description": "The message header value as inline data."
                           },
                           "name": {
                             "type": "string",
@@ -8177,6 +8743,9 @@
                             "$comment": "group:advanced"
                           },
                           "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The message header value."
                           }
                         },
                         "additionalProperties": false,
@@ -8184,14 +8753,9 @@
                           {
                             "oneOf": [
                               {
-                                "type": "object",
-                                "properties": {
-                                  "value": {
-                                    "type": "string",
-                                    "title": "Value",
-                                    "description": "The message header value."
-                                  }
-                                }
+                                "required": [
+                                  "value"
+                                ]
                               },
                               {
                                 "type": "object",
@@ -8221,13 +8785,29 @@
                                 }
                               },
                               {
-                                "type": "object",
-                                "properties": {
-                                  "data": {
-                                    "type": "string",
-                                    "title": "Data",
-                                    "description": "The message header value as inline data."
-                                  }
+                                "required": [
+                                  "data"
+                                ]
+                              },
+                              {
+                                "not": {
+                                  "anyOf": [
+                                    {
+                                      "required": [
+                                        "value"
+                                      ]
+                                    },
+                                    {
+                                      "required": [
+                                        "resource"
+                                      ]
+                                    },
+                                    {
+                                      "required": [
+                                        "data"
+                                      ]
+                                    }
+                                  ]
                                 }
                               }
                             ]
@@ -8311,6 +8891,52 @@
                   "title": "TRACE",
                   "description": "Http TRACE request"
                 }
+              }
+            },
+            {
+              "not": {
+                "anyOf": [
+                  {
+                    "required": [
+                      "GET"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "POST"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "PUT"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "DELETE"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "HEAD"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "OPTIONS"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "PATCH"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "TRACE"
+                    ]
+                  }
+                ]
               }
             }
           ]
@@ -8417,6 +9043,9 @@
               "type": "object",
               "properties": {
                 "data": {
+                  "type": "string",
+                  "title": "Data",
+                  "description": "The message body content as inline data."
                 },
                 "resource": {
                 },
@@ -8428,14 +9057,9 @@
                 {
                   "oneOf": [
                     {
-                      "type": "object",
-                      "properties": {
-                        "data": {
-                          "type": "string",
-                          "title": "Data",
-                          "description": "The message body content as inline data."
-                        }
-                      }
+                      "required": [
+                        "data"
+                      ]
                     },
                     {
                       "type": "object",
@@ -8492,6 +9116,27 @@
                           "title": "Script",
                           "description": "The message body set via script."
                         }
+                      }
+                    },
+                    {
+                      "not": {
+                        "anyOf": [
+                          {
+                            "required": [
+                              "data"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "resource"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "script"
+                            ]
+                          }
+                        ]
                       }
                     }
                   ]
@@ -8554,6 +9199,9 @@
                 "type": "object",
                 "properties": {
                   "data": {
+                    "type": "string",
+                    "title": "Data",
+                    "description": "The message header value as inline data."
                   },
                   "name": {
                     "type": "string",
@@ -8569,6 +9217,9 @@
                     "$comment": "group:advanced"
                   },
                   "value": {
+                    "type": "string",
+                    "title": "Value",
+                    "description": "The message header value."
                   }
                 },
                 "additionalProperties": false,
@@ -8576,14 +9227,9 @@
                   {
                     "oneOf": [
                       {
-                        "type": "object",
-                        "properties": {
-                          "value": {
-                            "type": "string",
-                            "title": "Value",
-                            "description": "The message header value."
-                          }
-                        }
+                        "required": [
+                          "value"
+                        ]
                       },
                       {
                         "type": "object",
@@ -8613,13 +9259,29 @@
                         }
                       },
                       {
-                        "type": "object",
-                        "properties": {
-                          "data": {
-                            "type": "string",
-                            "title": "Data",
-                            "description": "The message header value as inline data."
-                          }
+                        "required": [
+                          "data"
+                        ]
+                      },
+                      {
+                        "not": {
+                          "anyOf": [
+                            {
+                              "required": [
+                                "value"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "resource"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "data"
+                              ]
+                            }
+                          ]
                         }
                       }
                     ]
@@ -9030,6 +9692,9 @@
                       "type": "object",
                       "properties": {
                         "data": {
+                          "type": "string",
+                          "title": "Data",
+                          "description": "The message body content as inline data."
                         },
                         "resource": {
                         },
@@ -9041,14 +9706,9 @@
                         {
                           "oneOf": [
                             {
-                              "type": "object",
-                              "properties": {
-                                "data": {
-                                  "type": "string",
-                                  "title": "Data",
-                                  "description": "The message body content as inline data."
-                                }
-                              }
+                              "required": [
+                                "data"
+                              ]
                             },
                             {
                               "type": "object",
@@ -9105,6 +9765,27 @@
                                   "title": "Script",
                                   "description": "The message body set via script."
                                 }
+                              }
+                            },
+                            {
+                              "not": {
+                                "anyOf": [
+                                  {
+                                    "required": [
+                                      "data"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "resource"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "script"
+                                    ]
+                                  }
+                                ]
                               }
                             }
                           ]
@@ -9167,6 +9848,9 @@
                         "type": "object",
                         "properties": {
                           "data": {
+                            "type": "string",
+                            "title": "Data",
+                            "description": "The message header value as inline data."
                           },
                           "name": {
                             "type": "string",
@@ -9182,6 +9866,9 @@
                             "$comment": "group:advanced"
                           },
                           "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The message header value."
                           }
                         },
                         "additionalProperties": false,
@@ -9189,14 +9876,9 @@
                           {
                             "oneOf": [
                               {
-                                "type": "object",
-                                "properties": {
-                                  "value": {
-                                    "type": "string",
-                                    "title": "Value",
-                                    "description": "The message header value."
-                                  }
-                                }
+                                "required": [
+                                  "value"
+                                ]
                               },
                               {
                                 "type": "object",
@@ -9226,13 +9908,29 @@
                                 }
                               },
                               {
-                                "type": "object",
-                                "properties": {
-                                  "data": {
-                                    "type": "string",
-                                    "title": "Data",
-                                    "description": "The message header value as inline data."
-                                  }
+                                "required": [
+                                  "data"
+                                ]
+                              },
+                              {
+                                "not": {
+                                  "anyOf": [
+                                    {
+                                      "required": [
+                                        "value"
+                                      ]
+                                    },
+                                    {
+                                      "required": [
+                                        "resource"
+                                      ]
+                                    },
+                                    {
+                                      "required": [
+                                        "data"
+                                      ]
+                                    }
+                                  ]
                                 }
                               }
                             ]
@@ -9334,6 +10032,9 @@
                       "type": "object",
                       "properties": {
                         "data": {
+                          "type": "string",
+                          "title": "Data",
+                          "description": "The message body content as inline data."
                         },
                         "resource": {
                         },
@@ -9345,14 +10046,9 @@
                         {
                           "oneOf": [
                             {
-                              "type": "object",
-                              "properties": {
-                                "data": {
-                                  "type": "string",
-                                  "title": "Data",
-                                  "description": "The message body content as inline data."
-                                }
-                              }
+                              "required": [
+                                "data"
+                              ]
                             },
                             {
                               "type": "object",
@@ -9409,6 +10105,27 @@
                                   "title": "Script",
                                   "description": "The message body set via script."
                                 }
+                              }
+                            },
+                            {
+                              "not": {
+                                "anyOf": [
+                                  {
+                                    "required": [
+                                      "data"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "resource"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "script"
+                                    ]
+                                  }
+                                ]
                               }
                             }
                           ]
@@ -9471,6 +10188,9 @@
                         "type": "object",
                         "properties": {
                           "data": {
+                            "type": "string",
+                            "title": "Data",
+                            "description": "The message header value as inline data."
                           },
                           "name": {
                             "type": "string",
@@ -9486,6 +10206,9 @@
                             "$comment": "group:advanced"
                           },
                           "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The message header value."
                           }
                         },
                         "additionalProperties": false,
@@ -9493,14 +10216,9 @@
                           {
                             "oneOf": [
                               {
-                                "type": "object",
-                                "properties": {
-                                  "value": {
-                                    "type": "string",
-                                    "title": "Value",
-                                    "description": "The message header value."
-                                  }
-                                }
+                                "required": [
+                                  "value"
+                                ]
                               },
                               {
                                 "type": "object",
@@ -9530,13 +10248,29 @@
                                 }
                               },
                               {
-                                "type": "object",
-                                "properties": {
-                                  "data": {
-                                    "type": "string",
-                                    "title": "Data",
-                                    "description": "The message header value as inline data."
-                                  }
+                                "required": [
+                                  "data"
+                                ]
+                              },
+                              {
+                                "not": {
+                                  "anyOf": [
+                                    {
+                                      "required": [
+                                        "value"
+                                      ]
+                                    },
+                                    {
+                                      "required": [
+                                        "resource"
+                                      ]
+                                    },
+                                    {
+                                      "required": [
+                                        "data"
+                                      ]
+                                    }
+                                  ]
                                 }
                               }
                             ]
@@ -9638,6 +10372,9 @@
                       "type": "object",
                       "properties": {
                         "data": {
+                          "type": "string",
+                          "title": "Data",
+                          "description": "The message body content as inline data."
                         },
                         "resource": {
                         },
@@ -9649,14 +10386,9 @@
                         {
                           "oneOf": [
                             {
-                              "type": "object",
-                              "properties": {
-                                "data": {
-                                  "type": "string",
-                                  "title": "Data",
-                                  "description": "The message body content as inline data."
-                                }
-                              }
+                              "required": [
+                                "data"
+                              ]
                             },
                             {
                               "type": "object",
@@ -9713,6 +10445,27 @@
                                   "title": "Script",
                                   "description": "The message body set via script."
                                 }
+                              }
+                            },
+                            {
+                              "not": {
+                                "anyOf": [
+                                  {
+                                    "required": [
+                                      "data"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "resource"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "script"
+                                    ]
+                                  }
+                                ]
                               }
                             }
                           ]
@@ -9775,6 +10528,9 @@
                         "type": "object",
                         "properties": {
                           "data": {
+                            "type": "string",
+                            "title": "Data",
+                            "description": "The message header value as inline data."
                           },
                           "name": {
                             "type": "string",
@@ -9790,6 +10546,9 @@
                             "$comment": "group:advanced"
                           },
                           "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The message header value."
                           }
                         },
                         "additionalProperties": false,
@@ -9797,14 +10556,9 @@
                           {
                             "oneOf": [
                               {
-                                "type": "object",
-                                "properties": {
-                                  "value": {
-                                    "type": "string",
-                                    "title": "Value",
-                                    "description": "The message header value."
-                                  }
-                                }
+                                "required": [
+                                  "value"
+                                ]
                               },
                               {
                                 "type": "object",
@@ -9834,13 +10588,29 @@
                                 }
                               },
                               {
-                                "type": "object",
-                                "properties": {
-                                  "data": {
-                                    "type": "string",
-                                    "title": "Data",
-                                    "description": "The message header value as inline data."
-                                  }
+                                "required": [
+                                  "data"
+                                ]
+                              },
+                              {
+                                "not": {
+                                  "anyOf": [
+                                    {
+                                      "required": [
+                                        "value"
+                                      ]
+                                    },
+                                    {
+                                      "required": [
+                                        "resource"
+                                      ]
+                                    },
+                                    {
+                                      "required": [
+                                        "data"
+                                      ]
+                                    }
+                                  ]
                                 }
                               }
                             ]
@@ -9929,13 +10699,6 @@
             {
               "type": "object",
               "properties": {
-                "PUT": {
-                }
-              }
-            },
-            {
-              "type": "object",
-              "properties": {
                 "DELETE": {
                   "type": "object",
                   "properties": {
@@ -9949,6 +10712,9 @@
                       "type": "object",
                       "properties": {
                         "data": {
+                          "type": "string",
+                          "title": "Data",
+                          "description": "The message body content as inline data."
                         },
                         "resource": {
                         },
@@ -9960,14 +10726,9 @@
                         {
                           "oneOf": [
                             {
-                              "type": "object",
-                              "properties": {
-                                "data": {
-                                  "type": "string",
-                                  "title": "Data",
-                                  "description": "The message body content as inline data."
-                                }
-                              }
+                              "required": [
+                                "data"
+                              ]
                             },
                             {
                               "type": "object",
@@ -10024,6 +10785,27 @@
                                   "title": "Script",
                                   "description": "The message body set via script."
                                 }
+                              }
+                            },
+                            {
+                              "not": {
+                                "anyOf": [
+                                  {
+                                    "required": [
+                                      "data"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "resource"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "script"
+                                    ]
+                                  }
+                                ]
                               }
                             }
                           ]
@@ -10086,6 +10868,9 @@
                         "type": "object",
                         "properties": {
                           "data": {
+                            "type": "string",
+                            "title": "Data",
+                            "description": "The message header value as inline data."
                           },
                           "name": {
                             "type": "string",
@@ -10101,6 +10886,9 @@
                             "$comment": "group:advanced"
                           },
                           "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The message header value."
                           }
                         },
                         "additionalProperties": false,
@@ -10108,14 +10896,9 @@
                           {
                             "oneOf": [
                               {
-                                "type": "object",
-                                "properties": {
-                                  "value": {
-                                    "type": "string",
-                                    "title": "Value",
-                                    "description": "The message header value."
-                                  }
-                                }
+                                "required": [
+                                  "value"
+                                ]
                               },
                               {
                                 "type": "object",
@@ -10145,13 +10928,29 @@
                                 }
                               },
                               {
-                                "type": "object",
-                                "properties": {
-                                  "data": {
-                                    "type": "string",
-                                    "title": "Data",
-                                    "description": "The message header value as inline data."
-                                  }
+                                "required": [
+                                  "data"
+                                ]
+                              },
+                              {
+                                "not": {
+                                  "anyOf": [
+                                    {
+                                      "required": [
+                                        "value"
+                                      ]
+                                    },
+                                    {
+                                      "required": [
+                                        "resource"
+                                      ]
+                                    },
+                                    {
+                                      "required": [
+                                        "data"
+                                      ]
+                                    }
+                                  ]
                                 }
                               }
                             ]
@@ -10253,6 +11052,9 @@
                       "type": "object",
                       "properties": {
                         "data": {
+                          "type": "string",
+                          "title": "Data",
+                          "description": "The message body content as inline data."
                         },
                         "resource": {
                         },
@@ -10264,14 +11066,9 @@
                         {
                           "oneOf": [
                             {
-                              "type": "object",
-                              "properties": {
-                                "data": {
-                                  "type": "string",
-                                  "title": "Data",
-                                  "description": "The message body content as inline data."
-                                }
-                              }
+                              "required": [
+                                "data"
+                              ]
                             },
                             {
                               "type": "object",
@@ -10328,6 +11125,27 @@
                                   "title": "Script",
                                   "description": "The message body set via script."
                                 }
+                              }
+                            },
+                            {
+                              "not": {
+                                "anyOf": [
+                                  {
+                                    "required": [
+                                      "data"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "resource"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "script"
+                                    ]
+                                  }
+                                ]
                               }
                             }
                           ]
@@ -10390,6 +11208,9 @@
                         "type": "object",
                         "properties": {
                           "data": {
+                            "type": "string",
+                            "title": "Data",
+                            "description": "The message header value as inline data."
                           },
                           "name": {
                             "type": "string",
@@ -10405,6 +11226,9 @@
                             "$comment": "group:advanced"
                           },
                           "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The message header value."
                           }
                         },
                         "additionalProperties": false,
@@ -10412,14 +11236,9 @@
                           {
                             "oneOf": [
                               {
-                                "type": "object",
-                                "properties": {
-                                  "value": {
-                                    "type": "string",
-                                    "title": "Value",
-                                    "description": "The message header value."
-                                  }
-                                }
+                                "required": [
+                                  "value"
+                                ]
                               },
                               {
                                 "type": "object",
@@ -10449,13 +11268,29 @@
                                 }
                               },
                               {
-                                "type": "object",
-                                "properties": {
-                                  "data": {
-                                    "type": "string",
-                                    "title": "Data",
-                                    "description": "The message header value as inline data."
-                                  }
+                                "required": [
+                                  "data"
+                                ]
+                              },
+                              {
+                                "not": {
+                                  "anyOf": [
+                                    {
+                                      "required": [
+                                        "value"
+                                      ]
+                                    },
+                                    {
+                                      "required": [
+                                        "resource"
+                                      ]
+                                    },
+                                    {
+                                      "required": [
+                                        "data"
+                                      ]
+                                    }
+                                  ]
                                 }
                               }
                             ]
@@ -10557,6 +11392,9 @@
                       "type": "object",
                       "properties": {
                         "data": {
+                          "type": "string",
+                          "title": "Data",
+                          "description": "The message body content as inline data."
                         },
                         "resource": {
                         },
@@ -10568,14 +11406,9 @@
                         {
                           "oneOf": [
                             {
-                              "type": "object",
-                              "properties": {
-                                "data": {
-                                  "type": "string",
-                                  "title": "Data",
-                                  "description": "The message body content as inline data."
-                                }
-                              }
+                              "required": [
+                                "data"
+                              ]
                             },
                             {
                               "type": "object",
@@ -10632,6 +11465,27 @@
                                   "title": "Script",
                                   "description": "The message body set via script."
                                 }
+                              }
+                            },
+                            {
+                              "not": {
+                                "anyOf": [
+                                  {
+                                    "required": [
+                                      "data"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "resource"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "script"
+                                    ]
+                                  }
+                                ]
                               }
                             }
                           ]
@@ -10694,6 +11548,9 @@
                         "type": "object",
                         "properties": {
                           "data": {
+                            "type": "string",
+                            "title": "Data",
+                            "description": "The message header value as inline data."
                           },
                           "name": {
                             "type": "string",
@@ -10709,6 +11566,9 @@
                             "$comment": "group:advanced"
                           },
                           "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The message header value."
                           }
                         },
                         "additionalProperties": false,
@@ -10716,14 +11576,9 @@
                           {
                             "oneOf": [
                               {
-                                "type": "object",
-                                "properties": {
-                                  "value": {
-                                    "type": "string",
-                                    "title": "Value",
-                                    "description": "The message header value."
-                                  }
-                                }
+                                "required": [
+                                  "value"
+                                ]
                               },
                               {
                                 "type": "object",
@@ -10753,13 +11608,29 @@
                                 }
                               },
                               {
-                                "type": "object",
-                                "properties": {
-                                  "data": {
-                                    "type": "string",
-                                    "title": "Data",
-                                    "description": "The message header value as inline data."
-                                  }
+                                "required": [
+                                  "data"
+                                ]
+                              },
+                              {
+                                "not": {
+                                  "anyOf": [
+                                    {
+                                      "required": [
+                                        "value"
+                                      ]
+                                    },
+                                    {
+                                      "required": [
+                                        "resource"
+                                      ]
+                                    },
+                                    {
+                                      "required": [
+                                        "data"
+                                      ]
+                                    }
+                                  ]
                                 }
                               }
                             ]
@@ -10861,6 +11732,9 @@
                       "type": "object",
                       "properties": {
                         "data": {
+                          "type": "string",
+                          "title": "Data",
+                          "description": "The message body content as inline data."
                         },
                         "resource": {
                         },
@@ -10872,14 +11746,9 @@
                         {
                           "oneOf": [
                             {
-                              "type": "object",
-                              "properties": {
-                                "data": {
-                                  "type": "string",
-                                  "title": "Data",
-                                  "description": "The message body content as inline data."
-                                }
-                              }
+                              "required": [
+                                "data"
+                              ]
                             },
                             {
                               "type": "object",
@@ -10936,6 +11805,27 @@
                                   "title": "Script",
                                   "description": "The message body set via script."
                                 }
+                              }
+                            },
+                            {
+                              "not": {
+                                "anyOf": [
+                                  {
+                                    "required": [
+                                      "data"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "resource"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "script"
+                                    ]
+                                  }
+                                ]
                               }
                             }
                           ]
@@ -10998,6 +11888,9 @@
                         "type": "object",
                         "properties": {
                           "data": {
+                            "type": "string",
+                            "title": "Data",
+                            "description": "The message header value as inline data."
                           },
                           "name": {
                             "type": "string",
@@ -11013,6 +11906,9 @@
                             "$comment": "group:advanced"
                           },
                           "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The message header value."
                           }
                         },
                         "additionalProperties": false,
@@ -11020,14 +11916,9 @@
                           {
                             "oneOf": [
                               {
-                                "type": "object",
-                                "properties": {
-                                  "value": {
-                                    "type": "string",
-                                    "title": "Value",
-                                    "description": "The message header value."
-                                  }
-                                }
+                                "required": [
+                                  "value"
+                                ]
                               },
                               {
                                 "type": "object",
@@ -11057,13 +11948,29 @@
                                 }
                               },
                               {
-                                "type": "object",
-                                "properties": {
-                                  "data": {
-                                    "type": "string",
-                                    "title": "Data",
-                                    "description": "The message header value as inline data."
-                                  }
+                                "required": [
+                                  "data"
+                                ]
+                              },
+                              {
+                                "not": {
+                                  "anyOf": [
+                                    {
+                                      "required": [
+                                        "value"
+                                      ]
+                                    },
+                                    {
+                                      "required": [
+                                        "resource"
+                                      ]
+                                    },
+                                    {
+                                      "required": [
+                                        "data"
+                                      ]
+                                    }
+                                  ]
                                 }
                               }
                             ]
@@ -11165,6 +12072,9 @@
                       "type": "object",
                       "properties": {
                         "data": {
+                          "type": "string",
+                          "title": "Data",
+                          "description": "The message body content as inline data."
                         },
                         "resource": {
                         },
@@ -11176,14 +12086,9 @@
                         {
                           "oneOf": [
                             {
-                              "type": "object",
-                              "properties": {
-                                "data": {
-                                  "type": "string",
-                                  "title": "Data",
-                                  "description": "The message body content as inline data."
-                                }
-                              }
+                              "required": [
+                                "data"
+                              ]
                             },
                             {
                               "type": "object",
@@ -11240,6 +12145,27 @@
                                   "title": "Script",
                                   "description": "The message body set via script."
                                 }
+                              }
+                            },
+                            {
+                              "not": {
+                                "anyOf": [
+                                  {
+                                    "required": [
+                                      "data"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "resource"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "script"
+                                    ]
+                                  }
+                                ]
                               }
                             }
                           ]
@@ -11302,6 +12228,9 @@
                         "type": "object",
                         "properties": {
                           "data": {
+                            "type": "string",
+                            "title": "Data",
+                            "description": "The message header value as inline data."
                           },
                           "name": {
                             "type": "string",
@@ -11317,6 +12246,9 @@
                             "$comment": "group:advanced"
                           },
                           "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The message header value."
                           }
                         },
                         "additionalProperties": false,
@@ -11324,14 +12256,9 @@
                           {
                             "oneOf": [
                               {
-                                "type": "object",
-                                "properties": {
-                                  "value": {
-                                    "type": "string",
-                                    "title": "Value",
-                                    "description": "The message header value."
-                                  }
-                                }
+                                "required": [
+                                  "value"
+                                ]
                               },
                               {
                                 "type": "object",
@@ -11361,13 +12288,29 @@
                                 }
                               },
                               {
-                                "type": "object",
-                                "properties": {
-                                  "data": {
-                                    "type": "string",
-                                    "title": "Data",
-                                    "description": "The message header value as inline data."
-                                  }
+                                "required": [
+                                  "data"
+                                ]
+                              },
+                              {
+                                "not": {
+                                  "anyOf": [
+                                    {
+                                      "required": [
+                                        "value"
+                                      ]
+                                    },
+                                    {
+                                      "required": [
+                                        "resource"
+                                      ]
+                                    },
+                                    {
+                                      "required": [
+                                        "data"
+                                      ]
+                                    }
+                                  ]
                                 }
                               }
                             ]
@@ -11451,6 +12394,52 @@
                   "title": "TRACE",
                   "description": "Http TRACE request"
                 }
+              }
+            },
+            {
+              "not": {
+                "anyOf": [
+                  {
+                    "required": [
+                      "GET"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "POST"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "PUT"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "DELETE"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "HEAD"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "OPTIONS"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "PATCH"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "TRACE"
+                    ]
+                  }
+                ]
               }
             }
           ]
@@ -11545,6 +12534,9 @@
               "type": "object",
               "properties": {
                 "data": {
+                  "type": "string",
+                  "title": "Data",
+                  "description": "The message body content as inline data."
                 },
                 "resource": {
                 },
@@ -11556,14 +12548,9 @@
                 {
                   "oneOf": [
                     {
-                      "type": "object",
-                      "properties": {
-                        "data": {
-                          "type": "string",
-                          "title": "Data",
-                          "description": "The message body content as inline data."
-                        }
-                      }
+                      "required": [
+                        "data"
+                      ]
                     },
                     {
                       "type": "object",
@@ -11620,6 +12607,27 @@
                           "title": "Script",
                           "description": "The message body set via script."
                         }
+                      }
+                    },
+                    {
+                      "not": {
+                        "anyOf": [
+                          {
+                            "required": [
+                              "data"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "resource"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "script"
+                            ]
+                          }
+                        ]
                       }
                     }
                   ]
@@ -11682,6 +12690,9 @@
                 "type": "object",
                 "properties": {
                   "data": {
+                    "type": "string",
+                    "title": "Data",
+                    "description": "The message header value as inline data."
                   },
                   "name": {
                     "type": "string",
@@ -11697,6 +12708,9 @@
                     "$comment": "group:advanced"
                   },
                   "value": {
+                    "type": "string",
+                    "title": "Value",
+                    "description": "The message header value."
                   }
                 },
                 "additionalProperties": false,
@@ -11704,14 +12718,9 @@
                   {
                     "oneOf": [
                       {
-                        "type": "object",
-                        "properties": {
-                          "value": {
-                            "type": "string",
-                            "title": "Value",
-                            "description": "The message header value."
-                          }
-                        }
+                        "required": [
+                          "value"
+                        ]
                       },
                       {
                         "type": "object",
@@ -11741,13 +12750,29 @@
                         }
                       },
                       {
-                        "type": "object",
-                        "properties": {
-                          "data": {
-                            "type": "string",
-                            "title": "Data",
-                            "description": "The message header value as inline data."
-                          }
+                        "required": [
+                          "data"
+                        ]
+                      },
+                      {
+                        "not": {
+                          "anyOf": [
+                            {
+                              "required": [
+                                "value"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "resource"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "data"
+                              ]
+                            }
+                          ]
                         }
                       }
                     ]
@@ -12589,8 +13614,14 @@
           "title": "ApiVersion"
         },
         "data": {
+          "type": "string",
+          "title": "Data",
+          "description": "The custom resource specification as inline data."
         },
         "file": {
+          "type": "string",
+          "title": "File",
+          "description": "The custom resource specification loaded from a file resource."
         },
         "group": {
           "type": "string",
@@ -12614,23 +13645,29 @@
         {
           "oneOf": [
             {
-              "type": "object",
-              "properties": {
-                "data": {
-                  "type": "string",
-                  "title": "Data",
-                  "description": "The custom resource specification as inline data."
-                }
-              }
+              "required": [
+                "data"
+              ]
             },
             {
-              "type": "object",
-              "properties": {
-                "file": {
-                  "type": "string",
-                  "title": "File",
-                  "description": "The custom resource specification loaded from a file resource."
-                }
+              "required": [
+                "file"
+              ]
+            },
+            {
+              "not": {
+                "anyOf": [
+                  {
+                    "required": [
+                      "data"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "file"
+                    ]
+                  }
+                ]
               }
             }
           ]
@@ -12691,8 +13728,14 @@
       "type": "object",
       "properties": {
         "data": {
+          "type": "string",
+          "title": "Data",
+          "description": "The custom resource specification as inline data."
         },
         "file": {
+          "type": "string",
+          "title": "File",
+          "description": "The custom resource specification loaded from a file resource."
         }
       },
       "additionalProperties": false,
@@ -12700,23 +13743,29 @@
         {
           "oneOf": [
             {
-              "type": "object",
-              "properties": {
-                "data": {
-                  "type": "string",
-                  "title": "Data",
-                  "description": "The custom resource specification as inline data."
-                }
-              }
+              "required": [
+                "data"
+              ]
             },
             {
-              "type": "object",
-              "properties": {
-                "file": {
-                  "type": "string",
-                  "title": "File",
-                  "description": "The custom resource specification loaded from a file resource."
-                }
+              "required": [
+                "file"
+              ]
+            },
+            {
+              "not": {
+                "anyOf": [
+                  {
+                    "required": [
+                      "data"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "file"
+                    ]
+                  }
+                ]
               }
             }
           ]
@@ -12909,8 +13958,14 @@
       "type": "object",
       "properties": {
         "data": {
+          "type": "string",
+          "title": "Data",
+          "description": "The custom resource specification as inline data."
         },
         "file": {
+          "type": "string",
+          "title": "File",
+          "description": "The custom resource specification loaded from a file resource."
         }
       },
       "additionalProperties": false,
@@ -12918,23 +13973,29 @@
         {
           "oneOf": [
             {
-              "type": "object",
-              "properties": {
-                "data": {
-                  "type": "string",
-                  "title": "Data",
-                  "description": "The custom resource specification as inline data."
-                }
-              }
+              "required": [
+                "data"
+              ]
             },
             {
-              "type": "object",
-              "properties": {
-                "file": {
-                  "type": "string",
-                  "title": "File",
-                  "description": "The custom resource specification loaded from a file resource."
-                }
+              "required": [
+                "file"
+              ]
+            },
+            {
+              "not": {
+                "anyOf": [
+                  {
+                    "required": [
+                      "data"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "file"
+                    ]
+                  }
+                ]
               }
             }
           ]
@@ -14350,6 +15411,9 @@
               "type": "object",
               "properties": {
                 "data": {
+                  "type": "string",
+                  "title": "Data",
+                  "description": "The message body content as inline data."
                 },
                 "resource": {
                 },
@@ -14361,14 +15425,9 @@
                 {
                   "oneOf": [
                     {
-                      "type": "object",
-                      "properties": {
-                        "data": {
-                          "type": "string",
-                          "title": "Data",
-                          "description": "The message body content as inline data."
-                        }
-                      }
+                      "required": [
+                        "data"
+                      ]
                     },
                     {
                       "type": "object",
@@ -14426,6 +15485,27 @@
                           "description": "The message body set via script."
                         }
                       }
+                    },
+                    {
+                      "not": {
+                        "anyOf": [
+                          {
+                            "required": [
+                              "data"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "resource"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "script"
+                            ]
+                          }
+                        ]
+                      }
                     }
                   ]
                 }
@@ -14482,6 +15562,9 @@
                 "type": "object",
                 "properties": {
                   "data": {
+                    "type": "string",
+                    "title": "Data",
+                    "description": "The message header value as inline data."
                   },
                   "name": {
                     "type": "string",
@@ -14497,6 +15580,9 @@
                     "$comment": "group:advanced"
                   },
                   "value": {
+                    "type": "string",
+                    "title": "Value",
+                    "description": "The message header value."
                   }
                 },
                 "additionalProperties": false,
@@ -14504,14 +15590,9 @@
                   {
                     "oneOf": [
                       {
-                        "type": "object",
-                        "properties": {
-                          "value": {
-                            "type": "string",
-                            "title": "Value",
-                            "description": "The message header value."
-                          }
-                        }
+                        "required": [
+                          "value"
+                        ]
                       },
                       {
                         "type": "object",
@@ -14541,13 +15622,29 @@
                         }
                       },
                       {
-                        "type": "object",
-                        "properties": {
-                          "data": {
-                            "type": "string",
-                            "title": "Data",
-                            "description": "The message header value as inline data."
-                          }
+                        "required": [
+                          "data"
+                        ]
+                      },
+                      {
+                        "not": {
+                          "anyOf": [
+                            {
+                              "required": [
+                                "value"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "resource"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "data"
+                              ]
+                            }
+                          ]
                         }
                       }
                     ]
@@ -16292,6 +17389,9 @@
               "type": "object",
               "properties": {
                 "data": {
+                  "type": "string",
+                  "title": "Data",
+                  "description": "The message body content as inline data."
                 },
                 "resource": {
                 },
@@ -16303,14 +17403,9 @@
                 {
                   "oneOf": [
                     {
-                      "type": "object",
-                      "properties": {
-                        "data": {
-                          "type": "string",
-                          "title": "Data",
-                          "description": "The message body content as inline data."
-                        }
-                      }
+                      "required": [
+                        "data"
+                      ]
                     },
                     {
                       "type": "object",
@@ -16368,6 +17463,27 @@
                           "description": "The message body set via script."
                         }
                       }
+                    },
+                    {
+                      "not": {
+                        "anyOf": [
+                          {
+                            "required": [
+                              "data"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "resource"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "script"
+                            ]
+                          }
+                        ]
+                      }
                     }
                   ]
                 }
@@ -16424,6 +17540,9 @@
                 "type": "object",
                 "properties": {
                   "data": {
+                    "type": "string",
+                    "title": "Data",
+                    "description": "The message header value as inline data."
                   },
                   "name": {
                     "type": "string",
@@ -16439,6 +17558,9 @@
                     "$comment": "group:advanced"
                   },
                   "value": {
+                    "type": "string",
+                    "title": "Value",
+                    "description": "The message header value."
                   }
                 },
                 "additionalProperties": false,
@@ -16446,14 +17568,9 @@
                   {
                     "oneOf": [
                       {
-                        "type": "object",
-                        "properties": {
-                          "value": {
-                            "type": "string",
-                            "title": "Value",
-                            "description": "The message header value."
-                          }
-                        }
+                        "required": [
+                          "value"
+                        ]
                       },
                       {
                         "type": "object",
@@ -16483,13 +17600,29 @@
                         }
                       },
                       {
-                        "type": "object",
-                        "properties": {
-                          "data": {
-                            "type": "string",
-                            "title": "Data",
-                            "description": "The message header value as inline data."
-                          }
+                        "required": [
+                          "data"
+                        ]
+                      },
+                      {
+                        "not": {
+                          "anyOf": [
+                            {
+                              "required": [
+                                "value"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "resource"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "data"
+                              ]
+                            }
+                          ]
                         }
                       }
                     ]
@@ -17129,6 +18262,9 @@
               "type": "object",
               "properties": {
                 "data": {
+                  "type": "string",
+                  "title": "Data",
+                  "description": "The message body content as inline data."
                 },
                 "resource": {
                 },
@@ -17140,14 +18276,9 @@
                 {
                   "oneOf": [
                     {
-                      "type": "object",
-                      "properties": {
-                        "data": {
-                          "type": "string",
-                          "title": "Data",
-                          "description": "The message body content as inline data."
-                        }
-                      }
+                      "required": [
+                        "data"
+                      ]
                     },
                     {
                       "type": "object",
@@ -17204,6 +18335,27 @@
                           "title": "Script",
                           "description": "The message body set via script."
                         }
+                      }
+                    },
+                    {
+                      "not": {
+                        "anyOf": [
+                          {
+                            "required": [
+                              "data"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "resource"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "script"
+                            ]
+                          }
+                        ]
                       }
                     }
                   ]
@@ -17266,6 +18418,9 @@
                 "type": "object",
                 "properties": {
                   "data": {
+                    "type": "string",
+                    "title": "Data",
+                    "description": "The message header value as inline data."
                   },
                   "name": {
                     "type": "string",
@@ -17281,6 +18436,9 @@
                     "$comment": "group:advanced"
                   },
                   "value": {
+                    "type": "string",
+                    "title": "Value",
+                    "description": "The message header value."
                   }
                 },
                 "additionalProperties": false,
@@ -17288,14 +18446,9 @@
                   {
                     "oneOf": [
                       {
-                        "type": "object",
-                        "properties": {
-                          "value": {
-                            "type": "string",
-                            "title": "Value",
-                            "description": "The message header value."
-                          }
-                        }
+                        "required": [
+                          "value"
+                        ]
                       },
                       {
                         "type": "object",
@@ -17325,13 +18478,29 @@
                         }
                       },
                       {
-                        "type": "object",
-                        "properties": {
-                          "data": {
-                            "type": "string",
-                            "title": "Data",
-                            "description": "The message header value as inline data."
-                          }
+                        "required": [
+                          "data"
+                        ]
+                      },
+                      {
+                        "not": {
+                          "anyOf": [
+                            {
+                              "required": [
+                                "value"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "resource"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "data"
+                              ]
+                            }
+                          ]
                         }
                       }
                     ]
@@ -17615,6 +18784,9 @@
               "type": "object",
               "properties": {
                 "data": {
+                  "type": "string",
+                  "title": "Data",
+                  "description": "The message body content as inline data."
                 },
                 "resource": {
                 },
@@ -17626,14 +18798,9 @@
                 {
                   "oneOf": [
                     {
-                      "type": "object",
-                      "properties": {
-                        "data": {
-                          "type": "string",
-                          "title": "Data",
-                          "description": "The message body content as inline data."
-                        }
-                      }
+                      "required": [
+                        "data"
+                      ]
                     },
                     {
                       "type": "object",
@@ -17690,6 +18857,27 @@
                           "title": "Script",
                           "description": "The message body set via script."
                         }
+                      }
+                    },
+                    {
+                      "not": {
+                        "anyOf": [
+                          {
+                            "required": [
+                              "data"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "resource"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "script"
+                            ]
+                          }
+                        ]
                       }
                     }
                   ]
@@ -17752,6 +18940,9 @@
                 "type": "object",
                 "properties": {
                   "data": {
+                    "type": "string",
+                    "title": "Data",
+                    "description": "The message header value as inline data."
                   },
                   "name": {
                     "type": "string",
@@ -17767,6 +18958,9 @@
                     "$comment": "group:advanced"
                   },
                   "value": {
+                    "type": "string",
+                    "title": "Value",
+                    "description": "The message header value."
                   }
                 },
                 "additionalProperties": false,
@@ -17774,14 +18968,9 @@
                   {
                     "oneOf": [
                       {
-                        "type": "object",
-                        "properties": {
-                          "value": {
-                            "type": "string",
-                            "title": "Value",
-                            "description": "The message header value."
-                          }
-                        }
+                        "required": [
+                          "value"
+                        ]
                       },
                       {
                         "type": "object",
@@ -17811,13 +19000,29 @@
                         }
                       },
                       {
-                        "type": "object",
-                        "properties": {
-                          "data": {
-                            "type": "string",
-                            "title": "Data",
-                            "description": "The message header value as inline data."
-                          }
+                        "required": [
+                          "data"
+                        ]
+                      },
+                      {
+                        "not": {
+                          "anyOf": [
+                            {
+                              "required": [
+                                "value"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "resource"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "data"
+                              ]
+                            }
+                          ]
                         }
                       }
                     ]
@@ -18231,6 +19436,9 @@
               "type": "object",
               "properties": {
                 "data": {
+                  "type": "string",
+                  "title": "Data",
+                  "description": "The message body content as inline data."
                 },
                 "resource": {
                 },
@@ -18242,14 +19450,9 @@
                 {
                   "oneOf": [
                     {
-                      "type": "object",
-                      "properties": {
-                        "data": {
-                          "type": "string",
-                          "title": "Data",
-                          "description": "The message body content as inline data."
-                        }
-                      }
+                      "required": [
+                        "data"
+                      ]
                     },
                     {
                       "type": "object",
@@ -18306,6 +19509,27 @@
                           "title": "Script",
                           "description": "The message body set via script."
                         }
+                      }
+                    },
+                    {
+                      "not": {
+                        "anyOf": [
+                          {
+                            "required": [
+                              "data"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "resource"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "script"
+                            ]
+                          }
+                        ]
                       }
                     }
                   ]
@@ -18409,6 +19633,9 @@
                 "type": "object",
                 "properties": {
                   "data": {
+                    "type": "string",
+                    "title": "Data",
+                    "description": "The message header value as inline data."
                   },
                   "name": {
                     "type": "string",
@@ -18424,6 +19651,9 @@
                     "$comment": "group:advanced"
                   },
                   "value": {
+                    "type": "string",
+                    "title": "Value",
+                    "description": "The message header value."
                   }
                 },
                 "additionalProperties": false,
@@ -18431,14 +19661,9 @@
                   {
                     "oneOf": [
                       {
-                        "type": "object",
-                        "properties": {
-                          "value": {
-                            "type": "string",
-                            "title": "Value",
-                            "description": "The message header value."
-                          }
-                        }
+                        "required": [
+                          "value"
+                        ]
                       },
                       {
                         "type": "object",
@@ -18468,13 +19693,29 @@
                         }
                       },
                       {
-                        "type": "object",
-                        "properties": {
-                          "data": {
-                            "type": "string",
-                            "title": "Data",
-                            "description": "The message header value as inline data."
-                          }
+                        "required": [
+                          "data"
+                        ]
+                      },
+                      {
+                        "not": {
+                          "anyOf": [
+                            {
+                              "required": [
+                                "value"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "resource"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "data"
+                              ]
+                            }
+                          ]
                         }
                       }
                     ]
@@ -18680,6 +19921,9 @@
               "type": "object",
               "properties": {
                 "data": {
+                  "type": "string",
+                  "title": "Data",
+                  "description": "The message body content as inline data."
                 },
                 "resource": {
                 },
@@ -18691,14 +19935,9 @@
                 {
                   "oneOf": [
                     {
-                      "type": "object",
-                      "properties": {
-                        "data": {
-                          "type": "string",
-                          "title": "Data",
-                          "description": "The message body content as inline data."
-                        }
-                      }
+                      "required": [
+                        "data"
+                      ]
                     },
                     {
                       "type": "object",
@@ -18755,6 +19994,27 @@
                           "title": "Script",
                           "description": "The message body set via script."
                         }
+                      }
+                    },
+                    {
+                      "not": {
+                        "anyOf": [
+                          {
+                            "required": [
+                              "data"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "resource"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "script"
+                            ]
+                          }
+                        ]
                       }
                     }
                   ]
@@ -18817,6 +20077,9 @@
                 "type": "object",
                 "properties": {
                   "data": {
+                    "type": "string",
+                    "title": "Data",
+                    "description": "The message header value as inline data."
                   },
                   "name": {
                     "type": "string",
@@ -18832,6 +20095,9 @@
                     "$comment": "group:advanced"
                   },
                   "value": {
+                    "type": "string",
+                    "title": "Value",
+                    "description": "The message header value."
                   }
                 },
                 "additionalProperties": false,
@@ -18839,14 +20105,9 @@
                   {
                     "oneOf": [
                       {
-                        "type": "object",
-                        "properties": {
-                          "value": {
-                            "type": "string",
-                            "title": "Value",
-                            "description": "The message header value."
-                          }
-                        }
+                        "required": [
+                          "value"
+                        ]
                       },
                       {
                         "type": "object",
@@ -18876,13 +20137,29 @@
                         }
                       },
                       {
-                        "type": "object",
-                        "properties": {
-                          "data": {
-                            "type": "string",
-                            "title": "Data",
-                            "description": "The message header value as inline data."
-                          }
+                        "required": [
+                          "data"
+                        ]
+                      },
+                      {
+                        "not": {
+                          "anyOf": [
+                            {
+                              "required": [
+                                "value"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "resource"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "data"
+                              ]
+                            }
+                          ]
                         }
                       }
                     ]
@@ -19088,6 +20365,9 @@
               "type": "object",
               "properties": {
                 "data": {
+                  "type": "string",
+                  "title": "Data",
+                  "description": "The message body content as inline data."
                 },
                 "resource": {
                 },
@@ -19099,14 +20379,9 @@
                 {
                   "oneOf": [
                     {
-                      "type": "object",
-                      "properties": {
-                        "data": {
-                          "type": "string",
-                          "title": "Data",
-                          "description": "The message body content as inline data."
-                        }
-                      }
+                      "required": [
+                        "data"
+                      ]
                     },
                     {
                       "type": "object",
@@ -19163,6 +20438,27 @@
                           "title": "Script",
                           "description": "The message body set via script."
                         }
+                      }
+                    },
+                    {
+                      "not": {
+                        "anyOf": [
+                          {
+                            "required": [
+                              "data"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "resource"
+                            ]
+                          },
+                          {
+                            "required": [
+                              "script"
+                            ]
+                          }
+                        ]
                       }
                     }
                   ]
@@ -19225,6 +20521,9 @@
                 "type": "object",
                 "properties": {
                   "data": {
+                    "type": "string",
+                    "title": "Data",
+                    "description": "The message header value as inline data."
                   },
                   "name": {
                     "type": "string",
@@ -19240,6 +20539,9 @@
                     "$comment": "group:advanced"
                   },
                   "value": {
+                    "type": "string",
+                    "title": "Value",
+                    "description": "The message header value."
                   }
                 },
                 "additionalProperties": false,
@@ -19247,14 +20549,9 @@
                   {
                     "oneOf": [
                       {
-                        "type": "object",
-                        "properties": {
-                          "value": {
-                            "type": "string",
-                            "title": "Value",
-                            "description": "The message header value."
-                          }
-                        }
+                        "required": [
+                          "value"
+                        ]
                       },
                       {
                         "type": "object",
@@ -19284,13 +20581,29 @@
                         }
                       },
                       {
-                        "type": "object",
-                        "properties": {
-                          "data": {
-                            "type": "string",
-                            "title": "Data",
-                            "description": "The message header value as inline data."
-                          }
+                        "required": [
+                          "data"
+                        ]
+                      },
+                      {
+                        "not": {
+                          "anyOf": [
+                            {
+                              "required": [
+                                "value"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "resource"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "data"
+                              ]
+                            }
+                          ]
                         }
                       }
                     ]
@@ -21082,6 +22395,32 @@
                   "title": "Action",
                   "description": "Waits for the test action to complete."
                 }
+              }
+            },
+            {
+              "not": {
+                "anyOf": [
+                  {
+                    "required": [
+                      "message"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "http"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "file"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "action"
+                    ]
+                  }
+                ]
               }
             }
           ]


### PR DESCRIPTION
## Summary
- Add `not { anyOf }` constraint to oneOf schema generation in `CitrusModule` to enforce proper mutual exclusivity in generated JSON schemas
- Remove duplicate `PUT` entries in HTTP method enums in `Http.java`
- Update control test resource to reflect the corrected schema output

Fixes #1609

## Test plan
- [ ] Verify `citrus-catalog-aggregate-test-actions.json` control file matches generated output
- [ ] Run schema-generator tests: `./mvnw test -pl tools/schema-generator`
- [ ] Run citrus-http tests: `./mvnw test -pl endpoints/citrus-http`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)