### PR TITLE
fix(#1655): Support property placeholders in JBang Maven GAV dependency coordinates

### DIFF
--- a/tools/jbang/src/main/java/org/citrusframework/jbang/cli/maven/MavenDependencyResolver.java
+++ b/tools/jbang/src/main/java/org/citrusframework/jbang/cli/maven/MavenDependencyResolver.java
@@ -27,6 +27,7 @@ import org.apache.camel.tooling.maven.MavenArtifact;
 import org.apache.camel.tooling.maven.MavenDownloader;
 import org.apache.camel.tooling.maven.MavenDownloaderImpl;
 import org.citrusframework.CitrusVersion;
+import org.citrusframework.jbang.cli.CitrusJBangMain;
 import org.citrusframework.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,6 +59,8 @@ public class MavenDependencyResolver {
      */
     public List<MavenArtifact> resolve(String gav, boolean useSnapshots, boolean transitive) {
         try {
+            gav = resolveGavPlaceholders(gav);
+
             Set<String> extraRepositories = new LinkedHashSet<>(repositories.values());
 
             logger.info("Resolving Maven dependency: {}", gav);
@@ -102,5 +105,20 @@ public class MavenDependencyResolver {
     public MavenDependencyResolver withRepository(String key, String value) {
         repositories.put(key, value);
         return this;
+    }
+
+    /**
+     * Resolves property placeholders in Maven GAV coordinate strings.
+     * Supports ${camel.version} and ${citrus.version} placeholders.
+     */
+    static String resolveGavPlaceholders(String gav) {
+        if (gav == null || !gav.contains("${")) {
+            return gav;
+        }
+
+        gav = gav.replace("${camel.version}", CitrusJBangMain.Settings.getCamelVersion());
+        gav = gav.replace("${citrus.version}", CitrusVersion.version());
+
+        return gav;
     }
 }

--- a/tools/jbang/src/test/java/org/citrusframework/jbang/cli/maven/MavenDependencyResolverTest.java
+++ b/tools/jbang/src/test/java/org/citrusframework/jbang/cli/maven/MavenDependencyResolverTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.jbang.cli.maven;
+
+import org.citrusframework.CitrusVersion;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.citrusframework.jbang.cli.CitrusJBangMain.Settings.CAMEL_VERSION_DEFAULT;
+
+public class MavenDependencyResolverTest {
+
+    @Test
+    public void shouldResolveCamelVersionPlaceholder() {
+        String gav = "org.apache.camel:camel-aws2-s3:${camel.version}";
+        String resolved = MavenDependencyResolver.resolveGavPlaceholders(gav);
+        Assert.assertEquals(resolved, "org.apache.camel:camel-aws2-s3:" + CAMEL_VERSION_DEFAULT);
+    }
+
+    @Test
+    public void shouldResolveCamelVersionPlaceholderWithCustomVersion() {
+        String customVersion = "4.25.0";
+        System.setProperty("citrus.camel.jbang.version", customVersion);
+        try {
+            String gav = "org.apache.camel:camel-kafka:${camel.version}";
+            String resolved = MavenDependencyResolver.resolveGavPlaceholders(gav);
+            Assert.assertEquals(resolved, "org.apache.camel:camel-kafka:" + customVersion);
+        } finally {
+            System.clearProperty("citrus.camel.jbang.version");
+        }
+    }
+
+    @Test
+    public void shouldKeepGavWithoutPlaceholders() {
+        String gav = "org.apache.camel:camel-aws2-s3:4.21.0";
+        String resolved = MavenDependencyResolver.resolveGavPlaceholders(gav);
+        Assert.assertEquals(resolved, "org.apache.camel:camel-aws2-s3:4.21.0");
+    }
+
+    @Test
+    public void shouldHandleNullGav() {
+        Assert.assertNull(MavenDependencyResolver.resolveGavPlaceholders(null));
+    }
+
+    @Test
+    public void shouldHandleEmptyGav() {
+        Assert.assertEquals(MavenDependencyResolver.resolveGavPlaceholders(""), "");
+    }
+
+    @Test
+    public void shouldResolveCitrusVersionPlaceholder() {
+        String gav = "org.citrusframework:citrus-http:${citrus.version}";
+        String resolved = MavenDependencyResolver.resolveGavPlaceholders(gav);
+        Assert.assertEquals(resolved, "org.citrusframework:citrus-http:" + CitrusVersion.version());
+    }
+
+    @Test
+    public void shouldResolveBothPlaceholders() {
+        String gav = "org.apache.camel:camel-kafka:${camel.version}";
+        String gav2 = "org.citrusframework:citrus-http:${citrus.version}";
+
+        Assert.assertEquals(MavenDependencyResolver.resolveGavPlaceholders(gav),
+                "org.apache.camel:camel-kafka:" + CAMEL_VERSION_DEFAULT);
+        Assert.assertEquals(MavenDependencyResolver.resolveGavPlaceholders(gav2),
+                "org.citrusframework:citrus-http:" + CitrusVersion.version());
+    }
+
+    @Test
+    public void shouldKeepUnknownPlaceholders() {
+        String gav = "com.example:my-lib:${some.other.version}";
+        String resolved = MavenDependencyResolver.resolveGavPlaceholders(gav);
+        Assert.assertEquals(resolved, "com.example:my-lib:${some.other.version}");
+    }
+}


### PR DESCRIPTION
## Summary
- Adds support for `${camel.version}` and `${citrus.version}` property placeholders in Maven GAV dependency coordinates used by the JBang CLI
- Resolves placeholders before passing GAV strings to the Maven dependency resolver, allowing users to reference managed versions in their dependency declarations

Fixes #1655

## Test plan
- [x] Unit tests added for placeholder resolution (`MavenDependencyResolverTest`)
- [x] Covers `${camel.version}`, `${citrus.version}`, custom version via system property, null/empty input, unknown placeholders, and GAV without placeholders

🤖 Generated with [Claude Code](https://claude.com/claude-code)