### PR TITLE
fix(#1690): make HttpEndpointConfiguration RestTemplate access thread-safe

### DIFF
--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/client/HttpEndpointConfiguration.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/client/HttpEndpointConfiguration.java
@@ -152,7 +152,7 @@ public class HttpEndpointConfiguration extends AbstractPollableEndpointConfigura
      * Sets the restTemplate.
      * @param restTemplate the restTemplate to set
      */
-    public void setRestTemplate(RestTemplate restTemplate) {
+    public synchronized void setRestTemplate(RestTemplate restTemplate) {
         clientInterceptors.addAll(restTemplate.getInterceptors());
         restTemplate.setInterceptors(new ArrayList<>(clientInterceptors));
         this.restTemplate = restTemplate;
@@ -234,7 +234,7 @@ public class HttpEndpointConfiguration extends AbstractPollableEndpointConfigura
      * Gets the restTemplate.
      * @return the restTemplate
      */
-    public RestTemplate getRestTemplate() {
+    public synchronized RestTemplate getRestTemplate() {
         if (restTemplate == null) {
             restTemplate = new RestTemplate();
             restTemplate.setInterceptors(new ArrayList<>(clientInterceptors));
@@ -281,7 +281,7 @@ public class HttpEndpointConfiguration extends AbstractPollableEndpointConfigura
      * Sets the clientInterceptors on this implementation's rest template.
      * @param clientInterceptors the clientInterceptors to set
      */
-    public void setClientInterceptors(List<ClientHttpRequestInterceptor> clientInterceptors) {
+    public synchronized void setClientInterceptors(List<ClientHttpRequestInterceptor> clientInterceptors) {
         this.clientInterceptors = clientInterceptors;
 
         if (restTemplate == null) {

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/client/HttpClientTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/client/HttpClientTest.java
@@ -529,7 +529,7 @@ public class HttpClientTest extends AbstractTestNGUnitTest {
     public void testConcurrentGetRestTemplate() throws Exception {
         HttpEndpointConfiguration endpointConfiguration = new HttpEndpointConfiguration();
 
-        int threadCount = 10;
+        int threadCount = 32;
         CyclicBarrier barrier = new CyclicBarrier(threadCount);
         ExecutorService executor = Executors.newFixedThreadPool(threadCount);
         try {
@@ -541,12 +541,18 @@ public class HttpClientTest extends AbstractTestNGUnitTest {
                 }));
             }
 
+            RestTemplate first = null;
             for (Future<RestTemplate> future : futures) {
                 RestTemplate template = future.get();
                 Assert.assertNotNull(template);
                 Assert.assertFalse(template.getInterceptors().isEmpty());
                 Assert.assertTrue(template.getInterceptors().stream()
                         .anyMatch(LoggingClientInterceptor.class::isInstance));
+                if (first == null) {
+                    first = template;
+                } else {
+                    Assert.assertSame(first, template);
+                }
             }
         } finally {
             executor.shutdown();


### PR DESCRIPTION
## Summary

`HttpEndpointConfiguration.getRestTemplate()` lazily creates a shared `RestTemplate` without synchronization. Concurrent callers can race Spring's in-place interceptor sort and throw `ConcurrentModificationException`, which is what makes `HttpClientTest.testConcurrentGetRestTemplate` flake in CI.

This change:

- Marks `getRestTemplate`, `setRestTemplate`, and `setClientInterceptors` as `synchronized` so lazy init and interceptor updates share one monitor
- Strengthens the concurrent unit test (32 threads + `assertSame` on the shared instance)

Fixes #1690

## Test plan

- [x] `./mvnw -pl endpoints/citrus-http test -Dtest=HttpClientTest` — 20/20 GREEN