### PR TITLE
fix(#1645): Add JSON and XML marshalling/unmarshalling message processor implementations

### DIFF
--- a/core/citrus-api/src/main/java/org/citrusframework/message/MessageProcessorSupport.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/message/MessageProcessorSupport.java
@@ -19,10 +19,14 @@ package org.citrusframework.message;
 import org.citrusframework.message.processor.DelegatingVariableExtractorBuilder;
 import org.citrusframework.message.processor.camel.CamelMessageProcessors;
 import org.citrusframework.message.processor.json.JsonMappingValidationProcessorBuilder;
+import org.citrusframework.message.processor.json.JsonMarshallingMessageProcessorBuilder;
 import org.citrusframework.message.processor.json.JsonMessageProcessors;
 import org.citrusframework.message.processor.json.JsonPathMessageProcessorBuilder;
+import org.citrusframework.message.processor.json.JsonUnmarshallingMessageProcessorBuilder;
+import org.citrusframework.message.processor.xml.XmlMarshallingMessageProcessorBuilder;
 import org.citrusframework.message.processor.xml.XmlMarshallingValidationProcessorBuilder;
 import org.citrusframework.message.processor.xml.XmlMessageProcessors;
+import org.citrusframework.message.processor.xml.XmlUnmarshallingMessageProcessorBuilder;
 import org.citrusframework.message.processor.xml.XpathMessageProcessorBuilder;
 import org.citrusframework.validation.DelegatingPayloadVariableExtractor;
 import org.citrusframework.validation.GenericValidationProcessor;
@@ -92,6 +96,11 @@ public interface MessageProcessorSupport extends Processors, MessageProcessorLoo
             }
 
             @Override
+            public JsonMarshallingMessageProcessorBuilder<?, ?> marshal() {
+                return lookup("jsonMarshal");
+            }
+
+            @Override
             public MessagePayloadBuilder marshal(Object model) {
                 return lookupPayloadBuilder("jsonMarshal", model);
             }
@@ -99,6 +108,11 @@ public interface MessageProcessorSupport extends Processors, MessageProcessorLoo
             @Override
             public MessagePayloadBuilder marshal(Object model, Object mapper) {
                 return lookupPayloadBuilder("jsonMarshal", model, mapper);
+            }
+
+            @Override
+            public JsonUnmarshallingMessageProcessorBuilder<?, ?> unmarshal() {
+                return lookup("jsonUnmarshal");
             }
         };
     }
@@ -123,6 +137,11 @@ public interface MessageProcessorSupport extends Processors, MessageProcessorLoo
             }
 
             @Override
+            public XmlMarshallingMessageProcessorBuilder<?, ?> marshal() {
+                return lookup("xmlMarshal");
+            }
+
+            @Override
             public MessagePayloadBuilder marshal(Object model) {
                 return lookupPayloadBuilder("xmlMarshal", model);
             }
@@ -130,6 +149,11 @@ public interface MessageProcessorSupport extends Processors, MessageProcessorLoo
             @Override
             public MessagePayloadBuilder marshal(Object model, Object marshaller) {
                 return lookupPayloadBuilder("xmlMarshal", model, marshaller);
+            }
+
+            @Override
+            public XmlUnmarshallingMessageProcessorBuilder<?, ?> unmarshal() {
+                return lookup("xmlUnmarshal");
             }
         };
     }

--- a/core/citrus-api/src/main/java/org/citrusframework/message/processor/json/JsonMarshallingMessageProcessorBuilder.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/message/processor/json/JsonMarshallingMessageProcessorBuilder.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.message.processor.json;
+
+import org.citrusframework.message.MessageProcessor;
+
+public interface JsonMarshallingMessageProcessorBuilder<T extends MessageProcessor, B extends JsonMarshallingMessageProcessorBuilder<T, B>>
+        extends MessageProcessor.Builder<T, B> {
+
+    B mapper(Object mapper);
+}

--- a/core/citrus-api/src/main/java/org/citrusframework/message/processor/json/JsonMessageProcessors.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/message/processor/json/JsonMessageProcessors.java
@@ -28,9 +28,13 @@ public interface JsonMessageProcessors extends PayloadBuilderLookupSupport {
 
     <T> JsonMappingValidationProcessorBuilder<T, ?, ?> validate(Class<T> type);
 
+    JsonMarshallingMessageProcessorBuilder<?, ?> marshal();
+
     MessagePayloadBuilder marshal(Object model);
 
     MessagePayloadBuilder marshal(Object model, Object mapper);
+
+    JsonUnmarshallingMessageProcessorBuilder<?, ?> unmarshal();
 
     interface Factory {
 

--- a/core/citrus-api/src/main/java/org/citrusframework/message/processor/json/JsonUnmarshallingMessageProcessorBuilder.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/message/processor/json/JsonUnmarshallingMessageProcessorBuilder.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.message.processor.json;
+
+import org.citrusframework.message.MessageProcessor;
+
+public interface JsonUnmarshallingMessageProcessorBuilder<T extends MessageProcessor, B extends JsonUnmarshallingMessageProcessorBuilder<T, B>>
+        extends MessageProcessor.Builder<T, B> {
+
+    B type(Class<?> resultType);
+
+    B mapper(Object mapper);
+}

--- a/core/citrus-api/src/main/java/org/citrusframework/message/processor/xml/XmlMarshallingMessageProcessorBuilder.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/message/processor/xml/XmlMarshallingMessageProcessorBuilder.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.message.processor.xml;
+
+import org.citrusframework.message.MessageProcessor;
+
+public interface XmlMarshallingMessageProcessorBuilder<T extends MessageProcessor, B extends XmlMarshallingMessageProcessorBuilder<T, B>>
+        extends MessageProcessor.Builder<T, B> {
+
+    B marshaller(Object marshaller);
+}

--- a/core/citrus-api/src/main/java/org/citrusframework/message/processor/xml/XmlMessageProcessors.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/message/processor/xml/XmlMessageProcessors.java
@@ -29,9 +29,13 @@ public interface XmlMessageProcessors extends PayloadBuilderLookupSupport {
 
     <T> XmlMarshallingValidationProcessorBuilder<T, ?, ?> validate(GenericValidationProcessor<T> validationProcessor);
 
+    XmlMarshallingMessageProcessorBuilder<?, ?> marshal();
+
     MessagePayloadBuilder marshal(Object model);
 
     MessagePayloadBuilder marshal(Object model, Object mapper);
+
+    XmlUnmarshallingMessageProcessorBuilder<?, ?> unmarshal();
 
     interface Factory {
 

--- a/core/citrus-api/src/main/java/org/citrusframework/message/processor/xml/XmlUnmarshallingMessageProcessorBuilder.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/message/processor/xml/XmlUnmarshallingMessageProcessorBuilder.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.message.processor.xml;
+
+import org.citrusframework.message.MessageProcessor;
+
+public interface XmlUnmarshallingMessageProcessorBuilder<T extends MessageProcessor, B extends XmlUnmarshallingMessageProcessorBuilder<T, B>>
+        extends MessageProcessor.Builder<T, B> {
+
+    B unmarshaller(Object unmarshaller);
+}

--- a/validation/citrus-validation-json/src/main/java/org/citrusframework/json/message/processor/JsonMarshallingMessageProcessor.java
+++ b/validation/citrus-validation-json/src/main/java/org/citrusframework/json/message/processor/JsonMarshallingMessageProcessor.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.json.message.processor;
+
+import java.util.Map;
+
+import org.citrusframework.context.TestContext;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.message.AbstractMessageProcessor;
+import org.citrusframework.message.Message;
+import org.citrusframework.message.processor.json.JsonMarshallingMessageProcessorBuilder;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Message processor that marshals a Java object payload to a JSON string
+ * using Jackson ObjectMapper.
+ *
+ * @since 4.6
+ */
+public class JsonMarshallingMessageProcessor extends AbstractMessageProcessor {
+
+    private final ObjectMapper mapper;
+
+    public JsonMarshallingMessageProcessor() {
+        this(null);
+    }
+
+    public JsonMarshallingMessageProcessor(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    @Override
+    public void processMessage(Message message, TestContext context) {
+        if (message.getPayload() == null || message.getPayload() instanceof String) {
+            return;
+        }
+
+        ObjectMapper objectMapper = resolveMapper(context);
+
+        try {
+            message.setPayload(objectMapper.writer().writeValueAsString(message.getPayload()));
+        } catch (JacksonException e) {
+            throw new CitrusRuntimeException("Failed to marshal message payload to JSON", e);
+        }
+    }
+
+    private ObjectMapper resolveMapper(TestContext context) {
+        if (mapper != null) {
+            return mapper;
+        }
+
+        Map<String, ObjectMapper> mappers = context.getReferenceResolver().resolveAll(ObjectMapper.class);
+        if (mappers.size() == 1) {
+            return mappers.values().iterator().next();
+        } else {
+            throw new CitrusRuntimeException(String.format("Unable to auto detect object mapper - " +
+                    "found %d matching mapper instances in reference resolver", mappers.size()));
+        }
+    }
+
+    public static class Builder implements JsonMarshallingMessageProcessorBuilder<JsonMarshallingMessageProcessor, Builder> {
+
+        private ObjectMapper mapper;
+
+        @Override
+        public Builder mapper(Object mapper) {
+            if (mapper instanceof ObjectMapper objectMapper) {
+                this.mapper = objectMapper;
+            }
+
+            return this;
+        }
+
+        public Builder mapper(ObjectMapper mapper) {
+            this.mapper = mapper;
+            return this;
+        }
+
+        @Override
+        public JsonMarshallingMessageProcessor build() {
+            return new JsonMarshallingMessageProcessor(mapper);
+        }
+    }
+}

--- a/validation/citrus-validation-json/src/main/java/org/citrusframework/json/message/processor/JsonUnmarshallingMessageProcessor.java
+++ b/validation/citrus-validation-json/src/main/java/org/citrusframework/json/message/processor/JsonUnmarshallingMessageProcessor.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.json.message.processor;
+
+import java.util.Map;
+
+import org.citrusframework.context.TestContext;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.message.AbstractMessageProcessor;
+import org.citrusframework.message.Message;
+import org.citrusframework.message.processor.json.JsonUnmarshallingMessageProcessorBuilder;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Message processor that unmarshals a JSON string payload to a Java object
+ * using Jackson ObjectMapper.
+ *
+ * @since 4.6
+ */
+public class JsonUnmarshallingMessageProcessor extends AbstractMessageProcessor {
+
+    private final ObjectMapper mapper;
+    private final Class<?> resultType;
+
+    public JsonUnmarshallingMessageProcessor(Class<?> resultType) {
+        this(resultType, null);
+    }
+
+    public JsonUnmarshallingMessageProcessor(Class<?> resultType, ObjectMapper mapper) {
+        this.resultType = resultType;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public void processMessage(Message message, TestContext context) {
+        ObjectMapper objectMapper = resolveMapper(context);
+
+        try {
+            message.setPayload(objectMapper.readValue(message.getPayload(String.class), resultType));
+        } catch (JacksonException e) {
+            throw new CitrusRuntimeException("Failed to unmarshal JSON message payload", e);
+        }
+    }
+
+    private ObjectMapper resolveMapper(TestContext context) {
+        if (mapper != null) {
+            return mapper;
+        }
+
+        Map<String, ObjectMapper> mappers = context.getReferenceResolver().resolveAll(ObjectMapper.class);
+        if (mappers.size() == 1) {
+            return mappers.values().iterator().next();
+        } else {
+            throw new CitrusRuntimeException(String.format("Unable to auto detect object mapper - " +
+                    "found %d matching mapper instances in reference resolver", mappers.size()));
+        }
+    }
+
+    public static class Builder implements JsonUnmarshallingMessageProcessorBuilder<JsonUnmarshallingMessageProcessor, Builder> {
+
+        private ObjectMapper mapper;
+        private Class<?> resultType;
+
+        @Override
+        public Builder type(Class<?> resultType) {
+            this.resultType = resultType;
+            return this;
+        }
+
+        @Override
+        public Builder mapper(Object mapper) {
+            if (mapper instanceof ObjectMapper objectMapper) {
+                this.mapper = objectMapper;
+            }
+
+            return this;
+        }
+
+        public Builder mapper(ObjectMapper mapper) {
+            this.mapper = mapper;
+            return this;
+        }
+
+        @Override
+        public JsonUnmarshallingMessageProcessor build() {
+            if (resultType == null) {
+                throw new CitrusRuntimeException("Missing result type for JSON unmarshalling - " +
+                        "please set the target type to unmarshal to");
+            }
+            return new JsonUnmarshallingMessageProcessor(resultType, mapper);
+        }
+    }
+}

--- a/validation/citrus-validation-json/src/main/resources/META-INF/citrus/message/processor/jsonMarshal
+++ b/validation/citrus-validation-json/src/main/resources/META-INF/citrus/message/processor/jsonMarshal
@@ -1,0 +1,1 @@
+type=org.citrusframework.json.message.processor.JsonMarshallingMessageProcessor$Builder

--- a/validation/citrus-validation-json/src/main/resources/META-INF/citrus/message/processor/jsonUnmarshal
+++ b/validation/citrus-validation-json/src/main/resources/META-INF/citrus/message/processor/jsonUnmarshal
@@ -1,0 +1,1 @@
+type=org.citrusframework.json.message.processor.JsonUnmarshallingMessageProcessor$Builder

--- a/validation/citrus-validation-json/src/test/java/org/citrusframework/json/message/processor/JsonMarshallingMessageProcessorTest.java
+++ b/validation/citrus-validation-json/src/test/java/org/citrusframework/json/message/processor/JsonMarshallingMessageProcessorTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.json.message.processor;
+
+import java.util.Collections;
+
+import org.citrusframework.json.actions.dsl.TestRequest;
+import org.citrusframework.message.DefaultMessage;
+import org.citrusframework.message.Message;
+import org.citrusframework.message.MessageType;
+import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.testng.AbstractTestNGUnitTest;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+import static org.mockito.Mockito.when;
+
+public class JsonMarshallingMessageProcessorTest extends AbstractTestNGUnitTest {
+
+    private final JsonMapper mapper = JsonMapper.shared();
+
+    @Test
+    public void testMarshalMessage() {
+        ReferenceResolver referenceResolver = Mockito.mock(ReferenceResolver.class);
+        when(referenceResolver.resolveAll(ObjectMapper.class)).thenReturn(Collections.singletonMap("mapper", mapper));
+        context.setReferenceResolver(referenceResolver);
+
+        Message message = new DefaultMessage(new TestRequest("Hello Citrus!"));
+        new JsonMarshallingMessageProcessor().process(message, context);
+
+        Assert.assertEquals(message.getPayload(String.class), "{\"message\":\"Hello Citrus!\"}");
+    }
+
+    @Test
+    public void testMarshalMessageWithExplicitMapper() {
+        Message message = new DefaultMessage(new TestRequest("Hello Citrus!"));
+        new JsonMarshallingMessageProcessor(mapper).process(message, context);
+
+        Assert.assertEquals(message.getPayload(String.class), "{\"message\":\"Hello Citrus!\"}");
+    }
+
+    @Test
+    public void testMarshalStringPayloadSkipped() {
+        Message message = new DefaultMessage("{\"message\":\"already JSON\"}");
+        new JsonMarshallingMessageProcessor(mapper).process(message, context);
+
+        Assert.assertEquals(message.getPayload(String.class), "{\"message\":\"already JSON\"}");
+    }
+
+    @Test
+    public void testMarshalMessageWithPlaintextType() {
+        Message message = new DefaultMessage(new TestRequest("Hello Citrus!"));
+        message.setType(MessageType.PLAINTEXT.name());
+        new JsonMarshallingMessageProcessor(mapper).process(message, context);
+
+        Assert.assertEquals(message.getPayload(String.class), "{\"message\":\"Hello Citrus!\"}");
+    }
+}

--- a/validation/citrus-validation-json/src/test/java/org/citrusframework/json/message/processor/JsonUnmarshallingMessageProcessorTest.java
+++ b/validation/citrus-validation-json/src/test/java/org/citrusframework/json/message/processor/JsonUnmarshallingMessageProcessorTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.json.message.processor;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.citrusframework.message.DefaultMessage;
+import org.citrusframework.message.Message;
+import org.citrusframework.message.MessageType;
+import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.testng.AbstractTestNGUnitTest;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("unchecked")
+public class JsonUnmarshallingMessageProcessorTest extends AbstractTestNGUnitTest {
+
+    private final JsonMapper mapper = JsonMapper.shared();
+
+    @Test
+    public void testUnmarshalMessage() {
+        ReferenceResolver referenceResolver = Mockito.mock(ReferenceResolver.class);
+        when(referenceResolver.resolveAll(ObjectMapper.class)).thenReturn(Collections.singletonMap("mapper", mapper));
+        context.setReferenceResolver(referenceResolver);
+
+        Message message = new DefaultMessage("{\"message\":\"Hello Citrus!\"}");
+        new JsonUnmarshallingMessageProcessor(Map.class).process(message, context);
+
+        Assert.assertTrue(message.getPayload() instanceof Map);
+        Map<String, Object> result = (Map<String, Object>) message.getPayload();
+        Assert.assertEquals(result.get("message"), "Hello Citrus!");
+    }
+
+    @Test
+    public void testUnmarshalMessageWithExplicitMapper() {
+        Message message = new DefaultMessage("{\"message\":\"Hello Citrus!\"}");
+        new JsonUnmarshallingMessageProcessor(Map.class, mapper).process(message, context);
+
+        Assert.assertTrue(message.getPayload() instanceof Map);
+        Map<String, Object> result = (Map<String, Object>) message.getPayload();
+        Assert.assertEquals(result.get("message"), "Hello Citrus!");
+    }
+
+    @Test
+    public void testUnmarshalMessageWithPlaintextType() {
+        Message message = new DefaultMessage("{\"message\":\"Hello Citrus!\"}");
+        message.setType(MessageType.PLAINTEXT.name());
+        new JsonUnmarshallingMessageProcessor(Map.class, mapper).process(message, context);
+
+        Assert.assertTrue(message.getPayload() instanceof Map);
+        Map<String, Object> result = (Map<String, Object>) message.getPayload();
+        Assert.assertEquals(result.get("message"), "Hello Citrus!");
+    }
+}

--- a/validation/citrus-validation-xml/src/main/java/org/citrusframework/xml/message/processor/XmlMarshallingMessageProcessor.java
+++ b/validation/citrus-validation-xml/src/main/java/org/citrusframework/xml/message/processor/XmlMarshallingMessageProcessor.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.xml.message.processor;
+
+import java.util.Map;
+
+import org.citrusframework.api.xml.Marshaller;
+import org.citrusframework.api.xml.StringResult;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.message.AbstractMessageProcessor;
+import org.citrusframework.message.Message;
+import org.citrusframework.message.processor.xml.XmlMarshallingMessageProcessorBuilder;
+
+/**
+ * Message processor that marshals a Java object payload to an XML string
+ * using a Citrus Marshaller.
+ *
+ * @since 4.6
+ */
+public class XmlMarshallingMessageProcessor extends AbstractMessageProcessor {
+
+    private final Marshaller marshaller;
+
+    public XmlMarshallingMessageProcessor() {
+        this(null);
+    }
+
+    public XmlMarshallingMessageProcessor(Marshaller marshaller) {
+        this.marshaller = marshaller;
+    }
+
+    @Override
+    public void processMessage(Message message, TestContext context) {
+        if (message.getPayload() == null || message.getPayload() instanceof String) {
+            return;
+        }
+
+        Marshaller xmlMarshaller = resolveMarshaller(context);
+        StringResult result = new StringResult();
+
+        try {
+            xmlMarshaller.marshal(message.getPayload(), result);
+        } catch (Exception e) {
+            throw new CitrusRuntimeException("Failed to marshal message payload to XML", e);
+        }
+
+        message.setPayload(result.toString());
+    }
+
+    private Marshaller resolveMarshaller(TestContext context) {
+        if (marshaller != null) {
+            return marshaller;
+        }
+
+        Map<String, Marshaller> marshallerMap = context.getReferenceResolver().resolveAll(Marshaller.class);
+        if (marshallerMap.size() == 1) {
+            return marshallerMap.values().iterator().next();
+        } else {
+            throw new CitrusRuntimeException(String.format("Unable to auto detect XML marshaller - " +
+                    "found %d matching marshaller instances in reference resolver", marshallerMap.size()));
+        }
+    }
+
+    public static class Builder implements XmlMarshallingMessageProcessorBuilder<XmlMarshallingMessageProcessor, Builder> {
+
+        private Marshaller marshaller;
+
+        @Override
+        public Builder marshaller(Object marshaller) {
+            if (marshaller instanceof Marshaller xmlMarshaller) {
+                this.marshaller = xmlMarshaller;
+            }
+
+            return this;
+        }
+
+        public Builder marshaller(Marshaller marshaller) {
+            this.marshaller = marshaller;
+            return this;
+        }
+
+        @Override
+        public XmlMarshallingMessageProcessor build() {
+            return new XmlMarshallingMessageProcessor(marshaller);
+        }
+    }
+}

--- a/validation/citrus-validation-xml/src/main/java/org/citrusframework/xml/message/processor/XmlUnmarshallingMessageProcessor.java
+++ b/validation/citrus-validation-xml/src/main/java/org/citrusframework/xml/message/processor/XmlUnmarshallingMessageProcessor.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.xml.message.processor;
+
+import java.io.File;
+import java.util.Map;
+import javax.xml.transform.Source;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamSource;
+
+import org.citrusframework.api.xml.StringSource;
+import org.citrusframework.api.xml.Unmarshaller;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.message.AbstractMessageProcessor;
+import org.citrusframework.message.Message;
+import org.citrusframework.message.processor.xml.XmlUnmarshallingMessageProcessorBuilder;
+import org.w3c.dom.Document;
+
+/**
+ * Message processor that unmarshals an XML payload to a Java object
+ * using a Citrus Unmarshaller.
+ *
+ * @since 4.6
+ */
+public class XmlUnmarshallingMessageProcessor extends AbstractMessageProcessor {
+
+    private final Unmarshaller unmarshaller;
+
+    public XmlUnmarshallingMessageProcessor() {
+        this(null);
+    }
+
+    public XmlUnmarshallingMessageProcessor(Unmarshaller unmarshaller) {
+        this.unmarshaller = unmarshaller;
+    }
+
+    @Override
+    public void processMessage(Message message, TestContext context) {
+        Unmarshaller xmlUnmarshaller = resolveUnmarshaller(context);
+
+        try {
+            message.setPayload(xmlUnmarshaller.unmarshal(getPayloadSource(message.getPayload())));
+        } catch (Exception e) {
+            throw new CitrusRuntimeException("Failed to unmarshal XML message payload", e);
+        }
+    }
+
+    private Source getPayloadSource(Object payload) {
+        if (payload instanceof String stringPayload) {
+            return new StringSource(stringPayload);
+        } else if (payload instanceof File file) {
+            return new StreamSource(file);
+        } else if (payload instanceof Document document) {
+            return new DOMSource(document);
+        } else if (payload instanceof Source source) {
+            return source;
+        }
+
+        throw new CitrusRuntimeException("Failed to create payload source for unmarshalling message");
+    }
+
+    private Unmarshaller resolveUnmarshaller(TestContext context) {
+        if (unmarshaller != null) {
+            return unmarshaller;
+        }
+
+        Map<String, Unmarshaller> unmarshallerMap = context.getReferenceResolver().resolveAll(Unmarshaller.class);
+        if (unmarshallerMap.size() == 1) {
+            return unmarshallerMap.values().iterator().next();
+        } else {
+            throw new CitrusRuntimeException(String.format("Unable to auto detect XML unmarshaller - " +
+                    "found %d matching unmarshaller instances in reference resolver", unmarshallerMap.size()));
+        }
+    }
+
+    public static class Builder implements XmlUnmarshallingMessageProcessorBuilder<XmlUnmarshallingMessageProcessor, Builder> {
+
+        private Unmarshaller unmarshaller;
+
+        @Override
+        public Builder unmarshaller(Object unmarshaller) {
+            if (unmarshaller instanceof Unmarshaller xmlUnmarshaller) {
+                this.unmarshaller = xmlUnmarshaller;
+            }
+
+            return this;
+        }
+
+        public Builder unmarshaller(Unmarshaller unmarshaller) {
+            this.unmarshaller = unmarshaller;
+            return this;
+        }
+
+        @Override
+        public XmlUnmarshallingMessageProcessor build() {
+            return new XmlUnmarshallingMessageProcessor(unmarshaller);
+        }
+    }
+}

--- a/validation/citrus-validation-xml/src/main/resources/META-INF/citrus/message/processor/xmlMarshal
+++ b/validation/citrus-validation-xml/src/main/resources/META-INF/citrus/message/processor/xmlMarshal
@@ -1,0 +1,1 @@
+type=org.citrusframework.xml.message.processor.XmlMarshallingMessageProcessor$Builder

--- a/validation/citrus-validation-xml/src/main/resources/META-INF/citrus/message/processor/xmlUnmarshal
+++ b/validation/citrus-validation-xml/src/main/resources/META-INF/citrus/message/processor/xmlUnmarshal
@@ -1,0 +1,1 @@
+type=org.citrusframework.xml.message.processor.XmlUnmarshallingMessageProcessor$Builder

--- a/validation/citrus-validation-xml/src/test/java/org/citrusframework/xml/message/processor/XmlMarshallingMessageProcessorTest.java
+++ b/validation/citrus-validation-xml/src/test/java/org/citrusframework/xml/message/processor/XmlMarshallingMessageProcessorTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.xml.message.processor;
+
+import java.util.Collections;
+
+import jakarta.xml.bind.Marshaller;
+import org.citrusframework.message.DefaultMessage;
+import org.citrusframework.message.Message;
+import org.citrusframework.message.MessageType;
+import org.citrusframework.base.xml.Jaxb2Marshaller;
+import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.testng.AbstractTestNGUnitTest;
+import org.citrusframework.xml.actons.dsl.TestRequest;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.when;
+
+public class XmlMarshallingMessageProcessorTest extends AbstractTestNGUnitTest {
+
+    private final Jaxb2Marshaller marshaller = new Jaxb2Marshaller(TestRequest.class);
+
+    @BeforeClass
+    public void prepareMarshaller() {
+        marshaller.setProperty(Marshaller.JAXB_FRAGMENT, Boolean.TRUE);
+    }
+
+    @Test
+    public void testMarshalMessage() {
+        ReferenceResolver referenceResolver = Mockito.mock(ReferenceResolver.class);
+        when(referenceResolver.resolveAll(org.citrusframework.api.xml.Marshaller.class))
+                .thenReturn(Collections.singletonMap("marshaller", marshaller));
+        context.setReferenceResolver(referenceResolver);
+
+        Message message = new DefaultMessage(new TestRequest("Hello Citrus!"));
+        new XmlMarshallingMessageProcessor().process(message, context);
+
+        Assert.assertEquals(message.getPayload(String.class),
+                "<TestRequest><Message>Hello Citrus!</Message></TestRequest>");
+    }
+
+    @Test
+    public void testMarshalMessageWithExplicitMarshaller() {
+        Message message = new DefaultMessage(new TestRequest("Hello Citrus!"));
+        new XmlMarshallingMessageProcessor(marshaller).process(message, context);
+
+        Assert.assertEquals(message.getPayload(String.class),
+                "<TestRequest><Message>Hello Citrus!</Message></TestRequest>");
+    }
+
+    @Test
+    public void testMarshalStringPayloadSkipped() {
+        Message message = new DefaultMessage("<TestRequest><Message>already XML</Message></TestRequest>");
+        new XmlMarshallingMessageProcessor(marshaller).process(message, context);
+
+        Assert.assertEquals(message.getPayload(String.class),
+                "<TestRequest><Message>already XML</Message></TestRequest>");
+    }
+
+    @Test
+    public void testMarshalMessageWithPlaintextType() {
+        Message message = new DefaultMessage(new TestRequest("Hello Citrus!"));
+        message.setType(MessageType.PLAINTEXT.name());
+        new XmlMarshallingMessageProcessor(marshaller).process(message, context);
+
+        Assert.assertEquals(message.getPayload(String.class),
+                "<TestRequest><Message>Hello Citrus!</Message></TestRequest>");
+    }
+}

--- a/validation/citrus-validation-xml/src/test/java/org/citrusframework/xml/message/processor/XmlUnmarshallingMessageProcessorTest.java
+++ b/validation/citrus-validation-xml/src/test/java/org/citrusframework/xml/message/processor/XmlUnmarshallingMessageProcessorTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.xml.message.processor;
+
+import java.util.Collections;
+
+import org.citrusframework.api.xml.Unmarshaller;
+import org.citrusframework.base.xml.Jaxb2Marshaller;
+import org.citrusframework.message.DefaultMessage;
+import org.citrusframework.message.Message;
+import org.citrusframework.message.MessageType;
+import org.citrusframework.spi.ReferenceResolver;
+import org.citrusframework.testng.AbstractTestNGUnitTest;
+import org.citrusframework.xml.actons.dsl.TestRequest;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.when;
+
+public class XmlUnmarshallingMessageProcessorTest extends AbstractTestNGUnitTest {
+
+    private final Jaxb2Marshaller unmarshaller = new Jaxb2Marshaller(TestRequest.class);
+
+    @Test
+    public void testUnmarshalMessage() {
+        ReferenceResolver referenceResolver = Mockito.mock(ReferenceResolver.class);
+        when(referenceResolver.resolveAll(Unmarshaller.class))
+                .thenReturn(Collections.singletonMap("unmarshaller", unmarshaller));
+        context.setReferenceResolver(referenceResolver);
+
+        Message message = new DefaultMessage("<TestRequest><Message>Hello Citrus!</Message></TestRequest>");
+        new XmlUnmarshallingMessageProcessor().process(message, context);
+
+        Assert.assertTrue(message.getPayload() instanceof TestRequest);
+        Assert.assertEquals(((TestRequest) message.getPayload()).getMessage(), "Hello Citrus!");
+    }
+
+    @Test
+    public void testUnmarshalMessageWithExplicitUnmarshaller() {
+        Message message = new DefaultMessage("<TestRequest><Message>Hello Citrus!</Message></TestRequest>");
+        new XmlUnmarshallingMessageProcessor(unmarshaller).process(message, context);
+
+        Assert.assertTrue(message.getPayload() instanceof TestRequest);
+        Assert.assertEquals(((TestRequest) message.getPayload()).getMessage(), "Hello Citrus!");
+    }
+
+    @Test
+    public void testUnmarshalMessageWithPlaintextType() {
+        Message message = new DefaultMessage("<TestRequest><Message>Hello Citrus!</Message></TestRequest>");
+        message.setType(MessageType.PLAINTEXT.name());
+        new XmlUnmarshallingMessageProcessor(unmarshaller).process(message, context);
+
+        Assert.assertTrue(message.getPayload() instanceof TestRequest);
+        Assert.assertEquals(((TestRequest) message.getPayload()).getMessage(), "Hello Citrus!");
+    }
+}


### PR DESCRIPTION
## Summary
- Add `JsonMarshallingMessageProcessor` and `JsonUnmarshallingMessageProcessor` in `citrus-validation-json` module for in-place JSON serialization/deserialization of message payloads using Jackson ObjectMapper
- Add `XmlMarshallingMessageProcessor` and `XmlUnmarshallingMessageProcessor` in `citrus-validation-xml` module for in-place XML marshalling/unmarshalling using Citrus Marshaller/Unmarshaller API
- Extend `JsonMessageProcessors` and `XmlMessageProcessors` interfaces with no-arg `marshal()` / `unmarshal()` methods returning `MessageProcessor.Builder`
- Wire SPI lookup via META-INF registration files and `MessageProcessorSupport`

Closes #1645

## Test plan
- [x] Unit tests for all four processors (marshal/unmarshal with auto-detect, explicit mapper/marshaller, and any message type)
- [x] Module builds pass (`citrus-validation-json`, `citrus-validation-xml`)
- [x] Full root build passes

🤖 Generated with [Claude Code](https://claude.ai/code)