### PR TITLE
fix(#1667): Propagate bean references from Citrus to Camel with dynamic endpoints

### DIFF
--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/endpoint/CamelEndpointComponent.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/endpoint/CamelEndpointComponent.java
@@ -18,6 +18,8 @@ package org.citrusframework.camel.endpoint;
 
 import java.util.Map;
 
+import org.apache.camel.CamelContext;
+import org.apache.camel.NoSuchBeanException;
 import org.citrusframework.camel.util.CamelUtils;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.endpoint.AbstractEndpointComponent;
@@ -54,8 +56,31 @@ public class CamelEndpointComponent extends AbstractEndpointComponent {
         }
 
         if (context.getReferenceResolver() != null) {
-            endpoint.getEndpointConfiguration().setCamelContext(
-                    CamelUtils.resolveCamelContext(context.getReferenceResolver(), endpoint.getEndpointConfiguration()));
+            CamelContext camelContext = CamelUtils.resolveCamelContext(context.getReferenceResolver(), endpoint.getEndpointConfiguration());
+            endpoint.getEndpointConfiguration().setCamelContext(camelContext);
+
+            parameters.forEach((key, value) -> {
+                if (value.trim().startsWith("#")) {
+                    // found a bean reference in the Camel endpoint URI, make sure that the Camel context knows this bean
+                    String beanRef = value.trim().substring(1);
+
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Resolving bean reference '#{}' in Camel endpoint uri", beanRef);
+                    }
+
+                    boolean missing;
+                    try {
+                        missing = camelContext.getRegistry().lookupByName(beanRef) == null;
+                    } catch (NoSuchBeanException e) {
+                        missing = true;
+                    }
+
+                    if (missing && context.getReferenceResolver().isResolvable(beanRef)) {
+                        logger.info("Propagating bean reference '{}' to Camel registry", beanRef);
+                        camelContext.getRegistry().bind(beanRef, context.getReferenceResolver().resolve(beanRef));
+                    }
+                }
+            });
         }
 
         enrichEndpointConfiguration(endpoint.getEndpointConfiguration(),

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/util/CamelUtils.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/util/CamelUtils.java
@@ -86,9 +86,9 @@ public class CamelUtils {
                         URISupport.parseQuery(endpointUri).values().stream()
                                 .filter(Objects::nonNull)
                                 .filter(it -> it instanceof String)
-                                .filter(it -> it.toString().startsWith("#"))
-                                .peek(it -> logger.debug("Resolving bean reference '{}' in Camel endpoint uri", it))
-                                .map(it -> it.toString().substring(1))
+                                .map(it -> it.toString().trim())
+                                .filter(it -> it.startsWith("#"))
+                                .map(it -> it.substring(1))
                                 .forEach(beanRef -> {
                                     boolean missing;
                                     try {

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/endpoint/CamelEndpointComponentTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/endpoint/CamelEndpointComponentTest.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.camel.CamelContext;
+import org.apache.camel.support.SimpleRegistry;
 import org.citrusframework.camel.CamelSettings;
 import org.citrusframework.context.TestContext;
 import org.citrusframework.endpoint.Endpoint;
@@ -146,9 +147,16 @@ public class CamelEndpointComponentTest {
     public void testCreateEndpointWithBeanReference() {
         CamelEndpointComponent component = new CamelEndpointComponent();
 
+        SimpleRegistry registry = new SimpleRegistry();
+        Object newsProvider = new Object();
+
         reset(referenceResolver);
         when(referenceResolver.resolveAll(CamelContext.class)).thenReturn(Collections.singletonMap("myCamelContext", camelContext));
         when(referenceResolver.resolve(CamelContext.class)).thenReturn(camelContext);
+        when(referenceResolver.isResolvable("newsProvider")).thenReturn(true);
+        when(referenceResolver.resolve("newsProvider")).thenReturn(newsProvider);
+        when(camelContext.getRegistry()).thenReturn(registry);
+
         Endpoint endpoint = component.createEndpoint("camel:direct:news?provider=#newsProvider", context);
 
         Assert.assertEquals(endpoint.getClass(), CamelEndpoint.class);
@@ -156,6 +164,57 @@ public class CamelEndpointComponentTest {
         Assert.assertEquals(((CamelEndpoint)endpoint).getEndpointConfiguration().getEndpointUri(), "direct:news?provider=#newsProvider");
         Assert.assertEquals(((CamelEndpoint) endpoint).getEndpointConfiguration().getCamelContext(), camelContext);
         Assert.assertEquals(((CamelEndpoint) endpoint).getEndpointConfiguration().getTimeout(), 5000L);
+        Assert.assertTrue(registry.containsKey("newsProvider"));
+        Assert.assertEquals(registry.lookupByName("newsProvider"), newsProvider);
+    }
+
+    @Test
+    public void testCreateEndpointWithUnknownBeanReference() {
+        CamelEndpointComponent component = new CamelEndpointComponent();
+
+        SimpleRegistry registry = new SimpleRegistry();
+
+        reset(referenceResolver);
+        when(referenceResolver.resolveAll(CamelContext.class)).thenReturn(Collections.singletonMap("myCamelContext", camelContext));
+        when(referenceResolver.resolve(CamelContext.class)).thenReturn(camelContext);
+        when(referenceResolver.isResolvable("newsProvider")).thenReturn(false);
+        when(camelContext.getRegistry()).thenReturn(registry);
+
+        Endpoint endpoint = component.createEndpoint("camel:direct:news?provider=#newsProvider", context);
+
+        Assert.assertEquals(endpoint.getClass(), CamelEndpoint.class);
+
+        Assert.assertEquals(((CamelEndpoint)endpoint).getEndpointConfiguration().getEndpointUri(), "direct:news?provider=#newsProvider");
+        Assert.assertEquals(((CamelEndpoint) endpoint).getEndpointConfiguration().getCamelContext(), camelContext);
+        Assert.assertEquals(((CamelEndpoint) endpoint).getEndpointConfiguration().getTimeout(), 5000L);
+        Assert.assertFalse(registry.containsKey("newsProvider"));
+    }
+
+    @Test
+    public void testCreateEndpointWithBeanReferenceNoOverwrite() {
+        CamelEndpointComponent component = new CamelEndpointComponent();
+
+        Object newsProvider = new Object();
+        Object original = new Object();
+        SimpleRegistry registry = new SimpleRegistry();
+        registry.bind("newsProvider", original);
+
+        reset(referenceResolver);
+        when(referenceResolver.resolveAll(CamelContext.class)).thenReturn(Collections.singletonMap("myCamelContext", camelContext));
+        when(referenceResolver.resolve(CamelContext.class)).thenReturn(camelContext);
+        when(referenceResolver.isResolvable("newsProvider")).thenReturn(true);
+        when(referenceResolver.resolve("newsProvider")).thenReturn(newsProvider);
+        when(camelContext.getRegistry()).thenReturn(registry);
+
+        Endpoint endpoint = component.createEndpoint("camel:direct:news?provider=#newsProvider", context);
+
+        Assert.assertEquals(endpoint.getClass(), CamelEndpoint.class);
+
+        Assert.assertEquals(((CamelEndpoint)endpoint).getEndpointConfiguration().getEndpointUri(), "direct:news?provider=#newsProvider");
+        Assert.assertEquals(((CamelEndpoint) endpoint).getEndpointConfiguration().getCamelContext(), camelContext);
+        Assert.assertEquals(((CamelEndpoint) endpoint).getEndpointConfiguration().getTimeout(), 5000L);
+        Assert.assertTrue(registry.containsKey("newsProvider"));
+        Assert.assertEquals(registry.lookupByName("newsProvider"), original);
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Propagate `#beanName` references in Camel endpoint URIs from the Citrus `ReferenceResolver` to the Camel registry in `CamelEndpointComponent.createEndpoint()`
- Clean up whitespace trimming in `CamelUtils.resolveEndpointUri()` to trim before checking the `#` prefix
- Add tests for bean propagation, unknown bean references, and no-overwrite behavior

Fixes #1667

## Test plan

- [x] `testCreateEndpointWithBeanReference` — verifies bean is resolved from Citrus context and bound into Camel registry
- [x] `testCreateEndpointWithUnknownBeanReference` — verifies unresolvable beans are left alone (no error)
- [x] `testCreateEndpointWithBeanReferenceNoOverwrite` — verifies existing Camel registry beans are never overwritten
- [x] Full `citrus-camel` module verify passes (22 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)