### PR TITLE
fix(#1669): YamlCodeAnalyzer fails to detect Camel endpoints using YAML multiline scalar indicators

### DIFF
--- a/tools/jbang/src/main/java/org/citrusframework/jbang/cli/util/YamlCodeAnalyzer.java
+++ b/tools/jbang/src/main/java/org/citrusframework/jbang/cli/util/YamlCodeAnalyzer.java
@@ -31,6 +31,8 @@ public class YamlCodeAnalyzer implements CodeAnalyzer {
     private static final Pattern DEPS_MODELINE_PATTERN = Pattern.compile("^#\\s*deps:\\s*(.+)\\s*$", Pattern.MULTILINE);
     private static final Pattern MODULES_MODELINE_PATTERN = Pattern.compile("^#\\s*modules:\\s*(.+)\\s*$", Pattern.MULTILINE);
 
+    private static final String MULTILINE_ENDPOINT_REGEX = "endpoint:\\s*[|>]-?\\+?\\s*\n";
+
     private static final Pattern CAMEL_ENDPOINT_PATTERN = Pattern.compile("^\\s+endpoint:\\s+\"?'?camel:([^\\s:?]+)\"?'?.*$", Pattern.MULTILINE);
 
     private static final Pattern CAMEL_INFRA_SERVICE_PATTERN = Pattern.compile("^\\s+service:\\s*\"?'?([a-zA-Z][a-zA-Z0-9._-]*)\"?'?\\s*$", Pattern.MULTILINE);
@@ -154,7 +156,7 @@ public class YamlCodeAnalyzer implements CodeAnalyzer {
     @Override
     public Set<String> extractCamelEndpointComponents(String code) {
         Set<String> names = new HashSet<>();
-        Matcher matcher = CAMEL_ENDPOINT_PATTERN.matcher(code.replaceAll("endpoint:\\s*[|>]\\s*\n", "endpoint: "));
+        Matcher matcher = CAMEL_ENDPOINT_PATTERN.matcher(code.replaceAll(MULTILINE_ENDPOINT_REGEX, "endpoint: "));
         while (matcher.find()) {
             names.add(matcher.group(1));
         }
@@ -192,13 +194,15 @@ public class YamlCodeAnalyzer implements CodeAnalyzer {
             }
         }
 
+        String sanitized = code.replaceAll(MULTILINE_ENDPOINT_REGEX, "endpoint: ")
+                .replaceAll("endpoint:\\s+", "endpoint: ");
         for (Map.Entry<String, ComponentDefinition> entry : components.entrySet()) {
             ComponentDefinition component = components.get(entry.getKey());
             String name = Optional.ofNullable(component.group()).orElse(entry.getKey());
 
-            if (code.contains("endpoint: %s".formatted(name))
-                    || code.contains("endpoint: '%s".formatted(name))
-                    || code.contains("endpoint: \"%s".formatted(name))) {
+            if (sanitized.contains("endpoint: %s".formatted(name))
+                    || sanitized.contains("endpoint: '%s".formatted(name))
+                    || sanitized.contains("endpoint: \"%s".formatted(name))) {
                 items.add(name);
                 if (StringUtils.hasText(component.module())) {
                     modules.add(component.module());

--- a/tools/jbang/src/test/java/org/citrusframework/jbang/cli/util/YamlCodeAnalyzerTest.java
+++ b/tools/jbang/src/test/java/org/citrusframework/jbang/cli/util/YamlCodeAnalyzerTest.java
@@ -18,9 +18,11 @@ package org.citrusframework.jbang.cli.util;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Set;
 
 import org.citrusframework.spi.Resources;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static org.citrusframework.jbang.cli.CitrusJBangMain.Settings.CAMEL_VERSION_DEFAULT;
@@ -75,6 +77,70 @@ public class YamlCodeAnalyzerTest {
         String[] foundValidationMatcher = Arrays.stream(scanResult.validationMatcher()).sorted().toArray(String[]::new);
         Assert.assertEquals(foundValidationMatcher[0], "ignore");
         Assert.assertEquals(foundValidationMatcher[1], "isNumber");
+    }
+
+    @DataProvider(name = "multilineEndpointVariants")
+    public Object[][] multilineEndpointVariants() {
+        return new Object[][] {
+                { ">", "folded" },
+                { ">-", "folded strip" },
+                { ">+", "folded keep" },
+                { "|", "literal" },
+                { "|-", "literal strip" },
+                { "|+", "literal keep" },
+        };
+    }
+
+    @Test(dataProvider = "multilineEndpointVariants")
+    public void shouldExtractCamelEndpointFromMultilineScalar(String indicator, String description) {
+        YamlCodeAnalyzer analyzer = new YamlCodeAnalyzer();
+
+        String code = """
+                actions:
+                  - send:
+                      endpoint: %s
+                        camel:paho-mqtt5:myTopic?brokerUrl=tcp://localhost:12883
+                      message:
+                        body:
+                          data: Hi
+                """.formatted(indicator);
+
+        Set<String> components = analyzer.extractCamelEndpointComponents(code);
+        Assert.assertTrue(components.contains("paho-mqtt5"), "Failed to extract Camel endpoint with %s indicator".formatted(description));
+    }
+
+    @Test
+    public void shouldExtractCamelEndpointFromInlineValue() {
+        YamlCodeAnalyzer analyzer = new YamlCodeAnalyzer();
+
+        String code = """
+                actions:
+                  - send:
+                      endpoint: "camel:direct:news"
+                      message:
+                        body:
+                          data: Hi
+                """;
+
+        Set<String> components = analyzer.extractCamelEndpointComponents(code);
+        Assert.assertTrue(components.contains("direct"));
+    }
+
+    @Test
+    public void shouldExtractCamelEndpointFromUnquotedInlineValue() {
+        YamlCodeAnalyzer analyzer = new YamlCodeAnalyzer();
+
+        String code = """
+                actions:
+                  - send:
+                      endpoint: camel:seda:news
+                      message:
+                        body:
+                          data: Hi
+                """;
+
+        Set<String> components = analyzer.extractCamelEndpointComponents(code);
+        Assert.assertTrue(components.contains("seda"));
     }
 
 }

--- a/tools/jbang/src/test/resources/sample.citrus.it.yaml
+++ b/tools/jbang/src/test/resources/sample.citrus.it.yaml
@@ -20,12 +20,13 @@ actions:
         body:
           data: Howdy
   - send:
-      endpoint: "camel:paho-mqtt5:${mqtt.topic}?brokerUrl=tcp://localhost:12883&amp;clientId=${mqtt.client.id}"
+      endpoint: >- 
+        camel:paho-mqtt5:${mqtt.topic}?brokerUrl=tcp://localhost:12883&amp;clientId=${mqtt.client.id}
       message:
         body:
           data: Hi
   - send:
-      endpoint: "kafka:my-topic"
+      endpoint: kafka:my-topic
       message:
         body:
           data: Hello ${id}


### PR DESCRIPTION
## Summary

- Fix `extractCamelEndpointComponents()` and `scanEndpoints()` to handle YAML block scalar indicators with chomping/keep modifiers (`>-`, `>+`, `|-`, `|+`)
- Extract duplicated multiline sanitization regex into a `MULTILINE_ENDPOINT_REGEX` constant
- Update `sample.citrus.it.yaml` to use multiline and unquoted endpoint syntax for coverage
- Add data-driven unit tests covering all 6 block scalar indicator variants plus inline quoted/unquoted values

Fixes #1669

## Test plan

- [x] `shouldExtractCamelEndpointFromMultilineScalar` — data-driven test covering `>`, `>-`, `>+`, `|`, `|-`, `|+`
- [x] `shouldExtractCamelEndpointFromInlineValue` — quoted inline endpoint
- [x] `shouldExtractCamelEndpointFromUnquotedInlineValue` — unquoted inline endpoint
- [x] `shouldAnalyzeCode` — existing full-scan test passes with updated sample YAML
- [x] Full `citrus-jbang` module verify passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)