### PR TITLE
fix(#809): URL-encode commas in query param values to support complex query strings

### DIFF
--- a/core/citrus-api/src/main/java/org/citrusframework/endpoint/resolver/DynamicEndpointUriResolver.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/endpoint/resolver/DynamicEndpointUriResolver.java
@@ -21,6 +21,7 @@ import java.util.StringTokenizer;
 
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.message.Message;
+import org.citrusframework.message.MessageHeaderUtils;
 
 /**
  * Endpoint uri resolver working on message headers. Resolver is searching for a specific header entry which holds the actual
@@ -107,11 +108,11 @@ public class DynamicEndpointUriResolver implements EndpointUriResolver {
                 requestUri = requestUri.substring(0, requestUri.length() - 1);
             }
 
-            queryParamBuilder.append("?").append(tok.nextToken().replace("%2C", ","));
+            queryParamBuilder.append("?").append(MessageHeaderUtils.decodeQueryParam(tok.nextToken()));
         }
 
         while (tok.hasMoreTokens()) {
-            queryParamBuilder.append("&").append(tok.nextToken().replace("%2C", ","));
+            queryParamBuilder.append("&").append(MessageHeaderUtils.decodeQueryParam(tok.nextToken()));
         }
 
         return requestUri + queryParamBuilder;

--- a/core/citrus-api/src/main/java/org/citrusframework/endpoint/resolver/DynamicEndpointUriResolver.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/endpoint/resolver/DynamicEndpointUriResolver.java
@@ -85,7 +85,8 @@ public class DynamicEndpointUriResolver implements EndpointUriResolver {
     }
 
     /**
-     * Appends one to many query param key value paris to request uri. Syntax must be: param1=value1,param2=value2.
+     * Appends one to many query param key value pairs to request uri. Syntax must be: param1=value1,param2=value2.
+     * Literal commas in values must be percent-encoded as {@code %2C} to avoid conflicts with the comma delimiter.
      * Results in parameterized request uri such as http://localhost:8080/test?param1=value1&param2=value2
      * @param uri
      * @param headers
@@ -106,11 +107,11 @@ public class DynamicEndpointUriResolver implements EndpointUriResolver {
                 requestUri = requestUri.substring(0, requestUri.length() - 1);
             }
 
-            queryParamBuilder.append("?").append(tok.nextToken());
+            queryParamBuilder.append("?").append(tok.nextToken().replace("%2C", ","));
         }
 
         while (tok.hasMoreTokens()) {
-            queryParamBuilder.append("&").append(tok.nextToken());
+            queryParamBuilder.append("&").append(tok.nextToken().replace("%2C", ","));
         }
 
         return requestUri + queryParamBuilder;

--- a/core/citrus-api/src/main/java/org/citrusframework/message/MessageHeaderUtils.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/message/MessageHeaderUtils.java
@@ -113,4 +113,21 @@ public final class MessageHeaderUtils {
     public static boolean isInternalMessageHeader(String headerName) {
         return headerName.startsWith(MessageHeaders.PREFIX);
     }
+
+    /**
+     * Encodes reserved characters in a query parameter value so that they do
+     * not conflict with the internal comma-separated query parameter string
+     * representation. Currently, encodes commas as {@code %2C}.
+     */
+    public static String encodeQueryParam(String value) {
+        return value.replace(",", "%2C");
+    }
+
+    /**
+     * Decodes a query parameter value that was previously encoded with
+     * {@link #encodeQueryParam(String)}.
+     */
+    public static String decodeQueryParam(String value) {
+        return value.replace("%2C", ",");
+    }
 }

--- a/core/citrus-api/src/test/java/org/citrusframework/endpoint/resolver/DynamicEndpointUriResolverTest.java
+++ b/core/citrus-api/src/test/java/org/citrusframework/endpoint/resolver/DynamicEndpointUriResolverTest.java
@@ -82,6 +82,7 @@ public class DynamicEndpointUriResolverTest {
                 { "http://localhost:8080/request/", "param1=", "http://localhost:8080/request?param1=" },
                 { "http://localhost:8080/request/", "param1=value1,param2=value2,param3=value3", "http://localhost:8080/request?param1=value1&param2=value2&param3=value3" },
                 { "http://localhost:8080/request////", "param1=value1", "http://localhost:8080/request?param1=value1"},
+                { "http://localhost:8080/request", "$select=Name%2CValue,$top=10", "http://localhost:8080/request?$select=Name,Value&$top=10"},
         };
     }
 

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/controller/HttpMessageController.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/controller/HttpMessageController.java
@@ -161,7 +161,7 @@ public class HttpMessageController {
                 .uri(pathHelper.getRequestUri(servletRequest))
                 .contextPath(pathHelper.getContextPath(servletRequest))
                 .queryParams(Optional.ofNullable(pathHelper.getOriginatingQueryString(servletRequest))
-                                    .map(queryString -> queryString.replaceAll("&", ","))
+                                    .map(queryString -> queryString.replace(",", "%2C").replace("&", ","))
                                     .orElse(""))
                 .version(servletRequest.getProtocol())
                 .method(method);

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/controller/HttpMessageController.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/controller/HttpMessageController.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.citrusframework.message.MessageHeaderUtils;
 import org.citrusframework.endpoint.EndpointAdapter;
 import org.citrusframework.base.endpoint.adapter.EmptyResponseEndpointAdapter;
 import org.citrusframework.exceptions.CitrusRuntimeException;
@@ -161,7 +162,7 @@ public class HttpMessageController {
                 .uri(pathHelper.getRequestUri(servletRequest))
                 .contextPath(pathHelper.getContextPath(servletRequest))
                 .queryParams(Optional.ofNullable(pathHelper.getOriginatingQueryString(servletRequest))
-                                    .map(queryString -> queryString.replace(",", "%2C").replace("&", ","))
+                                    .map(queryString -> MessageHeaderUtils.encodeQueryParam(queryString).replace("&", ","))
                                     .orElse(""))
                 .version(servletRequest.getProtocol())
                 .method(method);

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/message/HttpMessage.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/message/HttpMessage.java
@@ -215,7 +215,8 @@ public class HttpMessage extends DefaultMessage {
 
     /**
      * Sets the Http request query params query String. Query String is a compilation of key-value pairs separated
-     * by comma character e.g. key1=value1[","key2=value2]. Query String can be empty.
+     * by comma character e.g. key1=value1[","key2=value2]. Literal commas in values must be percent-encoded as
+     * {@code %2C} to avoid conflicts with the comma delimiter. Query String can be empty.
      *
      * @param queryParamString The query parameter string to evaluate
      * @return The altered HttpMessage
@@ -233,7 +234,9 @@ public class HttpMessage extends DefaultMessage {
                     }
                     return keyValue;
                 })
-                .forEach(keyValue -> this.addQueryParam(keyValue[0], keyValue[1]));
+                .forEach(keyValue -> this.addQueryParam(
+                        keyValue[0].replace("%2C", ","),
+                        keyValue[1].replace("%2C", ",")));
 
         return this;
     }

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/message/HttpMessage.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/message/HttpMessage.java
@@ -34,6 +34,7 @@ import org.citrusframework.endpoint.resolver.EndpointUriResolver;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.message.DefaultMessage;
 import org.citrusframework.message.Message;
+import org.citrusframework.message.MessageHeaderUtils;
 import org.citrusframework.util.StringUtils;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -235,8 +236,8 @@ public class HttpMessage extends DefaultMessage {
                     return keyValue;
                 })
                 .forEach(keyValue -> this.addQueryParam(
-                        keyValue[0].replace("%2C", ","),
-                        keyValue[1].replace("%2C", ",")));
+                        MessageHeaderUtils.decodeQueryParam(keyValue[0]),
+                        MessageHeaderUtils.decodeQueryParam(keyValue[1])));
 
         return this;
     }

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/message/HttpMessageUtils.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/message/HttpMessageUtils.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.citrusframework.message.Message;
+import org.citrusframework.message.MessageHeaderUtils;
 import org.citrusframework.message.MessageHeaders;
 
 import static java.util.Collections.emptyMap;
@@ -94,8 +95,8 @@ public final class HttpMessageUtils {
                     if (keyAndValue.length == 0) {
                         throw new IllegalArgumentException("Query parameter must have a key.");
                     }
-                    String key = keyAndValue[0].replace("%2C", ",");
-                    String value = keyAndValue.length > 1 ? keyAndValue[1].replace("%2C", ",") : "";
+                    String key = MessageHeaderUtils.decodeQueryParam(keyAndValue[0]);
+                    String value = keyAndValue.length > 1 ? MessageHeaderUtils.decodeQueryParam(keyAndValue[1]) : "";
                     return Pair.of(key, value);
                 })
                 .collect(groupingBy(Pair::getLeft,mapping(Pair::getRight,toList())));

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/message/HttpMessageUtils.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/message/HttpMessageUtils.java
@@ -94,8 +94,8 @@ public final class HttpMessageUtils {
                     if (keyAndValue.length == 0) {
                         throw new IllegalArgumentException("Query parameter must have a key.");
                     }
-                    String key = keyAndValue[0];
-                    String value = keyAndValue.length > 1 ? keyAndValue[1] : "";
+                    String key = keyAndValue[0].replace("%2C", ",");
+                    String value = keyAndValue.length > 1 ? keyAndValue[1].replace("%2C", ",") : "";
                     return Pair.of(key, value);
                 })
                 .collect(groupingBy(Pair::getLeft,mapping(Pair::getRight,toList())));

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/message/HttpQueryParamHeaderValidator.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/message/HttpQueryParamHeaderValidator.java
@@ -78,10 +78,9 @@ public class HttpQueryParamHeaderValidator extends DefaultHeaderValidator {
             .map(keyValue -> keyValue.split("="))
             .filter(keyValue -> hasText(keyValue[0]))
             .collect(toMap(
-                keyValue -> keyValue[0],  // Key function
+                keyValue -> keyValue[0].replace("%2C", ","),
                 keyValue ->
-                    // Value function: if no value is present, use an empty string
-                     (keyValue.length < 2 ? "" : keyValue[1])
+                     (keyValue.length < 2 ? "" : keyValue[1].replace("%2C", ","))
                 ,
                 (existingValue, newValue) -> {  // Merge function to handle duplicate keys
                     if (existingValue instanceof List<?>) {

--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/message/HttpQueryParamHeaderValidator.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/message/HttpQueryParamHeaderValidator.java
@@ -24,6 +24,7 @@ import java.util.stream.Stream;
 
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.ValidationException;
+import org.citrusframework.message.MessageHeaderUtils;
 import org.citrusframework.validation.DefaultHeaderValidator;
 import org.citrusframework.validation.context.HeaderValidationContext;
 import org.citrusframework.validation.matcher.ValidationMatcherUtils;
@@ -78,9 +79,9 @@ public class HttpQueryParamHeaderValidator extends DefaultHeaderValidator {
             .map(keyValue -> keyValue.split("="))
             .filter(keyValue -> hasText(keyValue[0]))
             .collect(toMap(
-                keyValue -> keyValue[0].replace("%2C", ","),
+                keyValue -> MessageHeaderUtils.decodeQueryParam(keyValue[0]),
                 keyValue ->
-                     (keyValue.length < 2 ? "" : keyValue[1].replace("%2C", ","))
+                     (keyValue.length < 2 ? "" : MessageHeaderUtils.decodeQueryParam(keyValue[1]))
                 ,
                 (existingValue, newValue) -> {  // Merge function to handle duplicate keys
                     if (existingValue instanceof List<?>) {

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/message/HttpMessageTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/message/HttpMessageTest.java
@@ -290,6 +290,45 @@ public class HttpMessageTest {
     }
 
     @Test
+    public void testQueryParamsWithEncodedCommaInValue() {
+        //GIVEN
+        final String queryParamString = "$select=Name%2CValue,$top=10";
+
+        //WHEN
+        final HttpMessage resultMessage = httpMessage.queryParams(queryParamString);
+
+        //THEN
+        final Map<String, Collection<String>> queryParams = resultMessage.getQueryParams();
+        assertTrue(queryParams.get("$select").contains("Name,Value"));
+        assertTrue(queryParams.get("$top").contains("10"));
+    }
+
+    @Test
+    public void testQueryParamWithCommaInValueStoresCorrectly() {
+        //GIVEN
+
+        //WHEN
+        final HttpMessage resultMessage = httpMessage.queryParam("$select", "Name,Value");
+
+        //THEN
+        assertTrue(resultMessage.getQueryParams().get("$select").contains("Name,Value"));
+    }
+
+    @Test
+    public void testServerSideIngestionRoundTrip() {
+        //GIVEN - simulate HttpMessageController encoding: encode commas, then replace & with ,
+        final String rawQueryString = "$select=Name,Value&$top=10";
+        final String encodedQueryString = rawQueryString.replace(",", "%2C").replace("&", ",");
+
+        //WHEN
+        final HttpMessage resultMessage = httpMessage.queryParams(encodedQueryString);
+
+        //THEN
+        assertTrue(resultMessage.getQueryParams().get("$select").contains("Name,Value"));
+        assertTrue(resultMessage.getQueryParams().get("$top").contains("10"));
+    }
+
+    @Test
     public void testCopyConstructorPreservesIdAndTimestamp() {
         // Given
         httpMessage.setPayload("myPayload");

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/message/HttpMessageTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/message/HttpMessageTest.java
@@ -18,6 +18,7 @@ package org.citrusframework.http.message;
 
 import jakarta.servlet.http.Cookie;
 import org.citrusframework.endpoint.resolver.EndpointUriResolver;
+import org.citrusframework.message.MessageHeaderUtils;
 import org.citrusframework.message.MessageHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
@@ -318,7 +319,7 @@ public class HttpMessageTest {
     public void testServerSideIngestionRoundTrip() {
         //GIVEN - simulate HttpMessageController encoding: encode commas, then replace & with ,
         final String rawQueryString = "$select=Name,Value&$top=10";
-        final String encodedQueryString = rawQueryString.replace(",", "%2C").replace("&", ",");
+        final String encodedQueryString = MessageHeaderUtils.encodeQueryParam(rawQueryString).replace("&", ",");
 
         //WHEN
         final HttpMessage resultMessage = httpMessage.queryParams(encodedQueryString);

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/message/HttpMessageUtilsTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/message/HttpMessageUtilsTest.java
@@ -170,6 +170,20 @@ public class HttpMessageUtilsTest {
     }
 
     @Test
+    public void testGetQueryParameterMapWithEncodedCommaInValue() {
+        HttpMessage httpMessage = new HttpMessage();
+        httpMessage.queryParams("$select=Name%2CValue,$top=10");
+
+        Map<String, List<String>> queryParams = getQueryParameterMap(httpMessage);
+
+        assertEquals(queryParams.size(), 2);
+        List<String> selectValues = queryParams.get("$select");
+        assertTrue(selectValues.contains("Name,Value"));
+        List<String> topValues = queryParams.get("$top");
+        assertTrue(topValues.contains("10"));
+    }
+
+    @Test
     public void testGetQueryParameterMapWithNoValues() {
         HttpMessage httpMessage = new HttpMessage();
 

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/message/HttpQueryParamHeaderValidatorTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/message/HttpQueryParamHeaderValidatorTest.java
@@ -47,6 +47,7 @@ public class HttpQueryParamHeaderValidatorTest extends AbstractTestNGUnitTest {
                 new Object[] { "foo=,bar=barValue", "foo=,bar=barValue" },
                 new Object[] { "foo=1,foo=2,foo=3,bar=barValue", "foo=1,foo=2,foo=3,bar=barValue" },
                 new Object[] { "foo=1,foo=2,foo=3,bar=barValue", "foo=3,foo=2,foo=1,bar=barValue" },
+                new Object[] { "$select=Name%2CValue,$top=10", "$select=Name%2CValue,$top=10" },
                 new Object[] { null, null },
                 new Object[] { Collections.singletonMap("key", "value"), Collections.singletonMap("key", "value") },
                 new Object[] { Collections.singletonMap("key", "value"), Collections.singletonMap("key", is("value")) }

--- a/tools/test-generator/src/main/java/org/citrusframework/generate/provider/http/HttpCodeProvider.java
+++ b/tools/test-generator/src/main/java/org/citrusframework/generate/provider/http/HttpCodeProvider.java
@@ -22,6 +22,7 @@ import java.util.stream.Stream;
 import com.squareup.javapoet.CodeBlock;
 import org.citrusframework.generate.provider.MessageCodeProvider;
 import org.citrusframework.http.message.HttpMessage;
+import org.citrusframework.message.MessageHeaderUtils;
 import org.citrusframework.util.StringUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -78,8 +79,8 @@ class HttpCodeProvider {
                     .map(nameValuePair -> nameValuePair.split("="))
                     .forEach(param ->
                             code.add(".queryParam($S, $S)\n",
-                                    param[0].replace("%2C", ","),
-                                    param[1].replace("%2C", ","))
+                                    MessageHeaderUtils.decodeQueryParam(param[0]),
+                                    MessageHeaderUtils.decodeQueryParam(param[1]))
                     );
         }
     }

--- a/tools/test-generator/src/main/java/org/citrusframework/generate/provider/http/HttpCodeProvider.java
+++ b/tools/test-generator/src/main/java/org/citrusframework/generate/provider/http/HttpCodeProvider.java
@@ -77,7 +77,9 @@ class HttpCodeProvider {
                     .split(","))
                     .map(nameValuePair -> nameValuePair.split("="))
                     .forEach(param ->
-                            code.add(".queryParam($S, $S)\n", param[0], param[1])
+                            code.add(".queryParam($S, $S)\n",
+                                    param[0].replace("%2C", ","),
+                                    param[1].replace("%2C", ","))
                     );
         }
     }

--- a/tools/test-generator/src/main/java/org/citrusframework/generate/provider/http/ReceiveHttpRequestActionProvider.java
+++ b/tools/test-generator/src/main/java/org/citrusframework/generate/provider/http/ReceiveHttpRequestActionProvider.java
@@ -21,6 +21,7 @@ import java.util.stream.Stream;
 
 import org.citrusframework.generate.provider.MessageActionProvider;
 import org.citrusframework.http.message.HttpMessage;
+import org.citrusframework.message.MessageHeaderUtils;
 import org.citrusframework.message.MessageHeaders;
 import org.citrusframework.model.testcase.http.ParamType;
 import org.citrusframework.model.testcase.http.ReceiveRequestModel;
@@ -77,8 +78,8 @@ public class ReceiveHttpRequestActionProvider implements MessageActionProvider<R
                     .map(nameValuePair -> nameValuePair.split("="))
                     .forEach(param -> {
                         ParamType paramType = new ParamType();
-                        paramType.setName(param[0].replace("%2C", ","));
-                        paramType.setValue(param[1].replace("%2C", ","));
+                        paramType.setName(MessageHeaderUtils.decodeQueryParam(param[0]));
+                        paramType.setValue(MessageHeaderUtils.decodeQueryParam(param[1]));
                         requestType.getParams().add(paramType);
                     });
         }

--- a/tools/test-generator/src/main/java/org/citrusframework/generate/provider/http/ReceiveHttpRequestActionProvider.java
+++ b/tools/test-generator/src/main/java/org/citrusframework/generate/provider/http/ReceiveHttpRequestActionProvider.java
@@ -77,8 +77,8 @@ public class ReceiveHttpRequestActionProvider implements MessageActionProvider<R
                     .map(nameValuePair -> nameValuePair.split("="))
                     .forEach(param -> {
                         ParamType paramType = new ParamType();
-                        paramType.setName(param[0]);
-                        paramType.setValue(param[1]);
+                        paramType.setName(param[0].replace("%2C", ","));
+                        paramType.setValue(param[1].replace("%2C", ","));
                         requestType.getParams().add(paramType);
                     });
         }

--- a/tools/test-generator/src/main/java/org/citrusframework/generate/provider/http/SendHttpRequestActionProvider.java
+++ b/tools/test-generator/src/main/java/org/citrusframework/generate/provider/http/SendHttpRequestActionProvider.java
@@ -21,6 +21,7 @@ import java.util.stream.Stream;
 
 import org.citrusframework.generate.provider.MessageActionProvider;
 import org.citrusframework.http.message.HttpMessage;
+import org.citrusframework.message.MessageHeaderUtils;
 import org.citrusframework.message.MessageHeaders;
 import org.citrusframework.model.testcase.http.ClientRequestType;
 import org.citrusframework.model.testcase.http.ParamType;
@@ -78,8 +79,8 @@ public class SendHttpRequestActionProvider implements MessageActionProvider<Send
                     .map(nameValuePair -> nameValuePair.split("="))
                     .forEach(param -> {
                         ParamType paramType = new ParamType();
-                        paramType.setName(param[0].replace("%2C", ","));
-                        paramType.setValue(param[1].replace("%2C", ","));
+                        paramType.setName(MessageHeaderUtils.decodeQueryParam(param[0]));
+                        paramType.setValue(MessageHeaderUtils.decodeQueryParam(param[1]));
                         requestType.getParams().add(paramType);
                     });
         }

--- a/tools/test-generator/src/main/java/org/citrusframework/generate/provider/http/SendHttpRequestActionProvider.java
+++ b/tools/test-generator/src/main/java/org/citrusframework/generate/provider/http/SendHttpRequestActionProvider.java
@@ -78,8 +78,8 @@ public class SendHttpRequestActionProvider implements MessageActionProvider<Send
                     .map(nameValuePair -> nameValuePair.split("="))
                     .forEach(param -> {
                         ParamType paramType = new ParamType();
-                        paramType.setName(param[0]);
-                        paramType.setValue(param[1]);
+                        paramType.setName(param[0].replace("%2C", ","));
+                        paramType.setValue(param[1].replace("%2C", ","));
                         requestType.getParams().add(paramType);
                     });
         }


### PR DESCRIPTION
## Summary

- URL-encode literal commas (`%2C`) in query parameter values when storing in the internal comma-delimited format, and decode them back when reading values out
- Fixes all 10 locations in the query parameter pipeline: ingestion (`HttpMessageController`), parsing/serialization (`HttpMessage`), URI reconstruction (`DynamicEndpointUriResolver`), validation (`HttpQueryParamHeaderValidator`), utilities (`HttpMessageUtils`), and test generators
- Adds tests for comma-containing values across `HttpMessageTest`, `DynamicEndpointUriResolverTest`, `HttpQueryParamHeaderValidatorTest`, and `HttpMessageUtilsTest`

Closes #809

## Test plan

- [x] `HttpMessageTest` — round-trip encoding/decoding of comma-containing query param values
- [x] `DynamicEndpointUriResolverTest` — URL reconstruction with `%2C`-encoded values
- [x] `HttpQueryParamHeaderValidatorTest` — validation of encoded query params
- [x] `HttpMessageUtilsTest` — `getQueryParameterMap()` with comma-containing values
- [x] Full reactor build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)