### PR TITLE
fix(#1686): Add throws declaration to ThrowingHandler interface

### DIFF
--- a/tools/agent/src/main/java/org/citrusframework/agent/ThrowingHandler.java
+++ b/tools/agent/src/main/java/org/citrusframework/agent/ThrowingHandler.java
@@ -17,5 +17,5 @@
 package org.citrusframework.agent;
 
 public interface ThrowingHandler<T> {
-    void handle(T t);
+    void handle(T t) throws Exception;
 }


### PR DESCRIPTION
In order to make full use of the ThrowingHandler functionality of the Citrus Agent application the interface should have a 'throws exception' clause. We provide it here.

Closes #1686

