### PR TITLE
fix(#1609): Change Cli.cmd.receive.tail type from String to int

### DIFF
--- a/core/citrus-api/src/main/java/org/citrusframework/actions/camel/CamelCliCmdReceiveActionBuilder.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/actions/camel/CamelCliCmdReceiveActionBuilder.java
@@ -53,7 +53,7 @@ public interface CamelCliCmdReceiveActionBuilder<T extends TestAction, B extends
 
     B since(String duration);
 
-    B tail(String numberOfMessages);
+    B tail(int numberOfMessages);
 
     B maxAttempts(int maxAttempts);
 

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelCmdReceiveAction.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelCmdReceiveAction.java
@@ -61,7 +61,7 @@ public class CamelCmdReceiveAction extends AbstractCamelCliAction {
     private final String since;
 
     /** The number of messages from the end to show */
-    private final String tail;
+    private final int tail;
 
     /** Should use Json output and verify */
     private final boolean jsonOutput;
@@ -126,10 +126,8 @@ public class CamelCmdReceiveAction extends AbstractCamelCliAction {
             commandArgs.add(since);
         }
 
-        if (StringUtils.hasText(tail)) {
-            commandArgs.add("--tail");
-            commandArgs.add(tail);
-        }
+        commandArgs.add("--tail");
+        commandArgs.add(String.valueOf(tail));
 
         if (jsonOutput) {
             commandArgs.add("--output=json");
@@ -238,7 +236,7 @@ public class CamelCmdReceiveAction extends AbstractCamelCliAction {
         private String endpointUri;
         private String grep;
         private String since;
-        private String tail = "0";
+        private int tail = 0;
         private boolean jsonOutput;
         private final List<String> args = new ArrayList<>();
 
@@ -310,7 +308,7 @@ public class CamelCmdReceiveAction extends AbstractCamelCliAction {
         }
 
         @Override
-        public Builder tail(String numberOfMessages) {
+        public Builder tail(int numberOfMessages) {
             this.tail = numberOfMessages;
             return this;
         }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/Camel.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/Camel.java
@@ -405,9 +405,7 @@ public class Camel implements TestActionBuilder<TestAction>, ReferenceResolverAw
                     builder.since(cli.getCmd().getReceive().getSince());
                 }
 
-                if (cli.getCmd().getReceive().getTail() != null) {
-                    builder.tail(cli.getCmd().getReceive().getTail());
-                }
+                builder.tail(cli.getCmd().getReceive().getTail());
 
                 builder.maxAttempts(cli.getCmd().getReceive().getMaxAttempts());
                 builder.delayBetweenAttempts(cli.getCmd().getReceive().getDelayBetweenAttempts());

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/Cli.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/Cli.java
@@ -1235,7 +1235,7 @@ public class Cli {
             @XmlAttribute(name = "since")
             protected String since;
             @XmlAttribute(name = "tail")
-            protected String tail;
+            protected int tail;
 
             @XmlAttribute(name = "max-attempts")
             private int maxAttempts = CamelSettings.getMaxAttempts();
@@ -1306,11 +1306,11 @@ public class Cli {
                 return since;
             }
 
-            public void setTail(String tail) {
+            public void setTail(int tail) {
                 this.tail = tail;
             }
 
-            public String getTail() {
+            public int getTail() {
                 return tail;
             }
 

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/Cli.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/Cli.java
@@ -804,9 +804,7 @@ public class Cli implements CamelActionBuilderWrapper<AbstractCamelCliAction.Bui
                 builder.since(receive.getSince());
             }
 
-            if (receive.getTail() != null) {
-                builder.tail(receive.getTail());
-            }
+            builder.tail(receive.getTail());
 
             builder.maxAttempts(receive.getMaxAttempts());
             builder.delayBetweenAttempts(receive.getDelayBetweenAttempts());
@@ -958,7 +956,7 @@ public class Cli implements CamelActionBuilderWrapper<AbstractCamelCliAction.Bui
 
             protected String grep;
             protected String since;
-            protected String tail;
+            protected int tail;
 
             protected int maxAttempts = CamelSettings.getMaxAttempts();
             protected long delayBetweenAttempts = CamelSettings.getDelayBetweenAttempts();
@@ -1041,12 +1039,12 @@ public class Cli implements CamelActionBuilderWrapper<AbstractCamelCliAction.Bui
                 this.since = since;
             }
 
-            public String getTail() {
+            public int getTail() {
                 return tail;
             }
 
             @SchemaProperty(advanced = true, description = "The number of messages from the end to show.", defaultValue = "0")
-            public void setTail(String tail) {
+            public void setTail(int tail) {
                 this.tail = tail;
             }
 

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-5.0.0-SNAPSHOT.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-5.0.0-SNAPSHOT.xsd
@@ -2455,7 +2455,7 @@
                         <xs:attribute name="args" type="xs:string"/>
                         <xs:attribute name="grep" type="xs:string"/>
                         <xs:attribute name="since" type="xs:string"/>
-                        <xs:attribute name="tail" type="xs:string"/>
+                        <xs:attribute name="tail" type="xs:int"/>
                         <xs:attribute name="max-attempts" type="xs:int"/>
                         <xs:attribute name="delay-between-attempts" type="xs:int"/>
                         <xs:attribute name="print-logs" type="xs:boolean"/>
@@ -2901,7 +2901,7 @@
                         <xs:attribute name="args" type="xs:string"/>
                         <xs:attribute name="grep" type="xs:string"/>
                         <xs:attribute name="since" type="xs:string"/>
-                        <xs:attribute name="tail" type="xs:string"/>
+                        <xs:attribute name="tail" type="xs:int"/>
                         <xs:attribute name="max-attempts" type="xs:int"/>
                         <xs:attribute name="delay-between-attempts" type="xs:int"/>
                         <xs:attribute name="print-logs" type="xs:boolean"/>

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
@@ -2455,7 +2455,7 @@
                         <xs:attribute name="args" type="xs:string"/>
                         <xs:attribute name="grep" type="xs:string"/>
                         <xs:attribute name="since" type="xs:string"/>
-                        <xs:attribute name="tail" type="xs:string"/>
+                        <xs:attribute name="tail" type="xs:int"/>
                         <xs:attribute name="max-attempts" type="xs:int"/>
                         <xs:attribute name="delay-between-attempts" type="xs:int"/>
                         <xs:attribute name="print-logs" type="xs:boolean"/>
@@ -2901,7 +2901,7 @@
                         <xs:attribute name="args" type="xs:string"/>
                         <xs:attribute name="grep" type="xs:string"/>
                         <xs:attribute name="since" type="xs:string"/>
-                        <xs:attribute name="tail" type="xs:string"/>
+                        <xs:attribute name="tail" type="xs:int"/>
                         <xs:attribute name="max-attempts" type="xs:int"/>
                         <xs:attribute name="delay-between-attempts" type="xs:int"/>
                         <xs:attribute name="print-logs" type="xs:boolean"/>

--- a/tools/schema-generator/src/test/resources/control/citrus-catalog-aggregate-test-actions.json
+++ b/tools/schema-generator/src/test/resources/control/citrus-catalog-aggregate-test-actions.json
@@ -380,10 +380,10 @@
           "$comment": "group:advanced"
         },
         "tail": {
-          "type": "string",
+          "type": "integer",
           "title": "Tail",
           "description": "The number of messages from the end to show.",
-          "default": "0",
+          "default": 0,
           "$comment": "group:advanced"
         },
         "uri": {


### PR DESCRIPTION
## Summary
- Changes `tail` property type from `String` to `int` across the API interface, action builder, XML/YAML model classes, and XSD schemas
- Fixes the generated JSON Schema to emit `"type": "integer", "default": 0` instead of `"type": "string", "default": "0"`
- Updates schema-generator test control data to match the corrected output

Fixes point 1.5 of #1609.

## Test plan
- [x] `CamelCmdReceiveActionTest` — all 5 unit tests pass
- [x] `CitrusSchemaGeneratorTest` — all 8 tests pass after updating control file
- [x] Full build with `-DskipTests` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)