### PR TITLE
fix(#1657): Fix Java 25 compatibility

### DIFF
--- a/core/citrus-base/src/main/java/org/citrusframework/condition/HttpCondition.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/condition/HttpCondition.java
@@ -84,6 +84,7 @@ public class HttpCondition extends AbstractCondition {
         try {
             httpURLConnection = openConnection(contextUrl);
             httpURLConnection.setConnectTimeout(getTimeout(context));
+            httpURLConnection.setReadTimeout(getTimeout(context));
             httpURLConnection.setRequestMethod(context.resolveDynamicValue(method));
 
             responseCode = httpURLConnection.getResponseCode();

--- a/core/citrus-base/src/test/java/org/citrusframework/condition/HttpConditionTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/condition/HttpConditionTest.java
@@ -61,6 +61,7 @@ public class HttpConditionTest extends UnitTestSupport {
         Assert.assertTrue(testling.isSatisfied(context));
 
         verify(connection).setConnectTimeout(3000);
+        verify(connection).setReadTimeout(3000);
         verify(connection).setRequestMethod("HEAD");
         verify(connection).disconnect();
     }
@@ -91,6 +92,7 @@ public class HttpConditionTest extends UnitTestSupport {
         Assert.assertTrue(testling.isSatisfied(context));
 
         verify(connection).setConnectTimeout(3000);
+        verify(connection).setReadTimeout(3000);
         verify(connection).setRequestMethod("HEAD");
         verify(connection).disconnect();
     }

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/testng/integration/container/WaitIT.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/testng/integration/container/WaitIT.java
@@ -43,7 +43,10 @@ public class WaitIT extends TestNGCitrusSpringSupport {
         }
 
         server = HttpServer.create(new InetSocketAddress("localhost", 8001), 0);
-        server.createContext("/test", httpExchange -> httpExchange.sendResponseHeaders(200, 0));
+        server.createContext("/test", httpExchange -> {
+            httpExchange.sendResponseHeaders(200, -1);
+            httpExchange.close();
+        });
         server.setExecutor(Executors.newSingleThreadExecutor());
         server.start();
     }

--- a/runtime/citrus-testng/src/test/java/org/citrusframework/testng/integration/container/WaitJavaIT.java
+++ b/runtime/citrus-testng/src/test/java/org/citrusframework/testng/integration/container/WaitJavaIT.java
@@ -43,7 +43,10 @@ public class WaitJavaIT extends TestNGCitrusSpringSupport implements TestActionS
     @BeforeClass
     public void startHttpServer() throws IOException {
         server = HttpServer.create(new InetSocketAddress("localhost", serverPort), 0);
-        server.createContext("/test", httpExchange -> httpExchange.sendResponseHeaders(200, 0));
+        server.createContext("/test", httpExchange -> {
+            httpExchange.sendResponseHeaders(200, -1);
+            httpExchange.close();
+        });
         server.setExecutor(Executors.newSingleThreadExecutor());
         server.start();
     }

--- a/utils/metadata-processor/src/main/java/org/citrusframework/config/metadata/CitrusConfigMetadataProcessor.java
+++ b/utils/metadata-processor/src/main/java/org/citrusframework/config/metadata/CitrusConfigMetadataProcessor.java
@@ -19,7 +19,6 @@ package org.citrusframework.config.metadata;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
@@ -46,7 +45,6 @@ import org.citrusframework.config.CitrusConfigProperty;
         "org.citrusframework.config.CitrusConfigProperties",
         "org.citrusframework.config.CitrusConfigProperty"
 })
-@SupportedSourceVersion(SourceVersion.RELEASE_17)
 public class CitrusConfigMetadataProcessor extends AbstractProcessor {
 
     private static final String METADATA_PATH = "META-INF/spring-configuration-metadata.json";
@@ -122,6 +120,11 @@ public class CitrusConfigMetadataProcessor extends AbstractProcessor {
             processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR,
                     "Failed to write " + METADATA_PATH + ": " + e.getMessage());
         }
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latest();
     }
 
     @Override

--- a/utils/metadata-processor/src/test/java/org/citrusframework/config/metadata/CitrusConfigMetadataProcessorTest.java
+++ b/utils/metadata-processor/src/test/java/org/citrusframework/config/metadata/CitrusConfigMetadataProcessorTest.java
@@ -159,6 +159,7 @@ public class CitrusConfigMetadataProcessorTest {
 
         JavaCompiler.CompilationTask task = compiler.getTask(
                 null, fileManager, diagnostics, options, null, List.of(sourceFile));
+        task.setProcessors(List.of(new CitrusConfigMetadataProcessor()));
 
         boolean success = task.call();
         if (!success) {


### PR DESCRIPTION
## Summary

- Fix `WaitIT` and `WaitJavaIT` embedded HTTP server handlers to use `sendResponseHeaders(200, -1)` (no body) instead of `sendResponseHeaders(200, 0)` (chunked encoding), and properly close the exchange. Java 25 (JEP 517) replaced the `HttpURLConnection` internals with `java.net.http.HttpClient`, which waits for the chunked body that never arrives.
- Add `readTimeout` to `HttpCondition` alongside the existing `connectTimeout` to prevent hangs when a server accepts connections but responds slowly.
- Fix CitrusConfigMetadataProcessor for Java 23+ (JEP 477) which no longer auto-discovers annotation processors from the classpath. Explicitly register the processor in the test and use SourceVersion.latest() instead of the fixed RELEASE_17 annotation.

Fixes #1657

## Test plan

- [x] `core/citrus-base` unit tests pass (including updated `HttpConditionTest`)
- [x] `runtime/citrus-testng` integration tests pass (WaitIT, WaitJavaIT)
- [x] Full reactor build succeeds
- [x] Verify on Java 25 CI (lts_preview workflow)

🤖 Generated with [Claude Code](https://claude.ai/code)