### PR TITLE
fix(#1682): jar-file-test-scanner - jar entries from META-INF folders are no test candidates

### DIFF
--- a/core/citrus-base/src/main/java/org/citrusframework/base/main/scan/JarFileTestScanner.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/base/main/scan/JarFileTestScanner.java
@@ -58,6 +58,7 @@ public class JarFileTestScanner extends AbstractTestScanner {
                     String className = FileUtils.getBaseName(entry.getName()).replace( "/", "." );
                     boolean isTestClass = (packageIsEmpty || entry.getName().startsWith(packageAsPath))
                         && entry.getName().endsWith(".class")
+                        && !entry.getName().startsWith("META-INF")
                         && isIncluded(className);
                     if (isTestClass) {
                         logger.info("Found test class candidate in test jar file: {}",  entry.getName());


### PR DESCRIPTION
Again a rather simple fix. Maybe documentation needs an update, too. Then please point me to it and i will also amend it.

The whole test class detection can be refactored to stream with filter predicate, but that should be done in a separate refactoring ticket.