### PR TITLE
fix(#1658): Add migration prompt to Citrus MCP server

### DIFF
--- a/tools/mcp-server/src/main/java/org/citrusframework/mcp/PromptDefinitions.java
+++ b/tools/mcp-server/src/main/java/org/citrusframework/mcp/PromptDefinitions.java
@@ -99,4 +99,91 @@ public class PromptDefinitions {
         return List.of(PromptMessage.withUserRole(instructions));
     }
 
+    /**
+     * Guided workflow for migrating a Citrus project from one version to another.
+     */
+    @Prompt(name = "citrus_migrate_project",
+            description = "Guided workflow to migrate a Citrus project from one version to another: "
+                          + "retrieve the migration guide, analyze dependencies, apply package renames, "
+                          + "update DSL syntax, update configuration properties, flag API and SPI changes, "
+                          + "and present a summary of all changes.")
+    public List<PromptMessage> citrus_migrate_project(
+            @PromptArg(name = "sourceVersion",
+                       description = "Current Citrus version of the project (e.g. 4.x)") String sourceVersion,
+            @PromptArg(name = "targetVersion",
+                       description = "Target Citrus version to migrate to (e.g. 5.0)") String targetVersion) {
+
+        String instructions = """
+                You are migrating a Citrus project from version %s to version %s.
+
+                ## Versions
+                - **Source version:** %s
+                - **Target version:** %s
+
+                ## Workflow
+
+                Follow these steps in order:
+
+                ### Step 1: Retrieve the migration guide
+                Retrieve the migration guide by reading the MCP resource `citrus://docs/migration-guide/%s`. \
+                This contains the structured migration data including artifact renames, dependency upgrades, \
+                package renames, DSL renames, property renames, API changes, and SPI changes. \
+                Parse the JSON response and use it to drive the remaining steps.
+
+                ### Step 2: Analyze dependencies (pom.xml / build files)
+                Examine the project's `pom.xml` (or Gradle build files) and apply the following changes:
+                - **Artifact renames:** For each artifact rename in the migration guide, find the old artifactId \
+                in the project's dependencies and replace it with the new artifactId.
+                - **Dependency upgrades:** For each dependency upgrade in the migration guide, check if the project \
+                uses the listed dependency and update the version accordingly.
+                - Update the Citrus version from %s to %s in the project's dependency management.
+
+                ### Step 3: Apply package renames across source code
+                For each package rename in the migration guide, search the project's Java source files \
+                (both main and test sources) for import statements and fully-qualified references using \
+                the old package name. Replace them with the new package name. \
+                Pay attention to any notes on the renames — some renames apply only to API interfaces, \
+                not to implementation classes.
+
+                ### Step 4: Update DSL syntax
+                For each DSL rename in the migration guide, search the project's test files for the old syntax \
+                and replace it with the new syntax. Check all DSL formats:
+                - **Java DSL:** method calls in `.java` files
+                - **XML DSL:** elements in `.xml` test files
+                - **YAML DSL:** keys in `.yaml` / `.yml` test files
+
+                ### Step 5: Update configuration properties
+                For each property rename in the migration guide, search the project's configuration files \
+                (`application.properties`, `citrus-application.properties`, `citrus.properties`, \
+                and any YAML configuration files) for the old property name and replace it with the new one.
+
+                ### Step 6: Flag API changes
+                Review the API changes listed in the migration guide and check if the project is affected:
+                - For interface extractions: check if the project instantiates the old concrete class directly.
+                - For class relocations: check if the project references the old package.
+                - For class deletions: check if the project uses the deleted class.
+                Present each API change that affects the project and provide specific guidance for resolving it.
+
+                ### Step 7: Flag SPI changes
+                Review the SPI changes listed in the migration guide and check if the project has custom \
+                `META-INF/services/` files or `META-INF/citrus/` SPI files that reference the old class names. \
+                Flag any that need updating and provide the correct new values.
+
+                ### Step 8: Present migration summary
+                Present a comprehensive summary of all changes made and any manual steps remaining:
+                - List all dependency changes applied
+                - List all package renames applied (grouped by module)
+                - List all DSL syntax updates applied
+                - List all property renames applied
+                - List all API changes that require manual attention
+                - List all SPI changes that require manual attention
+                - Highlight any changes that could not be applied automatically and need manual review
+                """.formatted(sourceVersion, targetVersion,
+                              sourceVersion, targetVersion,
+                              targetVersion,
+                              sourceVersion, targetVersion);
+
+        return List.of(PromptMessage.withUserRole(instructions));
+    }
+
 }

--- a/tools/mcp-server/src/test/java/org/citrusframework/mcp/PromptDefinitionsTest.java
+++ b/tools/mcp-server/src/test/java/org/citrusframework/mcp/PromptDefinitionsTest.java
@@ -32,4 +32,43 @@ class PromptDefinitionsTest {
         List<PromptMessage> result = prompts.citrus_write_test("Send and receive messages to/from a direct endpoint", "yaml");
         assertThat(result).isNotEmpty();
     }
+
+    @Test
+    void migrateProjectReturnsNonEmptyMessages() {
+        List<PromptMessage> result = prompts.citrus_migrate_project("4.x", "5.0");
+        assertThat(result).isNotEmpty();
+    }
+
+    @Test
+    void migrateProjectContainsVersions() {
+        List<PromptMessage> result = prompts.citrus_migrate_project("4.x", "5.0");
+        assertThat(result).hasSize(1);
+        PromptMessage message = result.get(0);
+        assertThat(message.content().asText().text())
+                .contains("4.x")
+                .contains("5.0")
+                .contains("migration guide");
+    }
+
+    @Test
+    void migrateProjectContainsAllWorkflowSteps() {
+        List<PromptMessage> result = prompts.citrus_migrate_project("4.x", "5.0");
+        String content = result.get(0).content().asText().text();
+        assertThat(content)
+                .contains("Step 1:")
+                .contains("Step 2:")
+                .contains("Step 3:")
+                .contains("Step 4:")
+                .contains("Step 5:")
+                .contains("Step 6:")
+                .contains("Step 7:")
+                .contains("Step 8:");
+    }
+
+    @Test
+    void migrateProjectReferencesResourceTemplate() {
+        List<PromptMessage> result = prompts.citrus_migrate_project("4.x", "5.0");
+        String content = result.get(0).content().asText().text();
+        assertThat(content).contains("citrus://docs/migration-guide/5.0");
+    }
 }


### PR DESCRIPTION
## Summary
- Adds a new `citrus_migrate_project` MCP prompt to the Citrus MCP server that provides a guided 8-step workflow for migrating a Citrus project between versions
- The prompt accepts `sourceVersion` and `targetVersion` arguments and instructs the LLM to retrieve the migration guide via the existing `citrus://docs/migration-guide/{version}` resource template, then systematically apply artifact renames, dependency upgrades, package renames, DSL syntax updates, property renames, and flag API/SPI changes
- Adds unit tests verifying the prompt returns non-empty messages, embeds both version strings, includes all 8 workflow steps, and references the correct resource template URI

Resolves #1658

## Test plan
- [x] Unit tests pass for the new `citrus_migrate_project` prompt
- [x] Existing `citrus_write_test` prompt tests remain passing
- [x] Full reactor build passes (`mvn clean install -DskipTests`)
- [ ] Verify the prompt works end-to-end with an MCP client

🤖 Generated with [Claude Code](https://claude.ai/code)