### PR TITLE
fix(#1639): Simplify Java DSL access to data mapping payload builders

### DIFF
--- a/core/citrus-api/src/main/java/org/citrusframework/TestActionRunner.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/TestActionRunner.java
@@ -18,6 +18,7 @@ package org.citrusframework;
 
 import java.util.List;
 
+import org.citrusframework.message.PayloadBuilders;
 import org.citrusframework.message.Processors;
 import org.citrusframework.validation.Validations;
 import org.citrusframework.variable.VariableExtractors;
@@ -86,6 +87,11 @@ public interface TestActionRunner {
      * Provide access to all available message processors.
      */
     Processors processor();
+
+    /**
+     * Provide access to all available message payload builders.
+     */
+    PayloadBuilders buildPayload();
 
     /**
      * Builds and runs given test action.

--- a/core/citrus-api/src/main/java/org/citrusframework/message/DefaultPayloadBuilders.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/message/DefaultPayloadBuilders.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.message;
+
+/**
+ * Default implementation of Citrus message payload builders.
+ * Uses the default implementations of the support interface.
+ */
+public class DefaultPayloadBuilders implements PayloadBuilderSupport {
+
+}

--- a/core/citrus-api/src/main/java/org/citrusframework/message/MessagePayloadBuilder.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/message/MessagePayloadBuilder.java
@@ -16,10 +16,39 @@
 
 package org.citrusframework.message;
 
+import java.util.Optional;
+
 import org.citrusframework.context.TestContext;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.spi.ResourcePathTypeResolver;
+import org.citrusframework.spi.TypeResolver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @FunctionalInterface
 public interface MessagePayloadBuilder {
+
+    Logger logger = LoggerFactory.getLogger(MessagePayloadBuilder.class);
+
+    String RESOURCE_PATH = "META-INF/citrus/message/builder";
+
+    TypeResolver TYPE_RESOLVER = new ResourcePathTypeResolver(RESOURCE_PATH);
+
+    /**
+     * Resolves payload builder from resource path lookup with given resource name. Scans classpath for payload builder
+     * meta information with given name and returns instance. Returns optional instead of throwing exception when no
+     * payload builder could be found.
+     */
+    static Optional<MessagePayloadBuilder> lookup(String builder, Object... args) {
+        try {
+            MessagePayloadBuilder instance = TYPE_RESOLVER.resolve(builder, args);
+            return Optional.of(instance);
+        } catch (CitrusRuntimeException e) {
+            logger.warn("Failed to resolve message payload builder from resource '{}/{}' - caused by: {}", RESOURCE_PATH, builder, e.getMessage());
+        }
+
+        return Optional.empty();
+    }
 
     /**
      * Builds the message payload.

--- a/core/citrus-api/src/main/java/org/citrusframework/message/MessageProcessorSupport.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/message/MessageProcessorSupport.java
@@ -90,6 +90,16 @@ public interface MessageProcessorSupport extends Processors, MessageProcessorLoo
             public <T> JsonMappingValidationProcessorBuilder<T, ?, ?> validate(Class<T> type) {
                 return lookup("jsonValidate", type);
             }
+
+            @Override
+            public MessagePayloadBuilder marshal(Object model) {
+                return lookupPayloadBuilder("jsonMarshal", model);
+            }
+
+            @Override
+            public MessagePayloadBuilder marshal(Object model, Object mapper) {
+                return lookupPayloadBuilder("jsonMarshal", model, mapper);
+            }
         };
     }
 
@@ -110,6 +120,16 @@ public interface MessageProcessorSupport extends Processors, MessageProcessorLoo
             @Override
             public <T> XmlMarshallingValidationProcessorBuilder<T, ?, ?> validate(GenericValidationProcessor<T> validationProcessor) {
                 return lookup("xmlValidate", validationProcessor);
+            }
+
+            @Override
+            public MessagePayloadBuilder marshal(Object model) {
+                return lookupPayloadBuilder("xmlMarshal", model);
+            }
+
+            @Override
+            public MessagePayloadBuilder marshal(Object model, Object marshaller) {
+                return lookupPayloadBuilder("xmlMarshal", model, marshaller);
             }
         };
     }

--- a/core/citrus-api/src/main/java/org/citrusframework/message/PayloadBuilderLookupSupport.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/message/PayloadBuilderLookupSupport.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.message;
+
+import org.citrusframework.exceptions.CitrusRuntimeException;
+
+public interface PayloadBuilderLookupSupport {
+
+    default MessagePayloadBuilder lookupPayloadBuilder(String type, Object... args) {
+        return MessagePayloadBuilder.lookup(type, args)
+                .orElseThrow(() -> new CitrusRuntimeException(("Missing Citrus module for message payload builder '%s' - " +
+                        "please add the required module to your project").formatted(type)));
+    }
+}

--- a/core/citrus-api/src/main/java/org/citrusframework/message/PayloadBuilderSupport.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/message/PayloadBuilderSupport.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.message;
+
+import org.citrusframework.message.builder.json.JsonPayloadBuilders;
+import org.citrusframework.message.builder.xml.XmlPayloadBuilders;
+
+/**
+ * Interface combines default implementations with domain specific language methods for all message payload builders
+ * available in Citrus.
+ */
+public interface PayloadBuilderSupport extends PayloadBuilders, PayloadBuilderLookupSupport {
+
+    @Override
+    default JsonPayloadBuilders json() {
+        return new JsonPayloadBuilders() {
+            @Override
+            public MessagePayloadBuilder marshal(Object model) {
+                return lookupPayloadBuilder("jsonMarshal", model);
+            }
+
+            @Override
+            public MessagePayloadBuilder marshal(Object model, Object mapper) {
+                return lookupPayloadBuilder("jsonMarshal", model, mapper);
+            }
+        };
+    }
+
+    @Override
+    default XmlPayloadBuilders xml() {
+        return new XmlPayloadBuilders() {
+            @Override
+            public MessagePayloadBuilder marshal(Object model) {
+                return lookupPayloadBuilder("xmlMarshal", model);
+            }
+
+            @Override
+            public MessagePayloadBuilder marshal(Object model, Object marshaller) {
+                return lookupPayloadBuilder("xmlMarshal", model, marshaller);
+            }
+        };
+    }
+}

--- a/core/citrus-api/src/main/java/org/citrusframework/message/PayloadBuilders.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/message/PayloadBuilders.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.message;
+
+import org.citrusframework.message.builder.json.JsonPayloadBuilders;
+import org.citrusframework.message.builder.xml.XmlPayloadBuilders;
+
+public interface PayloadBuilders extends
+        JsonPayloadBuilders.Factory,
+        XmlPayloadBuilders.Factory {
+}

--- a/core/citrus-api/src/main/java/org/citrusframework/message/builder/json/JsonPayloadBuilders.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/message/builder/json/JsonPayloadBuilders.java
@@ -14,19 +14,11 @@
  * limitations under the License.
  */
 
-package org.citrusframework.message.processor.json;
+package org.citrusframework.message.builder.json;
 
 import org.citrusframework.message.MessagePayloadBuilder;
-import org.citrusframework.message.PayloadBuilderLookupSupport;
-import org.citrusframework.variable.json.JsonPathVariableExtractorBuilder;
 
-public interface JsonMessageProcessors extends PayloadBuilderLookupSupport {
-
-    JsonPathMessageProcessorBuilder<?, ?> jsonPath();
-
-    JsonPathVariableExtractorBuilder<?, ?> extract();
-
-    <T> JsonMappingValidationProcessorBuilder<T, ?, ?> validate(Class<T> type);
+public interface JsonPayloadBuilders {
 
     MessagePayloadBuilder marshal(Object model);
 
@@ -37,10 +29,6 @@ public interface JsonMessageProcessors extends PayloadBuilderLookupSupport {
         /**
          * Fluent API action building entry method used in Java DSL.
          */
-        JsonMessageProcessors json();
-
-        default JsonPathMessageProcessorBuilder<?, ?> jsonPath() {
-            return json().jsonPath();
-        }
+        JsonPayloadBuilders json();
     }
 }

--- a/core/citrus-api/src/main/java/org/citrusframework/message/builder/xml/XmlPayloadBuilders.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/message/builder/xml/XmlPayloadBuilders.java
@@ -14,33 +14,21 @@
  * limitations under the License.
  */
 
-package org.citrusframework.message.processor.json;
+package org.citrusframework.message.builder.xml;
 
 import org.citrusframework.message.MessagePayloadBuilder;
-import org.citrusframework.message.PayloadBuilderLookupSupport;
-import org.citrusframework.variable.json.JsonPathVariableExtractorBuilder;
 
-public interface JsonMessageProcessors extends PayloadBuilderLookupSupport {
-
-    JsonPathMessageProcessorBuilder<?, ?> jsonPath();
-
-    JsonPathVariableExtractorBuilder<?, ?> extract();
-
-    <T> JsonMappingValidationProcessorBuilder<T, ?, ?> validate(Class<T> type);
+public interface XmlPayloadBuilders {
 
     MessagePayloadBuilder marshal(Object model);
 
-    MessagePayloadBuilder marshal(Object model, Object mapper);
+    MessagePayloadBuilder marshal(Object model, Object marshaller);
 
     interface Factory {
 
         /**
          * Fluent API action building entry method used in Java DSL.
          */
-        JsonMessageProcessors json();
-
-        default JsonPathMessageProcessorBuilder<?, ?> jsonPath() {
-            return json().jsonPath();
-        }
+        XmlPayloadBuilders xml();
     }
 }

--- a/core/citrus-api/src/main/java/org/citrusframework/message/processor/xml/XmlMessageProcessors.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/message/processor/xml/XmlMessageProcessors.java
@@ -16,16 +16,22 @@
 
 package org.citrusframework.message.processor.xml;
 
+import org.citrusframework.message.MessagePayloadBuilder;
+import org.citrusframework.message.PayloadBuilderLookupSupport;
 import org.citrusframework.validation.GenericValidationProcessor;
 import org.citrusframework.variable.xml.XpathPayloadVariableExtractorBuilder;
 
-public interface XmlMessageProcessors {
+public interface XmlMessageProcessors extends PayloadBuilderLookupSupport {
 
     XpathMessageProcessorBuilder<?, ?> xpath();
 
     XpathPayloadVariableExtractorBuilder<?, ?> extract();
 
     <T> XmlMarshallingValidationProcessorBuilder<T, ?, ?> validate(GenericValidationProcessor<T> validationProcessor);
+
+    MessagePayloadBuilder marshal(Object model);
+
+    MessagePayloadBuilder marshal(Object model, Object mapper);
 
     interface Factory {
 

--- a/core/citrus-base/src/main/java/org/citrusframework/base/DefaultTestCaseRunner.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/base/DefaultTestCaseRunner.java
@@ -34,6 +34,8 @@ import org.citrusframework.container.FinallySequence;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.dsl.DefaultTestActions;
 import org.citrusframework.message.DefaultMessageProcessors;
+import org.citrusframework.message.DefaultPayloadBuilders;
+import org.citrusframework.message.PayloadBuilders;
 import org.citrusframework.message.Processors;
 import org.citrusframework.spi.ReferenceResolverAware;
 import org.citrusframework.validation.DefaultValidations;
@@ -163,6 +165,11 @@ public class DefaultTestCaseRunner implements TestCaseRunner {
     @Override
     public Processors processor() {
         return new DefaultMessageProcessors();
+    }
+
+    @Override
+    public PayloadBuilders buildPayload() {
+        return new DefaultPayloadBuilders();
     }
 
     @Override

--- a/core/citrus-base/src/main/java/org/citrusframework/dsl/TestActionSupport.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/dsl/TestActionSupport.java
@@ -33,6 +33,8 @@ import org.citrusframework.dsl.soap.SoapTestActionSupport;
 import org.citrusframework.dsl.sql.SqlTestActionSupport;
 import org.citrusframework.dsl.testcontainers.TestcontainersTestActionSupport;
 import org.citrusframework.message.DefaultMessageProcessors;
+import org.citrusframework.message.DefaultPayloadBuilders;
+import org.citrusframework.message.PayloadBuilders;
 import org.citrusframework.message.Processors;
 import org.citrusframework.validation.DefaultValidations;
 import org.citrusframework.validation.Validations;
@@ -77,5 +79,9 @@ public interface TestActionSupport extends TestActions, TestActionContainers,
 
     default Processors processor() {
         return new DefaultMessageProcessors();
+    }
+
+    default PayloadBuilders buildPayload() {
+        return new DefaultPayloadBuilders();
     }
 }

--- a/runtime/citrus-junit/src/main/java/org/citrusframework/junit/JUnit4CitrusSupport.java
+++ b/runtime/citrus-junit/src/main/java/org/citrusframework/junit/JUnit4CitrusSupport.java
@@ -39,6 +39,8 @@ import org.citrusframework.api.common.TestSourceAware;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.message.DefaultMessageProcessors;
+import org.citrusframework.message.DefaultPayloadBuilders;
+import org.citrusframework.message.PayloadBuilders;
 import org.citrusframework.message.Processors;
 import org.citrusframework.validation.DefaultValidations;
 import org.citrusframework.validation.Validations;
@@ -152,6 +154,11 @@ public class JUnit4CitrusSupport implements GherkinTestActionRunner, CitrusFrame
     @Override
     public Processors processor() {
         return new DefaultMessageProcessors();
+    }
+
+    @Override
+    public PayloadBuilders buildPayload() {
+        return new DefaultPayloadBuilders();
     }
 
     @Override

--- a/runtime/citrus-junit/src/main/java/org/citrusframework/junit/spring/JUnit4CitrusSpringSupport.java
+++ b/runtime/citrus-junit/src/main/java/org/citrusframework/junit/spring/JUnit4CitrusSpringSupport.java
@@ -27,6 +27,8 @@ import org.citrusframework.common.DefaultTestLoader;
 import org.citrusframework.api.common.TestLoader;
 import org.citrusframework.api.common.TestSourceAware;
 import org.citrusframework.dsl.DefaultTestActions;
+import org.citrusframework.message.DefaultPayloadBuilders;
+import org.citrusframework.message.PayloadBuilders;
 import org.citrusframework.spring.config.CitrusSpringConfig;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;
@@ -175,6 +177,11 @@ public class JUnit4CitrusSpringSupport extends AbstractJUnit4SpringContextTests
     @Override
     public Processors processor() {
         return new DefaultMessageProcessors();
+    }
+
+    @Override
+    public PayloadBuilders buildPayload() {
+        return new DefaultPayloadBuilders();
     }
 
     @Override

--- a/runtime/citrus-testng/src/main/java/org/citrusframework/testng/TestNGCitrusSupport.java
+++ b/runtime/citrus-testng/src/main/java/org/citrusframework/testng/TestNGCitrusSupport.java
@@ -45,6 +45,8 @@ import org.citrusframework.common.TestSourceHelper;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.message.DefaultMessageProcessors;
+import org.citrusframework.message.DefaultPayloadBuilders;
+import org.citrusframework.message.PayloadBuilders;
 import org.citrusframework.message.Processors;
 import org.citrusframework.validation.DefaultValidations;
 import org.citrusframework.validation.Validations;
@@ -287,6 +289,11 @@ public class TestNGCitrusSupport implements IHookable, GherkinTestActionRunner {
     @Override
     public Processors processor() {
         return new DefaultMessageProcessors();
+    }
+
+    @Override
+    public PayloadBuilders buildPayload() {
+        return new DefaultPayloadBuilders();
     }
 
     @Override

--- a/runtime/citrus-testng/src/main/java/org/citrusframework/testng/spring/TestNGCitrusSpringSupport.java
+++ b/runtime/citrus-testng/src/main/java/org/citrusframework/testng/spring/TestNGCitrusSpringSupport.java
@@ -33,6 +33,8 @@ import org.citrusframework.api.common.TestLoader;
 import org.citrusframework.api.common.TestSourceAware;
 import org.citrusframework.common.TestSourceHelper;
 import org.citrusframework.dsl.DefaultTestActions;
+import org.citrusframework.message.DefaultPayloadBuilders;
+import org.citrusframework.message.PayloadBuilders;
 import org.citrusframework.spring.config.CitrusSpringConfig;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.exceptions.CitrusRuntimeException;
@@ -314,6 +316,11 @@ public class TestNGCitrusSpringSupport extends AbstractTestNGSpringContextTests
     @Override
     public Processors processor() {
         return new DefaultMessageProcessors();
+    }
+
+    @Override
+    public PayloadBuilders buildPayload() {
+        return new DefaultPayloadBuilders();
     }
 
     @Override

--- a/validation/citrus-validation-json/src/main/resources/META-INF/citrus/message/builder/jsonMarshal
+++ b/validation/citrus-validation-json/src/main/resources/META-INF/citrus/message/builder/jsonMarshal
@@ -1,0 +1,1 @@
+type=org.citrusframework.json.message.builder.ObjectMappingPayloadBuilder

--- a/validation/citrus-validation-json/src/test/java/org/citrusframework/json/actions/dsl/ReceiveMessageActionBuilderTest.java
+++ b/validation/citrus-validation-json/src/test/java/org/citrusframework/json/actions/dsl/ReceiveMessageActionBuilderTest.java
@@ -16,27 +16,31 @@
 
 package org.citrusframework.json.actions.dsl;
 
+import java.io.ByteArrayInputStream;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 import com.networknt.schema.Schema;
-import org.citrusframework.base.DefaultTestCaseRunner;
-import org.citrusframework.dsl.TestActionSupport;
 import org.citrusframework.TestCase;
-import org.citrusframework.json.UnitTestSupport;
 import org.citrusframework.actions.ReceiveMessageAction;
+import org.citrusframework.base.DefaultTestCaseRunner;
 import org.citrusframework.container.SequenceAfterTest;
 import org.citrusframework.container.SequenceBeforeTest;
-import org.citrusframework.spring.context.SpringBeanReferenceResolver;
 import org.citrusframework.context.TestContext;
+import org.citrusframework.dsl.TestActionSupport;
 import org.citrusframework.endpoint.Endpoint;
 import org.citrusframework.endpoint.EndpointConfiguration;
 import org.citrusframework.exceptions.TestCaseFailedException;
+import org.citrusframework.json.UnitTestSupport;
+import org.citrusframework.json.message.builder.ObjectMappingHeaderDataBuilder;
 import org.citrusframework.json.schema.SimpleJsonSchema;
 import org.citrusframework.message.DefaultMessage;
-import org.citrusframework.json.message.builder.ObjectMappingHeaderDataBuilder;
-import org.citrusframework.json.message.builder.ObjectMappingPayloadBuilder;
 import org.citrusframework.messaging.Consumer;
 import org.citrusframework.report.TestActionListeners;
 import org.citrusframework.spi.ReferenceResolver;
 import org.citrusframework.spi.Resource;
+import org.citrusframework.spring.context.SpringBeanReferenceResolver;
 import org.citrusframework.validation.DelegatingPayloadVariableExtractor;
 import org.citrusframework.validation.builder.DefaultMessageBuilder;
 import org.citrusframework.validation.builder.StaticMessageBuilder;
@@ -52,11 +56,6 @@ import org.testng.annotations.Test;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 
-import java.io.ByteArrayInputStream;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
 import static java.util.Collections.emptyList;
 import static org.citrusframework.message.MessageType.JSON;
 import static org.citrusframework.message.MessageType.PLAINTEXT;
@@ -64,11 +63,7 @@ import static org.citrusframework.message.MessageType.XML;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.nullValue;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyLong;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class ReceiveMessageActionBuilderTest extends UnitTestSupport implements TestActionSupport {
 
@@ -102,7 +97,7 @@ public class ReceiveMessageActionBuilderTest extends UnitTestSupport implements 
         DefaultTestCaseRunner runner = new DefaultTestCaseRunner(context);
         runner.run(receive(messageEndpoint)
                 .message()
-                .body(new ObjectMappingPayloadBuilder(new TestRequest("Hello Citrus!"))));
+                .body(buildPayload().json().marshal(new TestRequest("Hello Citrus!"))));
 
         TestCase test = runner.getTestCase();
         Assert.assertEquals(test.getActionCount(), 1);
@@ -135,7 +130,7 @@ public class ReceiveMessageActionBuilderTest extends UnitTestSupport implements 
         DefaultTestCaseRunner runner = new DefaultTestCaseRunner(context);
         runner.run(receive(messageEndpoint)
                 .message()
-                .body(new ObjectMappingPayloadBuilder(new TestRequest("Hello Citrus!"), mapper)));
+                .body(buildPayload().json().marshal(new TestRequest("Hello Citrus!"), mapper)));
 
         TestCase test = runner.getTestCase();
         Assert.assertEquals(test.getActionCount(), 1);
@@ -177,7 +172,7 @@ public class ReceiveMessageActionBuilderTest extends UnitTestSupport implements 
         DefaultTestCaseRunner runner = new DefaultTestCaseRunner(context);
         runner.run(receive(messageEndpoint)
                 .message()
-                .body(new ObjectMappingPayloadBuilder(new TestRequest("Hello Citrus!"), "myObjectMapper")));
+                .body(buildPayload().json().marshal(new TestRequest("Hello Citrus!"), "myObjectMapper")));
 
         TestCase test = runner.getTestCase();
         Assert.assertEquals(test.getActionCount(), 1);

--- a/validation/citrus-validation-json/src/test/java/org/citrusframework/json/actions/dsl/SendMessageActionBuilderTest.java
+++ b/validation/citrus-validation-json/src/test/java/org/citrusframework/json/actions/dsl/SendMessageActionBuilderTest.java
@@ -16,19 +16,23 @@
 
 package org.citrusframework.json.actions.dsl;
 
-import org.citrusframework.base.DefaultTestCaseRunner;
-import org.citrusframework.dsl.TestActionSupport;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.citrusframework.TestCase;
-import org.citrusframework.json.UnitTestSupport;
 import org.citrusframework.actions.SendMessageAction;
+import org.citrusframework.base.DefaultTestCaseRunner;
 import org.citrusframework.container.SequenceAfterTest;
 import org.citrusframework.container.SequenceBeforeTest;
 import org.citrusframework.context.TestContext;
+import org.citrusframework.dsl.TestActionSupport;
 import org.citrusframework.endpoint.Endpoint;
 import org.citrusframework.json.JsonSchemaRepository;
+import org.citrusframework.json.UnitTestSupport;
+import org.citrusframework.json.variable.dictionary.JsonMappingDataDictionary;
 import org.citrusframework.message.Message;
 import org.citrusframework.message.MessageType;
-import org.citrusframework.json.message.builder.ObjectMappingPayloadBuilder;
 import org.citrusframework.messaging.Producer;
 import org.citrusframework.report.TestActionListeners;
 import org.citrusframework.spi.ReferenceResolver;
@@ -36,16 +40,11 @@ import org.citrusframework.validation.builder.DefaultMessageBuilder;
 import org.citrusframework.validation.json.JsonPathMessageProcessor;
 import org.citrusframework.validation.json.JsonPathVariableExtractor;
 import org.citrusframework.variable.dictionary.DataDictionary;
-import org.citrusframework.json.variable.dictionary.JsonMappingDataDictionary;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
-
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -80,7 +79,7 @@ public class SendMessageActionBuilderTest extends UnitTestSupport implements Tes
 
         context.setReferenceResolver(referenceResolver);
         DefaultTestCaseRunner runner = new DefaultTestCaseRunner(context);
-        runner.run(send(messageEndpoint).message().body(new ObjectMappingPayloadBuilder(new TestRequest("Hello Citrus!"))));
+        runner.run(send(messageEndpoint).message().body(buildPayload().json().marshal(new TestRequest("Hello Citrus!"))));
 
         final TestCase test = runner.getTestCase();
         Assert.assertEquals(test.getActionCount(), 1);
@@ -110,7 +109,7 @@ public class SendMessageActionBuilderTest extends UnitTestSupport implements Tes
         }).when(messageProducer).send(any(Message.class), any(TestContext.class));
 
         DefaultTestCaseRunner runner = new DefaultTestCaseRunner(context);
-        runner.run(send(messageEndpoint).message().body(new ObjectMappingPayloadBuilder(new TestRequest("Hello Citrus!"), mapper)));
+        runner.run(send(messageEndpoint).message().body(buildPayload().json().marshal(new TestRequest("Hello Citrus!"), mapper)));
 
         final TestCase test = runner.getTestCase();
         Assert.assertEquals(test.getActionCount(), 1);
@@ -148,7 +147,7 @@ public class SendMessageActionBuilderTest extends UnitTestSupport implements Tes
 
         context.setReferenceResolver(referenceResolver);
         DefaultTestCaseRunner runner = new DefaultTestCaseRunner(context);
-        runner.run(send(messageEndpoint).message().body(new ObjectMappingPayloadBuilder(new TestRequest("Hello Citrus!"), "myObjectMapper")));
+        runner.run(send(messageEndpoint).message().body(buildPayload().json().marshal(new TestRequest("Hello Citrus!"), "myObjectMapper")));
 
         final TestCase test = runner.getTestCase();
         Assert.assertEquals(test.getActionCount(), 1);

--- a/validation/citrus-validation-json/src/test/java/org/citrusframework/json/dsl/JsonPayloadBuildersTest.java
+++ b/validation/citrus-validation-json/src/test/java/org/citrusframework/json/dsl/JsonPayloadBuildersTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.json.dsl;
+
+import org.citrusframework.json.UnitTestSupport;
+import org.citrusframework.json.actions.dsl.TestRequest;
+import org.citrusframework.message.DefaultPayloadBuilders;
+import org.citrusframework.message.MessagePayloadBuilder;
+import org.citrusframework.message.PayloadBuilders;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+public class JsonPayloadBuildersTest extends UnitTestSupport {
+
+    private final JsonMapper mapper = JsonMapper.shared();
+    private final TestRequest request = new TestRequest("Hello Citrus!");
+
+    @Test
+    public void shouldMarshalWithMapper() {
+        PayloadBuilders builders = new DefaultPayloadBuilders();
+
+        MessagePayloadBuilder payloadBuilder = builders.json().marshal(request, mapper);
+
+        Assert.assertNotNull(payloadBuilder);
+        Assert.assertEquals(payloadBuilder.buildPayload(context), "{\"message\":\"Hello Citrus!\"}");
+    }
+
+    @Test
+    public void shouldMarshalWithAutoDetect() {
+        PayloadBuilders builders = new DefaultPayloadBuilders();
+
+        MessagePayloadBuilder payloadBuilder = builders.json().marshal(request);
+
+        Assert.assertNotNull(payloadBuilder);
+    }
+}

--- a/validation/citrus-validation-xml/src/main/java/org/citrusframework/xml/dsl/XmlSupport.java
+++ b/validation/citrus-validation-xml/src/main/java/org/citrusframework/xml/dsl/XmlSupport.java
@@ -16,9 +16,11 @@
 
 package org.citrusframework.xml.dsl;
 
+import org.citrusframework.api.xml.Marshaller;
 import org.citrusframework.validation.GenericValidationProcessor;
 import org.citrusframework.validation.xml.XmlMarshallingValidationProcessor;
 import org.citrusframework.validation.context.xml.XmlMessageValidationContext;
+import org.citrusframework.xml.message.builder.MarshallingPayloadBuilder;
 
 public class XmlSupport {
 
@@ -38,5 +40,24 @@ public class XmlSupport {
      */
     public static <T> XmlMarshallingValidationProcessor.Builder<T> validate(GenericValidationProcessor<T> validationProcessor) {
         return XmlMarshallingValidationProcessor.Builder.validate(validationProcessor);
+    }
+
+    /**
+     * Static builder method constructing a marshalling payload builder.
+     * @param payload
+     * @return
+     */
+    public static MarshallingPayloadBuilder marshal(Object payload) {
+        return new MarshallingPayloadBuilder(payload);
+    }
+
+    /**
+     * Static builder method constructing a marshalling payload builder.
+     * @param payload
+     * @param marshaller
+     * @return
+     */
+    public static MarshallingPayloadBuilder marshal(Object payload, Marshaller marshaller) {
+        return new MarshallingPayloadBuilder(payload, marshaller);
     }
 }

--- a/validation/citrus-validation-xml/src/main/resources/META-INF/citrus/message/builder/xmlMarshal
+++ b/validation/citrus-validation-xml/src/main/resources/META-INF/citrus/message/builder/xmlMarshal
@@ -1,0 +1,1 @@
+type=org.citrusframework.xml.message.builder.MarshallingPayloadBuilder

--- a/validation/citrus-validation-xml/src/test/java/org/citrusframework/xml/actons/dsl/ReceiveMessageActionBuilderTest.java
+++ b/validation/citrus-validation-xml/src/test/java/org/citrusframework/xml/actons/dsl/ReceiveMessageActionBuilderTest.java
@@ -23,27 +23,27 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.xml.transform.Source;
 
-import org.citrusframework.base.DefaultTestCaseRunner;
-import org.citrusframework.dsl.TestActionSupport;
 import org.citrusframework.TestCase;
-import org.citrusframework.xml.UnitTestSupport;
 import org.citrusframework.actions.ReceiveMessageAction;
+import org.citrusframework.api.xml.Marshaller;
+import org.citrusframework.api.xml.StringSource;
+import org.citrusframework.base.DefaultTestCaseRunner;
+import org.citrusframework.base.xml.Jaxb2Marshaller;
 import org.citrusframework.container.SequenceAfterTest;
 import org.citrusframework.container.SequenceBeforeTest;
-import org.citrusframework.spring.context.SpringBeanReferenceResolver;
 import org.citrusframework.context.TestContext;
+import org.citrusframework.dsl.TestActionSupport;
 import org.citrusframework.endpoint.Endpoint;
 import org.citrusframework.endpoint.EndpointConfiguration;
 import org.citrusframework.message.DefaultMessage;
 import org.citrusframework.message.Message;
 import org.citrusframework.message.MessageType;
-import org.citrusframework.xml.message.builder.MarshallingHeaderDataBuilder;
-import org.citrusframework.xml.message.builder.MarshallingPayloadBuilder;
 import org.citrusframework.messaging.Consumer;
 import org.citrusframework.messaging.SelectiveConsumer;
 import org.citrusframework.report.TestActionListeners;
 import org.citrusframework.spi.ReferenceResolver;
 import org.citrusframework.spi.Resource;
+import org.citrusframework.spring.context.SpringBeanReferenceResolver;
 import org.citrusframework.validation.AbstractValidationProcessor;
 import org.citrusframework.validation.builder.DefaultMessageBuilder;
 import org.citrusframework.validation.builder.StaticMessageBuilder;
@@ -54,10 +54,9 @@ import org.citrusframework.validation.context.xml.XpathMessageValidationContext;
 import org.citrusframework.validation.xml.XpathPayloadVariableExtractor;
 import org.citrusframework.variable.MessageHeaderVariableExtractor;
 import org.citrusframework.variable.dictionary.DataDictionary;
+import org.citrusframework.xml.UnitTestSupport;
+import org.citrusframework.xml.message.builder.MarshallingHeaderDataBuilder;
 import org.citrusframework.xml.variable.dictionary.NodeMappingDataDictionary;
-import org.citrusframework.base.xml.Jaxb2Marshaller;
-import org.citrusframework.api.xml.Marshaller;
-import org.citrusframework.api.xml.StringSource;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -170,7 +169,7 @@ public class ReceiveMessageActionBuilderTest extends UnitTestSupport implements 
         DefaultTestCaseRunner runner = new DefaultTestCaseRunner(context);
         runner.run(receive(messageEndpoint)
                 .message()
-                .body(new MarshallingPayloadBuilder(new TestRequest("Hello Citrus!"))));
+                .body(buildPayload().xml().marshal(new TestRequest("Hello Citrus!"))));
 
         TestCase test = runner.getTestCase();
         Assert.assertEquals(test.getActionCount(), 1);
@@ -203,7 +202,7 @@ public class ReceiveMessageActionBuilderTest extends UnitTestSupport implements 
         DefaultTestCaseRunner runner = new DefaultTestCaseRunner(context);
         runner.run(receive(messageEndpoint)
                 .message()
-                .body(new MarshallingPayloadBuilder(new TestRequest("Hello Citrus!"), marshaller)));
+                .body(buildPayload().xml().marshal(new TestRequest("Hello Citrus!"), marshaller)));
 
         TestCase test = runner.getTestCase();
         Assert.assertEquals(test.getActionCount(), 1);
@@ -244,7 +243,7 @@ public class ReceiveMessageActionBuilderTest extends UnitTestSupport implements 
         DefaultTestCaseRunner runner = new DefaultTestCaseRunner(context);
         runner.run(receive(messageEndpoint)
                 .message()
-                .body(new MarshallingPayloadBuilder(new TestRequest("Hello Citrus!"), "myMarshaller")));
+                .body(buildPayload().xml().marshal(new TestRequest("Hello Citrus!"), "myMarshaller")));
 
         TestCase test = runner.getTestCase();
         Assert.assertEquals(test.getActionCount(), 1);

--- a/validation/citrus-validation-xml/src/test/java/org/citrusframework/xml/actons/dsl/SendMessageActionBuilderTest.java
+++ b/validation/citrus-validation-xml/src/test/java/org/citrusframework/xml/actons/dsl/SendMessageActionBuilderTest.java
@@ -19,26 +19,25 @@ package org.citrusframework.xml.actons.dsl;
 import java.util.Collections;
 import java.util.HashMap;
 
-import org.citrusframework.base.DefaultTestCaseRunner;
-import org.citrusframework.dsl.TestActionSupport;
 import org.citrusframework.TestCase;
-import org.citrusframework.xml.UnitTestSupport;
 import org.citrusframework.actions.SendMessageAction;
+import org.citrusframework.api.xml.Marshaller;
+import org.citrusframework.base.DefaultTestCaseRunner;
+import org.citrusframework.base.xml.Jaxb2Marshaller;
 import org.citrusframework.container.SequenceAfterTest;
 import org.citrusframework.container.SequenceBeforeTest;
 import org.citrusframework.context.TestContext;
+import org.citrusframework.dsl.TestActionSupport;
 import org.citrusframework.endpoint.Endpoint;
 import org.citrusframework.message.Message;
 import org.citrusframework.message.MessageType;
-import org.citrusframework.xml.message.builder.MarshallingPayloadBuilder;
 import org.citrusframework.messaging.Producer;
 import org.citrusframework.report.TestActionListeners;
 import org.citrusframework.spi.ReferenceResolver;
 import org.citrusframework.validation.builder.DefaultMessageBuilder;
 import org.citrusframework.validation.xml.XpathMessageProcessor;
 import org.citrusframework.validation.xml.XpathPayloadVariableExtractor;
-import org.citrusframework.base.xml.Jaxb2Marshaller;
-import org.citrusframework.api.xml.Marshaller;
+import org.citrusframework.xml.UnitTestSupport;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.Assert;
@@ -89,7 +88,7 @@ public class SendMessageActionBuilderTest extends UnitTestSupport implements Tes
         DefaultTestCaseRunner runner = new DefaultTestCaseRunner(context);
         runner.run(send(messageEndpoint)
                 .message()
-                .body(new MarshallingPayloadBuilder(new TestRequest("Hello Citrus!"))));
+                .body(buildPayload().xml().marshal(new TestRequest("Hello Citrus!"))));
 
         final TestCase test = runner.getTestCase();
         Assert.assertEquals(test.getActionCount(), 1);
@@ -121,7 +120,7 @@ public class SendMessageActionBuilderTest extends UnitTestSupport implements Tes
         DefaultTestCaseRunner runner = new DefaultTestCaseRunner(context);
         runner.run(send(messageEndpoint)
                 .message()
-                .body(new MarshallingPayloadBuilder(new TestRequest("Hello Citrus!"), marshaller)));
+                .body(buildPayload().xml().marshal(new TestRequest("Hello Citrus!"), marshaller)));
 
         final TestCase test = runner.getTestCase();
         Assert.assertEquals(test.getActionCount(), 1);
@@ -161,7 +160,7 @@ public class SendMessageActionBuilderTest extends UnitTestSupport implements Tes
         DefaultTestCaseRunner runner = new DefaultTestCaseRunner(context);
         runner.run(send(messageEndpoint)
                 .message()
-                .body(new MarshallingPayloadBuilder(new TestRequest("Hello Citrus!"), "myMarshaller")));
+                .body(buildPayload().xml().marshal(new TestRequest("Hello Citrus!"), "myMarshaller")));
 
         final TestCase test = runner.getTestCase();
         Assert.assertEquals(test.getActionCount(), 1);
@@ -268,7 +267,7 @@ public class SendMessageActionBuilderTest extends UnitTestSupport implements Tes
         DefaultTestCaseRunner runner = new DefaultTestCaseRunner(context);
         runner.run(send(messageEndpoint).message()
                 .schemaValidation(true).schema("fooSchema").schemaRepository("fooRepository")
-                .type(MessageType.JSON).body(new MarshallingPayloadBuilder(new TestRequest("Hello Citrus!"), marshaller)));
+                .type(MessageType.JSON).body(buildPayload().xml().marshal(new TestRequest("Hello Citrus!"), marshaller)));
 
         final TestCase test = runner.getTestCase();
         Assert.assertEquals(test.getActionCount(), 1);

--- a/validation/citrus-validation-xml/src/test/java/org/citrusframework/xml/dsl/XmlPayloadBuildersTest.java
+++ b/validation/citrus-validation-xml/src/test/java/org/citrusframework/xml/dsl/XmlPayloadBuildersTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.xml.dsl;
+
+import org.citrusframework.xml.UnitTestSupport;
+import org.citrusframework.xml.actons.dsl.TestRequest;
+import org.citrusframework.api.xml.Marshaller;
+import org.citrusframework.base.xml.Jaxb2Marshaller;
+import org.citrusframework.message.DefaultPayloadBuilders;
+import org.citrusframework.message.MessagePayloadBuilder;
+import org.citrusframework.message.PayloadBuilders;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class XmlPayloadBuildersTest extends UnitTestSupport {
+
+    private final Marshaller marshaller = new Jaxb2Marshaller(TestRequest.class);
+    private final TestRequest request = new TestRequest("Hello Citrus!");
+
+    @BeforeClass
+    public void prepareMarshaller() {
+        ((Jaxb2Marshaller) marshaller).setProperty(jakarta.xml.bind.Marshaller.JAXB_FRAGMENT, Boolean.TRUE);
+    }
+
+    @Test
+    public void shouldMarshalWithMarshaller() {
+        PayloadBuilders builders = new DefaultPayloadBuilders();
+
+        MessagePayloadBuilder payloadBuilder = builders.xml().marshal(request, marshaller);
+
+        Assert.assertNotNull(payloadBuilder);
+        Assert.assertEquals(payloadBuilder.buildPayload(context), "<TestRequest><Message>Hello Citrus!</Message></TestRequest>");
+    }
+
+    @Test
+    public void shouldMarshalWithAutoDetect() {
+        PayloadBuilders builders = new DefaultPayloadBuilders();
+
+        MessagePayloadBuilder payloadBuilder = builders.xml().marshal(request);
+
+        Assert.assertNotNull(payloadBuilder);
+    }
+}

--- a/validation/citrus-validation-xml/src/test/java/org/citrusframework/xml/dsl/XmlSupportTest.java
+++ b/validation/citrus-validation-xml/src/test/java/org/citrusframework/xml/dsl/XmlSupportTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.xml.dsl;
+
+import org.citrusframework.xml.UnitTestSupport;
+import org.citrusframework.xml.actons.dsl.TestRequest;
+import org.citrusframework.xml.message.builder.MarshallingPayloadBuilder;
+import org.citrusframework.api.xml.Marshaller;
+import org.citrusframework.base.xml.Jaxb2Marshaller;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class XmlSupportTest extends UnitTestSupport {
+
+    private final Marshaller marshaller = new Jaxb2Marshaller(TestRequest.class);
+    private final TestRequest request = new TestRequest("Hello Citrus!");
+
+    @BeforeClass
+    public void prepareMarshaller() {
+        ((Jaxb2Marshaller) marshaller).setProperty(jakarta.xml.bind.Marshaller.JAXB_FRAGMENT, Boolean.TRUE);
+    }
+
+    @Test
+    public void shouldMarshal() {
+        MarshallingPayloadBuilder builder = XmlSupport.marshal(request, marshaller);
+
+        Assert.assertNotNull(builder);
+        Assert.assertEquals(builder.buildPayload(context), "<TestRequest><Message>Hello Citrus!</Message></TestRequest>");
+    }
+
+    @Test
+    public void shouldMarshalWithAutoDetect() {
+        MarshallingPayloadBuilder builder = XmlSupport.marshal(request);
+
+        Assert.assertNotNull(builder);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `buildPayload()` method to `TestActionSupport` providing unified DSL access to payload builders via `buildPayload().json().marshal(...)` and `buildPayload().xml().marshal(...)`
- Add missing `marshal()` static methods to `XmlSupport` for consistency with `JsonSupport`
- Follow the existing processor SPI pattern: interfaces in `citrus-api`, SPI registration in validation modules, runtime classpath resolution

## Changes

**New API entry point (`TestActionSupport.buildPayload()`):**
```java
// JSON object mapping
.body(buildPayload().json().marshal(model))
.body(buildPayload().json().marshal(model, objectMapper))

// XML marshalling
.body(buildPayload().xml().marshal(model))
.body(buildPayload().xml().marshal(model, marshaller))
```

**New `XmlSupport.marshal()` static methods** (matching `JsonSupport`):
```java
import static org.citrusframework.xml.dsl.XmlSupport.marshal;
.body(marshal(model, marshaller))
```

**Architecture** (follows `Processors` / `MessageProcessorSupport` pattern):
- `PayloadBuilders` → composition interface (`JsonPayloadBuilders.Factory` + `XmlPayloadBuilders.Factory`)
- `PayloadBuilderSupport` → default implementations using SPI lookup
- `DefaultPayloadBuilders` → empty impl class (inherits defaults)
- SPI files at `META-INF/citrus/message/builder/jsonMarshal` and `xmlMarshal`

Resolves #1639

## Test plan
- [x] `XmlSupportTest` — verifies new `XmlSupport.marshal()` methods
- [x] `JsonPayloadBuildersTest` — verifies `buildPayload().json().marshal()` SPI lookup and payload generation
- [x] `XmlPayloadBuildersTest` — verifies `buildPayload().xml().marshal()` SPI lookup and payload generation
- [x] Full reactor build passes (`mvn clean install -DskipTests`)
- [x] Module-level `mvn verify` passes for both `citrus-validation-json` and `citrus-validation-xml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)