### PR TITLE
fix(#1656): Filter .java extension from JBang dynamic module resolution

### DIFF
--- a/tools/jbang/src/main/java/org/citrusframework/jbang/cli/commands/Run.java
+++ b/tools/jbang/src/main/java/org/citrusframework/jbang/cli/commands/Run.java
@@ -232,8 +232,9 @@ public class Run extends CitrusCommand {
         // Handle DSL test loaders according to file extensions
         tests.stream().map(FileUtils::getFileExtension).distinct().forEach(ext -> {
             if (StringUtils.hasText(ext)) {
-                if ("feature".equals(ext)) {
-                    // Add Cucumber DSL support modules and a set of default Citrus steps
+                if ("java".equals(ext)) {
+                    // Java DSL is on the classpath by default - no dynamic module needed
+                } else if ("feature".equals(ext)) {
                     allModules.add("citrus-cucumber");
                     allModules.add("citrus-cucumber-core");
                 } else {


### PR DESCRIPTION
## Summary

- Filter out `.java` file extension from dynamic module resolution in the JBang `Run` command
- The Java DSL runtime is already on the classpath by default, so attempting to resolve `citrus-java` (a non-existent module) produced unnecessary error warnings

Fixes #1656

## Test plan

- [x] Existing `RunTest#shouldRunAllTest` exercises this path (processes `SampleIT.java` alongside YAML/XML/Groovy/Feature files)
- [x] All 17 tests in the jbang module pass
- [x] Full reactor build succeeds

Generated with [Claude Code](https://claude.ai/code)