### PR TITLE
fix(#1676): Overwrite stale AWS clients when LocalStack containers are recreated

### DIFF
--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/actions/StartTestcontainersAction.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/actions/StartTestcontainersAction.java
@@ -68,7 +68,7 @@ public class StartTestcontainersAction<C extends GenericContainer<?>> extends Ab
 
         container.start();
 
-        if (containerName != null && !context.getReferenceResolver().isResolvable(containerName)) {
+        if (containerName != null) {
             context.getReferenceResolver().bind(containerName, container);
         }
 

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/StartFlociAction.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/StartFlociAction.java
@@ -75,14 +75,12 @@ public class StartFlociAction extends StartTestcontainersAction<FlociContainer> 
                 String clientName = "%sClient".formatted(service.getServiceName());
                 clientName = options.getOrDefault(clientName + "Name", clientName);
 
-                if (context.getReferenceResolver().isResolvable(clientName)) {
-                    logger.debug("Client {} already exists - do not overwrite", clientName);
-                    // client bean with same name already exists - do not overwrite
-                    continue;
-                }
-
                 Optional<ClientFactory<?>> clientFactory = clientFactoryResolver.resolve(context.getReferenceResolver(), service);
                 if (clientFactory.isPresent()) {
+                    if (context.getReferenceResolver().isResolvable(clientName)) {
+                        logger.debug("Overwriting existing client {} with new instance", clientName);
+                    }
+
                     Object client = clientFactory.get().createClient(new AwsContainerWrapper(container), context.resolveDynamicValuesInMap(options));
                     PropertyUtils.configure(clientName, client, context.getReferenceResolver());
                     logger.debug("Auto create client {} for service {}", clientName, service.name());

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/StartLocalStackAction.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/aws2/StartLocalStackAction.java
@@ -89,14 +89,12 @@ public class StartLocalStackAction extends StartTestcontainersAction<LocalStackC
                 clientName = context.replaceDynamicContentInString(
                         options.getOrDefault(clientName + "Name", clientName));
 
-                if (context.getReferenceResolver().isResolvable(clientName)) {
-                    logger.debug("Client {} already exists - do not overwrite", clientName);
-                    // client bean with same name already exists - do not overwrite
-                    continue;
-                }
-
                 Optional<ClientFactory<?>> clientFactory = clientFactoryResolver.resolve(context.getReferenceResolver(), service);
                 if (clientFactory.isPresent()) {
+                    if (context.getReferenceResolver().isResolvable(clientName)) {
+                        logger.debug("Overwriting existing client {} with new instance", clientName);
+                    }
+
                     Object client = clientFactory.get().createClient(container, context.resolveDynamicValuesInMap(options));
                     PropertyUtils.configure(clientName, client, context.getReferenceResolver());
                     container.addClient(service, client);

--- a/connectors/citrus-testcontainers/src/test/java/org/citrusframework/testcontainers/integration/aws2/StartLocalStackContainerIT.java
+++ b/connectors/citrus-testcontainers/src/test/java/org/citrusframework/testcontainers/integration/aws2/StartLocalStackContainerIT.java
@@ -46,6 +46,23 @@ public class StartLocalStackContainerIT extends AbstractTestcontainersIT impleme
         then(this::verifyContainer);
     }
 
+    @Test
+    @CitrusTest
+    public void shouldOverwriteExistingClient() {
+        given(doFinally().actions(testcontainers().stop()
+                .containerName(LocalStackSettings.CONTAINER_NAME_DEFAULT)));
+
+        given((TestContext context) ->
+                context.getReferenceResolver().bind("s3Client", "staleClient"));
+
+        when(testcontainers()
+                .localstack()
+                .start()
+                .withService(AwsService.S3));
+
+        then(this::verifyClientOverwritten);
+    }
+
     private void verifyContainer(TestContext context) {
         try (DockerClient dockerClient = createDockerClient()) {
             InspectContainerResponse response = dockerClient.inspectContainerCmd(context.getVariable("${CITRUS_TESTCONTAINERS_LOCALSTACK_CONTAINER_ID}"))
@@ -59,5 +76,12 @@ public class StartLocalStackContainerIT extends AbstractTestcontainersIT impleme
 
         // verify auto created S3 client
         Assert.assertTrue(context.getReferenceResolver().isResolvable("s3Client"));
+    }
+
+    private void verifyClientOverwritten(TestContext context) {
+        Assert.assertTrue(context.getReferenceResolver().isResolvable("s3Client"));
+        Object client = context.getReferenceResolver().resolve("s3Client");
+        Assert.assertNotEquals(client, "staleClient",
+                "Expected s3Client to be overwritten with a real client instance");
     }
 }


### PR DESCRIPTION
## Summary
- Remove the guard in `StartLocalStackAction` and `StartFlociAction` that prevented overwriting existing AWS clients in the reference resolver. When a LocalStack/Floci container is recreated between tests, fresh clients are now created with the new container's port mappings.
- Also update `StartTestcontainersAction` to always rebind the container reference, preventing stale container references.
- Add IT test verifying that pre-existing clients are overwritten when a new container is started.

Fixes #1676

## Test plan
- [x] Existing unit tests pass (28/28)
- [x] Full reactor build succeeds
- [ ] IT test `shouldOverwriteExistingClient` passes (requires Docker)

Generated with [Claude Code](https://claude.ai/code)