### PR TITLE
fix(#1647): Add formatting message processors (JSON, XML, SOAP) to the message processor API

### DIFF
--- a/core/citrus-api/src/main/java/org/citrusframework/message/MessageProcessorSupport.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/message/MessageProcessorSupport.java
@@ -19,10 +19,14 @@ package org.citrusframework.message;
 import org.citrusframework.message.processor.DelegatingVariableExtractorBuilder;
 import org.citrusframework.message.processor.camel.CamelMessageProcessors;
 import org.citrusframework.message.processor.json.JsonMappingValidationProcessorBuilder;
+import org.citrusframework.message.processor.json.JsonFormattingMessageProcessorBuilder;
 import org.citrusframework.message.processor.json.JsonMarshallingMessageProcessorBuilder;
 import org.citrusframework.message.processor.json.JsonMessageProcessors;
 import org.citrusframework.message.processor.json.JsonPathMessageProcessorBuilder;
 import org.citrusframework.message.processor.json.JsonUnmarshallingMessageProcessorBuilder;
+import org.citrusframework.message.processor.xml.SoapFormattingMessageProcessorBuilder;
+import org.citrusframework.message.processor.xml.SoapMessageProcessors;
+import org.citrusframework.message.processor.xml.XmlFormattingMessageProcessorBuilder;
 import org.citrusframework.message.processor.xml.XmlMarshallingMessageProcessorBuilder;
 import org.citrusframework.message.processor.xml.XmlMarshallingValidationProcessorBuilder;
 import org.citrusframework.message.processor.xml.XmlMessageProcessors;
@@ -114,6 +118,11 @@ public interface MessageProcessorSupport extends Processors, MessageProcessorLoo
             public JsonUnmarshallingMessageProcessorBuilder<?, ?> unmarshal() {
                 return lookup("jsonUnmarshal");
             }
+
+            @Override
+            public JsonFormattingMessageProcessorBuilder<?, ?> prettyPrint() {
+                return lookup("jsonPrettyPrint");
+            }
         };
     }
 
@@ -154,6 +163,21 @@ public interface MessageProcessorSupport extends Processors, MessageProcessorLoo
             @Override
             public XmlUnmarshallingMessageProcessorBuilder<?, ?> unmarshal() {
                 return lookup("xmlUnmarshal");
+            }
+
+            @Override
+            public XmlFormattingMessageProcessorBuilder<?, ?> prettyPrint() {
+                return lookup("xmlPrettyPrint");
+            }
+
+            @Override
+            public SoapMessageProcessors soap() {
+                return new SoapMessageProcessors() {
+                    @Override
+                    public SoapFormattingMessageProcessorBuilder<?, ?> prettyPrint() {
+                        return lookup("soapPrettyPrint");
+                    }
+                };
             }
         };
     }

--- a/core/citrus-api/src/main/java/org/citrusframework/message/processor/json/JsonFormattingMessageProcessorBuilder.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/message/processor/json/JsonFormattingMessageProcessorBuilder.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.message.processor.json;
+
+import org.citrusframework.message.MessageProcessor;
+
+public interface JsonFormattingMessageProcessorBuilder<T extends MessageProcessor, B extends JsonFormattingMessageProcessorBuilder<T, B>>
+        extends MessageProcessor.Builder<T, B> {
+}

--- a/core/citrus-api/src/main/java/org/citrusframework/message/processor/json/JsonMessageProcessors.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/message/processor/json/JsonMessageProcessors.java
@@ -36,6 +36,8 @@ public interface JsonMessageProcessors extends PayloadBuilderLookupSupport {
 
     JsonUnmarshallingMessageProcessorBuilder<?, ?> unmarshal();
 
+    JsonFormattingMessageProcessorBuilder<?, ?> prettyPrint();
+
     interface Factory {
 
         /**

--- a/core/citrus-api/src/main/java/org/citrusframework/message/processor/xml/SoapFormattingMessageProcessorBuilder.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/message/processor/xml/SoapFormattingMessageProcessorBuilder.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.message.processor.xml;
+
+import org.citrusframework.message.MessageProcessor;
+
+public interface SoapFormattingMessageProcessorBuilder<T extends MessageProcessor, B extends SoapFormattingMessageProcessorBuilder<T, B>>
+        extends MessageProcessor.Builder<T, B> {
+}

--- a/core/citrus-api/src/main/java/org/citrusframework/message/processor/xml/SoapMessageProcessors.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/message/processor/xml/SoapMessageProcessors.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.message.processor.xml;
+
+public interface SoapMessageProcessors {
+
+    SoapFormattingMessageProcessorBuilder<?, ?> prettyPrint();
+}

--- a/core/citrus-api/src/main/java/org/citrusframework/message/processor/xml/XmlFormattingMessageProcessorBuilder.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/message/processor/xml/XmlFormattingMessageProcessorBuilder.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.message.processor.xml;
+
+import org.citrusframework.message.MessageProcessor;
+
+public interface XmlFormattingMessageProcessorBuilder<T extends MessageProcessor, B extends XmlFormattingMessageProcessorBuilder<T, B>>
+        extends MessageProcessor.Builder<T, B> {
+}

--- a/core/citrus-api/src/main/java/org/citrusframework/message/processor/xml/XmlMessageProcessors.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/message/processor/xml/XmlMessageProcessors.java
@@ -37,6 +37,10 @@ public interface XmlMessageProcessors extends PayloadBuilderLookupSupport {
 
     XmlUnmarshallingMessageProcessorBuilder<?, ?> unmarshal();
 
+    XmlFormattingMessageProcessorBuilder<?, ?> prettyPrint();
+
+    SoapMessageProcessors soap();
+
     interface Factory {
 
         /**

--- a/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/message/SoapFormattingMessageProcessor.java
+++ b/endpoints/citrus-ws/src/main/java/org/citrusframework/ws/message/SoapFormattingMessageProcessor.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.citrusframework.context.TestContext;
 import org.citrusframework.message.Message;
+import org.citrusframework.message.processor.xml.SoapFormattingMessageProcessorBuilder;
 import org.citrusframework.xml.support.XMLUtils;
 import org.citrusframework.xml.message.processor.XmlFormattingMessageProcessor;
 
@@ -43,5 +44,13 @@ public class SoapFormattingMessageProcessor extends XmlFormattingMessageProcesso
         }
 
         super.processMessage(message, context);
+    }
+
+    public static class Builder implements SoapFormattingMessageProcessorBuilder<SoapFormattingMessageProcessor, Builder> {
+
+        @Override
+        public SoapFormattingMessageProcessor build() {
+            return new SoapFormattingMessageProcessor();
+        }
     }
 }

--- a/endpoints/citrus-ws/src/main/resources/META-INF/citrus/message/processor/soapPrettyPrint
+++ b/endpoints/citrus-ws/src/main/resources/META-INF/citrus/message/processor/soapPrettyPrint
@@ -1,0 +1,1 @@
+type=org.citrusframework.ws.message.SoapFormattingMessageProcessor$Builder

--- a/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/message/SoapFormattingMessageProcessorTest.java
+++ b/endpoints/citrus-ws/src/test/java/org/citrusframework/ws/message/SoapFormattingMessageProcessorTest.java
@@ -18,6 +18,7 @@ package org.citrusframework.ws.message;
 
 import org.citrusframework.message.DefaultMessage;
 import org.citrusframework.message.Message;
+import org.citrusframework.message.MessageProcessor;
 import org.citrusframework.message.MessageType;
 import org.citrusframework.testng.AbstractTestNGUnitTest;
 import org.testng.Assert;
@@ -69,5 +70,30 @@ public class SoapFormattingMessageProcessorTest extends AbstractTestNGUnitTest {
 
         messageProcessor.process(message, context);
         Assert.assertEquals(message.getPayload(String.class), "This is plaintext");
+    }
+
+    @Test
+    public void testBuilder() {
+        SoapFormattingMessageProcessor processor = new SoapFormattingMessageProcessor.Builder().build();
+
+        SoapMessage message = new SoapMessage("<root>"
+                    + "<element attribute='attribute-value'>"
+                        + "<sub-element>text-value</sub-element>"
+                    + "</element>"
+                + "</root>");
+        message.setType(MessageType.XML.name());
+
+        processor.process(message, context);
+
+        Assert.assertTrue(message.getPayload(String.class).contains("\n"));
+    }
+
+    @Test
+    public void testLookup() {
+        MessageProcessor.Builder<?, ?> builder = MessageProcessor.lookup("soapPrettyPrint")
+                .orElse(null);
+
+        Assert.assertNotNull(builder);
+        Assert.assertEquals(builder.getClass(), SoapFormattingMessageProcessor.Builder.class);
     }
 }

--- a/src/manual/index.adoc
+++ b/src/manual/index.adoc
@@ -73,6 +73,7 @@ include::functions.adoc[]
 include::validation-matchers.adoc[]
 
 include::agent.adoc[]
+include::message-processors.adoc[]
 include::data-dictionary.adoc[]
 include::test-actors.adoc[]
 include::test-suite.adoc[]

--- a/src/manual/message-processors.adoc
+++ b/src/manual/message-processors.adoc
@@ -1,0 +1,84 @@
+[[message-processors]]
+== Message processors
+
+Message processors allow you to manipulate message payloads before sending or after receiving messages.
+The `processor()` fluent API provides access to various message processors for JSON, XML, and SOAP message formats.
+
+You apply a message processor on a send or receive action using the `.process()` method.
+
+=== JSON pretty print
+
+The JSON formatting message processor pretty-prints a JSON message payload with proper indentation.
+
+.Java
+[source,java,indent=0,role="primary"]
+----
+@CitrusTest
+public void jsonPrettyPrintTest() {
+    $(send("helloService")
+        .message()
+        .type(MessageType.JSON)
+        .body("{\"name\":\"Citrus\",\"version\":\"4.6\"}")
+        .process(processor().json().prettyPrint())
+    );
+}
+----
+
+The processor takes a compact JSON string and formats it with line breaks and indentation before sending. This is useful when you want to ensure that the transmitted JSON payload is human-readable.
+
+You can also apply the pretty print processor on a received message.
+
+.Java
+[source,java,indent=0]
+----
+@CitrusTest
+public void jsonPrettyPrintReceiveTest() {
+    $(receive("helloService")
+        .message()
+        .type(MessageType.JSON)
+        .body("{\"name\":\"Citrus\",\"version\":\"4.6\"}")
+        .process(processor().json().prettyPrint())
+    );
+}
+----
+
+=== XML pretty print
+
+The XML formatting message processor pretty-prints an XML message payload with proper indentation.
+
+.Java
+[source,java,indent=0,role="primary"]
+----
+@CitrusTest
+public void xmlPrettyPrintTest() {
+    $(send("helloService")
+        .message()
+        .type(MessageType.XML)
+        .body("<root><element attribute='value'><sub-element>text</sub-element></element></root>")
+        .process(processor().xml().prettyPrint())
+    );
+}
+----
+
+The processor handles both XML `String` payloads and `org.w3c.dom.Document` object payloads.
+
+=== SOAP pretty print
+
+The SOAP formatting message processor extends the XML formatter with additional SOAP-specific handling.
+It pretty-prints both the SOAP message body and any SOAP fault detail elements.
+
+.Java
+[source,java,indent=0,role="primary"]
+----
+@CitrusTest
+public void soapPrettyPrintTest() {
+    $(send("soapService")
+        .message()
+        .type(MessageType.XML)
+        .body("<root><element>text</element></root>")
+        .process(processor().xml().soap().prettyPrint())
+    );
+}
+----
+
+NOTE: The SOAP pretty print processor requires the `citrus-ws` module on the classpath.

--- a/validation/citrus-validation-json/src/main/java/org/citrusframework/json/message/processor/JsonFormattingMessageProcessor.java
+++ b/validation/citrus-validation-json/src/main/java/org/citrusframework/json/message/processor/JsonFormattingMessageProcessor.java
@@ -21,6 +21,7 @@ import org.citrusframework.message.AbstractMessageProcessor;
 import org.citrusframework.message.Message;
 import org.citrusframework.message.MessagePayloadUtils;
 import org.citrusframework.message.MessageType;
+import org.citrusframework.message.processor.json.JsonFormattingMessageProcessorBuilder;
 
 /**
  * @since 4.6
@@ -35,5 +36,13 @@ public class JsonFormattingMessageProcessor extends AbstractMessageProcessor {
     @Override
     public boolean supportsMessageType(String messageType) {
         return messageType.equalsIgnoreCase(MessageType.JSON.name());
+    }
+
+    public static class Builder implements JsonFormattingMessageProcessorBuilder<JsonFormattingMessageProcessor, Builder> {
+
+        @Override
+        public JsonFormattingMessageProcessor build() {
+            return new JsonFormattingMessageProcessor();
+        }
     }
 }

--- a/validation/citrus-validation-json/src/main/resources/META-INF/citrus/message/processor/jsonPrettyPrint
+++ b/validation/citrus-validation-json/src/main/resources/META-INF/citrus/message/processor/jsonPrettyPrint
@@ -1,0 +1,1 @@
+type=org.citrusframework.json.message.processor.JsonFormattingMessageProcessor$Builder

--- a/validation/citrus-validation-json/src/test/java/org/citrusframework/json/message/processor/JsonFormattingMessageProcessorTest.java
+++ b/validation/citrus-validation-json/src/test/java/org/citrusframework/json/message/processor/JsonFormattingMessageProcessorTest.java
@@ -18,6 +18,7 @@ package org.citrusframework.json.message.processor;
 
 import org.citrusframework.message.DefaultMessage;
 import org.citrusframework.message.Message;
+import org.citrusframework.message.MessageProcessor;
 import org.citrusframework.message.MessageType;
 import org.citrusframework.testng.AbstractTestNGUnitTest;
 import org.testng.Assert;
@@ -50,5 +51,24 @@ public class JsonFormattingMessageProcessorTest extends AbstractTestNGUnitTest {
         message.setType(MessageType.PLAINTEXT.name());
         messageProcessor.process(message, context);
         Assert.assertEquals(message.getPayload(String.class), "This is plaintext");
+    }
+
+    @Test
+    public void testBuilder() {
+        JsonFormattingMessageProcessor processor = new JsonFormattingMessageProcessor.Builder().build();
+
+        Message message = new DefaultMessage("{\"name\":\"Citrus\",\"version\":\"4.6\"}");
+        processor.process(message, context);
+
+        Assert.assertTrue(message.getPayload(String.class).contains("\n"));
+    }
+
+    @Test
+    public void testLookup() {
+        MessageProcessor.Builder<?, ?> builder = MessageProcessor.lookup("jsonPrettyPrint")
+                .orElse(null);
+
+        Assert.assertNotNull(builder);
+        Assert.assertEquals(builder.getClass(), JsonFormattingMessageProcessor.Builder.class);
     }
 }

--- a/validation/citrus-validation-xml/src/main/java/org/citrusframework/xml/message/processor/XmlFormattingMessageProcessor.java
+++ b/validation/citrus-validation-xml/src/main/java/org/citrusframework/xml/message/processor/XmlFormattingMessageProcessor.java
@@ -21,6 +21,7 @@ import org.citrusframework.message.AbstractMessageProcessor;
 import org.citrusframework.message.Message;
 import org.citrusframework.message.MessagePayloadUtils;
 import org.citrusframework.message.MessageType;
+import org.citrusframework.message.processor.xml.XmlFormattingMessageProcessorBuilder;
 import org.citrusframework.xml.support.XMLUtils;
 import org.w3c.dom.Document;
 
@@ -41,5 +42,13 @@ public class XmlFormattingMessageProcessor extends AbstractMessageProcessor {
     @Override
     public boolean supportsMessageType(String messageType) {
         return messageType.equalsIgnoreCase(MessageType.XML.name());
+    }
+
+    public static class Builder implements XmlFormattingMessageProcessorBuilder<XmlFormattingMessageProcessor, Builder> {
+
+        @Override
+        public XmlFormattingMessageProcessor build() {
+            return new XmlFormattingMessageProcessor();
+        }
     }
 }

--- a/validation/citrus-validation-xml/src/main/resources/META-INF/citrus/message/processor/xmlPrettyPrint
+++ b/validation/citrus-validation-xml/src/main/resources/META-INF/citrus/message/processor/xmlPrettyPrint
@@ -1,0 +1,1 @@
+type=org.citrusframework.xml.message.processor.XmlFormattingMessageProcessor$Builder

--- a/validation/citrus-validation-xml/src/test/java/org/citrusframework/xml/message/processor/XmlFormattingMessageProcessorTest.java
+++ b/validation/citrus-validation-xml/src/test/java/org/citrusframework/xml/message/processor/XmlFormattingMessageProcessorTest.java
@@ -20,6 +20,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.citrusframework.message.DefaultMessage;
 import org.citrusframework.message.Message;
+import org.citrusframework.message.MessageProcessor;
 import org.citrusframework.message.MessageType;
 import org.citrusframework.testng.AbstractTestNGUnitTest;
 import org.testng.Assert;
@@ -86,5 +87,28 @@ public class XmlFormattingMessageProcessorTest extends AbstractTestNGUnitTest {
         message.setType(MessageType.PLAINTEXT.name());
         messageProcessor.process(message, context);
         Assert.assertEquals(message.getPayload(String.class), "This is plaintext");
+    }
+
+    @Test
+    public void testBuilder() {
+        XmlFormattingMessageProcessor processor = new XmlFormattingMessageProcessor.Builder().build();
+
+        Message message = new DefaultMessage("<root>"
+                    + "<element attribute='attribute-value'>"
+                        + "<sub-element>text-value</sub-element>"
+                    + "</element>"
+                + "</root>");
+        processor.process(message, context);
+
+        Assert.assertTrue(message.getPayload(String.class).contains("\n"));
+    }
+
+    @Test
+    public void testLookup() {
+        MessageProcessor.Builder<?, ?> builder = MessageProcessor.lookup("xmlPrettyPrint")
+                .orElse(null);
+
+        Assert.assertNotNull(builder);
+        Assert.assertEquals(builder.getClass(), XmlFormattingMessageProcessor.Builder.class);
     }
 }


### PR DESCRIPTION
## Summary
- Adds `prettyPrint()` convenience methods to `JsonMessageProcessors` and `XmlMessageProcessors` interfaces, enabling the fluent API: `processor().json().prettyPrint()`, `processor().xml().prettyPrint()`, `processor().xml().soap().prettyPrint()`
- Adds `Builder` inner classes and SPI registrations (`jsonPrettyPrint`, `xmlPrettyPrint`, `soapPrettyPrint`) to `JsonFormattingMessageProcessor`, `XmlFormattingMessageProcessor`, and `SoapFormattingMessageProcessor`
- Introduces `SoapMessageProcessors` interface and `SoapFormattingMessageProcessorBuilder` to support the `soap().prettyPrint()` chain

Closes #1647

## Test plan
- [x] Builder tests verify that each `Builder.build()` produces a working processor
- [x] SPI lookup tests verify that `MessageProcessor.lookup("jsonPrettyPrint")`, `MessageProcessor.lookup("xmlPrettyPrint")`, and `MessageProcessor.lookup("soapPrettyPrint")` resolve to the correct builder classes
- [x] Existing formatting processor tests continue to pass
- [x] Full reactor build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)