### PR TITLE
fix(#1592): Fix compiler warnings in validation modules

### DIFF
--- a/validation/citrus-validation-groovy/src/main/java/org/citrusframework/validation/script/GroovyScriptMessageValidator.java
+++ b/validation/citrus-validation-groovy/src/main/java/org/citrusframework/validation/script/GroovyScriptMessageValidator.java
@@ -88,7 +88,7 @@ public class GroovyScriptMessageValidator extends AbstractMessageValidator<Scrip
                         throw new CitrusRuntimeException("Failed to load groovy validation script resource");
                     }
 
-                    GroovyObject groovyObject = (GroovyObject) groovyClass.newInstance();
+                    GroovyObject groovyObject = (GroovyObject) groovyClass.getDeclaredConstructor().newInstance();
                     ((GroovyScriptExecutor) groovyObject).validate(receivedMessage, context);
                 } catch (IOException e) {
                     throw new CitrusRuntimeException("Failed to load groovy validation script resource", e);
@@ -96,13 +96,14 @@ public class GroovyScriptMessageValidator extends AbstractMessageValidator<Scrip
 
                 logger.debug("Groovy message validation successful: All values OK");
             }
-        } catch (CompilationFailedException | InstantiationException | IllegalAccessException e) {
+        } catch (CompilationFailedException | ReflectiveOperationException e) {
             throw new CitrusRuntimeException(e);
         } catch (AssertionError e) {
             throw new ValidationException("Groovy script validation failed with assertion error:\n" + e.getMessage(), e);
         }
     }
 
+    @SuppressWarnings("removal")
     private static GroovyClassLoader getPrivilegedGroovyLoader() {
         return AccessController.doPrivileged((PrivilegedAction<GroovyClassLoader>) () -> new GroovyClassLoader(ClassLoaderHelper.getClassLoader()));
     }

--- a/validation/citrus-validation-groovy/src/test/java/org/citrusframework/actions/dsl/ExecuteSQLQueryTestActionBuilderTest.java
+++ b/validation/citrus-validation-groovy/src/test/java/org/citrusframework/actions/dsl/ExecuteSQLQueryTestActionBuilderTest.java
@@ -187,6 +187,7 @@ public class ExecuteSQLQueryTestActionBuilderTest extends UnitTestSupport implem
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testCustomScriptValidator() {
         List<Map<String, Object>> results = new ArrayList<>();
         results.add(Collections.<String, Object>singletonMap("NAME", "Howard"));

--- a/validation/citrus-validation-groovy/src/test/java/org/citrusframework/validation/script/ReceiveMessageActionTest.java
+++ b/validation/citrus-validation-groovy/src/test/java/org/citrusframework/validation/script/ReceiveMessageActionTest.java
@@ -154,6 +154,7 @@ public class ReceiveMessageActionTest extends AbstractTestNGUnitTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testInjectedMessageValidators() {
         DefaultMessageBuilder controlMessageBuilder = new DefaultMessageBuilder();
         controlMessageBuilder.setPayloadBuilder(new DefaultPayloadBuilder("<TestRequest><Message>Hello World!</Message></TestRequest>"));

--- a/validation/citrus-validation-hamcrest/src/test/java/org/citrusframework/container/RepeatOnErrorTestActionBuilderTest.java
+++ b/validation/citrus-validation-hamcrest/src/test/java/org/citrusframework/container/RepeatOnErrorTestActionBuilderTest.java
@@ -29,6 +29,7 @@ import static org.hamcrest.Matchers.is;
 import static org.testng.Assert.assertEquals;
 
 public class RepeatOnErrorTestActionBuilderTest extends UnitTestSupport implements TestActionSupport {
+    @SuppressWarnings({"deprecation", "removal"})
     @Test
     public void testRepeatOnErrorBuilderWithHamcrestConditionExpression() {
         DefaultTestCaseRunner builder = new DefaultTestCaseRunner(context);

--- a/validation/citrus-validation-hamcrest/src/test/java/org/citrusframework/container/RepeatOnErrorUntilTrueTest.java
+++ b/validation/citrus-validation-hamcrest/src/test/java/org/citrusframework/container/RepeatOnErrorUntilTrueTest.java
@@ -33,6 +33,7 @@ public class RepeatOnErrorUntilTrueTest extends AbstractTestNGUnitTest {
 
     private TestAction action = Mockito.mock(TestAction.class);
 
+    @SuppressWarnings("deprecation")
     @Test(expectedExceptions=CitrusRuntimeException.class)
     public void testRepeatOnErrorNoSuccessHamcrestConditionExpression() {
         reset(action);

--- a/validation/citrus-validation-hamcrest/src/test/java/org/citrusframework/validation/ValidationUtilsTest.java
+++ b/validation/citrus-validation-hamcrest/src/test/java/org/citrusframework/validation/ValidationUtilsTest.java
@@ -43,6 +43,7 @@ public class ValidationUtilsTest extends AbstractTestNGUnitTest {
         ValidationUtils.validateValues(actualValue, expectedValue, path, context);
     }
 
+    @SuppressWarnings("deprecation")
     @DataProvider
     public Object[][] testData() {
         return new Object[][] {
@@ -52,6 +53,7 @@ public class ValidationUtilsTest extends AbstractTestNGUnitTest {
         };
     }
 
+    @SuppressWarnings("deprecation")
     @DataProvider
     public Object[][] testDataFailed() {
         return new Object[][] {

--- a/validation/citrus-validation-json/src/main/java/org/citrusframework/functions/core/JsonPatchFunction.java
+++ b/validation/citrus-validation-json/src/main/java/org/citrusframework/functions/core/JsonPatchFunction.java
@@ -193,6 +193,7 @@ public class JsonPatchFunction implements ParameterizedFunction<JsonPatchFunctio
         return result;
     }
 
+    @SuppressWarnings("deprecation")
     private JsonNode parseValue(String value) {
         try {
             return jsonMapper.readTree(value);

--- a/validation/citrus-validation-json/src/main/java/org/citrusframework/validation/json/JsonElementValidatorItem.java
+++ b/validation/citrus-validation-json/src/main/java/org/citrusframework/validation/json/JsonElementValidatorItem.java
@@ -100,10 +100,11 @@ public class JsonElementValidatorItem<T> {
 
     /**
      * @param type to cast the values to
-     * @return {@link this} as {@link JsonElementValidatorItem<O>}
+     * @return {@code this} as {@link JsonElementValidatorItem<O>}
      * @throws ValidationException if either {@link JsonElementValidatorItem#expected}
      *                             or {@link JsonElementValidatorItem#expected} is not of the given {@code type}
      */
+    @SuppressWarnings("unchecked")
     public <O> JsonElementValidatorItem<O> ensureType(Class<O> type) {
         if (((actual != null) && !type.isInstance(actual)) || ((expected != null) && !type.isInstance(expected))) {
             throw new ValidationException(buildValueMismatchErrorMessage(

--- a/validation/citrus-validation-xml/src/main/java/org/citrusframework/functions/core/EscapeXmlFunction.java
+++ b/validation/citrus-validation-xml/src/main/java/org/citrusframework/functions/core/EscapeXmlFunction.java
@@ -21,17 +21,16 @@ import org.citrusframework.functions.ParameterizedFunction;
 import org.citrusframework.functions.parameter.StringParameter;
 import org.citrusframework.yaml.SchemaType;
 
-import static org.apache.commons.lang3.StringEscapeUtils.escapeXml;
-
 /**
- * Escapes XML fragment with escaped characters for '<', '>'.
+ * Escapes XML fragment with escaped characters for {@code '<'}, {@code '>'}.
  */
+@SuppressWarnings("deprecation")
 @SchemaType(module = "citrus-validation-xml")
 public class EscapeXmlFunction implements ParameterizedFunction<StringParameter> {
 
     @Override
     public String execute(StringParameter param, TestContext context) {
-        return escapeXml(param.getValue());
+        return org.apache.commons.lang3.StringEscapeUtils.escapeXml(param.getValue());
     }
 
     @Override

--- a/validation/citrus-validation-xml/src/main/java/org/citrusframework/validation/matcher/core/XmlValidationMatcher.java
+++ b/validation/citrus-validation-xml/src/main/java/org/citrusframework/validation/matcher/core/XmlValidationMatcher.java
@@ -60,6 +60,7 @@ public class XmlValidationMatcher implements StringValidationMatcher {
      * Find proper XML message validator. Uses several strategies to lookup default XML message validator. Caches found validator for
      * future usage once the lookup is done.
      */
+    @SuppressWarnings("unchecked")
     private MessageValidator<? extends ValidationContext> getMessageValidator(TestContext context) {
         if (messageValidator != null) {
             return messageValidator;

--- a/validation/citrus-validation-xml/src/main/java/org/citrusframework/validation/xml/XpathPayloadVariableExtractor.java
+++ b/validation/citrus-validation-xml/src/main/java/org/citrusframework/validation/xml/XpathPayloadVariableExtractor.java
@@ -73,6 +73,7 @@ public class XpathPayloadVariableExtractor implements VariableExtractor {
     /**
      * Extract variables using Xpath expressions.
      */
+    @SuppressWarnings("unchecked")
     public void extractVariables(Message message, TestContext context) {
         if (xPathExpressions == null || xPathExpressions.isEmpty()) {
             return;

--- a/validation/citrus-validation-xml/src/main/java/org/citrusframework/xml/schema/AbstractSchemaCollection.java
+++ b/validation/citrus-validation-xml/src/main/java/org/citrusframework/xml/schema/AbstractSchemaCollection.java
@@ -91,6 +91,7 @@ public abstract class AbstractSchemaCollection extends SimpleXsdSchema implement
      *
      * @param schema
      */
+    @SuppressWarnings("unchecked")
     protected void addImportedSchemas(Schema schema) throws TransformerException, TransformerFactoryConfigurationError {
         for (Object imports : schema.getImports().values()) {
             for (SchemaImport schemaImport : (Vector<SchemaImport>)imports) {
@@ -118,6 +119,7 @@ public abstract class AbstractSchemaCollection extends SimpleXsdSchema implement
     /**
      * Recursively add all included schemas as schema resource.
      */
+    @SuppressWarnings("unchecked")
     protected void addIncludedSchemas(Schema schema) throws TransformerException, TransformerFactoryConfigurationError {
         List<SchemaReference> includes = schema.getIncludes();
         for (SchemaReference schemaReference : includes) {

--- a/validation/citrus-validation-xml/src/main/java/org/citrusframework/xml/schema/WsdlXsdSchema.java
+++ b/validation/citrus-validation-xml/src/main/java/org/citrusframework/xml/schema/WsdlXsdSchema.java
@@ -100,6 +100,7 @@ public class WsdlXsdSchema extends AbstractSchemaCollection {
      * @throws TransformerFactoryConfigurationError
      * @throws TransformerException
      */
+    @SuppressWarnings("unchecked")
     private Resource loadSchemas(Definition definition) throws WSDLException, IOException, TransformerException, TransformerFactoryConfigurationError {
         Types types = definition.getTypes();
         Resource targetXsd = null;

--- a/validation/citrus-validation-yaml/src/main/java/org/citrusframework/validation/yaml/YamlNodeValidator.java
+++ b/validation/citrus-validation-yaml/src/main/java/org/citrusframework/validation/yaml/YamlNodeValidator.java
@@ -59,6 +59,7 @@ public class YamlNodeValidator {
         }
     }
 
+    @SuppressWarnings("unchecked")
     private void validateObject(YamlNodeValidator validator, YamlNodeValidatorItem<?> control) {
         var objectControl = control.ensureType(Map.class);
 
@@ -92,6 +93,7 @@ public class YamlNodeValidator {
         return ignoreExpressions.stream().anyMatch(controlEntry::isPathIgnoredBy);
     }
 
+    @SuppressWarnings("unchecked")
     private void validateArray(YamlNodeValidator validator, YamlNodeValidatorItem<?> control) {
         var arrayControl = control.ensureType(Iterable.class);
         List<Object> controlItems = new ArrayList<>();

--- a/validation/citrus-validation-yaml/src/main/java/org/citrusframework/validation/yaml/YamlNodeValidatorItem.java
+++ b/validation/citrus-validation-yaml/src/main/java/org/citrusframework/validation/yaml/YamlNodeValidatorItem.java
@@ -73,10 +73,11 @@ public class YamlNodeValidatorItem<T> {
 
     /**
      * @param type to cast the values to
-     * @return {@link this} as {@link YamlNodeValidatorItem<O>}
+     * @return {@code this} as {@link YamlNodeValidatorItem<O>}
      * @throws ValidationException if either {@link YamlNodeValidatorItem#expected}
      *                             or {@link YamlNodeValidatorItem#expected} is not of the given {@code type}
      */
+    @SuppressWarnings("unchecked")
     public <O> YamlNodeValidatorItem<O> ensureType(Class<O> type) {
         if (((actual != null) && !type.isInstance(actual)) || ((expected != null) && !type.isInstance(expected))) {
             throw new ValidationException(buildValueMismatchErrorMessage(

--- a/validation/citrus-validation-yaml/src/main/java/org/citrusframework/validation/yaml/YamlSupport.java
+++ b/validation/citrus-validation-yaml/src/main/java/org/citrusframework/validation/yaml/YamlSupport.java
@@ -32,6 +32,7 @@ public final class YamlSupport {
         // prevent instantiation of utility class
     }
 
+    @SuppressWarnings("deprecation")
     public static Yaml yaml() {
         Representer representer = new Representer(new DumperOptions()) {
             @Override


### PR DESCRIPTION
## Summary
- Fix compiler warnings in all 7 validation modules (hamcrest, json, groovy, xml, yaml, binary, text)
- Addresses unchecked casts, deprecated API usage, raw types, and malformed Javadoc
- Part of #1592 — module-by-module compiler warning cleanup

## Changes
- **citrus-validation-hamcrest** (3 files): `@SuppressWarnings` for deprecated `autoSleep`/`getAutoSleep` and `isEmptyString()`
- **citrus-validation-json** (2 files): `@SuppressWarnings("deprecation")` for `textNode()`, fix `{@link this}` → `{@code this}` Javadoc, suppress unchecked cast
- **citrus-validation-groovy** (3 files): Replace `Class.newInstance()` with `getDeclaredConstructor().newInstance()`, `@SuppressWarnings("removal")` for `AccessController`, suppress unchecked warnings in tests
- **citrus-validation-xml** (5 files): Remove static import of deprecated `StringEscapeUtils.escapeXml` and use FQN, fix Javadoc raw `<` chars, suppress unchecked casts/conversions in schema and WSDL handling
- **citrus-validation-yaml** (3 files): Suppress unchecked raw `Iterator` usage, fix `{@link this}` Javadoc, suppress deprecated `Yaml(Representer)` constructor
- **citrus-validation-binary, citrus-validation-text**: Already warning-free

## Test plan
- [x] Module-specific build passes with zero validation module warnings
- [x] Full root build (`mvn clean install -DskipTests`) succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)