### PR TITLE
fix(#1592): Fix compiler warnings in connector modules

### DIFF
--- a/connectors/citrus-agent-connector/src/main/java/org/citrusframework/agent/connector/yaml/YamlSupport.java
+++ b/connectors/citrus-agent-connector/src/main/java/org/citrusframework/agent/connector/yaml/YamlSupport.java
@@ -61,6 +61,7 @@ public final class YamlSupport {
         return yaml().dumpAsMap(json().convertValue(model, Map.class));
     }
 
+    @SuppressWarnings("deprecation")
     public static Yaml yaml() {
         Representer representer = new Representer(new DumperOptions()) {
             @Override

--- a/connectors/citrus-agent-connector/src/test/java/org/citrusframework/agent/connector/yaml/AbstractYamlActionTest.java
+++ b/connectors/citrus-agent-connector/src/test/java/org/citrusframework/agent/connector/yaml/AbstractYamlActionTest.java
@@ -78,6 +78,7 @@ public class AbstractYamlActionTest extends AbstractTestNGUnitTest {
         return testLoader;
     }
 
+    @SuppressWarnings("unchecked")
     protected static class NoopTestCaseRunner extends DefaultTestCaseRunner {
         public NoopTestCaseRunner(TestContext context) {
             super(context);

--- a/connectors/citrus-docker/src/main/java/org/citrusframework/docker/actions/DockerExecuteAction.java
+++ b/connectors/citrus-docker/src/main/java/org/citrusframework/docker/actions/DockerExecuteAction.java
@@ -120,6 +120,7 @@ public class DockerExecuteAction extends AbstractTestAction {
     /**
      * Validate command results.
      */
+    @SuppressWarnings("unchecked")
     private void validateCommandResult(DockerCommand command, TestContext context) {
         logger.debug("Starting Docker command result validation");
 
@@ -146,6 +147,7 @@ public class DockerExecuteAction extends AbstractTestAction {
     /**
      * Find proper JSON message validator. Uses several strategies to lookup default JSON message validator.
      */
+    @SuppressWarnings("unchecked")
     private MessageValidator<? extends ValidationContext> getMessageValidator(TestContext context) {
         if (jsonMessageValidator != null) {
             return jsonMessageValidator;

--- a/connectors/citrus-docker/src/main/java/org/citrusframework/docker/client/DockerClient.java
+++ b/connectors/citrus-docker/src/main/java/org/citrusframework/docker/client/DockerClient.java
@@ -68,6 +68,7 @@ public class DockerClient extends AbstractEndpoint implements Producer, ReplyCon
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public void send(Message message, TestContext context) {
         String correlationKeyName = getEndpointConfiguration().getCorrelator().getCorrelationKeyName(getName());
         String correlationKey = getEndpointConfiguration().getCorrelator().getCorrelationKey(message);

--- a/connectors/citrus-docker/src/main/java/org/citrusframework/docker/command/AbstractDockerCommandBuilder.java
+++ b/connectors/citrus-docker/src/main/java/org/citrusframework/docker/command/AbstractDockerCommandBuilder.java
@@ -34,6 +34,7 @@ public abstract class AbstractDockerCommandBuilder<R, T extends AbstractDockerCo
 
     protected final DockerExecuteAction.Builder delegate;
 
+    @SuppressWarnings("unchecked")
     public AbstractDockerCommandBuilder(DockerExecuteAction.Builder delegate, T command) {
         this.delegate = delegate;
         this.command = command;

--- a/connectors/citrus-docker/src/main/java/org/citrusframework/docker/command/ContainerCreate.java
+++ b/connectors/citrus-docker/src/main/java/org/citrusframework/docker/command/ContainerCreate.java
@@ -57,6 +57,7 @@ public class ContainerCreate extends AbstractDockerCommand<CreateContainerRespon
         }
     }
 
+    @SuppressWarnings("deprecation")
     private void executeDockerCommand(DockerClient dockerClient, CreateContainerCmd command, TestContext testContext) {
         if (hasParameter("name")) {
             command.withName(getParameter("name", testContext));

--- a/connectors/citrus-docker/src/main/java/org/citrusframework/docker/config/xml/DockerExecuteActionParser.java
+++ b/connectors/citrus-docker/src/main/java/org/citrusframework/docker/config/xml/DockerExecuteActionParser.java
@@ -115,8 +115,8 @@ public class DockerExecuteActionParser implements BeanDefinitionParser {
      */
     private DockerCommand<?> createCommand(Class<? extends DockerCommand<?>> commandType) {
         try {
-            return commandType.newInstance();
-        } catch (InstantiationException | IllegalAccessException e) {
+            return commandType.getDeclaredConstructor().newInstance();
+        } catch (ReflectiveOperationException e) {
             throw new BeanCreationException("Failed to create Docker command of type: " + commandType, e);
         }
     }

--- a/connectors/citrus-docker/src/test/java/org/citrusframework/docker/integration/AbstractDockerIT.java
+++ b/connectors/citrus-docker/src/test/java/org/citrusframework/docker/integration/AbstractDockerIT.java
@@ -43,6 +43,7 @@ public class AbstractDockerIT extends TestNGCitrusSpringSupport {
     private static boolean connected = false;
 
     @BeforeSuite(alwaysRun = true)
+    @SuppressWarnings("deprecation")
     public void checkDockerEnvironment() {
         boolean enabled = Boolean.parseBoolean(System.getProperty("citrus.docker.it.enabled", Boolean.FALSE.toString()));
         if (enabled) {

--- a/connectors/citrus-jbang-connector/src/test/java/org/citrusframework/jbang/yaml/AbstractYamlActionTest.java
+++ b/connectors/citrus-jbang-connector/src/test/java/org/citrusframework/jbang/yaml/AbstractYamlActionTest.java
@@ -78,6 +78,7 @@ public class AbstractYamlActionTest extends AbstractTestNGUnitTest {
         return testLoader;
     }
 
+    @SuppressWarnings("unchecked")
     protected static class NoopTestCaseRunner extends DefaultTestCaseRunner {
         public NoopTestCaseRunner(TestContext context) {
             super(context);

--- a/connectors/citrus-knative/src/main/java/org/citrusframework/knative/KnativeSupport.java
+++ b/connectors/citrus-knative/src/main/java/org/citrusframework/knative/KnativeSupport.java
@@ -104,6 +104,7 @@ public final class KnativeSupport {
      * Get secure http client implementation with trust all strategy and noop host name verifier.
      * @return
      */
+    @SuppressWarnings("deprecation")
     private static HttpClient sslClient() {
         try {
             SSLContext sslcontext = SSLContexts

--- a/connectors/citrus-knative/src/test/java/org/citrusframework/knative/yaml/AbstractYamlActionTest.java
+++ b/connectors/citrus-knative/src/test/java/org/citrusframework/knative/yaml/AbstractYamlActionTest.java
@@ -107,6 +107,7 @@ public class AbstractYamlActionTest extends AbstractTestNGUnitTest {
         return testLoader;
     }
 
+    @SuppressWarnings("unchecked")
     protected static class NoopTestCaseRunner extends DefaultTestCaseRunner {
         public NoopTestCaseRunner(TestContext context) {
             super(context);

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/KubernetesSupport.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/KubernetesSupport.java
@@ -126,6 +126,7 @@ public final class KubernetesSupport {
         return !KubernetesSettings.isLocal();
     }
 
+    @SuppressWarnings("deprecation")
     public static Yaml yaml() {
         Representer representer = new Representer(new DumperOptions()) {
             @Override

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/actions/CreateCustomResourceAction.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/actions/CreateCustomResourceAction.java
@@ -163,6 +163,7 @@ public class CreateCustomResourceAction extends AbstractKubernetesAction impleme
         }
 
         @Override
+        @SuppressWarnings("unchecked")
         public Builder resourceType(Class<?> resourceType) {
             if (HasMetadata.class.isAssignableFrom(resourceType)) {
                 this.resourceType = (Class<? extends HasMetadata>) resourceType;

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/actions/CreateResourceAction.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/actions/CreateResourceAction.java
@@ -40,6 +40,7 @@ public class CreateResourceAction extends AbstractKubernetesAction implements Ku
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void doExecute(TestContext context) {
         InputStream is;
         if (content != null) {

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/actions/DeleteCustomResourceAction.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/actions/DeleteCustomResourceAction.java
@@ -86,6 +86,7 @@ public class DeleteCustomResourceAction extends AbstractKubernetesAction {
         }
 
         @Override
+        @SuppressWarnings("unchecked")
         public Builder resourceType(Class<?> resourceType) {
             if (HasMetadata.class.isAssignableFrom(resourceType)) {
                 this.resourceType = (Class<? extends HasMetadata>) resourceType;
@@ -97,6 +98,7 @@ public class DeleteCustomResourceAction extends AbstractKubernetesAction {
         }
 
         @Override
+        @SuppressWarnings("unchecked")
         public Builder type(Class<?> resourceType) {
             if (HasMetadata.class.isAssignableFrom(resourceType)) {
                 version(resourceType.getAnnotation(Version.class).value());

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/actions/KubernetesExecuteAction.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/actions/KubernetesExecuteAction.java
@@ -163,6 +163,7 @@ public class KubernetesExecuteAction extends AbstractTestAction {
     /**
      * Find proper JSON message validator. Uses several strategies to lookup default JSON message validator.
      */
+    @SuppressWarnings("unchecked")
     private MessageValidator<? extends ValidationContext> getMessageValidator(TestContext context) {
         if (jsonMessageValidator != null) {
             return jsonMessageValidator;
@@ -191,6 +192,7 @@ public class KubernetesExecuteAction extends AbstractTestAction {
     /**
      * Find proper JSON path message validator. Uses several strategies to lookup default JSON path message validator.
      */
+    @SuppressWarnings("unchecked")
     private MessageValidator<? extends ValidationContext> getPathValidator(TestContext context) {
         if (jsonPathMessageValidator != null) {
             return jsonPathMessageValidator;

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/actions/VerifyCustomResourceAction.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/actions/VerifyCustomResourceAction.java
@@ -127,6 +127,7 @@ public class VerifyCustomResourceAction extends AbstractKubernetesAction {
      * @param context
      * @return
      */
+    @SuppressWarnings("unchecked")
     private HasMetadata getResource(String name, String condition, TestContext context) {
         if (resourceType != null) {
             CustomResource<?, ?> resource = getKubernetesClient().resources(resourceType)
@@ -154,6 +155,7 @@ public class VerifyCustomResourceAction extends AbstractKubernetesAction {
      * @param context
      * @return
      */
+    @SuppressWarnings("unchecked")
     private HasMetadata getResourceFromLabel(String labelExpression, String condition, TestContext context) {
         if (labelExpression == null || labelExpression.isEmpty()) {
             return null;
@@ -238,6 +240,7 @@ public class VerifyCustomResourceAction extends AbstractKubernetesAction {
      * @param objectMap
      * @return
      */
+    @SuppressWarnings("unchecked")
     private Map<String, Object> getAsPropertyMap(String property, Map<String, Object> objectMap) {
         if (objectMap != null && objectMap.containsKey(property) && objectMap.get(property) instanceof Map) {
             return (Map<String, Object>) objectMap.get(property);
@@ -252,6 +255,7 @@ public class VerifyCustomResourceAction extends AbstractKubernetesAction {
      * @param objectMap
      * @return
      */
+    @SuppressWarnings("unchecked")
     private List<Map<String, Object>> getAsPropertyList(String property, Map<String, Object> objectMap) {
         if (objectMap.containsKey(property) && objectMap.get(property) instanceof List) {
             return ((List<?>) objectMap.get(property)).stream()
@@ -300,6 +304,7 @@ public class VerifyCustomResourceAction extends AbstractKubernetesAction {
         }
 
         @Override
+        @SuppressWarnings("unchecked")
         public Builder resourceType(Class<?> resourceType) {
             if (CustomResource.class.isAssignableFrom(resourceType)) {
                 this.resourceType = (Class<? extends CustomResource<?, ?>>) resourceType;
@@ -311,6 +316,7 @@ public class VerifyCustomResourceAction extends AbstractKubernetesAction {
         }
 
         @Override
+        @SuppressWarnings("unchecked")
         public Builder type(Class<?> resourceType) {
             if (CustomResource.class.isAssignableFrom(resourceType)) {
                 version(resourceType.getAnnotation(Version.class).value());

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/command/AbstractClientCommand.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/command/AbstractClientCommand.java
@@ -38,6 +38,7 @@ public abstract class AbstractClientCommand<T extends HasMetadata, O, L extends 
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public final void execute(KubernetesClient kubernetesClient, TestContext context) {
         MixedOperation<T, L, R> operation = operation(kubernetesClient, context);
 

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/command/AbstractDeleteCommand.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/command/AbstractDeleteCommand.java
@@ -48,6 +48,7 @@ public abstract class AbstractDeleteCommand<T extends HasMetadata, L extends Kub
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void execute(MixedOperation<T, L, R> operation, TestContext context) {
         boolean success;
 

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/command/AbstractKubernetesCommand.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/command/AbstractKubernetesCommand.java
@@ -52,6 +52,7 @@ public abstract class AbstractKubernetesCommand<T extends HasMetadata, O, C exte
      * Default constructor initializing the command name.
      * @param name
      */
+    @SuppressWarnings("unchecked")
     public AbstractKubernetesCommand(String name) {
         this.name = name;
         this.self = (C) this;

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/config/xml/KubernetesExecuteActionParser.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/config/xml/KubernetesExecuteActionParser.java
@@ -120,8 +120,8 @@ public class KubernetesExecuteActionParser<T extends KubernetesCommand<?, ?>> im
      */
     private T createCommand(Class<T> commandType) {
         try {
-            return commandType.newInstance();
-        } catch (InstantiationException | IllegalAccessException e) {
+            return commandType.getDeclaredConstructor().newInstance();
+        } catch (ReflectiveOperationException e) {
             throw new BeanCreationException("Failed to create Kubernetes command of type: " + commandType, e);
         }
     }
@@ -153,7 +153,6 @@ public class KubernetesExecuteActionParser<T extends KubernetesCommand<?, ?>> im
         /**
          * Sets kubernetes command to execute.
          * @param command
-         * @return
          */
         public void setCommand(KubernetesCommand<?, ?> command) {
             builder.command(command);

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/endpoint/KubernetesEndpointConfiguration.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/endpoint/KubernetesEndpointConfiguration.java
@@ -60,6 +60,7 @@ public class KubernetesEndpointConfiguration extends AbstractPollableEndpointCon
      *
      * @return
      */
+    @SuppressWarnings("deprecation")
     private io.fabric8.kubernetes.client.KubernetesClient createKubernetesClient() {
         return new DefaultKubernetesClient(getKubernetesClientConfig());
     }

--- a/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/message/KubernetesMessage.java
+++ b/connectors/citrus-kubernetes/src/main/java/org/citrusframework/kubernetes/message/KubernetesMessage.java
@@ -164,6 +164,7 @@ public class KubernetesMessage extends DefaultMessage {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <T> T getPayload(Class<T> type) {
         try {
             if (KubernetesRequest.class.isAssignableFrom(type)) {

--- a/connectors/citrus-kubernetes/src/test/java/org/citrusframework/kubernetes/actions/KubernetesExecuteActionTest.java
+++ b/connectors/citrus-kubernetes/src/test/java/org/citrusframework/kubernetes/actions/KubernetesExecuteActionTest.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@SuppressWarnings({"unchecked", "deprecation"})
 public class KubernetesExecuteActionTest extends AbstractTestNGUnitTest {
 
     private final KubernetesClient client = new KubernetesClient();

--- a/connectors/citrus-kubernetes/src/test/java/org/citrusframework/kubernetes/actions/dsl/KubernetesTestActionBuilderTest.java
+++ b/connectors/citrus-kubernetes/src/test/java/org/citrusframework/kubernetes/actions/dsl/KubernetesTestActionBuilderTest.java
@@ -84,6 +84,7 @@ public class KubernetesTestActionBuilderTest extends UnitTestSupport implements 
         MockitoAnnotations.openMocks(this);
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void testKubernetesBuilder() throws Exception {
         Watch watch = Mockito.mock(Watch.class);

--- a/connectors/citrus-kubernetes/src/test/java/org/citrusframework/kubernetes/yaml/AbstractYamlActionTest.java
+++ b/connectors/citrus-kubernetes/src/test/java/org/citrusframework/kubernetes/yaml/AbstractYamlActionTest.java
@@ -102,6 +102,7 @@ public class AbstractYamlActionTest extends AbstractTestNGUnitTest {
         return testLoader;
     }
 
+    @SuppressWarnings("unchecked")
     protected static class NoopTestCaseRunner extends DefaultTestCaseRunner {
         public NoopTestCaseRunner(TestContext context) {
             super(context);

--- a/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/OpenApiSupport.java
+++ b/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/OpenApiSupport.java
@@ -65,6 +65,7 @@ public class OpenApiSupport {
         return OBJECT_MAPPER;
     }
 
+    @SuppressWarnings("deprecation")
     public static Yaml yaml() {
         Representer representer = new Representer(new DumperOptions()) {
             @Override

--- a/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/actions/OpenApiClientActionBuilder.java
+++ b/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/actions/OpenApiClientActionBuilder.java
@@ -33,6 +33,7 @@ import static org.springframework.http.HttpStatus.OK;
  *
  * @since 4.1
  */
+@SuppressWarnings("unchecked")
 public class OpenApiClientActionBuilder extends AbstractReferenceResolverAwareTestActionBuilder<TestAction>
         implements OpenApiSpecificationSourceAwareBuilder<TestAction>, org.citrusframework.actions.openapi.OpenApiClientActionBuilder<TestAction, OpenApiClientActionBuilder> {
 

--- a/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/actions/OpenApiPayloadBuilder.java
+++ b/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/actions/OpenApiPayloadBuilder.java
@@ -42,6 +42,7 @@ public class OpenApiPayloadBuilder extends DefaultPayloadBuilder {
         }
     }
 
+    @SuppressWarnings("unchecked")
     private static void replaceDynamicContentInEntry(TestContext context, MultiValueMap<Object, Object> multiValueMap, Entry<?, ?> entry) {
         Object key = entry.getKey();
 
@@ -59,6 +60,7 @@ public class OpenApiPayloadBuilder extends DefaultPayloadBuilder {
         multiValueMap.put(newKey, list);
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public Object buildPayload(TestContext context) {
         if (getPayload() instanceof MultiValueMap<?, ?> multiValueMap) {

--- a/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/actions/OpenApiServerActionBuilder.java
+++ b/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/actions/OpenApiServerActionBuilder.java
@@ -31,6 +31,7 @@ import org.springframework.http.HttpStatus;
  *
  * @since 4.1
  */
+@SuppressWarnings("unchecked")
 public class OpenApiServerActionBuilder extends
     AbstractReferenceResolverAwareTestActionBuilder<TestAction> implements
     OpenApiSpecificationSourceAwareBuilder<TestAction>, org.citrusframework.actions.openapi.OpenApiServerActionBuilder<TestAction, OpenApiServerActionBuilder> {

--- a/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/random/RandomContext.java
+++ b/connectors/citrus-openapi/src/main/java/org/citrusframework/openapi/random/RandomContext.java
@@ -128,6 +128,7 @@ public class RandomContext {
      * @param mappingFunction the function to compute the value if it is not present
      * @return the context variable value
      */
+    @SuppressWarnings("unchecked")
     public <T> T get(String key, Function<String, T> mappingFunction) {
         //noinspection unchecked
         return (T) contextVariables.computeIfAbsent(key, mappingFunction);

--- a/connectors/citrus-openapi/src/test/java/org/citrusframework/openapi/actions/OpenApiPayloadBuilderTest.java
+++ b/connectors/citrus-openapi/src/test/java/org/citrusframework/openapi/actions/OpenApiPayloadBuilderTest.java
@@ -34,6 +34,7 @@ public class OpenApiPayloadBuilderTest {
         context = new TestContext();
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void testBuildPayloadWithMultiValueMap() {
         // Given

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/actions/JavaScriptAction.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/actions/JavaScriptAction.java
@@ -66,6 +66,7 @@ public class JavaScriptAction extends AbstractSeleniumAction {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     protected void execute(SeleniumBrowser browser, TestContext context) {
         try {
             if (browser.getWebDriver() instanceof JavascriptExecutor jsEngine) {

--- a/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/endpoint/SeleniumBrowser.java
+++ b/connectors/citrus-selenium/src/main/java/org/citrusframework/selenium/endpoint/SeleniumBrowser.java
@@ -106,6 +106,7 @@ public class SeleniumBrowser extends AbstractEndpoint implements Producer, Shutd
     /**
      * Starts the browser and create local or remote web driver.
      */
+    @SuppressWarnings("unchecked")
     public void start() {
         if (!isStarted()) {
             if (getEndpointConfiguration().getWebDriver() != null) {

--- a/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/HoverActionTest.java
+++ b/connectors/citrus-selenium/src/test/java/org/citrusframework/selenium/actions/HoverActionTest.java
@@ -41,6 +41,7 @@ public class HoverActionTest extends AbstractTestNGUnitTest {
     private final RemoteWebElement element = Mockito.mock(RemoteWebElement.class);
 
     @BeforeMethod
+    @SuppressWarnings("unchecked")
     public void setup() {
         reset(webDriver, element);
 

--- a/connectors/citrus-sql/src/main/java/org/citrusframework/actions/AbstractDatabaseConnectingTestAction.java
+++ b/connectors/citrus-sql/src/main/java/org/citrusframework/actions/AbstractDatabaseConnectingTestAction.java
@@ -46,6 +46,7 @@ import org.springframework.transaction.TransactionDefinition;
  * access to a {@link javax.sql.DataSource}.
  *
  */
+@SuppressWarnings("removal")
 public abstract class AbstractDatabaseConnectingTestAction extends JdbcDaoSupport implements TestAction, Named, Described, TestActorAware {
 
     /** Text describing the test action */

--- a/connectors/citrus-sql/src/test/java/org/citrusframework/actions/ExecuteSQLQueryActionTest.java
+++ b/connectors/citrus-sql/src/test/java/org/citrusframework/actions/ExecuteSQLQueryActionTest.java
@@ -541,6 +541,7 @@ public class ExecuteSQLQueryActionTest extends UnitTestSupport {
         Assert.assertEquals(context.getVariable("${height}"), "0,3");
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void testResultSetScriptValidation() {
         String sql = "select ORDERTYPES, STATUS from orders where ID=5";
@@ -564,6 +565,7 @@ public class ExecuteSQLQueryActionTest extends UnitTestSupport {
         verify(resultSetScriptValidator).validateSqlResultSet(any(List.class), any(ScriptValidationContext.class), eq(context));
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void testResultSetScriptValidationMultipleStatements() {
         String sql1 = "select ORDERTYPES, STATUS from orders where ID=5";
@@ -604,6 +606,7 @@ public class ExecuteSQLQueryActionTest extends UnitTestSupport {
         verify(resultSetScriptValidator).validateSqlResultSet(any(List.class), any(ScriptValidationContext.class), eq(context));
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void testResultSetScriptValidationWrongValue() {
         String sql = "select ORDERTYPES, STATUS from orders where ID=5";
@@ -634,6 +637,7 @@ public class ExecuteSQLQueryActionTest extends UnitTestSupport {
         verify(resultSetScriptValidator).validateSqlResultSet(any(List.class), any(ScriptValidationContext.class), eq(context));
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void testResultSetScriptValidationCombination() {
         String sql = "select ORDERTYPES, STATUS from orders where ID=5";

--- a/connectors/citrus-sql/src/test/java/org/citrusframework/integration/actions/QueryDatabaseRetriesJavaIT.java
+++ b/connectors/citrus-sql/src/test/java/org/citrusframework/integration/actions/QueryDatabaseRetriesJavaIT.java
@@ -32,6 +32,7 @@ public class QueryDatabaseRetriesJavaIT extends TestNGCitrusSpringSupport implem
     @Qualifier("testDataSource")
     private DataSource dataSource;
 
+    @SuppressWarnings("deprecation")
     @CitrusTest
     public void sqlQueryRetries() {
         run(sql().dataSource(dataSource)

--- a/connectors/citrus-sql/src/test/java/org/citrusframework/sql/xml/AbstractXmlActionTest.java
+++ b/connectors/citrus-sql/src/test/java/org/citrusframework/sql/xml/AbstractXmlActionTest.java
@@ -78,6 +78,7 @@ public class AbstractXmlActionTest extends AbstractTestNGUnitTest {
         return testLoader;
     }
 
+    @SuppressWarnings("unchecked")
     protected static class NoopTestCaseRunner extends DefaultTestCaseRunner {
         public NoopTestCaseRunner(TestContext context) {
             super(context);

--- a/connectors/citrus-sql/src/test/java/org/citrusframework/sql/yaml/AbstractYamlActionTest.java
+++ b/connectors/citrus-sql/src/test/java/org/citrusframework/sql/yaml/AbstractYamlActionTest.java
@@ -78,6 +78,7 @@ public class AbstractYamlActionTest extends AbstractTestNGUnitTest {
         return testLoader;
     }
 
+    @SuppressWarnings("unchecked")
     protected static class NoopTestCaseRunner extends DefaultTestCaseRunner {
         public NoopTestCaseRunner(TestContext context) {
             super(context);

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/actions/StartTestcontainersAction.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/actions/StartTestcontainersAction.java
@@ -379,6 +379,7 @@ public class StartTestcontainersAction<C extends GenericContainer<?>> extends Ab
         protected void prepareBuild() {
         }
 
+        @SuppressWarnings("unchecked")
         protected C buildContainer() {
             String imageName;
             if (StringUtils.hasText(TestContainersSettings.getRegistry()) &&

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/LocalStackContainer.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/LocalStackContainer.java
@@ -196,6 +196,7 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> i
         this.clients.put(service, client);
     }
 
+    @SuppressWarnings("unchecked")
     public <T> T getClient(AwsService service) {
         if (!services.contains(service)) {
             throw new CitrusRuntimeException("Unable to create client for disabled service: %s".formatted(service));

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/mongodb/MongoDBSettings.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/mongodb/MongoDBSettings.java
@@ -103,6 +103,7 @@ public class MongoDBSettings {
      * @param serviceName the service name of the container.
      * @param context the test context to receive the test variables.
      */
+    @SuppressWarnings("deprecation")
     public static void exposeConnectionSettings(MongoDBContainer container, String serviceName, TestContext context) {
         if (container.getContainerId() != null) {
             String dockerContainerId = container.getContainerId().substring(0, 12);

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/mongodb/StartMongoDBAction.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/mongodb/StartMongoDBAction.java
@@ -25,6 +25,7 @@ import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
+@SuppressWarnings("deprecation")
 public class StartMongoDBAction extends StartTestcontainersAction<MongoDBContainer> {
 
     public StartMongoDBAction(Builder builder) {

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/quarkus/GenericContainerResource.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/quarkus/GenericContainerResource.java
@@ -22,6 +22,7 @@ import io.quarkus.test.common.QuarkusTestResourceConfigurableLifecycleManager;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.testcontainers.containers.GenericContainer;
 
+@SuppressWarnings("unchecked")
 public class GenericContainerResource extends TestcontainersResource<GenericContainer<?>>
         implements QuarkusTestResourceConfigurableLifecycleManager<TestcontainersSupport> {
 

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/quarkus/TestcontainersResource.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/quarkus/TestcontainersResource.java
@@ -40,6 +40,7 @@ public class TestcontainersResource<T extends GenericContainer<?>> implements Qu
         this.containerType = containerType;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public final void init(Map<String, String> initArgs) {
         String[] qualifiedClassNames = initArgs.getOrDefault(ContainerLifecycleListener.INIT_ARG, "").split(",");

--- a/connectors/citrus-testcontainers/src/test/java/org/citrusframework/testcontainers/integration/yaml/AbstractYamlActionTest.java
+++ b/connectors/citrus-testcontainers/src/test/java/org/citrusframework/testcontainers/integration/yaml/AbstractYamlActionTest.java
@@ -84,6 +84,7 @@ public class AbstractYamlActionTest extends AbstractTestNGUnitTest {
         return testLoader;
     }
 
+    @SuppressWarnings("unchecked")
     protected static class NoopTestCaseRunner extends DefaultTestCaseRunner {
         public NoopTestCaseRunner(TestContext context) {
             super(context);


### PR DESCRIPTION
## Summary
- Fix compiler warnings in all 9 connector modules (sql, openapi, docker, kubernetes, knative, selenium, agent-connector, jbang-connector, testcontainers)
- Addresses unchecked casts, deprecated API usage, raw types, `Class.newInstance()` replacement, Javadoc fixes, and method signature warnings
- Part of #1592 — module-by-module compiler warning cleanup

## Changes (47 files)
- **citrus-sql** (5 files): `@SuppressWarnings("removal")` for deprecated `JdbcDaoSupport`, unchecked `validateSqlResultSet` calls, deprecated `autoSleep`, `applyBehavior` signature warnings
- **citrus-openapi** (6 files): Class-level `@SuppressWarnings("unchecked")` for method signature warnings on `OpenApiClientActionBuilder`/`OpenApiServerActionBuilder`, deprecated `Yaml(Representer)`, unchecked casts
- **citrus-docker** (6 files): Unchecked raw `doWithCommandResult` calls, deprecated Docker API (`withCapAdd`/`withPortBindings`), replaced `Class.newInstance()` with `getDeclaredConstructor().newInstance()`, deprecated Docker client factory
- **citrus-kubernetes** (14 files): Unchecked `Optional.of()` invocations, deprecated Fabric8 APIs (`DefaultKubernetesClient`, `withoutLabels`, `createOrReplace`, `delete(List)`), replaced `Class.newInstance()`, unchecked casts in custom resource actions, Javadoc `@return` on void method
- **citrus-knative** (2 files): Deprecated SSL factory, `applyBehavior` signature warning
- **citrus-selenium** (3 files): Unchecked `WebDriverDecorator.decorate()`, unchecked cast, generic array creation for varargs
- **citrus-agent-connector** (2 files): Deprecated `Yaml(Representer)`, `applyBehavior` signature warning
- **citrus-jbang-connector** (1 file): `applyBehavior` signature warning
- **citrus-testcontainers** (7 files): Deprecated `MongoDBContainer`, unchecked casts in `LocalStackContainer`/`TestcontainersResource`/`GenericContainerResource`, `applyBehavior` signature warning

## Test plan
- [x] All connector module builds pass with zero connector warnings
- [x] Full root build (`mvn clean install -DskipTests`) succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)