### PR TITLE
fix(#1673): Fix registry mirror breaking alternate registry images and Kafka compatibility check

### DIFF
--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/TestContainersSettings.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/TestContainersSettings.java
@@ -173,4 +173,32 @@ public final class TestContainersSettings {
 
         return registry;
     }
+
+    /**
+     * Applies the Docker registry or mirror prefix to the given image name.
+     * Images from alternative registries (e.g. quay.io, ghcr.io) are returned unchanged
+     * because the mirror only covers Docker Hub images.
+     * @param imageName the Docker image name (e.g. "postgres", "apache/kafka", "quay.io/strimzi/kafka")
+     * @return the image name with registry prefix applied if appropriate
+     */
+    public static String getDockerImageName(String imageName) {
+        if (hasAlternateRegistry(imageName)) {
+            return imageName;
+        }
+        return getDockerRegistry() + imageName;
+    }
+
+    /**
+     * Checks whether the image name references an alternate (non-Docker Hub) registry.
+     * An image has an alternate registry when the first path segment contains a dot or colon
+     * (e.g. "quay.io/strimzi/kafka", "localhost:5000/myimage").
+     */
+    private static boolean hasAlternateRegistry(String imageName) {
+        int slashIndex = imageName.indexOf('/');
+        if (slashIndex < 0) {
+            return false;
+        }
+        String firstSegment = imageName.substring(0, slashIndex);
+        return firstSegment.contains(".") || firstSegment.contains(":");
+    }
 }

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/actions/StartTestcontainersAction.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/actions/StartTestcontainersAction.java
@@ -33,7 +33,6 @@ import org.citrusframework.spi.Resource;
 import org.citrusframework.spi.Resources;
 import org.citrusframework.testcontainers.TestContainersSettings;
 import org.citrusframework.testcontainers.WaitStrategyHelper;
-import org.citrusframework.util.StringUtils;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -381,13 +380,7 @@ public class StartTestcontainersAction<C extends GenericContainer<?>> extends Ab
 
         @SuppressWarnings("unchecked")
         protected C buildContainer() {
-            String imageName;
-            if (StringUtils.hasText(TestContainersSettings.getRegistry()) &&
-                    !image.startsWith(TestContainersSettings.getDockerRegistry())) {
-                imageName = TestContainersSettings.getDockerRegistry() + image;
-            } else {
-                imageName = image;
-            }
+            String imageName = TestContainersSettings.getDockerImageName(image);
 
             C container = (C) new GenericContainer<>(imageName);
 

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/FlociSettings.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/FlociSettings.java
@@ -89,8 +89,8 @@ public class FlociSettings {
      * @return
      */
     public static String getImageName() {
-        return TestContainersSettings.getDockerRegistry() + System.getProperty(IMAGE_NAME_PROPERTY,
-                System.getenv(IMAGE_NAME_ENV) != null ? System.getenv(IMAGE_NAME_ENV) : IMAGE_NAME_DEFAULT);
+        return TestContainersSettings.getDockerImageName(System.getProperty(IMAGE_NAME_PROPERTY,
+                System.getenv(IMAGE_NAME_ENV) != null ? System.getenv(IMAGE_NAME_ENV) : IMAGE_NAME_DEFAULT));
     }
 
     /**

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/LocalStackSettings.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/LocalStackSettings.java
@@ -90,8 +90,8 @@ public class LocalStackSettings {
      * @return
      */
     public static String getImageName() {
-        return TestContainersSettings.getDockerRegistry() + System.getProperty(IMAGE_NAME_PROPERTY,
-                System.getenv(IMAGE_NAME_ENV) != null ? System.getenv(IMAGE_NAME_ENV) : IMAGE_NAME_DEFAULT);
+        return TestContainersSettings.getDockerImageName(System.getProperty(IMAGE_NAME_PROPERTY,
+                System.getenv(IMAGE_NAME_ENV) != null ? System.getenv(IMAGE_NAME_ENV) : IMAGE_NAME_DEFAULT));
     }
 
     /**

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/KafkaSettings.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/KafkaSettings.java
@@ -99,16 +99,29 @@ public class KafkaSettings {
      */
     public static String getImageName(KafkaImplementation implementation) {
         return switch (implementation) {
-            case CONFLUENT -> TestContainersSettings.getDockerRegistry() + System.getProperty(CONFLUENT_IMAGE_NAME_PROPERTY,
-                    System.getenv(CONFLUENT_IMAGE_NAME_ENV) != null ? System.getenv(CONFLUENT_IMAGE_NAME_ENV) : CONFLUENT_IMAGE_NAME_DEFAULT);
-            case APACHE -> TestContainersSettings.getDockerRegistry() + System.getProperty(APACHE_IMAGE_NAME_PROPERTY,
-                    System.getenv(APACHE_IMAGE_NAME_ENV) != null ? System.getenv(APACHE_IMAGE_NAME_ENV) : APACHE_IMAGE_NAME_DEFAULT);
-            case APACHE_NATIVE -> TestContainersSettings.getDockerRegistry() + System.getProperty(APACHE_NATIVE_IMAGE_NAME_PROPERTY,
-                    System.getenv(APACHE_NATIVE_IMAGE_NAME_ENV) != null ? System.getenv(APACHE_NATIVE_IMAGE_NAME_ENV) : APACHE_NATIVE_IMAGE_NAME_DEFAULT);
-            case STRIMZI -> TestContainersSettings.getDockerRegistry() + System.getProperty(STRIMZI_IMAGE_NAME_PROPERTY,
-                    System.getenv(STRIMZI_IMAGE_NAME_ENV) != null ? System.getenv(STRIMZI_IMAGE_NAME_ENV) : STRIMZI_IMAGE_NAME_DEFAULT);
-            case DEFAULT -> TestContainersSettings.getDockerRegistry() + System.getProperty(IMAGE_NAME_PROPERTY,
-                    System.getenv(IMAGE_NAME_ENV) != null ? System.getenv(IMAGE_NAME_ENV) : IMAGE_NAME_DEFAULT);
+            case CONFLUENT -> TestContainersSettings.getDockerImageName(System.getProperty(CONFLUENT_IMAGE_NAME_PROPERTY,
+                    System.getenv(CONFLUENT_IMAGE_NAME_ENV) != null ? System.getenv(CONFLUENT_IMAGE_NAME_ENV) : CONFLUENT_IMAGE_NAME_DEFAULT));
+            case APACHE -> TestContainersSettings.getDockerImageName(System.getProperty(APACHE_IMAGE_NAME_PROPERTY,
+                    System.getenv(APACHE_IMAGE_NAME_ENV) != null ? System.getenv(APACHE_IMAGE_NAME_ENV) : APACHE_IMAGE_NAME_DEFAULT));
+            case APACHE_NATIVE -> TestContainersSettings.getDockerImageName(System.getProperty(APACHE_NATIVE_IMAGE_NAME_PROPERTY,
+                    System.getenv(APACHE_NATIVE_IMAGE_NAME_ENV) != null ? System.getenv(APACHE_NATIVE_IMAGE_NAME_ENV) : APACHE_NATIVE_IMAGE_NAME_DEFAULT));
+            case STRIMZI -> TestContainersSettings.getDockerImageName(System.getProperty(STRIMZI_IMAGE_NAME_PROPERTY,
+                    System.getenv(STRIMZI_IMAGE_NAME_ENV) != null ? System.getenv(STRIMZI_IMAGE_NAME_ENV) : STRIMZI_IMAGE_NAME_DEFAULT));
+            case DEFAULT -> TestContainersSettings.getDockerImageName(System.getProperty(IMAGE_NAME_PROPERTY,
+                    System.getenv(IMAGE_NAME_ENV) != null ? System.getenv(IMAGE_NAME_ENV) : IMAGE_NAME_DEFAULT));
+        };
+    }
+
+    /**
+     * Default Kafka image name without any registry prefix.
+     */
+    public static String getDefaultImageName(KafkaImplementation implementation) {
+        return switch (implementation) {
+            case CONFLUENT -> CONFLUENT_IMAGE_NAME_DEFAULT;
+            case APACHE -> APACHE_IMAGE_NAME_DEFAULT;
+            case APACHE_NATIVE -> APACHE_NATIVE_IMAGE_NAME_DEFAULT;
+            case STRIMZI -> STRIMZI_IMAGE_NAME_DEFAULT;
+            case DEFAULT -> IMAGE_NAME_DEFAULT;
         };
     }
 

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/StartKafkaAction.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/kafka/StartKafkaAction.java
@@ -169,7 +169,7 @@ public class StartKafkaAction<T extends GenericContainer<?>> extends StartTestco
                 if (TestContainersSettings.isRegistryMirrorEnabled()) {
                     // make sure the mirror image is declared as compatible with original image
                     imageName = DockerImageName.parse(image).withTag(kafkaVersion)
-                            .asCompatibleSubstituteFor(DockerImageName.parse(image));
+                            .asCompatibleSubstituteFor(DockerImageName.parse(KafkaSettings.getDefaultImageName(implementation)));
                 } else {
                     imageName = DockerImageName.parse(image).withTag(kafkaVersion);
                 }

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/mongodb/MongoDBSettings.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/mongodb/MongoDBSettings.java
@@ -57,8 +57,8 @@ public class MongoDBSettings {
      * @return
      */
     public static String getImageName() {
-        return TestContainersSettings.getDockerRegistry() + System.getProperty(IMAGE_NAME_PROPERTY,
-                System.getenv(IMAGE_NAME_ENV) != null ? System.getenv(IMAGE_NAME_ENV) : IMAGE_NAME_DEFAULT);
+        return TestContainersSettings.getDockerImageName(System.getProperty(IMAGE_NAME_PROPERTY,
+                System.getenv(IMAGE_NAME_ENV) != null ? System.getenv(IMAGE_NAME_ENV) : IMAGE_NAME_DEFAULT));
     }
 
     /**

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/postgresql/PostgreSQLSettings.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/postgresql/PostgreSQLSettings.java
@@ -69,8 +69,8 @@ public class PostgreSQLSettings {
      * @return
      */
     public static String getImageName() {
-        return TestContainersSettings.getDockerRegistry() + System.getProperty(IMAGE_NAME_PROPERTY,
-                System.getenv(IMAGE_NAME_ENV) != null ? System.getenv(IMAGE_NAME_ENV) : IMAGE_NAME_DEFAULT);
+        return TestContainersSettings.getDockerImageName(System.getProperty(IMAGE_NAME_PROPERTY,
+                System.getenv(IMAGE_NAME_ENV) != null ? System.getenv(IMAGE_NAME_ENV) : IMAGE_NAME_DEFAULT));
     }
 
     /**

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/redpanda/RedpandaSettings.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/redpanda/RedpandaSettings.java
@@ -59,8 +59,8 @@ public class RedpandaSettings {
      * @return
      */
     public static String getImageName() {
-        return TestContainersSettings.getDockerRegistry() + System.getProperty(IMAGE_NAME_PROPERTY,
-                System.getenv(IMAGE_NAME_ENV) != null ? System.getenv(IMAGE_NAME_ENV) : IMAGE_NAME_DEFAULT);
+        return TestContainersSettings.getDockerImageName(System.getProperty(IMAGE_NAME_PROPERTY,
+                System.getenv(IMAGE_NAME_ENV) != null ? System.getenv(IMAGE_NAME_ENV) : IMAGE_NAME_DEFAULT));
     }
 
     /**

--- a/connectors/citrus-testcontainers/src/test/java/org/citrusframework/testcontainers/TestContainersSettingsTest.java
+++ b/connectors/citrus-testcontainers/src/test/java/org/citrusframework/testcontainers/TestContainersSettingsTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.testcontainers;
+
+import static org.citrusframework.testcontainers.TestContainersSettings.TESTCONTAINERS_PROPERTY_PREFIX;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+public class TestContainersSettingsTest {
+
+    private static final String REGISTRY_MIRROR_ENABLED_PROPERTY = TESTCONTAINERS_PROPERTY_PREFIX + "registry.mirror.enabled";
+    private static final String REGISTRY_MIRROR_PROPERTY = TESTCONTAINERS_PROPERTY_PREFIX + "registry.mirror";
+    private static final String REGISTRY_PROPERTY = TESTCONTAINERS_PROPERTY_PREFIX + "registry";
+
+    @AfterMethod
+    public void cleanup() {
+        System.clearProperty(REGISTRY_MIRROR_ENABLED_PROPERTY);
+        System.clearProperty(REGISTRY_MIRROR_PROPERTY);
+        System.clearProperty(REGISTRY_PROPERTY);
+    }
+
+    @Test
+    public void shouldReturnImageUnchangedWhenMirrorDisabled() {
+        Assert.assertEquals(TestContainersSettings.getDockerImageName("postgres"), "postgres");
+        Assert.assertEquals(TestContainersSettings.getDockerImageName("apache/kafka"), "apache/kafka");
+        Assert.assertEquals(TestContainersSettings.getDockerImageName("quay.io/strimzi/kafka"), "quay.io/strimzi/kafka");
+    }
+
+    @Test
+    public void shouldApplyMirrorToDockerHubImages() {
+        System.setProperty(REGISTRY_MIRROR_ENABLED_PROPERTY, "true");
+
+        Assert.assertEquals(TestContainersSettings.getDockerImageName("postgres"), "mirror.gcr.io/postgres");
+        Assert.assertEquals(TestContainersSettings.getDockerImageName("apache/kafka"), "mirror.gcr.io/apache/kafka");
+        Assert.assertEquals(TestContainersSettings.getDockerImageName("confluentinc/cp-kafka"), "mirror.gcr.io/confluentinc/cp-kafka");
+    }
+
+    @Test
+    public void shouldNotApplyMirrorToAlternateRegistryImages() {
+        System.setProperty(REGISTRY_MIRROR_ENABLED_PROPERTY, "true");
+
+        Assert.assertEquals(TestContainersSettings.getDockerImageName("quay.io/strimzi/kafka"), "quay.io/strimzi/kafka");
+        Assert.assertEquals(TestContainersSettings.getDockerImageName("ghcr.io/some/image"), "ghcr.io/some/image");
+        Assert.assertEquals(TestContainersSettings.getDockerImageName("localhost:5000/myimage"), "localhost:5000/myimage");
+        Assert.assertEquals(TestContainersSettings.getDockerImageName("registry.example.com/image"), "registry.example.com/image");
+    }
+
+    @Test
+    public void shouldApplyCustomMirror() {
+        System.setProperty(REGISTRY_MIRROR_ENABLED_PROPERTY, "true");
+        System.setProperty(REGISTRY_MIRROR_PROPERTY, "my-mirror.example.com");
+
+        Assert.assertEquals(TestContainersSettings.getDockerImageName("postgres"), "my-mirror.example.com/postgres");
+        Assert.assertEquals(TestContainersSettings.getDockerImageName("apache/kafka"), "my-mirror.example.com/apache/kafka");
+        Assert.assertEquals(TestContainersSettings.getDockerImageName("quay.io/strimzi/kafka"), "quay.io/strimzi/kafka");
+    }
+
+    @Test
+    public void shouldApplyCustomRegistryToDockerHubImages() {
+        System.setProperty(REGISTRY_PROPERTY, "my-registry.example.com");
+
+        Assert.assertEquals(TestContainersSettings.getDockerImageName("postgres"), "my-registry.example.com/postgres");
+        Assert.assertEquals(TestContainersSettings.getDockerImageName("apache/kafka"), "my-registry.example.com/apache/kafka");
+        Assert.assertEquals(TestContainersSettings.getDockerImageName("quay.io/strimzi/kafka"), "quay.io/strimzi/kafka");
+    }
+}


### PR DESCRIPTION
## Summary
- Add `TestContainersSettings.getDockerImageName(String)` that skips the mirror/registry prefix for images from alternate registries (e.g., `quay.io`, `ghcr.io`) where the mirror does not apply
- Fix `StartKafkaAction` to use the original default image name for `asCompatibleSubstituteFor` (matching the pattern already used by Redpanda, PostgreSQL, and MongoDB actions)
- Update all `*Settings.getImageName()` methods to use the new `getDockerImageName()` instead of blindly prepending `getDockerRegistry()`
- Simplify the generic `StartTestcontainersAction.buildContainer()` registry handling to use the same method

Fixes #1673

## Test plan
- [x] New unit tests for `TestContainersSettings.getDockerImageName()` covering Docker Hub images, alternate registry images, mirror enabled/disabled, and custom mirror/registry scenarios
- [x] All 28 existing unit tests pass
- [x] Full reactor build succeeds

Generated with [Claude Code](https://claude.ai/code)