### PR TITLE
fix(#1643): Add Camel unmarshal data format support in YAML DSL message processing

### DIFF
--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/yaml/CamelMessageProcessorTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/yaml/CamelMessageProcessorTest.java
@@ -53,7 +53,7 @@ public class CamelMessageProcessorTest extends AbstractYamlActionTest {
         Assert.assertEquals(result.getName(), "CamelMessageProcessorTest");
         Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
         Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
-        Assert.assertEquals(result.getActionCount(), 4L);
+        Assert.assertEquals(result.getActionCount(), 5L);
         Assert.assertEquals(result.getTestAction(0).getClass(), SendMessageAction.class);
 
         Message receivedMessage = messageQueue.receive();
@@ -73,6 +73,11 @@ public class CamelMessageProcessorTest extends AbstractYamlActionTest {
                 aXRy
                 dXMh
                 """);
+
+        receivedMessage = messageQueue.receive();
+        Assert.assertNotNull(receivedMessage);
+        Assert.assertTrue(receivedMessage.getPayload() instanceof InputStream);
+        Assert.assertEquals(FileUtils.readToString(receivedMessage.getPayload(InputStream.class)), "Hello from Citrus!");
 
         receivedMessage = messageQueue.receive();
         Assert.assertNotNull(receivedMessage);

--- a/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/yaml/camel-message-processor.citrus.it.yaml
+++ b/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/yaml/camel-message-processor.citrus.it.yaml
@@ -30,6 +30,15 @@ actions:
       endpoint: messages
       message:
         body:
+          data: "SGVsbG8gZnJvbSBDaXRydXMh"
+      process:
+        - camel:
+            unmarshal:
+              base64: {}
+  - send:
+      endpoint: messages
+      message:
+        body:
           data: "Hello from Citrus!"
       process:
         - camel:

--- a/runtime/citrus-yaml/src/main/java/org/citrusframework/yaml/actions/MessageSupport.java
+++ b/runtime/citrus-yaml/src/main/java/org/citrusframework/yaml/actions/MessageSupport.java
@@ -243,6 +243,12 @@ public final class MessageSupport {
                         .operation("Marshal"));
             }
 
+            if (camel.getUnmarshal() != null) {
+                builder.process(processors.camel().dataFormat()
+                        .spec(value.getCamel().getUnmarshal())
+                        .operation("Unmarshal"));
+            }
+
             if (camel.getTransform() != null) {
                 builder.process(processors.camel().transform()
                         .spec(value.getCamel().getTransform()));


### PR DESCRIPTION
## Summary
- Adds missing `unmarshal` data format support in the YAML DSL `MessageSupport`, mirroring the existing `marshal` handling
- Adds YAML test fixture and Java test coverage for base64 unmarshal in `CamelMessageProcessorTest`

## Test plan
- [x] Added unmarshal action to `camel-message-processor.citrus.it.yaml` that decodes a base64-encoded payload
- [x] Updated `CamelMessageProcessorTest` to verify the unmarshal result produces the expected decoded output
- [x] All existing tests continue to pass

Closes #1643

🤖 Generated with [Claude Code](https://claude.ai/code)