### PR TITLE
fix(#1674): Add bootstrapServers as alias for Kafka bootstrap server property

### DIFF
--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/config/annotation/KafkaEndpointConfig.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/config/annotation/KafkaEndpointConfig.java
@@ -16,17 +16,17 @@
 
 package org.citrusframework.kafka.config.annotation;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.citrusframework.annotations.CitrusEndpointConfig;
 import org.citrusframework.kafka.message.KafkaMessageHeaders;
-
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
 
 /**
  * @since 2.8
@@ -43,10 +43,16 @@ public @interface KafkaEndpointConfig {
     String topic() default "";
 
     /**
-     * Server connection url.
+     * Server connection url (alias for bootstrapServers).
      * @return
      */
-    String server() default "localhost:9092";
+    String server() default "";
+
+    /**
+     * Bootstrap servers connection url.
+     * @return
+     */
+    String bootstrapServers() default "localhost:9092";
 
     /**
      * Server offset reset.

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/config/annotation/KafkaEndpointConfigParser.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/config/annotation/KafkaEndpointConfigParser.java
@@ -40,12 +40,13 @@ public class KafkaEndpointConfigParser implements AnnotationConfigParser<KafkaEn
         KafkaEndpointBuilder builder = new KafkaEndpointBuilder();
 
         String server = context.replaceDynamicContentInString(annotation.server());
+        String bootstrapServers = StringUtils.hasText(server) ? server : context.replaceDynamicContentInString(annotation.bootstrapServers());
 
-        if (!StringUtils.hasText(server)) {
-            throw new CitrusRuntimeException("Required server is missing for kafka configuration");
+        if (!StringUtils.hasText(bootstrapServers)) {
+            throw new CitrusRuntimeException("Required bootstrapServers property is missing for kafka configuration");
         }
 
-        builder.server(server);
+        builder.bootstrapServers(bootstrapServers);
         builder.topic(context.replaceDynamicContentInString(annotation.topic()));
         builder.partition(annotation.partition());
 

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/config/xml/KafkaEndpointParser.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/config/xml/KafkaEndpointParser.java
@@ -44,6 +44,7 @@ public class KafkaEndpointParser extends AbstractEndpointParser {
 
         setPropertyValue(endpointConfiguration, element.getAttribute("client-id"), "clientId");
         setPropertyValue(endpointConfiguration, element.getAttribute("server"), "server");
+        setPropertyValue(endpointConfiguration, element.getAttribute("bootstrap-servers"), "bootstrapServers");
         setPropertyValue(endpointConfiguration, element.getAttribute("topic"), "topic");
         setPropertyValue(endpointConfiguration, element.getAttribute("partition"), "partition");
 

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaConsumer.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaConsumer.java
@@ -16,27 +16,20 @@
 
 package org.citrusframework.kafka.endpoint;
 
-import static java.util.UUID.randomUUID;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.AUTO_OFFSET_RESET_CONFIG;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.CLIENT_ID_CONFIG;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.MAX_POLL_RECORDS_CONFIG;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
-import static org.citrusframework.kafka.message.KafkaMessageHeaders.KAFKA_PREFIX;
-
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+
 import org.citrusframework.context.TestContext;
 import org.citrusframework.message.Message;
 import org.citrusframework.messaging.AbstractSelectiveMessageConsumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static java.util.UUID.randomUUID;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.*;
+import static org.citrusframework.kafka.message.KafkaMessageHeaders.KAFKA_PREFIX;
 
 public class KafkaConsumer extends AbstractSelectiveMessageConsumer {
 
@@ -106,7 +99,7 @@ public class KafkaConsumer extends AbstractSelectiveMessageConsumer {
         Map<String, Object> consumerProps = new HashMap<>();
         consumerProps.put(CLIENT_ID_CONFIG, Optional.ofNullable(getEndpointConfiguration().getClientId()).orElseGet(() -> KAFKA_PREFIX + "consumer_" + randomUUID()));
         consumerProps.put(GROUP_ID_CONFIG, getEndpointConfiguration().getConsumerGroup());
-        consumerProps.put(BOOTSTRAP_SERVERS_CONFIG, Optional.ofNullable(getEndpointConfiguration().getServer()).orElse("localhost:9092"));
+        consumerProps.put(BOOTSTRAP_SERVERS_CONFIG, Optional.ofNullable(getEndpointConfiguration().getBootstrapServers()).orElse("localhost:9092"));
         consumerProps.put(MAX_POLL_RECORDS_CONFIG, 1);
         consumerProps.put(ENABLE_AUTO_COMMIT_CONFIG, getEndpointConfiguration().isAutoCommit());
         consumerProps.put(AUTO_COMMIT_INTERVAL_MS_CONFIG, getEndpointConfiguration().getAutoCommitInterval());

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaEndpoint.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaEndpoint.java
@@ -77,7 +77,7 @@ public class KafkaEndpoint extends AbstractEndpoint implements ShutdownPhase {
 
     static KafkaEndpoint newKafkaEndpoint(
             @Nullable Boolean randomConsumerGroup,
-            @Nullable String server,
+            @Nullable String bootstrapServers,
             @Nullable Long timeout,
             @Nullable String topic,
             KafkaMessageSelectorFactory.KafkaMessageSelectorFactories customStrategies,
@@ -89,8 +89,8 @@ public class KafkaEndpoint extends AbstractEndpoint implements ShutdownPhase {
             kafkaEndpoint.getEndpointConfiguration()
                     .setConsumerGroup(KAFKA_PREFIX + RandomStringUtils.insecure().nextAlphabetic(10).toLowerCase());
         }
-        if (hasText(server)) {
-            kafkaEndpoint.getEndpointConfiguration().setServer(server);
+        if (hasText(bootstrapServers)) {
+            kafkaEndpoint.getEndpointConfiguration().setBootstrapServers(bootstrapServers);
         }
         if (nonNull(timeout)) {
             kafkaEndpoint.getEndpointConfiguration().setTimeout(timeout);
@@ -222,6 +222,11 @@ public class KafkaEndpoint extends AbstractEndpoint implements ShutdownPhase {
 
         public SimpleKafkaEndpointBuilder server(String server) {
             this.server = server;
+            return this;
+        }
+
+        public SimpleKafkaEndpointBuilder bootstrapServers(String bootstrapServers) {
+            this.server = bootstrapServers;
             return this;
         }
 

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaEndpointBuilder.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaEndpointBuilder.java
@@ -70,15 +70,28 @@ public class KafkaEndpointBuilder extends AbstractEndpointBuilder<KafkaEndpoint>
     /**
      * Sets the server property.
      */
-    public KafkaEndpointBuilder server(String server) {
-        endpoint.getEndpointConfiguration().setServer(server);
-        return this;
+    public KafkaEndpointBuilder server(String bootstrapServers) {
+        return bootstrapServers(bootstrapServers);
     }
 
     @SchemaProperty(description = "Sets the Kafka bootstrap server.")
     @XmlAttribute
     public void setServer(String server) {
-        server(server);
+        bootstrapServers(server);
+    }
+
+    /**
+     * Sets the bootstrapServers property.
+     */
+    public KafkaEndpointBuilder bootstrapServers(String bootstrapServers) {
+        endpoint.getEndpointConfiguration().setBootstrapServers(bootstrapServers);
+        return this;
+    }
+
+    @SchemaProperty(description = "Sets the Kafka bootstrap servers.")
+    @XmlAttribute(name = "bootstrap-servers")
+    public void setBootstrapServers(String bootstrapServers) {
+        bootstrapServers(bootstrapServers);
     }
 
     /**

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaEndpointComponent.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaEndpointComponent.java
@@ -50,6 +50,10 @@ public class KafkaEndpointComponent extends AbstractEndpointComponent {
             endpoint.getEndpointConfiguration().setTopic(parameters.getOrDefault("topic", resourcePath));
         }
 
+        if (parameters.containsKey("server")) {
+            parameters.put("bootstrapServers", parameters.remove("server"));
+        }
+
         enrichEndpointConfiguration(endpoint.getEndpointConfiguration(), parameters, context);
 
         return endpoint;

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaEndpointConfiguration.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaEndpointConfiguration.java
@@ -16,6 +16,9 @@
 
 package org.citrusframework.kafka.endpoint;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import jakarta.annotation.Nonnull;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serializer;
@@ -26,9 +29,6 @@ import org.citrusframework.kafka.endpoint.selector.KafkaMessageSelectorFactory;
 import org.citrusframework.kafka.message.KafkaMessageConverter;
 import org.citrusframework.kafka.message.KafkaMessageHeaderMapper;
 import org.citrusframework.kafka.message.KafkaMessageHeaders;
-
-import java.util.HashMap;
-import java.util.Map;
 
 public class KafkaEndpointConfiguration extends AbstractPollableEndpointConfiguration {
 
@@ -48,9 +48,9 @@ public class KafkaEndpointConfiguration extends AbstractPollableEndpointConfigur
     private String topic;
 
     /**
-     * List of server to connect with
+     * List of Kafka bootstrap servers to connect with
      */
-    private String server = "localhost:9092";
+    private String bootstrapServers = "localhost:9092";
 
     /**
      * The header mapper
@@ -125,11 +125,19 @@ public class KafkaEndpointConfiguration extends AbstractPollableEndpointConfigur
     }
 
     public String getServer() {
-        return server;
+        return bootstrapServers;
     }
 
     public void setServer(String server) {
-        this.server = server;
+        this.bootstrapServers = server;
+    }
+
+    public String getBootstrapServers() {
+        return bootstrapServers;
+    }
+
+    public void setBootstrapServers(String bootstrapServers) {
+        this.bootstrapServers = bootstrapServers;
     }
 
     public KafkaMessageHeaderMapper getHeaderMapper() {

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaProducer.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaProducer.java
@@ -128,7 +128,7 @@ public class KafkaProducer implements Producer {
      */
     private org.apache.kafka.clients.producer.KafkaProducer<Object, Object> createKafkaProducer() {
         Map<String, Object> producerProps = new HashMap<>();
-        producerProps.put(BOOTSTRAP_SERVERS_CONFIG, endpointConfiguration.getServer());
+        producerProps.put(BOOTSTRAP_SERVERS_CONFIG, endpointConfiguration.getBootstrapServers());
         producerProps.put(REQUEST_TIMEOUT_MS_CONFIG, Long.valueOf(endpointConfiguration.getTimeout()).intValue());
         producerProps.put(KEY_SERIALIZER_CLASS_CONFIG, endpointConfiguration.getKeySerializer());
         producerProps.put(VALUE_SERIALIZER_CLASS_CONFIG, endpointConfiguration.getValueSerializer());

--- a/endpoints/citrus-kafka/src/main/resources/org/citrusframework/schema/citrus-kafka-config-5.1.0-SNAPSHOT.xsd
+++ b/endpoints/citrus-kafka/src/main/resources/org/citrusframework/schema/citrus-kafka-config-5.1.0-SNAPSHOT.xsd
@@ -49,6 +49,7 @@
       <xs:attribute name="auto-commit" type="xs:string"/>
       <xs:attribute name="auto-commit-interval" type="xs:int"/>
       <xs:attribute name="server" type="xs:string"/>
+      <xs:attribute name="bootstrap-servers" type="xs:string"/>
       <xs:attribute name="offset-reset" type="xs:string"/>
       <xs:attribute name="topic" type="xs:string"/>
       <xs:attribute name="partition" type="xs:int"/>

--- a/endpoints/citrus-kafka/src/main/resources/org/citrusframework/schema/citrus-kafka-config.xsd
+++ b/endpoints/citrus-kafka/src/main/resources/org/citrusframework/schema/citrus-kafka-config.xsd
@@ -49,6 +49,7 @@
       <xs:attribute name="auto-commit" type="xs:string"/>
       <xs:attribute name="auto-commit-interval" type="xs:int"/>
       <xs:attribute name="server" type="xs:string"/>
+      <xs:attribute name="bootstrap-servers" type="xs:string"/>
       <xs:attribute name="offset-reset" type="xs:string"/>
       <xs:attribute name="topic" type="xs:string"/>
       <xs:attribute name="partition" type="xs:int"/>

--- a/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/config/annotation/KafkaEndpointConfigParserTest.java
+++ b/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/config/annotation/KafkaEndpointConfigParserTest.java
@@ -48,7 +48,7 @@ import static org.mockito.Mockito.when;
 public class KafkaEndpointConfigParserTest extends AbstractTestNGUnitTest {
 
     @CitrusEndpoint
-    @KafkaEndpointConfig(server="localhost:9091", topic="test")
+    @KafkaEndpointConfig(bootstrapServers="localhost:9091", topic="test")
     private KafkaEndpoint kafkaEndpoint1;
 
     @CitrusEndpoint
@@ -70,12 +70,16 @@ public class KafkaEndpointConfigParserTest extends AbstractTestNGUnitTest {
     private KafkaEndpoint kafkaEndpoint2;
 
     @CitrusEndpoint
-    @KafkaEndpointConfig(server="localhost:9093",
+    @KafkaEndpointConfig(bootstrapServers="localhost:9093",
             topic="test",
             producerProperties = "producerProps",
             consumerProperties = "consumerProps",
             actor="testActor")
     private KafkaEndpoint kafkaEndpoint3;
+
+    @CitrusEndpoint
+    @KafkaEndpointConfig(server="localhost:9094", topic="test")
+    private KafkaEndpoint kafkaEndpoint4;
 
     @Mock
     private ReferenceResolver referenceResolver;
@@ -105,8 +109,8 @@ public class KafkaEndpointConfigParserTest extends AbstractTestNGUnitTest {
         CitrusAnnotations.injectEndpoints(this, context);
 
         // 1st endpoint
-        Assert.assertNotNull(kafkaEndpoint1.getEndpointConfiguration().getServer());
-        Assert.assertEquals(kafkaEndpoint1.getEndpointConfiguration().getServer(), "localhost:9091");
+        Assert.assertNotNull(kafkaEndpoint1.getEndpointConfiguration().getBootstrapServers());
+        Assert.assertEquals(kafkaEndpoint1.getEndpointConfiguration().getBootstrapServers(), "localhost:9091");
         Assert.assertNull(kafkaEndpoint1.getEndpointConfiguration().getClientId());
         Assert.assertEquals(kafkaEndpoint1.getEndpointConfiguration().getHeaderMapper().getClass(), KafkaMessageHeaderMapper.class);
         Assert.assertEquals(kafkaEndpoint1.getEndpointConfiguration().getMessageConverter().getClass(), KafkaMessageConverter.class);
@@ -123,8 +127,8 @@ public class KafkaEndpointConfigParserTest extends AbstractTestNGUnitTest {
         Assert.assertEquals(kafkaEndpoint1.getEndpointConfiguration().getValueDeserializer(), StringDeserializer.class);
 
         // 2nd endpoint
-        Assert.assertNotNull(kafkaEndpoint2.getEndpointConfiguration().getServer());
-        Assert.assertEquals(kafkaEndpoint2.getEndpointConfiguration().getServer(), "localhost:9092");
+        Assert.assertNotNull(kafkaEndpoint2.getEndpointConfiguration().getBootstrapServers());
+        Assert.assertEquals(kafkaEndpoint2.getEndpointConfiguration().getBootstrapServers(), "localhost:9092");
         Assert.assertEquals(kafkaEndpoint2.getEndpointConfiguration().getClientId(), "kafkaEndpoint2");
         Assert.assertEquals(kafkaEndpoint2.getEndpointConfiguration().getHeaderMapper(), headerMapper);
         Assert.assertEquals(kafkaEndpoint2.getEndpointConfiguration().getMessageConverter(), messageConverter);
@@ -143,6 +147,12 @@ public class KafkaEndpointConfigParserTest extends AbstractTestNGUnitTest {
         // 3rd endpoint
         Assert.assertNotNull(kafkaEndpoint3.getActor());
         Assert.assertEquals(kafkaEndpoint3.getActor(), testActor);
+
+        // 4th endpoint (bootstrapServers alias)
+        Assert.assertNotNull(kafkaEndpoint4.getEndpointConfiguration().getBootstrapServers());
+        Assert.assertEquals(kafkaEndpoint4.getEndpointConfiguration().getServer(), "localhost:9094");
+        Assert.assertEquals(kafkaEndpoint4.getEndpointConfiguration().getBootstrapServers(), "localhost:9094");
+        Assert.assertEquals(kafkaEndpoint4.getEndpointConfiguration().getTopic(), "test");
     }
 
     @Test

--- a/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/config/xml/KafkaEndpointParserTest.java
+++ b/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/config/xml/KafkaEndpointParserTest.java
@@ -16,6 +16,8 @@
 
 package org.citrusframework.kafka.config.xml;
 
+import java.util.Map;
+
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
@@ -31,15 +33,9 @@ import org.citrusframework.kafka.message.KafkaMessageHeaderMapper;
 import org.citrusframework.testng.AbstractBeanDefinitionParserTest;
 import org.testng.annotations.Test;
 
-import java.util.Map;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.citrusframework.kafka.message.KafkaMessageHeaders.KAFKA_PREFIX;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.*;
 
 public class KafkaEndpointParserTest extends AbstractBeanDefinitionParserTest {
 
@@ -48,13 +44,13 @@ public class KafkaEndpointParserTest extends AbstractBeanDefinitionParserTest {
         Map<String, KafkaEndpoint> endpoints = beanDefinitionContext.getBeansOfType(KafkaEndpoint.class);
 
         assertThat(endpoints)
-            .hasSize(4);
+            .hasSize(5);
 
         // 1st message receiver
         KafkaEndpoint kafkaEndpoint = endpoints.get("kafkaEndpoint1");
         assertNull(kafkaEndpoint.getEndpointConfiguration().getClientId());
-        assertNotNull(kafkaEndpoint.getEndpointConfiguration().getServer());
-        assertEquals(kafkaEndpoint.getEndpointConfiguration().getServer(), "localhost:9091");
+        assertNotNull(kafkaEndpoint.getEndpointConfiguration().getBootstrapServers());
+        assertEquals(kafkaEndpoint.getEndpointConfiguration().getBootstrapServers(), "localhost:9091");
         assertEquals(kafkaEndpoint.getEndpointConfiguration().getHeaderMapper().getClass(), KafkaMessageHeaderMapper.class);
         assertEquals(kafkaEndpoint.getEndpointConfiguration().getMessageConverter().getClass(), KafkaMessageConverter.class);
         assertTrue(kafkaEndpoint.getEndpointConfiguration().isAutoCommit());
@@ -76,8 +72,8 @@ public class KafkaEndpointParserTest extends AbstractBeanDefinitionParserTest {
         kafkaEndpoint = endpoints.get("kafkaEndpoint2");
         assertNotNull(kafkaEndpoint.getEndpointConfiguration().getClientId());
         assertEquals(kafkaEndpoint.getEndpointConfiguration().getClientId(), "kafkaEndpoint2");
-        assertNotNull(kafkaEndpoint.getEndpointConfiguration().getServer());
-        assertEquals(kafkaEndpoint.getEndpointConfiguration().getServer(), "localhost:9092");
+        assertNotNull(kafkaEndpoint.getEndpointConfiguration().getBootstrapServers());
+        assertEquals(kafkaEndpoint.getEndpointConfiguration().getBootstrapServers(), "localhost:9092");
         assertEquals(kafkaEndpoint.getEndpointConfiguration().getHeaderMapper(), beanDefinitionContext.getBean("headerMapper"));
         assertEquals(kafkaEndpoint.getEndpointConfiguration().getMessageConverter(), beanDefinitionContext.getBean("messageConverter"));
         assertFalse(kafkaEndpoint.getEndpointConfiguration().isAutoCommit());
@@ -95,8 +91,8 @@ public class KafkaEndpointParserTest extends AbstractBeanDefinitionParserTest {
 
         // 3rd message receiver
         kafkaEndpoint = endpoints.get("kafkaEndpoint3");
-        assertNotNull(kafkaEndpoint.getEndpointConfiguration().getServer());
-        assertEquals(kafkaEndpoint.getEndpointConfiguration().getServer(), "localhost:9093");
+        assertNotNull(kafkaEndpoint.getEndpointConfiguration().getBootstrapServers());
+        assertEquals(kafkaEndpoint.getEndpointConfiguration().getBootstrapServers(), "localhost:9093");
         assertNull(kafkaEndpoint.getEndpointConfiguration().getTopic());
         assertNotNull(kafkaEndpoint.getActor());
         assertEquals(kafkaEndpoint.getActor(), beanDefinitionContext.getBean("testActor", TestActor.class));
@@ -113,5 +109,12 @@ public class KafkaEndpointParserTest extends AbstractBeanDefinitionParserTest {
             .hasSize(23)
             .containsPattern(".*[a-z]{10}$");
         assertEquals(kafkaEndpoint.getEndpointConfiguration().useThreadSafeConsumer(), true);
+
+        // 5th message receiver (bootstrap-servers alias)
+        kafkaEndpoint = endpoints.get("kafkaEndpoint5");
+        assertNotNull(kafkaEndpoint.getEndpointConfiguration().getBootstrapServers());
+        assertEquals(kafkaEndpoint.getEndpointConfiguration().getServer(), "localhost:9094");
+        assertEquals(kafkaEndpoint.getEndpointConfiguration().getBootstrapServers(), "localhost:9094");
+        assertEquals(kafkaEndpoint.getEndpointConfiguration().getTopic(), "test");
     }
 }

--- a/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/KafkaEndpointComponentTest.java
+++ b/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/KafkaEndpointComponentTest.java
@@ -40,7 +40,7 @@ public class KafkaEndpointComponentTest {
         Assert.assertEquals(endpoint.getClass(), KafkaEndpoint.class);
 
         Assert.assertEquals(((KafkaEndpoint)endpoint).getEndpointConfiguration().getTopic(), "test");
-        Assert.assertEquals(((KafkaEndpoint) endpoint).getEndpointConfiguration().getServer(), "localhost:9092");
+        Assert.assertEquals(((KafkaEndpoint) endpoint).getEndpointConfiguration().getBootstrapServers(), "localhost:9092");
         Assert.assertEquals(((KafkaEndpoint) endpoint).getEndpointConfiguration().getTimeout(), 5000L);
     }
 
@@ -53,7 +53,7 @@ public class KafkaEndpointComponentTest {
         Assert.assertEquals(endpoint.getClass(), KafkaEndpoint.class);
 
         Assert.assertEquals(((KafkaEndpoint)endpoint).getEndpointConfiguration().getTopic(), "test");
-        Assert.assertEquals(((KafkaEndpoint) endpoint).getEndpointConfiguration().getServer(), "localhost:9091");
+        Assert.assertEquals(((KafkaEndpoint) endpoint).getEndpointConfiguration().getBootstrapServers(), "localhost:9091");
         Assert.assertEquals(((KafkaEndpoint) endpoint).getEndpointConfiguration().getTimeout(), 10000L);
     }
 
@@ -66,7 +66,21 @@ public class KafkaEndpointComponentTest {
         Assert.assertEquals(endpoint.getClass(), KafkaEndpoint.class);
 
         Assert.assertEquals(((KafkaEndpoint)endpoint).getEndpointConfiguration().getTopic(), "test");
-        Assert.assertEquals(((KafkaEndpoint) endpoint).getEndpointConfiguration().getServer(), "localhost:9091");
+        Assert.assertEquals(((KafkaEndpoint) endpoint).getEndpointConfiguration().getBootstrapServers(), "localhost:9091");
+        Assert.assertEquals(((KafkaEndpoint) endpoint).getEndpointConfiguration().getTimeout(), 10000L);
+    }
+
+    @Test
+    public void testCreateEndpointWithBootstrapServersParameter() {
+        KafkaEndpointComponent component = new KafkaEndpointComponent();
+
+        Endpoint endpoint = component.createEndpoint("kafka:test?bootstrapServers=localhost:9091&timeout=10000", context);
+
+        Assert.assertEquals(endpoint.getClass(), KafkaEndpoint.class);
+
+        Assert.assertEquals(((KafkaEndpoint)endpoint).getEndpointConfiguration().getTopic(), "test");
+        Assert.assertEquals(((KafkaEndpoint) endpoint).getEndpointConfiguration().getBootstrapServers(), "localhost:9091");
+        Assert.assertEquals(((KafkaEndpoint) endpoint).getEndpointConfiguration().getBootstrapServers(), "localhost:9091");
         Assert.assertEquals(((KafkaEndpoint) endpoint).getEndpointConfiguration().getTimeout(), 10000L);
     }
 
@@ -79,7 +93,7 @@ public class KafkaEndpointComponentTest {
         Assert.assertEquals(endpoint.getClass(), KafkaEndpoint.class);
 
         Assert.assertEquals(((KafkaEndpoint)endpoint).getEndpointConfiguration().getTopic(), "test");
-        Assert.assertNull(((KafkaEndpoint) endpoint).getEndpointConfiguration().getServer());
+        Assert.assertNull(((KafkaEndpoint) endpoint).getEndpointConfiguration().getBootstrapServers());
     }
 
     @Test

--- a/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/KafkaEndpointTest.java
+++ b/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/KafkaEndpointTest.java
@@ -16,12 +16,12 @@
 
 package org.citrusframework.kafka.endpoint;
 
+import java.util.function.Function;
+import java.util.function.Predicate;
+
 import org.citrusframework.kafka.endpoint.selector.KafkaMessageSelectorFactory;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-
-import java.util.function.Function;
-import java.util.function.Predicate;
 
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
@@ -151,8 +151,24 @@ public class KafkaEndpointTest {
                 .isNotNull()
                 .extracting(KafkaEndpoint::getEndpointConfiguration)
                 .isNotNull()
-                .extracting(KafkaEndpointConfiguration::getServer)
+                .extracting(KafkaEndpointConfiguration::getBootstrapServers)
                 .isEqualTo(server);
+    }
+
+    @Test
+    public void newKafkaEndpoint_acceptsBootstrapServers() {
+        var fixture = KafkaEndpoint.builder()
+                .bootstrapServers("localhost:9094")
+                .build();
+
+        assertThat(fixture)
+                .isNotNull()
+                .extracting(KafkaEndpoint::getEndpointConfiguration)
+                .isNotNull()
+                .satisfies(config -> {
+                    assertThat(config.getBootstrapServers()).isEqualTo("localhost:9094");
+                    assertThat(config.getServer()).isEqualTo("localhost:9094");
+                });
     }
 
     @Test

--- a/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/KafkaProducerTest.java
+++ b/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/KafkaProducerTest.java
@@ -16,6 +16,9 @@
 
 package org.citrusframework.kafka.endpoint;
 
+import java.util.Collections;
+import java.util.concurrent.Future;
+
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -33,9 +36,6 @@ import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import java.util.Collections;
-import java.util.concurrent.Future;
 
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.reset;
@@ -112,7 +112,7 @@ public class KafkaProducerTest extends AbstractTestNGUnitTest {
     @Test
     public void testSendMessageTimeout() {
         KafkaEndpoint endpoint = new KafkaEndpoint();
-        endpoint.getEndpointConfiguration().setServer("localhost:" + SocketUtils.findAvailableTcpPort());
+        endpoint.getEndpointConfiguration().setBootstrapServers("localhost:" + SocketUtils.findAvailableTcpPort());
         endpoint.getEndpointConfiguration().setTopic("test");
         endpoint.getEndpointConfiguration().setProducerProperties(Collections.singletonMap(ProducerConfig.MAX_BLOCK_MS_CONFIG, 1000));
 
@@ -131,7 +131,7 @@ public class KafkaProducerTest extends AbstractTestNGUnitTest {
     @Test(expectedExceptions = CitrusRuntimeException.class, expectedExceptionsMessageRegExp = "Message is empty - unable to send empty message")
     public void testSendEmptyMessage() {
         KafkaEndpoint endpoint = new KafkaEndpoint();
-        endpoint.getEndpointConfiguration().setServer("localhost:9092");
+        endpoint.getEndpointConfiguration().setBootstrapServers("localhost:9092");
         endpoint.getEndpointConfiguration().setTopic("test");
 
         endpoint.createProducer().send(null, context);

--- a/endpoints/citrus-kafka/src/test/resources/org/citrusframework/kafka/config/xml/KafkaEndpointParserTest-context.xml
+++ b/endpoints/citrus-kafka/src/test/resources/org/citrusframework/kafka/config/xml/KafkaEndpointParserTest-context.xml
@@ -40,6 +40,10 @@
                                random-consumer-group="true"
                                thread-safe-consumer="true"/>
 
+  <citrus-kafka:endpoint id="kafkaEndpoint5"
+                               bootstrap-servers="localhost:9094"
+                               topic="test"/>
+
   <citrus:actor id="testActor" name="TESTACTOR" disabled="false"/>
 
   <util:map id="producerProps">

--- a/tools/cucumber-steps/citrus-cucumber-kafka/src/main/java/org/citrusframework/cucumber/steps/kafka/KafkaSteps.java
+++ b/tools/cucumber-steps/citrus-cucumber-kafka/src/main/java/org/citrusframework/cucumber/steps/kafka/KafkaSteps.java
@@ -101,7 +101,7 @@ public class KafkaSteps {
         String offsetReset = connectionProps.getOrDefault("offsetReset", "earliest");
 
         setTopic(context.replaceDynamicContentInString(topicName));
-        kafkaEndpoint.getEndpointConfiguration().setServer(context.replaceDynamicContentInString(url));
+        kafkaEndpoint.getEndpointConfiguration().setBootstrapServers(context.replaceDynamicContentInString(url));
         kafkaEndpoint.getEndpointConfiguration().setOffsetReset(context.replaceDynamicContentInString(offsetReset));
         kafkaEndpoint.getEndpointConfiguration().setConsumerGroup(context.replaceDynamicContentInString(consumerGroup));
     }

--- a/tools/schema-generator/src/test/resources/control/citrus-catalog-aggregate-endpoints.json
+++ b/tools/schema-generator/src/test/resources/control/citrus-catalog-aggregate-endpoints.json
@@ -129,6 +129,11 @@
           "description": "Sets the auto commit interval.",
           "$comment": "group:consume"
         },
+        "bootstrapServers": {
+          "type": "string",
+          "title": "BootstrapServers",
+          "description": "Sets the Kafka bootstrap servers."
+        },
         "clientId": {
           "type": "string",
           "title": "ClientId",
@@ -626,6 +631,11 @@
           "title": "AutoCommitInterval",
           "description": "Sets the auto commit interval.",
           "$comment": "group:consume"
+        },
+        "bootstrapServers": {
+          "type": "string",
+          "title": "BootstrapServers",
+          "description": "Sets the Kafka bootstrap servers."
         },
         "clientId": {
           "type": "string",

--- a/tools/schema-generator/src/test/resources/control/citrus-catalog-aggregate-test-actions.json
+++ b/tools/schema-generator/src/test/resources/control/citrus-catalog-aggregate-test-actions.json
@@ -4840,6 +4840,11 @@
                                   "description": "Sets the auto commit interval.",
                                   "$comment": "group:consume"
                                 },
+                                "bootstrapServers": {
+                                  "type": "string",
+                                  "title": "BootstrapServers",
+                                  "description": "Sets the Kafka bootstrap servers."
+                                },
                                 "clientId": {
                                   "type": "string",
                                   "title": "ClientId",
@@ -4965,6 +4970,11 @@
                                   "title": "AutoCommitInterval",
                                   "description": "Sets the auto commit interval.",
                                   "$comment": "group:consume"
+                                },
+                                "bootstrapServers": {
+                                  "type": "string",
+                                  "title": "BootstrapServers",
+                                  "description": "Sets the Kafka bootstrap servers."
                                 },
                                 "clientId": {
                                   "type": "string",


### PR DESCRIPTION
## Summary

- Adds `bootstrapServers` as an additional property name for configuring Kafka bootstrap servers, while keeping `server` for backward compatibility
- Both properties are aliases — setting either one configures the same underlying connection
- The new property is exposed in endpoint configuration, Java DSL builders, YAML DSL (via `@SchemaProperty`), XML DSL (via `@XmlAttribute` and XSD schemas), annotation config (`@KafkaEndpointConfig`), and endpoint URI parameters

Closes #1674

## Test plan

- [x] Unit tests verify `bootstrapServers` works via endpoint URI, builder, XML config, and annotation config
- [x] Existing `server` tests still pass (backward compatibility)
- [x] Schema generator control files updated and validated
- [x] Full reactor build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)