### PR TITLE
fix(#1648): Use lightweight pretty print for String payloads in XmlFormattingMessageProcessor

### DIFF
--- a/validation/citrus-validation-xml/src/main/java/org/citrusframework/xml/message/processor/XmlFormattingMessageProcessor.java
+++ b/validation/citrus-validation-xml/src/main/java/org/citrusframework/xml/message/processor/XmlFormattingMessageProcessor.java
@@ -19,8 +19,10 @@ package org.citrusframework.xml.message.processor;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.message.AbstractMessageProcessor;
 import org.citrusframework.message.Message;
+import org.citrusframework.message.MessagePayloadUtils;
 import org.citrusframework.message.MessageType;
 import org.citrusframework.xml.support.XMLUtils;
+import org.w3c.dom.Document;
 
 /**
  * @since 2.6.2
@@ -29,7 +31,11 @@ public class XmlFormattingMessageProcessor extends AbstractMessageProcessor {
 
     @Override
     public void processMessage(Message message, TestContext context) {
-        message.setPayload(XMLUtils.prettyPrint(message.getPayload(String.class)));
+        if (message.getPayload() instanceof Document document) {
+            message.setPayload(XMLUtils.serialize(document));
+        } else {
+            message.setPayload(MessagePayloadUtils.prettyPrintXml(message.getPayload(String.class)));
+        }
     }
 
     @Override

--- a/validation/citrus-validation-xml/src/test/java/org/citrusframework/xml/message/processor/XmlFormattingMessageProcessorTest.java
+++ b/validation/citrus-validation-xml/src/test/java/org/citrusframework/xml/message/processor/XmlFormattingMessageProcessorTest.java
@@ -16,12 +16,18 @@
 
 package org.citrusframework.xml.message.processor;
 
+import javax.xml.parsers.DocumentBuilderFactory;
+
 import org.citrusframework.message.DefaultMessage;
 import org.citrusframework.message.Message;
 import org.citrusframework.message.MessageType;
 import org.citrusframework.testng.AbstractTestNGUnitTest;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+
+import java.io.StringReader;
 
 /**
  * @since 2.6.2
@@ -53,6 +59,25 @@ public class XmlFormattingMessageProcessorTest extends AbstractTestNGUnitTest {
         messageProcessor.process(message, context);
 
         Assert.assertTrue(message.getPayload(String.class).contains("\n"));
+    }
+
+    @Test
+    public void testProcessDocumentPayload() throws Exception {
+        String xml = "<root><element attribute='attribute-value'><sub-element>text-value</sub-element></element></root>";
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        Document document = factory.newDocumentBuilder()
+                .parse(new InputSource(new StringReader(xml)));
+
+        Message message = new DefaultMessage(document);
+        message.setType(MessageType.XML.name());
+        messageProcessor.process(message, context);
+
+        Assert.assertTrue(message.getPayload() instanceof String);
+        String result = message.getPayload(String.class);
+        Assert.assertTrue(result.contains("root"), "Expected 'root' in: " + result);
+        Assert.assertTrue(result.contains("sub-element"), "Expected 'sub-element' in: " + result);
+        Assert.assertTrue(result.contains("text-value"), "Expected 'text-value' in: " + result);
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Improves `XmlFormattingMessageProcessor` to check the message payload type before formatting
- **String payloads** now use the lightweight `MessagePayloadUtils.prettyPrintXml()` instead of the heavy `XMLUtils.prettyPrint()` which parses into a full DOM Document
- **Document payloads** use `XMLUtils.serialize()` directly since the DOM is already available, avoiding redundant String→Document→String conversion
- Adds test coverage for Document payload formatting

Closes #1648

Generated with [Claude Code](https://claude.ai/code)