### PR TITLE
fix(#1688): Add ComposeContainerSupport annotation for Quarkus tests

### DIFF
--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/compose/quarkus/ComposeContainerResource.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/compose/quarkus/ComposeContainerResource.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.testcontainers.compose.quarkus;
+
+import java.lang.reflect.InvocationTargetException;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import io.quarkus.test.common.QuarkusTestResourceConfigurableLifecycleManager;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import org.citrusframework.annotations.CitrusResource;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.spi.Resources;
+import org.citrusframework.testcontainers.compose.ComposeContainerSettings;
+import org.citrusframework.testcontainers.quarkus.ContainerLifecycleListener;
+import org.citrusframework.util.StringUtils;
+import org.testcontainers.containers.ComposeContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.Base58;
+
+public class ComposeContainerResource
+        implements QuarkusTestResourceLifecycleManager,
+        QuarkusTestResourceConfigurableLifecycleManager<ComposeContainerSupport> {
+
+    private final Set<ContainerLifecycleListener<ComposeContainer>> containerLifecycleListeners = new HashSet<>();
+
+    protected ComposeContainer container;
+
+    @Override
+    public void init(ComposeContainerSupport config) {
+        for (Class<? extends ContainerLifecycleListener<ComposeContainer>> lifecycleListenerType :
+                config.containerLifecycleListener()) {
+            try {
+                containerLifecycleListeners.add(lifecycleListenerType.getDeclaredConstructor().newInstance());
+            } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+                throw new CitrusRuntimeException("Failed to instantiate container lifecycle listener from type: %s"
+                        .formatted(lifecycleListenerType), e);
+            }
+        }
+
+        String composeFile = config.composeFile();
+        int startupTimeout = config.startupTimeout();
+        ComposeContainerSupport.ExposedService[] exposedServices = config.exposedServices();
+
+        String identifier = Base58.randomString(6).toLowerCase();
+
+        if (StringUtils.hasText(composeFile)) {
+            container = new ComposeContainer(identifier, Resources.create(composeFile).file());
+        } else if (Resources.create("compose.yaml").exists()) {
+            container = new ComposeContainer(identifier, Resources.create("compose.yaml").file());
+        }
+
+        if (container == null) {
+            throw new CitrusRuntimeException(
+                    "Missing proper ComposeContainer specification - " +
+                            "provide a compose file via the composeFile attribute or place a compose.yaml on the classpath");
+        }
+
+        Duration timeout = startupTimeout > 0
+                ? Duration.ofSeconds(startupTimeout)
+                : Duration.ofSeconds(ComposeContainerSettings.getStartupTimeout());
+
+        for (ComposeContainerSupport.ExposedService service : exposedServices) {
+            container.withExposedService(service.name(), service.port(),
+                    Wait.forListeningPort().withStartupTimeout(timeout));
+        }
+    }
+
+    @Override
+    public Map<String, String> start() {
+        container.start();
+
+        Map<String, String> conf = new HashMap<>();
+        for (ContainerLifecycleListener<ComposeContainer> listener : containerLifecycleListeners) {
+            conf.putAll(listener.started(container));
+        }
+        return conf;
+    }
+
+    @Override
+    public void stop() {
+        if (container != null) {
+            container.stop();
+        }
+        containerLifecycleListeners.forEach(listener -> listener.stopped(container));
+    }
+
+    @Override
+    public void inject(TestInjector testInjector) {
+        testInjector.injectIntoFields(container,
+                new TestInjector.AnnotatedAndMatchesType(CitrusResource.class, ComposeContainer.class));
+    }
+}

--- a/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/compose/quarkus/ComposeContainerSupport.java
+++ b/connectors/citrus-testcontainers/src/main/java/org/citrusframework/testcontainers/compose/quarkus/ComposeContainerSupport.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.testcontainers.compose.quarkus;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import org.citrusframework.testcontainers.quarkus.ContainerLifecycleListener;
+import org.testcontainers.containers.ComposeContainer;
+
+@QuarkusTestResource(ComposeContainerResource.class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ComposeContainerSupport {
+
+    /**
+     * Path to the Docker Compose file. When empty, defaults to "compose.yaml" on the classpath.
+     */
+    String composeFile() default "";
+
+    /**
+     * Services to expose from the compose environment.
+     */
+    ExposedService[] exposedServices() default {};
+
+    /**
+     * Startup timeout in seconds. When set to -1, uses the default from ComposeContainerSettings.
+     */
+    int startupTimeout() default -1;
+
+    /**
+     * Container lifecycle listeners.
+     */
+    Class<? extends ContainerLifecycleListener<ComposeContainer>>[] containerLifecycleListener() default {};
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({})
+    @interface ExposedService {
+
+        /**
+         * The service name as defined in the compose file.
+         */
+        String name();
+
+        /**
+         * The port exposed by the service.
+         */
+        int port();
+    }
+}

--- a/src/manual/runtimes-quarkus.adoc
+++ b/src/manual/runtimes-quarkus.adoc
@@ -407,11 +407,66 @@ This is how Citrus is able to start Testcontainers instances as part of a Quarku
 The application properties supplier as well as the container lifecycle listener interfaces allow us to connect the Quarkus application with the Testcontainers instance.
 The test is able to use the services on the Testcontainers instance to trigger some test data that is consumed by the application under test.
 
+[[runtime-quarkus-compose-container]]
+=== Docker Compose support
+
+Citrus provides a `@ComposeContainerSupport` annotation that allows you to start a Docker Compose environment as part of your Quarkus test.
+This is useful when your application under test depends on multiple services that are defined in a Docker Compose file.
+
+.ComposeContainerTest
+[source,java]
+----
+@QuarkusTest
+@CitrusSupport
+@ComposeContainerSupport(
+    composeFile = "compose.yaml",
+    exposedServices = {
+        @ComposeContainerSupport.ExposedService(name = "db", port = 5432),
+        @ComposeContainerSupport.ExposedService(name = "broker", port = 9092)
+    },
+    containerLifecycleListener = ComposeContainerTest.class
+)
+public class ComposeContainerTest implements TestActionSupport, ContainerLifecycleListener<ComposeContainer> {
+
+    @CitrusResource
+    private TestCaseRunner tc;
+
+    @CitrusResource
+    private ComposeContainer composeContainer;
+
+    @Test
+    public void shouldTestWithComposeServices() {
+        // test logic using the compose services
+    }
+
+    @Override
+    public Map<String, String> started(ComposeContainer container) {
+        Map<String, String> conf = new HashMap<>();
+        conf.put("my.app.db.port",
+            String.valueOf(container.getServicePort("db", 5432)));
+        conf.put("my.app.db.host",
+            container.getServiceHost("db", 5432));
+        return conf;
+    }
+}
+----
+
+The `@ComposeContainerSupport` annotation accepts the following attributes:
+
+* `composeFile` - Path to the Docker Compose file. Defaults to `compose.yaml` on the classpath when not set.
+* `exposedServices` - Services and ports to expose from the compose environment. Each exposed service is defined with a `name` (as defined in the compose file) and a `port`.
+* `startupTimeout` - Startup timeout in seconds. Uses the default from `ComposeContainerSettings` when set to `-1`.
+* `containerLifecycleListener` - Container lifecycle listener classes to handle post-start and pre-stop events.
+
+The test can inject the `ComposeContainer` instance using the `@CitrusResource` annotation to interact with the compose environment directly.
+As with other Testcontainers annotations in Citrus the `ContainerLifecycleListener` interface allows you to react to container lifecycle events and return application properties that get set for the Quarkus application under test.
+
 Please also have a look into the other provided Testcontainers annotations in Citrus:
 
 * @LocalStackContainerSupport
-* @KakfaContainerSupport
+* @KafkaContainerSupport
 * @RedpandaContainerSupport
+* @ComposeContainerSupport
 * @TestcontainersSupport
 
 All of these annotations allow you to start Testcontainers instances as part of your Quarkus test and provides the opportunity to participate in the container lifecycle to access managed ports and connectivity settings for instance.


### PR DESCRIPTION
## Summary

- Adds `@ComposeContainerSupport` annotation for managing `ComposeContainer` instances in Citrus-enabled Quarkus tests
- Adds `ComposeContainerResource` implementing `QuarkusTestResourceLifecycleManager` directly (since `ComposeContainer` does not extend `GenericContainer`, it cannot use the existing `TestcontainersResource` base class)
- Follows the pattern established by `@KafkaContainerSupport` in `kafka/quarkus/apache/`

Closes #1688

🤖 Generated with [Claude Code](https://claude.com/claude-code)