### PR TITLE
fix(#1592): Fix compiler warnings in citrus-spring module

### DIFF
--- a/core/citrus-spring/src/main/java/org/citrusframework/config/xml/AbstractEndpointParser.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/config/xml/AbstractEndpointParser.java
@@ -70,7 +70,6 @@ public abstract class AbstractEndpointParser extends AbstractBeanDefinitionParse
      * @param endpointConfigurationBuilder
      * @param element
      * @param parserContext
-     * @return
      */
     protected void parseEndpointConfiguration(BeanDefinitionBuilder endpointConfigurationBuilder, Element element, ParserContext parserContext) {
         BeanDefinitionParserUtils.setPropertyValue(endpointConfigurationBuilder, element.getAttribute("timeout"), "timeout");
@@ -81,7 +80,6 @@ public abstract class AbstractEndpointParser extends AbstractBeanDefinitionParse
      * @param endpointBuilder
      * @param element
      * @param parserContext
-     * @return
      */
     protected void parseEndpoint(BeanDefinitionBuilder endpointBuilder, Element element, ParserContext parserContext) {
     }

--- a/core/citrus-spring/src/main/java/org/citrusframework/config/xml/AbstractSendMessageActionFactoryBean.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/config/xml/AbstractSendMessageActionFactoryBean.java
@@ -48,7 +48,6 @@ public abstract class AbstractSendMessageActionFactoryBean<T extends SendMessage
      * Sets schema validation enabled/disabled for this message.
      *
      * @param enabled
-     * @return
      */
     public void setSchemaValidation(final boolean enabled) {
         getBuilder().getMessageBuilderSupport().schemaValidation(enabled);
@@ -58,7 +57,6 @@ public abstract class AbstractSendMessageActionFactoryBean<T extends SendMessage
      * Sets explicit schema instance name to use for schema validation.
      *
      * @param schemaName
-     * @return
      */
     public void setSchema(final String schemaName) {
         getBuilder().getMessageBuilderSupport().schema(schemaName);
@@ -68,7 +66,6 @@ public abstract class AbstractSendMessageActionFactoryBean<T extends SendMessage
      * Sets explicit schema repository instance to use for validation.
      *
      * @param schemaRepository
-     * @return
      */
     public void setSchemaRepository(final String schemaRepository) {
         getBuilder().getMessageBuilderSupport().schemaRepository(schemaRepository);

--- a/core/citrus-spring/src/main/java/org/citrusframework/config/xml/AbstractServerParser.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/config/xml/AbstractServerParser.java
@@ -63,7 +63,6 @@ public abstract class AbstractServerParser extends AbstractBeanDefinitionParser 
      * @param serverBuilder
      * @param element
      * @param parserContext
-     * @return
      */
     protected abstract void parseServer(BeanDefinitionBuilder serverBuilder, Element element, ParserContext parserContext);
 

--- a/core/citrus-spring/src/main/java/org/citrusframework/config/xml/MessageValidatorRegistryParser.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/config/xml/MessageValidatorRegistryParser.java
@@ -48,7 +48,7 @@ public class MessageValidatorRegistryParser implements BeanDefinitionParser {
      * @param element the source element.
      */
     private void parseValidators(BeanDefinitionBuilder builder, Element element) {
-        ManagedMap validators = new ManagedMap();
+        ManagedMap<String, Object> validators = new ManagedMap<>();
         for (Element validator : DomUtils.getChildElementsByTagName(element, "validator")) {
 
             if (validator.hasAttribute("ref")) {

--- a/core/citrus-spring/src/main/java/org/citrusframework/config/xml/RepeatOnErrorUntilTrueParser.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/config/xml/RepeatOnErrorUntilTrueParser.java
@@ -48,6 +48,7 @@ public class RepeatOnErrorUntilTrueParser extends AbstractIterationTestActionPar
          * Setter for auto sleep time (in milliseconds).
          * @param autoSleep the auto sleep time in between repeats in milliseconds
          */
+        @SuppressWarnings("deprecation")
         public void setAutoSleep(Long autoSleep) {
             this.builder.autoSleep(autoSleep);
         }

--- a/core/citrus-spring/src/main/java/org/citrusframework/io/CitrusResourceEditor.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/io/CitrusResourceEditor.java
@@ -21,7 +21,7 @@ import org.citrusframework.spi.Resource;
 import org.citrusframework.spi.Resources;
 import org.springframework.core.env.PropertyResolver;
 import org.springframework.core.env.StandardEnvironment;
-import org.springframework.lang.Nullable;
+import jakarta.annotation.Nullable;
 import org.springframework.util.StringUtils;
 
 /**

--- a/core/citrus-spring/src/main/java/org/citrusframework/util/SpringBeanTypeConverter.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/util/SpringBeanTypeConverter.java
@@ -48,6 +48,7 @@ public final class SpringBeanTypeConverter extends DefaultTypeConverter {
     private SpringBeanTypeConverter() {
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     protected <T> Optional<T> convertBefore(Object target, Class<T> type) {
         if (Source.class.isAssignableFrom(type) &&

--- a/core/citrus-spring/src/main/java/org/citrusframework/validation/MessageValidatorRegistryFactory.java
+++ b/core/citrus-spring/src/main/java/org/citrusframework/validation/MessageValidatorRegistryFactory.java
@@ -41,6 +41,7 @@ public class MessageValidatorRegistryFactory implements FactoryBean<MessageValid
         this.registry = messageValidatorRegistry;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public MessageValidatorRegistry getObject() {
         if (applicationContext != null) {

--- a/core/citrus-spring/src/test/java/org/citrusframework/config/xml/CustomTestCaseParserTest.java
+++ b/core/citrus-spring/src/test/java/org/citrusframework/config/xml/CustomTestCaseParserTest.java
@@ -85,7 +85,7 @@ public class CustomTestCaseParserTest extends AbstractActionParserTest<EchoActio
         }
     }
 
-    public static class CustomTestCaseParser extends BaseTestCaseParser {
+    public static class CustomTestCaseParser extends BaseTestCaseParser<CustomTestCase> {
 
         public CustomTestCaseParser() {
             super(CustomTestCase.class);

--- a/core/citrus-spring/src/test/java/org/citrusframework/config/xml/RepeatOnErrorUntilTrueParserTest.java
+++ b/core/citrus-spring/src/test/java/org/citrusframework/config/xml/RepeatOnErrorUntilTrueParserTest.java
@@ -27,6 +27,7 @@ import static org.testng.Assert.assertNull;
 
 public class RepeatOnErrorUntilTrueParserTest extends AbstractActionParserTest<RepeatOnErrorUntilTrue> {
 
+    @SuppressWarnings("removal")
     @Test
     public void testRepeatOnErrorParser() {
         assertActionCount(4);

--- a/core/citrus-spring/src/test/java/org/citrusframework/util/SpringBeanTypeConverterTest.java
+++ b/core/citrus-spring/src/test/java/org/citrusframework/util/SpringBeanTypeConverterTest.java
@@ -26,6 +26,7 @@ public class SpringBeanTypeConverterTest {
 
     private final SpringBeanTypeConverter converter = SpringBeanTypeConverter.INSTANCE;
 
+    @SuppressWarnings("unchecked")
     @Test
     public void testConverter() {
         Assert.assertEquals(converter.convertIfNecessary("{key=[value]}", MultiValueMap.class).getFirst("key"), new String[] {"value"});

--- a/utils/citrus-test-support/src/main/java/org/citrusframework/testng/AbstractBeanDefinitionParserTest.java
+++ b/utils/citrus-test-support/src/main/java/org/citrusframework/testng/AbstractBeanDefinitionParserTest.java
@@ -35,7 +35,6 @@ public abstract class AbstractBeanDefinitionParserTest extends AbstractTestNGUni
      * for SimpleClassName-context.xml application context file in test package and
      * builds child application context.
      *
-     * @return
      */
     @BeforeClass(alwaysRun = true, dependsOnMethods = "springTestContextPrepareTestInstance")
     protected void parseBeanDefinitions() {


### PR DESCRIPTION
## Summary
Fixes all compiler warnings in the `core/citrus-spring` module (and one Javadoc warning in `utils/citrus-test-support`) as part of #1592.

- Parameterize raw `ManagedMap` in `MessageValidatorRegistryParser`
- Replace deprecated `org.springframework.lang.Nullable` with `jakarta.annotation.Nullable` in `CitrusResourceEditor`
- `@SuppressWarnings("unchecked")` for generic casts in `SpringBeanTypeConverter` and `MessageValidatorRegistryFactory`
- `@SuppressWarnings("deprecation")` for deprecated `autoSleep(long)` call in `RepeatOnErrorUntilTrueParser`
- `@SuppressWarnings("removal")` for deprecated-for-removal `getAutoSleep()` in test
- Remove `@return` tags from void method Javadocs (4 files)
- Parameterize raw `BaseTestCaseParser` in `CustomTestCaseParserTest`
- `@SuppressWarnings("unchecked")` for raw `MultiValueMap` usage in test

## Test plan
- [x] Zero compiler warnings in `core/citrus-spring` module build
- [x] All 100 tests pass (97 unit + 3 integration)
- [x] Full root build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)