### PR TITLE
fix(#1634): Add migration guide resource to the Citrus MCP server

### DIFF
--- a/src/manual/tools-mcp-server.adoc
+++ b/src/manual/tools-mcp-server.adoc
@@ -17,6 +17,8 @@ The MCP server exposes Citrus framework capabilities through standardized tools 
 * Documentation tools
     ** **Documentation index**: Query all available documentation files with filter criteria
     ** **Documentation**: Access AsciiDoc documentation for specific Citrus components
+* Migration resources
+    ** **Migration Guides**: Retrieve structured version migration guides with package renames, Maven dependency changes, API changes, and SPI changes
 
 This enables AI assistants to provide context-aware suggestions, validate component usage, and generate syntactically correct Citrus tests.
 
@@ -388,7 +390,7 @@ Retrieves documentation content for a specific component.
 [[citrus-mcp-server-resources]]
 == Resources
 
-Resources provide read-only access to schemas and specifications.
+Resources provide read-only access to schemas, specifications, and documentation.
 
 === YAML DSL Schema
 
@@ -431,6 +433,45 @@ Retrieves the JSON schema for a specific endpoint.
 **MIME Type:** `application/json`
 
 **Example URI:** `citrus://schema/endpoint/kafka`
+
+=== Migration Guide
+
+**URI Template:** `citrus://docs/migration-guide/{version}`
+
+Retrieves the Citrus version migration guide for a given target version in a structured JSON format.
+The guide covers package renames, Maven artifact renames, dependency upgrades, API changes, and SPI changes to assist with automated migration from the previous major version.
+
+**Parameters:**
+* `version`: Target migration version (e.g., 5.0)
+
+**MIME Type:** `application/json`
+
+**Example URI:** `citrus://docs/migration-guide/5.0`
+
+**Response structure:**
+[source,json]
+----
+{
+  "targetVersion": "5.0",
+  "title": "Citrus 4.x to 5.x",
+  "description": "...",
+  "artifactRenames": [
+    { "groupId": "org.citrusframework", "oldArtifactId": "citrus-junit5", "newArtifactId": "citrus-junit-jupiter" }
+  ],
+  "dependencyUpgrades": [
+    { "dependency": "Spring Framework", "oldVersion": "6.x", "newVersion": "7.x" }
+  ],
+  "packageRenames": [
+    { "oldPackage": "org.citrusframework.TestActionSupport", "newPackage": "org.citrusframework.dsl.TestActionSupport", "module": "citrus-base" }
+  ],
+  "apiChanges": [
+    { "type": "interface-extraction", "summary": "CitrusContext is now an interface", "details": "..." }
+  ],
+  "spiChanges": [
+    { "serviceFile": "META-INF/services/org.citrusframework.CitrusContext", "implementation": "...", "changeType": "new" }
+  ]
+}
+----
 
 [[citrus-mcp-server-configuration]]
 == Server Configuration
@@ -497,4 +538,13 @@ Tools can query documentation resources to:
 
 * Display contextual help for components
 * Search documentation by component type and name
+
+=== Version Migration
+
+AI assistants can use the migration guide resource to:
+
+* Read structured package rename mappings and apply them to import statements
+* Identify Maven artifact renames and dependency upgrades required for a version upgrade
+* Detect API changes (interface extractions, deleted classes) that need manual attention
+* Update SPI registrations referencing moved classes
 * Provide code examples from documentation

--- a/tools/mcp-server/src/main/java/org/citrusframework/mcp/MigrationData.java
+++ b/tools/mcp-server/src/main/java/org/citrusframework/mcp/MigrationData.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.mcp;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class MigrationData {
+
+    private static final Map<String, MigrationGuide> GUIDES = new LinkedHashMap<>();
+
+    static {
+        GUIDES.put("5.0", createGuide5_0());
+    }
+
+    public MigrationGuide getGuide(String version) {
+        return GUIDES.get(version);
+    }
+
+    public List<String> getAvailableVersions() {
+        return List.copyOf(GUIDES.keySet());
+    }
+
+    private static MigrationGuide createGuide5_0() {
+        return new MigrationGuide(
+                "5.0",
+                "Citrus 4.x to 5.x",
+                "Migration guide for upgrading from Citrus 4.x to 5.0. " +
+                        "Covers split package removal, Maven artifact renames, dependency upgrades, " +
+                        "API changes, and SPI changes.",
+                createArtifactRenames5_0(),
+                createDependencyUpgrades5_0(),
+                createPackageRenames5_0(),
+                createApiChanges5_0(),
+                createSpiChanges5_0()
+        );
+    }
+
+    private static List<ArtifactRename> createArtifactRenames5_0() {
+        List<ArtifactRename> renames = new ArrayList<>();
+        renames.add(new ArtifactRename("org.citrusframework", "citrus-junit5", "citrus-junit-jupiter"));
+        return renames;
+    }
+
+    private static List<DependencyUpgrade> createDependencyUpgrades5_0() {
+        List<DependencyUpgrade> upgrades = new ArrayList<>();
+        upgrades.add(new DependencyUpgrade("Spring Framework", "6.x", "7.x"));
+        upgrades.add(new DependencyUpgrade("Spring Boot", "3.x", "4.x"));
+        upgrades.add(new DependencyUpgrade("Spring WS", "4.x", "5.x"));
+        upgrades.add(new DependencyUpgrade("Spring Integration", "6.x", "7.x"));
+        upgrades.add(new DependencyUpgrade("Jackson", "2.x (com.fasterxml.jackson)", "3.x (tools.jackson)"));
+        return upgrades;
+    }
+
+    private static List<PackageRename> createPackageRenames5_0() {
+        List<PackageRename> renames = new ArrayList<>();
+
+        // citrus-api: actions, containers, conditions, etc.
+        renames.add(new PackageRename("org.citrusframework.actions.", "org.citrusframework.api.actions.", "citrus-api"));
+        renames.add(new PackageRename("org.citrusframework.container.", "org.citrusframework.api.container.", "citrus-api"));
+        renames.add(new PackageRename("org.citrusframework.condition.", "org.citrusframework.api.condition.", "citrus-api"));
+        renames.add(new PackageRename("org.citrusframework.common.", "org.citrusframework.api.common.", "citrus-api"));
+        renames.add(new PackageRename("org.citrusframework.agent.", "org.citrusframework.api.agent.", "citrus-api"));
+        renames.add(new PackageRename("org.citrusframework.openapi.", "org.citrusframework.api.openapi.", "citrus-api"));
+        renames.add(new PackageRename("org.citrusframework.kubernetes.", "org.citrusframework.api.kubernetes.", "citrus-api"));
+        renames.add(new PackageRename("org.citrusframework.main.", "org.citrusframework.api.main.", "citrus-api"));
+        renames.add(new PackageRename("org.citrusframework.xml.namespace.", "org.citrusframework.api.xml.namespace.", "citrus-api"));
+        renames.add(new PackageRename("org.citrusframework.xml.Marshaller", "org.citrusframework.api.xml.Marshaller", "citrus-api"));
+        renames.add(new PackageRename("org.citrusframework.xml.Unmarshaller", "org.citrusframework.api.xml.Unmarshaller", "citrus-api"));
+        renames.add(new PackageRename("org.citrusframework.xml.StringResult", "org.citrusframework.api.xml.StringResult", "citrus-api"));
+        renames.add(new PackageRename("org.citrusframework.xml.StringSource", "org.citrusframework.api.xml.StringSource", "citrus-api"));
+        renames.add(new PackageRename("org.citrusframework.yaml.", "org.citrusframework.api.yaml.", "citrus-api"));
+
+        // citrus-api: validation contexts
+        renames.add(new PackageRename("org.citrusframework.validation.json.", "org.citrusframework.validation.context.json.", "citrus-api"));
+        renames.add(new PackageRename("org.citrusframework.validation.xml.", "org.citrusframework.validation.context.xml.", "citrus-api"));
+        renames.add(new PackageRename("org.citrusframework.validation.yaml.", "org.citrusframework.validation.context.yaml.", "citrus-api"));
+        renames.add(new PackageRename("org.citrusframework.validation.script.", "org.citrusframework.validation.context.script.", "citrus-api"));
+        renames.add(new PackageRename("org.citrusframework.validation.ws.", "org.citrusframework.validation.context.ws.", "citrus-api"));
+        renames.add(new PackageRename("org.citrusframework.validation.openapi.", "org.citrusframework.validation.context.openapi.", "citrus-api"));
+
+        // citrus-api: utilities
+        renames.add(new PackageRename("org.citrusframework.json.", "org.citrusframework.util.json.", "citrus-api"));
+        renames.add(new PackageRename("org.citrusframework.yaml.YamlNodeStringBuilder", "org.citrusframework.util.yaml.YamlNodeStringBuilder", "citrus-api"));
+        renames.add(new PackageRename("org.citrusframework.yaml.YamlStringBuilder", "org.citrusframework.util.yaml.YamlStringBuilder", "citrus-api"));
+
+        // citrus-base
+        renames.add(new PackageRename("org.citrusframework.functions.", "org.citrusframework.base.functions.", "citrus-base"));
+        renames.add(new PackageRename("org.citrusframework.validation.matcher.", "org.citrusframework.base.validation.matcher.", "citrus-base"));
+        renames.add(new PackageRename("org.citrusframework.report.", "org.citrusframework.base.report.", "citrus-base"));
+        renames.add(new PackageRename("org.citrusframework.endpoint.adapter.", "org.citrusframework.base.endpoint.adapter.", "citrus-base"));
+        renames.add(new PackageRename("org.citrusframework.endpoint.AbstractEndpointAdapter", "org.citrusframework.base.endpoint.AbstractEndpointAdapter", "citrus-base"));
+        renames.add(new PackageRename("org.citrusframework.endpoint.AbstractEndpointBuilder", "org.citrusframework.base.endpoint.AbstractEndpointBuilder", "citrus-base"));
+        renames.add(new PackageRename("org.citrusframework.endpoint.DefaultEndpointFactory", "org.citrusframework.base.endpoint.DefaultEndpointFactory", "citrus-base"));
+        renames.add(new PackageRename("org.citrusframework.server.", "org.citrusframework.base.server.", "citrus-base"));
+        renames.add(new PackageRename("org.citrusframework.context.StaticTestContextFactory", "org.citrusframework.base.context.StaticTestContextFactory", "citrus-base"));
+        renames.add(new PackageRename("org.citrusframework.annotations.CitrusAnnotations", "org.citrusframework.base.annotations.CitrusAnnotations", "citrus-base"));
+        renames.add(new PackageRename("org.citrusframework.message.builder.", "org.citrusframework.base.message.builder.", "citrus-base"));
+        renames.add(new PackageRename("org.citrusframework.main.AbstractTestEngine", "org.citrusframework.base.main.AbstractTestEngine", "citrus-base"));
+        renames.add(new PackageRename("org.citrusframework.main.scan.", "org.citrusframework.base.main.scan.", "citrus-base"));
+
+        // citrus-base: DSL classes
+        renames.add(new PackageRename("org.citrusframework.DefaultTestActionBuilder", "org.citrusframework.dsl.DefaultTestActionBuilder", "citrus-base"));
+        renames.add(new PackageRename("org.citrusframework.DefaultTestActions", "org.citrusframework.dsl.DefaultTestActions", "citrus-base"));
+        renames.add(new PackageRename("org.citrusframework.TestActionSupport", "org.citrusframework.dsl.TestActionSupport", "citrus-base"));
+
+        // citrus-docker (connector)
+        renames.add(new PackageRename("org.citrusframework.actions.docker.", "org.citrusframework.docker.", "citrus-docker"));
+
+        // citrus-spring
+        renames.add(new PackageRename("org.citrusframework.config.xml.", "org.citrusframework.spring.config.xml.", "citrus-spring"));
+        renames.add(new PackageRename("org.citrusframework.config.handler.", "org.citrusframework.spring.config.handler.", "citrus-spring"));
+        renames.add(new PackageRename("org.citrusframework.config.util.", "org.citrusframework.spring.config.util.", "citrus-spring"));
+        renames.add(new PackageRename("org.citrusframework.config.", "org.citrusframework.spring.config.", "citrus-spring"));
+        renames.add(new PackageRename("org.citrusframework.context.SpringBeanReferenceResolver", "org.citrusframework.spring.context.SpringBeanReferenceResolver", "citrus-spring"));
+        renames.add(new PackageRename("org.citrusframework.context.TestContextFactoryBean", "org.citrusframework.spring.context.TestContextFactoryBean", "citrus-spring"));
+        renames.add(new PackageRename("org.citrusframework.CitrusSpringContext", "org.citrusframework.spring.CitrusSpringContext", "citrus-spring"));
+        renames.add(new PackageRename("org.citrusframework.CitrusSpringContextProvider", "org.citrusframework.spring.CitrusSpringContextProvider", "citrus-spring"));
+        renames.add(new PackageRename("org.citrusframework.CitrusSpringSettings", "org.citrusframework.spring.CitrusSpringSettings", "citrus-spring"));
+
+        // citrus-spring-integration
+        renames.add(new PackageRename("org.citrusframework.channel.", "org.citrusframework.springintegration.channel.", "citrus-spring-integration"));
+        renames.add(new PackageRename("org.citrusframework.actions.PurgeMessageChannelAction", "org.citrusframework.springintegration.actions.PurgeMessageChannelAction", "citrus-spring-integration"));
+
+        // citrus-groovy (runtime)
+        renames.add(new PackageRename("org.citrusframework.script.", "org.citrusframework.groovy.actions.", "citrus-groovy"));
+        renames.add(new PackageRename("org.citrusframework.message.builder.script.", "org.citrusframework.groovy.message.builder.", "citrus-groovy"));
+        renames.add(new PackageRename("org.citrusframework.util.GroovyTypeConverter", "org.citrusframework.groovy.util.GroovyTypeConverter", "citrus-groovy"));
+
+        // citrus-sql (connector)
+        renames.add(new PackageRename("org.citrusframework.actions.AbstractDatabaseConnectingTestAction", "org.citrusframework.sql.actions.AbstractDatabaseConnectingTestAction", "citrus-sql"));
+        renames.add(new PackageRename("org.citrusframework.actions.ExecutePLSQLAction", "org.citrusframework.sql.actions.ExecutePLSQLAction", "citrus-sql"));
+        renames.add(new PackageRename("org.citrusframework.actions.ExecuteSQLAction", "org.citrusframework.sql.actions.ExecuteSQLAction", "citrus-sql"));
+        renames.add(new PackageRename("org.citrusframework.actions.ExecuteSQLQueryAction", "org.citrusframework.sql.actions.ExecuteSQLQueryAction", "citrus-sql"));
+        renames.add(new PackageRename("org.citrusframework.util.SqlUtils", "org.citrusframework.sql.util.SqlUtils", "citrus-sql"));
+
+        // citrus-validation-xml
+        renames.add(new PackageRename("org.citrusframework.variable.dictionary.xml.", "org.citrusframework.xml.variable.dictionary.", "citrus-validation-xml"));
+        renames.add(new PackageRename("org.citrusframework.xml.XsdSchemaRepository", "org.citrusframework.xml.schema.XsdSchemaRepository", "citrus-validation-xml"));
+        renames.add(new PackageRename("org.citrusframework.xml.XmlFormattingMessageProcessor", "org.citrusframework.xml.message.processor.XmlFormattingMessageProcessor", "citrus-validation-xml"));
+        renames.add(new PackageRename("org.citrusframework.xml.LSResolverImpl", "org.citrusframework.xml.support.LSResolverImpl", "citrus-validation-xml"));
+        renames.add(new PackageRename("org.citrusframework.xml.XmlConfigurer", "org.citrusframework.xml.support.XmlConfigurer", "citrus-validation-xml"));
+        renames.add(new PackageRename("org.citrusframework.util.XMLUtils", "org.citrusframework.xml.support.XMLUtils", "citrus-validation-xml"));
+        renames.add(new PackageRename("org.citrusframework.XmlValidationHelper", "org.citrusframework.xml.support.XmlValidationHelper", "citrus-validation-xml"));
+        renames.add(new PackageRename("org.citrusframework.dsl.XmlSupport", "org.citrusframework.xml.dsl.XmlSupport", "citrus-validation-xml"));
+        renames.add(new PackageRename("org.citrusframework.dsl.XpathSupport", "org.citrusframework.xml.dsl.XpathSupport", "citrus-validation-xml"));
+        renames.add(new PackageRename("org.citrusframework.message.builder.MarshallingPayloadBuilder", "org.citrusframework.xml.message.builder.MarshallingPayloadBuilder", "citrus-validation-xml"));
+
+        // citrus-validation-json
+        renames.add(new PackageRename("org.citrusframework.variable.dictionary.json.", "org.citrusframework.json.variable.dictionary.", "citrus-validation-json"));
+        renames.add(new PackageRename("org.citrusframework.dsl.JsonSupport", "org.citrusframework.json.dsl.JsonSupport", "citrus-validation-json"));
+        renames.add(new PackageRename("org.citrusframework.dsl.JsonPathSupport", "org.citrusframework.json.dsl.JsonPathSupport", "citrus-validation-json"));
+        renames.add(new PackageRename("org.citrusframework.message.builder.ObjectMappingPayloadBuilder", "org.citrusframework.json.message.builder.ObjectMappingPayloadBuilder", "citrus-validation-json"));
+
+        // citrus-validation-groovy
+        renames.add(new PackageRename("org.citrusframework.validation.script.Groovy", "org.citrusframework.validation.groovy.Groovy", "citrus-validation-groovy"));
+
+        // citrus-validation-hamcrest
+        renames.add(new PackageRename("org.citrusframework.validation.matcher.hamcrest.", "org.citrusframework.validation.hamcrest.matcher.", "citrus-validation-hamcrest"));
+        renames.add(new PackageRename("org.citrusframework.validation.HamcrestHeaderValidator", "org.citrusframework.validation.hamcrest.HamcrestHeaderValidator", "citrus-validation-hamcrest"));
+        renames.add(new PackageRename("org.citrusframework.validation.HamcrestValueMatcher", "org.citrusframework.validation.hamcrest.HamcrestValueMatcher", "citrus-validation-hamcrest"));
+        renames.add(new PackageRename("org.citrusframework.container.HamcrestConditionExpression", "org.citrusframework.validation.hamcrest.HamcrestConditionExpression", "citrus-validation-hamcrest"));
+
+        // citrus-jbang (tools)
+        renames.add(new PackageRename("org.citrusframework.jbang.", "org.citrusframework.jbang.cli.", "citrus-jbang"));
+
+        return renames;
+    }
+
+    private static List<ApiChange> createApiChanges5_0() {
+        List<ApiChange> changes = new ArrayList<>();
+        changes.add(new ApiChange("interface-extraction",
+                "CitrusContext is now an interface",
+                "The concrete CitrusContext class has been extracted into an interface in citrus-api. " +
+                        "The implementation is now DefaultCitrusContext in citrus-base, discovered via ServiceLoader. " +
+                        "Use CitrusContext.newInstance() instead of new CitrusContext()."));
+        changes.add(new ApiChange("interface-extraction",
+                "TestContextFactory is now an interface",
+                "The concrete TestContextFactory class has been extracted into an interface in citrus-api. " +
+                        "The implementation is now DefaultTestContextFactory in citrus-base, discovered via ServiceLoader. " +
+                        "Use TestContextFactory.newInstance() instead of new TestContextFactory()."));
+        changes.add(new ApiChange("new-interface",
+                "New container interfaces: IteratingActionContainer, TestBoundaryActionContainer, TestSuiteActionContainer",
+                "Three new interfaces introduced in citrus-api under org.citrusframework.api.container. " +
+                        "These are transparent additions - existing container implementations now implement these interfaces."));
+        changes.add(new ApiChange("class-relocation",
+                "DSL classes relocated to org.citrusframework.dsl",
+                "DefaultTestActionBuilder, DefaultTestActions, and TestActionSupport moved from " +
+                        "org.citrusframework to org.citrusframework.dsl."));
+        changes.add(new ApiChange("class-deletion",
+                "Deleted: AbstractEndpointFactoryBean and AbstractServerFactoryBean",
+                "These Spring XML factory beans have been removed without replacement. " +
+                        "Use AbstractEndpointParser / AbstractServerParser (now in org.citrusframework.spring.config.xml) instead."));
+        return changes;
+    }
+
+    private static List<SpiChange> createSpiChanges5_0() {
+        List<SpiChange> changes = new ArrayList<>();
+        changes.add(new SpiChange(
+                "META-INF/services/org.citrusframework.CitrusContext",
+                "org.citrusframework.base.DefaultCitrusContext",
+                "new"));
+        changes.add(new SpiChange(
+                "META-INF/services/org.citrusframework.context.TestContextFactory",
+                "org.citrusframework.base.context.DefaultTestContextFactory",
+                "new"));
+        changes.add(new SpiChange(
+                "META-INF/citrus/ SPI files",
+                "~43 internal SPI files updated with new fully-qualified class names",
+                "updated"));
+        changes.add(new SpiChange(
+                "spring.handlers",
+                "Updated for citrus-spring and citrus-spring-integration to reflect new namespace handler packages",
+                "updated"));
+        return changes;
+    }
+
+    public record MigrationGuide(
+            String targetVersion,
+            String title,
+            String description,
+            List<ArtifactRename> artifactRenames,
+            List<DependencyUpgrade> dependencyUpgrades,
+            List<PackageRename> packageRenames,
+            List<ApiChange> apiChanges,
+            List<SpiChange> spiChanges
+    ) {}
+
+    public record ArtifactRename(String groupId, String oldArtifactId, String newArtifactId) {}
+
+    public record DependencyUpgrade(String dependency, String oldVersion, String newVersion) {}
+
+    public record PackageRename(String oldPackage, String newPackage, String module) {}
+
+    public record ApiChange(String type, String summary, String details) {}
+
+    public record SpiChange(String serviceFile, String implementation, String changeType) {}
+}

--- a/tools/mcp-server/src/main/java/org/citrusframework/mcp/MigrationResources.java
+++ b/tools/mcp-server/src/main/java/org/citrusframework/mcp/MigrationResources.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.mcp;
+
+import io.quarkiverse.mcp.server.ResourceTemplate;
+import io.quarkiverse.mcp.server.ResourceTemplateArg;
+import io.quarkiverse.mcp.server.TextResourceContents;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class MigrationResources {
+
+    @Inject
+    MigrationData migrationData;
+
+    @ResourceTemplate(uriTemplate = "citrus://docs/migration-guide/{version}",
+            name = "citrus_docs_migration_guide",
+            title = "Citrus Migration Guide",
+            description = "Retrieves the Citrus version migration guide for a given target version (e.g. 5.0). " +
+                    "Returns structured JSON with package renames, Maven dependency changes, API changes, and SPI changes " +
+                    "to assist with automated migration from the previous major version.",
+            mimeType = "application/json")
+    public TextResourceContents citrus_docs_migration_guide(@ResourceTemplateArg(name = "version") String version) {
+        String uri = "citrus://docs/migration-guide/" + version;
+
+        if (version == null || version.isBlank()) {
+            return error(uri, "Version is required. Available versions: " + migrationData.getAvailableVersions());
+        }
+
+        try {
+            MigrationData.MigrationGuide guide = migrationData.getGuide(version);
+            if (guide == null) {
+                return error(uri, "Migration guide not found for version: " + version +
+                        ". Available versions: " + migrationData.getAvailableVersions());
+            }
+
+            return new TextResourceContents(uri,
+                    JsonSupport.json().writeValueAsString(guide), "application/json");
+        } catch (Throwable ex) {
+            return error(uri, ex.getMessage());
+        }
+    }
+
+    private TextResourceContents error(String uri, String message) {
+        return new TextResourceContents(uri, "{ \"error\": \"%s\" }".formatted(message), "application/json");
+    }
+}

--- a/tools/mcp-server/src/test/java/org/citrusframework/mcp/MigrationDataTest.java
+++ b/tools/mcp-server/src/test/java/org/citrusframework/mcp/MigrationDataTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.mcp;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MigrationDataTest {
+
+    private final MigrationData migrationData = new MigrationData();
+
+    @Test
+    void shouldReturnGuideForVersion5() {
+        MigrationData.MigrationGuide guide = migrationData.getGuide("5.0");
+
+        assertThat(guide).isNotNull();
+        assertThat(guide.targetVersion()).isEqualTo("5.0");
+        assertThat(guide.title()).isEqualTo("Citrus 4.x to 5.x");
+    }
+
+    @Test
+    void shouldReturnNullForUnknownVersion() {
+        assertThat(migrationData.getGuide("99.0")).isNull();
+    }
+
+    @Test
+    void shouldListAvailableVersions() {
+        assertThat(migrationData.getAvailableVersions()).containsExactly("5.0");
+    }
+
+    @Test
+    void shouldContainArtifactRenames() {
+        MigrationData.MigrationGuide guide = migrationData.getGuide("5.0");
+
+        assertThat(guide.artifactRenames()).isNotEmpty();
+        assertThat(guide.artifactRenames()).anyMatch(r ->
+                "citrus-junit5".equals(r.oldArtifactId()) && "citrus-junit-jupiter".equals(r.newArtifactId()));
+    }
+
+    @Test
+    void shouldContainDependencyUpgrades() {
+        MigrationData.MigrationGuide guide = migrationData.getGuide("5.0");
+
+        assertThat(guide.dependencyUpgrades()).isNotEmpty();
+        assertThat(guide.dependencyUpgrades()).anyMatch(u ->
+                "Spring Framework".equals(u.dependency()) && "7.x".equals(u.newVersion()));
+        assertThat(guide.dependencyUpgrades()).anyMatch(u ->
+                "Jackson".equals(u.dependency()));
+    }
+
+    @Test
+    void shouldContainPackageRenames() {
+        MigrationData.MigrationGuide guide = migrationData.getGuide("5.0");
+
+        assertThat(guide.packageRenames()).isNotEmpty();
+        assertThat(guide.packageRenames()).anyMatch(r ->
+                "org.citrusframework.TestActionSupport".equals(r.oldPackage()) &&
+                        "org.citrusframework.dsl.TestActionSupport".equals(r.newPackage()));
+        assertThat(guide.packageRenames()).anyMatch(r ->
+                "org.citrusframework.actions.".equals(r.oldPackage()) &&
+                        "org.citrusframework.api.actions.".equals(r.newPackage()));
+    }
+
+    @Test
+    void shouldContainApiChanges() {
+        MigrationData.MigrationGuide guide = migrationData.getGuide("5.0");
+
+        assertThat(guide.apiChanges()).isNotEmpty();
+        assertThat(guide.apiChanges()).anyMatch(c ->
+                "interface-extraction".equals(c.type()) && c.summary().contains("CitrusContext"));
+    }
+
+    @Test
+    void shouldContainSpiChanges() {
+        MigrationData.MigrationGuide guide = migrationData.getGuide("5.0");
+
+        assertThat(guide.spiChanges()).isNotEmpty();
+        assertThat(guide.spiChanges()).anyMatch(s ->
+                s.serviceFile().contains("CitrusContext") && "new".equals(s.changeType()));
+    }
+}

--- a/tools/mcp-server/src/test/java/org/citrusframework/mcp/MigrationResourcesTest.java
+++ b/tools/mcp-server/src/test/java/org/citrusframework/mcp/MigrationResourcesTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.mcp;
+
+import io.quarkiverse.mcp.server.TextResourceContents;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MigrationResourcesTest {
+
+    private MigrationResources createResources() {
+        MigrationResources resources = new MigrationResources();
+        resources.migrationData = new MigrationData();
+        return resources;
+    }
+
+    @Test
+    void shouldGetMigrationGuide() {
+        MigrationResources resources = createResources();
+
+        TextResourceContents result = resources.citrus_docs_migration_guide("5.0");
+
+        assertThat(result).isNotNull();
+        assertThat(result.uri()).isEqualTo("citrus://docs/migration-guide/5.0");
+        assertThat(result.text()).contains("\"targetVersion\":\"5.0\"");
+        assertThat(result.text()).contains("\"packageRenames\"");
+        assertThat(result.text()).contains("\"artifactRenames\"");
+        assertThat(result.text()).contains("\"dependencyUpgrades\"");
+        assertThat(result.text()).contains("\"apiChanges\"");
+        assertThat(result.text()).contains("\"spiChanges\"");
+    }
+
+    @Test
+    void shouldReturnErrorForUnknownVersion() {
+        MigrationResources resources = createResources();
+
+        TextResourceContents result = resources.citrus_docs_migration_guide("99.0");
+
+        assertThat(result).isNotNull();
+        assertThat(result.uri()).isEqualTo("citrus://docs/migration-guide/99.0");
+        assertThat(result.text()).contains("\"error\"");
+        assertThat(result.text()).contains("Migration guide not found");
+    }
+
+    @Test
+    void shouldReturnErrorForBlankVersion() {
+        MigrationResources resources = createResources();
+
+        TextResourceContents result = resources.citrus_docs_migration_guide("");
+
+        assertThat(result).isNotNull();
+        assertThat(result.text()).contains("\"error\"");
+        assertThat(result.text()).contains("Version is required");
+    }
+
+    @Test
+    void shouldContainPackageRenameDetails() {
+        MigrationResources resources = createResources();
+
+        TextResourceContents result = resources.citrus_docs_migration_guide("5.0");
+
+        assertThat(result.text()).contains("org.citrusframework.TestActionSupport");
+        assertThat(result.text()).contains("org.citrusframework.dsl.TestActionSupport");
+        assertThat(result.text()).contains("citrus-junit-jupiter");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a new `MigrationData` service class that provides structured migration guide data (package renames, Maven artifact renames, dependency upgrades, API changes, SPI changes) for Citrus version upgrades
- Adds a new `MigrationResources` class with a `@ResourceTemplate` at `citrus://docs/migration-guide/{version}` that returns the migration guide as machine-readable JSON
- The first included guide covers the Citrus 4.x to 5.x migration, based on the [wiki migration guide](https://github.com/citrusframework/citrus/wiki/Migration-guide:-Citrus-4.x-to-5.x)
- The versioned URI template (`{version}`) allows future migration guides to be added without changing the resource contract

Closes #1634

## Test plan

- [x] Unit tests for `MigrationData` — verifies guide lookup, available versions, and all data sections (artifact renames, dependency upgrades, package renames, API changes, SPI changes)
- [x] Unit tests for `MigrationResources` — verifies JSON resource output, error handling for unknown/blank versions, and content completeness
- [x] Module build passes (`mvn verify` in `tools/mcp-server`)
- [x] Full reactor build passes (`mvn clean install -DskipTests` from root)

Generated with [Claude Code](https://claude.ai/code)