### PR TITLE
fix(#1678): jar-test-file-scanner - Fix test candidate detection in provided packages

### DIFF
--- a/core/citrus-base/src/main/java/org/citrusframework/base/main/scan/JarFileTestScanner.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/base/main/scan/JarFileTestScanner.java
@@ -56,7 +56,7 @@ public class JarFileTestScanner extends AbstractTestScanner {
                 for (Enumeration<JarEntry> entries = jar.entries(); entries.hasMoreElements();) {
                     JarEntry entry = entries.nextElement();
                     String className = FileUtils.getBaseName(entry.getName()).replace( "/", "." );
-                    boolean isTestClass = (packageIsEmpty || packageAsPath.startsWith(entry.getName()))
+                    boolean isTestClass = (packageIsEmpty || entry.getName().startsWith(packageAsPath))
                         && entry.getName().endsWith(".class")
                         && isIncluded(className);
                     if (isTestClass) {


### PR DESCRIPTION
…rovided packages

Simple fix. The startsWith participants have been confused. This fixes it.