### PR TITLE
fix(#1671): Use MockitoAnnotations.openMocks() to create fresh mocks per test method

### DIFF
--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/actions/dsl/ReceiveHttpMessageTestActionBuilderTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/actions/dsl/ReceiveHttpMessageTestActionBuilderTest.java
@@ -34,27 +34,46 @@ import org.citrusframework.message.MessageHeaders;
 import org.citrusframework.messaging.SelectiveConsumer;
 import org.citrusframework.validation.context.HeaderValidationContext;
 import org.citrusframework.validation.context.xml.XmlMessageValidationContext;
-import org.mockito.Mockito;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyLong;
-import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
 public class ReceiveHttpMessageTestActionBuilderTest extends UnitTestSupport implements TestActionSupport {
 
-    private final SelectiveConsumer messageConsumer = Mockito.mock(SelectiveConsumer.class);
-    private final HttpEndpointConfiguration configuration = Mockito.mock(HttpEndpointConfiguration.class);
-    private final HttpClient httpClient = Mockito.mock(HttpClient.class);
-    private final HttpServer httpServer = Mockito.mock(HttpServer.class);
+    @Mock
+    private SelectiveConsumer messageConsumer;
+    @Mock
+    private HttpEndpointConfiguration configuration;
+    @Mock
+    private HttpClient httpClient;
+    @Mock
+    private HttpServer httpServer;
+
+    private AutoCloseable mockCloseable;
+
+    @Override
+    @BeforeMethod
+    public void prepareTest() {
+        super.prepareTest();
+        mockCloseable = MockitoAnnotations.openMocks(this);
+    }
+
+    @AfterMethod
+    public void closeMocks() throws Exception {
+        mockCloseable.close();
+    }
 
     @Test
     public void testHttpRequestProperties() {
-        reset(httpServer, messageConsumer, configuration);
         when(httpServer.createConsumer()).thenReturn(messageConsumer);
         when(httpServer.getEndpointConfiguration()).thenReturn(configuration);
         when(configuration.getTimeout()).thenReturn(100L);
@@ -98,7 +117,6 @@ public class ReceiveHttpMessageTestActionBuilderTest extends UnitTestSupport imp
 
     @Test
     public void testMessageObjectOverride() {
-        reset(httpServer, messageConsumer, configuration);
         when(httpServer.createConsumer()).thenReturn(messageConsumer);
         when(httpServer.getEndpointConfiguration()).thenReturn(configuration);
         when(configuration.getTimeout()).thenReturn(100L);
@@ -151,7 +169,6 @@ public class ReceiveHttpMessageTestActionBuilderTest extends UnitTestSupport imp
 
     @Test
     public void testHttpResponseProperties() {
-        reset(httpClient, messageConsumer, configuration);
         when(httpClient.createConsumer()).thenReturn(messageConsumer);
         when(httpClient.getEndpointConfiguration()).thenReturn(configuration);
         when(configuration.getTimeout()).thenReturn(100L);

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/actions/dsl/SendHttpMessageTestActionBuilderTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/actions/dsl/SendHttpMessageTestActionBuilderTest.java
@@ -34,24 +34,41 @@ import org.citrusframework.message.Message;
 import org.citrusframework.message.MessageHeaders;
 import org.citrusframework.message.MessageType;
 import org.citrusframework.messaging.Producer;
-import org.mockito.Mockito;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpMethod;
 import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
 public class SendHttpMessageTestActionBuilderTest extends UnitTestSupport implements TestActionSupport {
 
-    private final HttpClient httpClient = Mockito.mock(HttpClient.class);
-    private final Producer messageProducer = Mockito.mock(Producer.class);
+    @Mock
+    private HttpClient httpClient;
+    @Mock
+    private Producer messageProducer;
+
+    private AutoCloseable mockCloseable;
+
+    @Override
+    @BeforeMethod
+    public void prepareTest() {
+        super.prepareTest();
+        mockCloseable = MockitoAnnotations.openMocks(this);
+    }
+
+    @AfterMethod
+    public void closeMocks() throws Exception {
+        mockCloseable.close();
+    }
 
     @Test
     public void testFork() {
-        reset(httpClient, messageProducer);
         when(httpClient.createProducer()).thenReturn(messageProducer);
         when(httpClient.getActor()).thenReturn(null);
         doAnswer(invocation -> {
@@ -116,7 +133,6 @@ public class SendHttpMessageTestActionBuilderTest extends UnitTestSupport implem
 
     @Test
     public void testMessageObjectOverride() {
-        reset(httpClient, messageProducer);
         when(httpClient.createProducer()).thenReturn(messageProducer);
         when(httpClient.getActor()).thenReturn(null);
         doAnswer(invocation -> {
@@ -163,7 +179,6 @@ public class SendHttpMessageTestActionBuilderTest extends UnitTestSupport implem
 
     @Test
     public void testHttpMethod() {
-        reset(httpClient, messageProducer);
         when(httpClient.createProducer()).thenReturn(messageProducer);
         when(httpClient.getActor()).thenReturn(null);
         doAnswer(invocation -> {
@@ -198,7 +213,6 @@ public class SendHttpMessageTestActionBuilderTest extends UnitTestSupport implem
 
     @Test
     public void testHttpRequestUriAndPath() {
-        reset(httpClient, messageProducer);
         when(httpClient.createProducer()).thenReturn(messageProducer);
         when(httpClient.getActor()).thenReturn(null);
         doAnswer(invocation -> {
@@ -238,7 +252,6 @@ public class SendHttpMessageTestActionBuilderTest extends UnitTestSupport implem
 
     @Test
     public void testHttpRequestUriAndQueryParams() {
-        reset(httpClient, messageProducer);
         when(httpClient.createProducer()).thenReturn(messageProducer);
         when(httpClient.getActor()).thenReturn(null);
         doAnswer(invocation -> {


### PR DESCRIPTION
## Summary

- Fixes flaky `SendHttpMessageTestActionBuilderTest.testHttpMethod` that failed intermittently with Mockito `UnfinishedStubbingException`
- Replaced class-level shared mock instances with `@Mock` annotations and `MockitoAnnotations.openMocks()` in `@BeforeMethod`, ensuring fresh mocks per test with no state leakage
- Applied the same fix to `ReceiveHttpMessageTestActionBuilderTest` which had the identical anti-pattern

Closes #1671

## Test plan

- [x] All 8 tests in both test classes pass
- [x] Full reactor build succeeds

Generated with [Claude Code](https://claude.com/claude-code)