### PR TITLE
fix(#1592): Fix compiler warnings in all runtime modules

### DIFF
--- a/runtime/citrus-cucumber/src/main/java/org/citrusframework/cucumber/CitrusReporter.java
+++ b/runtime/citrus-cucumber/src/main/java/org/citrusframework/cucumber/CitrusReporter.java
@@ -27,6 +27,7 @@ import io.cucumber.plugin.event.TestRunFinished;
 /**
  * @since 2.6
  */
+@SuppressWarnings("deprecation")
 public class CitrusReporter implements SummaryPrinter, ColorAware, ConcurrentEventListener {
 
     public static final String SUITE_NAME = "cucumber-suite";

--- a/runtime/citrus-cucumber/src/main/java/org/citrusframework/cucumber/CucumberTestEngine.java
+++ b/runtime/citrus-cucumber/src/main/java/org/citrusframework/cucumber/CucumberTestEngine.java
@@ -198,6 +198,7 @@ public class CucumberTestEngine extends AbstractTestEngine {
             );
         }
 
+        @SuppressWarnings("unchecked")
         <T> T getOptionValue(String optionName) {
             try {
                 Method method = options.annotationType().getDeclaredMethod(optionName);

--- a/runtime/citrus-cucumber/src/main/java/org/citrusframework/cucumber/backend/CitrusObjectFactory.java
+++ b/runtime/citrus-cucumber/src/main/java/org/citrusframework/cucumber/backend/CitrusObjectFactory.java
@@ -64,6 +64,7 @@ public class CitrusObjectFactory implements ObjectFactory {
         instances.clear();
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public <T> T getInstance(Class<T> type) {
         if (CitrusObjectFactory.class.isAssignableFrom(type)) {

--- a/runtime/citrus-cucumber/src/main/java/org/citrusframework/cucumber/backend/spring/CitrusSpringObjectFactory.java
+++ b/runtime/citrus-cucumber/src/main/java/org/citrusframework/cucumber/backend/spring/CitrusSpringObjectFactory.java
@@ -75,6 +75,7 @@ public class CitrusSpringObjectFactory implements ObjectFactory {
         delegate.stop();
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public <T> T getInstance(Class<T> type) {
         if (TestContext.class.isAssignableFrom(type)) {

--- a/runtime/citrus-cucumber/src/main/java/org/citrusframework/cucumber/report/json/TerminationLogReporter.java
+++ b/runtime/citrus-cucumber/src/main/java/org/citrusframework/cucumber/report/json/TerminationLogReporter.java
@@ -62,6 +62,7 @@ public class TerminationLogReporter extends CitrusReporter {
         super.setEventPublisher(publisher);
     }
 
+    @SuppressWarnings("deprecation")
     private void addTestDetail(TestCaseStarted event) {
         testResults.addTestResult(new TestResult(event.getTestCase().getId(), event.getTestCase().getName(),
                 FeatureHelper.extractFeatureFileName(event.getTestCase().getUri()) + ":" + event.getTestCase().getLine()));
@@ -70,6 +71,7 @@ public class TerminationLogReporter extends CitrusReporter {
     /**
      * Adds step error to test results.
      */
+    @SuppressWarnings("deprecation")
     private void checkStepErrors(TestStepFinished event) {
         if (event.getTestStep() instanceof HookTestStep) {
             return;

--- a/runtime/citrus-cucumber/src/test/java/org/citrusframework/cucumber/integration/birthday/BirthdayXmlFeatureIT.java
+++ b/runtime/citrus-cucumber/src/test/java/org/citrusframework/cucumber/integration/birthday/BirthdayXmlFeatureIT.java
@@ -23,6 +23,7 @@ import org.junit.runner.RunWith;
 /**
  * @since 2.6
  */
+@SuppressWarnings("deprecation")
 @RunWith(Cucumber.class)
 @CucumberOptions(
         glue = { "org.citrusframework.cucumber.integration.birthday" },

--- a/runtime/citrus-cucumber/src/test/java/org/citrusframework/cucumber/integration/echo/EchoFeatureIT.java
+++ b/runtime/citrus-cucumber/src/test/java/org/citrusframework/cucumber/integration/echo/EchoFeatureIT.java
@@ -23,6 +23,7 @@ import org.junit.runner.RunWith;
 /**
  * @since 2.6
  */
+@SuppressWarnings("deprecation")
 @RunWith(Cucumber.class)
 @CucumberOptions(
         plugin = { "pretty", "org.citrusframework.cucumber.CitrusReporter" } )

--- a/runtime/citrus-cucumber/src/test/java/org/citrusframework/cucumber/integration/report/ReportVerifyPlugin.java
+++ b/runtime/citrus-cucumber/src/test/java/org/citrusframework/cucumber/integration/report/ReportVerifyPlugin.java
@@ -29,6 +29,7 @@ import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@SuppressWarnings("deprecation")
 public class ReportVerifyPlugin implements SummaryPrinter, EventListener {
 
     /** Logger */

--- a/runtime/citrus-cucumber/src/test/java/org/citrusframework/cucumber/integration/report/TerminationLogReporterTest.java
+++ b/runtime/citrus-cucumber/src/test/java/org/citrusframework/cucumber/integration/report/TerminationLogReporterTest.java
@@ -20,6 +20,7 @@ import io.cucumber.junit.Cucumber;
 import io.cucumber.junit.CucumberOptions;
 import org.junit.runner.RunWith;
 
+@SuppressWarnings("deprecation")
 @RunWith(Cucumber.class)
 @CucumberOptions(
         plugin = {

--- a/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/GroovyShellUtils.java
+++ b/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/GroovyShellUtils.java
@@ -72,6 +72,7 @@ public class GroovyShellUtils {
      * @param <T> return type
      * @return script result
      */
+    @SuppressWarnings("unchecked")
     public static <T> T run(ImportCustomizer ic, Object delegate, String scriptCode, Citrus citrus, TestContext context) {
         CompilerConfiguration cc = new CompilerConfiguration();
         cc.addCompilationCustomizers(ic);

--- a/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/actions/ActionsBuilder.java
+++ b/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/actions/ActionsBuilder.java
@@ -41,7 +41,6 @@ public interface ActionsBuilder extends TestActionSupport {
      * Shortcut method running given test action builder.
      * @param builder
      * @param <T>
-     * @return
      */
     <T extends TestAction> void $(TestActionBuilder<T> builder);
 

--- a/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/configuration/endpoints/EndpointBuilderHelper.java
+++ b/runtime/citrus-groovy/src/main/java/org/citrusframework/groovy/dsl/configuration/endpoints/EndpointBuilderHelper.java
@@ -59,8 +59,9 @@ public class EndpointBuilderHelper {
             }
 
             // Remove when bug in EndpointBuilder.lookup() with cached endpoint builders is fixed
-            return builder.getClass().newInstance();
-        } catch (InstantiationException | IllegalAccessException e) {
+            return builder.getClass().getDeclaredConstructor().newInstance();
+        } catch (InstantiationException | IllegalAccessException | NoSuchMethodException |
+                 java.lang.reflect.InvocationTargetException e) {
             throw new CitrusRuntimeException("Unable to instantiate endpoint builder", e);
         }
     }

--- a/runtime/citrus-groovy/src/main/java/org/citrusframework/message/builder/script/GroovyScriptPayloadBuilder.java
+++ b/runtime/citrus-groovy/src/main/java/org/citrusframework/message/builder/script/GroovyScriptPayloadBuilder.java
@@ -86,9 +86,9 @@ public class GroovyScriptPayloadBuilder implements ScriptPayloadBuilder {
                 throw new CitrusRuntimeException("Could not load groovy script!");
             }
 
-            GroovyObject groovyObject = (GroovyObject) groovyClass.newInstance();
+            GroovyObject groovyObject = (GroovyObject) groovyClass.getDeclaredConstructor().newInstance();
             return (String) groovyObject.invokeMethod("run", new Object[] {});
-        } catch (CompilationFailedException | IllegalAccessException | InstantiationException | IOException e) {
+        } catch (CompilationFailedException | ReflectiveOperationException | IOException e) {
             throw new CitrusRuntimeException(e);
         }
     }

--- a/runtime/citrus-groovy/src/main/java/org/citrusframework/script/GroovyAction.java
+++ b/runtime/citrus-groovy/src/main/java/org/citrusframework/script/GroovyAction.java
@@ -140,6 +140,7 @@ public class GroovyAction extends AbstractTestAction {
         }
     }
 
+    @SuppressWarnings("removal")
     private GroovyClassLoader getPrivilegedGroovyLoader() {
         return AccessController.doPrivileged((PrivilegedAction<GroovyClassLoader>) () -> {
             ClassLoader parent = ClassLoaderHelper.getClassLoader();

--- a/runtime/citrus-groovy/src/main/java/org/citrusframework/util/GroovyTypeConverter.java
+++ b/runtime/citrus-groovy/src/main/java/org/citrusframework/util/GroovyTypeConverter.java
@@ -32,6 +32,7 @@ public final class GroovyTypeConverter extends DefaultTypeConverter {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     protected <T> Optional<T> convertBefore(Object target, Class<T> type) {
         if (GString.class.isAssignableFrom(type)) {
             return (Optional<T>) Optional.of(new GStringImpl(new Object[]{ target }, new String[] {"", ""}));
@@ -43,6 +44,7 @@ public final class GroovyTypeConverter extends DefaultTypeConverter {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <T> T convertStringToType(String value, Class<T> type) {
         if (GString.class.isAssignableFrom(type)) {
             return (T) new GStringImpl(new Object[]{ value }, new String[] {"", ""});

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/ReceiveTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/ReceiveTest.java
@@ -74,6 +74,7 @@ public class ReceiveTest extends AbstractGroovyActionDslTest {
     final MessageValidator<?> defaultMessageValidator = Mockito.mock(MessageValidator.class);
 
     @Test
+    @SuppressWarnings("unchecked")
     public void shouldLoadReceive() throws IOException {
         GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/groovy/dsl/receive.citrus.test.groovy");
 

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/RepeatOnErrorTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/dsl/container/RepeatOnErrorTest.java
@@ -28,6 +28,7 @@ import org.testng.annotations.Test;
 public class RepeatOnErrorTest extends AbstractGroovyActionDslTest {
 
     @Test
+    @SuppressWarnings("removal")
     public void shouldLoadRepeatOnError() {
         GroovyTestLoader testLoader = createTestLoader("classpath:org/citrusframework/groovy/dsl/container/repeat-on-error.citrus.test.groovy");
 

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/xml/AbstractXmlActionTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/xml/AbstractXmlActionTest.java
@@ -78,6 +78,7 @@ public class AbstractXmlActionTest extends AbstractTestNGUnitTest {
         return testLoader;
     }
 
+    @SuppressWarnings("unchecked")
     protected static class NoopTestCaseRunner extends DefaultTestCaseRunner {
         public NoopTestCaseRunner(TestContext context) {
             super(context);

--- a/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/yaml/AbstractYamlActionTest.java
+++ b/runtime/citrus-groovy/src/test/java/org/citrusframework/groovy/yaml/AbstractYamlActionTest.java
@@ -78,6 +78,7 @@ public class AbstractYamlActionTest extends AbstractTestNGUnitTest {
         return testLoader;
     }
 
+    @SuppressWarnings("unchecked")
     protected static class NoopTestCaseRunner extends DefaultTestCaseRunner {
         public NoopTestCaseRunner(TestContext context) {
             super(context);

--- a/runtime/citrus-junit-jupiter/src/main/java/org/citrusframework/junit/jupiter/CitrusExtension.java
+++ b/runtime/citrus-junit-jupiter/src/main/java/org/citrusframework/junit/jupiter/CitrusExtension.java
@@ -274,6 +274,7 @@ public class CitrusExtension implements BeforeAllCallback, InvocationInterceptor
         }
     }
 
+    @SuppressWarnings("deprecation")
     private record AfterSuiteCallback(ExtensionContext extensionContext, String suiteName,
                                       String... tags) implements ExtensionContext.Store.CloseableResource, AutoCloseable {
 

--- a/runtime/citrus-junit-jupiter/src/main/java/org/citrusframework/junit/jupiter/CitrusExtensionHelper.java
+++ b/runtime/citrus-junit-jupiter/src/main/java/org/citrusframework/junit/jupiter/CitrusExtensionHelper.java
@@ -85,6 +85,7 @@ public final class CitrusExtensionHelper {
      * Get the {@link TestCaseRunner} associated with the supplied {@code ExtensionContext} and its required test class name.
      * @return the {@code TestCaseRunner} (never {@code null})
      */
+    @SuppressWarnings("deprecation")
     public static TestCaseRunner getTestRunner(ExtensionContext extensionContext) {
         ObjectHelper.assertNotNull(extensionContext, "ExtensionContext must not be null");
 
@@ -106,6 +107,7 @@ public final class CitrusExtensionHelper {
      * Get the {@link TestLoader} associated with the supplied {@code ExtensionContext} and its required test class name.
      * @return the {@code TestLoader} (never {@code null})
      */
+    @SuppressWarnings("deprecation")
     public static TestLoader getTestLoader(ExtensionContext extensionContext) {
         ObjectHelper.assertNotNull(extensionContext, "ExtensionContext must not be null");
 
@@ -117,6 +119,7 @@ public final class CitrusExtensionHelper {
      * Get the {@link TestCase} associated with the supplied {@code ExtensionContext} and its required test class name.
      * @return the {@code TestCase} (never {@code null})
      */
+    @SuppressWarnings("deprecation")
     public static TestCase getTestCase(ExtensionContext extensionContext) {
         ObjectHelper.assertNotNull(extensionContext, "ExtensionContext must not be null");
         return extensionContext.getRoot().getStore(CitrusExtension.NAMESPACE).getOrComputeIfAbsent(getBaseKey(extensionContext) + TestCase.class.getSimpleName(), key -> {
@@ -163,6 +166,7 @@ public final class CitrusExtensionHelper {
      * Get the {@link TestContext} associated with the supplied {@code ExtensionContext} and its required test class name.
      * @return the {@code TestContext} (never {@code null})
      */
+    @SuppressWarnings("deprecation")
     public static TestContext getTestContext(ExtensionContext extensionContext) {
         ObjectHelper.assertNotNull(extensionContext, "ExtensionContext must not be null");
         return extensionContext.getRoot().getStore(CitrusExtension.NAMESPACE).getOrComputeIfAbsent(getBaseKey(extensionContext) + TestContext.class.getSimpleName(),

--- a/runtime/citrus-junit/src/main/java/org/citrusframework/junit/spring/CitrusSpringJUnit4Runner.java
+++ b/runtime/citrus-junit/src/main/java/org/citrusframework/junit/spring/CitrusSpringJUnit4Runner.java
@@ -37,6 +37,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  *
  * @since 2.2
  */
+@SuppressWarnings("deprecation")
 public class CitrusSpringJUnit4Runner extends SpringJUnit4ClassRunner {
 
     /**

--- a/runtime/citrus-junit/src/main/java/org/citrusframework/junit/spring/JUnit4CitrusSpringSupport.java
+++ b/runtime/citrus-junit/src/main/java/org/citrusframework/junit/spring/JUnit4CitrusSpringSupport.java
@@ -48,6 +48,7 @@ import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
  */
 @RunWith(CitrusSpringJUnit4Runner.class)
 @ContextConfiguration(classes = CitrusSpringConfig.class)
+@SuppressWarnings("deprecation")
 public class JUnit4CitrusSpringSupport extends AbstractJUnit4SpringContextTests
         implements GherkinTestActionRunner, CitrusFrameworkMethod.Runner {
 

--- a/runtime/citrus-main/src/main/java/org/citrusframework/main/CitrusAppOptions.java
+++ b/runtime/citrus-main/src/main/java/org/citrusframework/main/CitrusAppOptions.java
@@ -208,6 +208,7 @@ public class CitrusAppOptions<T extends CitrusAppConfiguration> {
      * Apply options based on given argument line.
      * @param arguments
      */
+    @SuppressWarnings("unchecked")
     public T apply(String[] arguments) {
         return apply((T) new CitrusAppConfiguration(), arguments);
     }

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/RepeatOnErrorTestActionBuilderTest.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/actions/dsl/RepeatOnErrorTestActionBuilderTest.java
@@ -28,6 +28,7 @@ import static org.testng.Assert.assertEquals;
 
 public class RepeatOnErrorTestActionBuilderTest extends UnitTestSupport {
     @Test
+    @SuppressWarnings({"deprecation", "removal"})
     public void testRepeatOnErrorBuilder() {
         DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
         builder.variable("var", "foo");
@@ -70,6 +71,7 @@ public class RepeatOnErrorTestActionBuilderTest extends UnitTestSupport {
     }
 
     @Test
+    @SuppressWarnings({"deprecation", "removal"})
     public void testRepeatOnErrorBuilderWithConditionExpression() {
         DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);
         builder.variable("var", "foo");

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/integration/container/RepeatOnErrorJavaIT.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/integration/container/RepeatOnErrorJavaIT.java
@@ -26,6 +26,7 @@ import org.testng.annotations.Test;
 public class RepeatOnErrorJavaIT extends TestNGCitrusSpringSupport implements TestActionSupport {
 
     @CitrusTest
+    @SuppressWarnings("deprecation")
     public void repeatOnErrorContainer() {
         variable("message", "Hello TestFramework");
 

--- a/runtime/citrus-xml/src/main/java/org/citrusframework/xml/actions/AntRun.java
+++ b/runtime/citrus-xml/src/main/java/org/citrusframework/xml/actions/AntRun.java
@@ -45,7 +45,6 @@ public class AntRun implements TestActionBuilder<AntRunAction>, ReferenceResolve
     /**
      * Sets the build file path.
      * @param buildFilePath
-     * @return
      */
     @XmlAttribute(name = "build-file")
     public void setBuildFile(String buildFilePath) {

--- a/runtime/citrus-xml/src/main/java/org/citrusframework/xml/container/RepeatOnError.java
+++ b/runtime/citrus-xml/src/main/java/org/citrusframework/xml/container/RepeatOnError.java
@@ -51,6 +51,7 @@ public class RepeatOnError implements TestActionBuilder<org.citrusframework.cont
         builder.until(condition);
     }
 
+    @SuppressWarnings("deprecation")
     @XmlAttribute
     public void setAutoSleep(long milliseconds) {
         builder.autoSleep(milliseconds);

--- a/runtime/citrus-xml/src/test/java/org/citrusframework/xml/actions/AbstractXmlActionTest.java
+++ b/runtime/citrus-xml/src/test/java/org/citrusframework/xml/actions/AbstractXmlActionTest.java
@@ -78,6 +78,7 @@ public class AbstractXmlActionTest extends AbstractTestNGUnitTest {
         return testLoader;
     }
 
+    @SuppressWarnings("unchecked")
     protected static class NoopTestCaseRunner extends DefaultTestCaseRunner {
         public NoopTestCaseRunner(TestContext context) {
             super(context);

--- a/runtime/citrus-xml/src/test/java/org/citrusframework/xml/actions/ReceiveTest.java
+++ b/runtime/citrus-xml/src/test/java/org/citrusframework/xml/actions/ReceiveTest.java
@@ -73,6 +73,7 @@ public class ReceiveTest extends AbstractXmlActionTest {
     final MessageValidator<?> defaultMessageValidator = Mockito.mock(MessageValidator.class);
 
     @Test
+    @SuppressWarnings("unchecked")
     public void shouldLoadReceive() throws IOException {
         XmlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/xml/actions/receive.citrus.it.xml");
 

--- a/runtime/citrus-xml/src/test/java/org/citrusframework/xml/container/RepeatOnErrorTest.java
+++ b/runtime/citrus-xml/src/test/java/org/citrusframework/xml/container/RepeatOnErrorTest.java
@@ -28,6 +28,7 @@ import org.testng.annotations.Test;
 public class RepeatOnErrorTest extends AbstractXmlActionTest {
 
     @Test
+    @SuppressWarnings("removal")
     public void shouldLoadRepeatOnError() {
         XmlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/xml/container/repeat-on-error.citrus.it.xml");
 

--- a/runtime/citrus-yaml/src/main/java/org/citrusframework/yaml/container/RepeatOnError.java
+++ b/runtime/citrus-yaml/src/main/java/org/citrusframework/yaml/container/RepeatOnError.java
@@ -54,6 +54,7 @@ public class RepeatOnError implements TestActionBuilder<RepeatOnErrorUntilTrue>,
         builder.until(condition);
     }
 
+    @SuppressWarnings("deprecation")
     @SchemaProperty(description = "Automatically sleep the time in milliseconds with each attempt.")
     public void setAutoSleep(long milliseconds) {
         builder.autoSleep(milliseconds);

--- a/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/actions/ReceiveTest.java
+++ b/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/actions/ReceiveTest.java
@@ -72,6 +72,7 @@ public class ReceiveTest extends AbstractYamlActionTest {
     final MessageValidator<?> defaultMessageValidator = Mockito.mock(MessageValidator.class);
 
     @Test
+    @SuppressWarnings("unchecked")
     public void shouldLoadReceive() throws IOException {
         YamlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/yaml/actions/receive.citrus.it.yaml");
 

--- a/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/container/RepeatOnErrorTest.java
+++ b/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/container/RepeatOnErrorTest.java
@@ -28,6 +28,7 @@ import org.testng.annotations.Test;
 public class RepeatOnErrorTest extends AbstractYamlActionTest {
 
     @Test
+    @SuppressWarnings("removal")
     public void shouldLoadRepeatOnError() {
         YamlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/yaml/container/repeat-on-error.citrus.it.yaml");
 


### PR DESCRIPTION
## Summary
Fixes all compiler warnings across the 8 runtime modules (34 files) as part of #1592.

### Modules covered
- **citrus-main** (1 file) — unchecked cast suppression
- **citrus-junit** (2 files) — suppress deprecated Spring JUnit4 runner/support classes
- **citrus-junit-jupiter** (2 files) — suppress deprecated JUnit Jupiter `getOrComputeIfAbsent` and `CloseableResource`
- **citrus-yaml** (3 files) — suppress deprecated `autoSleep(long)` / `getAutoSleep()`, unchecked casts
- **citrus-xml** (5 files) — same patterns + `@return` on void Javadoc fix
- **citrus-testng** (2 files) — suppress deprecated `autoSleep(long)` / `getAutoSleep()`
- **citrus-groovy** (10 files) — replace `Class.newInstance()` with `getDeclaredConstructor().newInstance()`, suppress `AccessController` removal, unchecked casts, `@return` on void Javadoc
- **citrus-cucumber** (9 files) — suppress deprecated Cucumber JUnit4/SummaryPrinter/getLine, unchecked casts

## Test plan
- [x] Zero compiler warnings across all 8 runtime modules
- [x] All runtime module tests pass
- [x] Full root build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)