### PR TITLE
fix(#1697): Add shutdown strategy options (timeout, immediate) to Camel context stop action

### DIFF
--- a/core/citrus-api/src/main/java/org/citrusframework/api/actions/camel/CamelStopContextActionBuilder.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/api/actions/camel/CamelStopContextActionBuilder.java
@@ -23,4 +23,8 @@ public interface CamelStopContextActionBuilder<T extends TestAction, B extends C
 
     B contextName(String name);
 
+    B timeout(long timeout);
+
+    B immediate();
+
 }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/StopCamelContextAction.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/StopCamelContextAction.java
@@ -16,6 +16,8 @@
 
 package org.citrusframework.camel.actions;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.camel.CamelContext;
 import org.citrusframework.api.actions.camel.CamelStopContextActionBuilder;
 import org.citrusframework.camel.CamelSettings;
@@ -27,17 +29,17 @@ import org.slf4j.LoggerFactory;
 public class StopCamelContextAction extends AbstractCamelAction {
 
     private final String contextName;
+    private final long timeout;
+    private final boolean immediate;
 
-    /** Logger */
     private static final Logger logger = LoggerFactory.getLogger(StopCamelContextAction.class);
 
-    /**
-     * Default constructor.
-     */
     public StopCamelContextAction(Builder builder) {
         super("stop-context", builder);
 
         this.contextName = builder.contextName;
+        this.timeout = builder.timeout;
+        this.immediate = builder.immediate;
     }
 
     @Override
@@ -52,12 +54,33 @@ public class StopCamelContextAction extends AbstractCamelAction {
         }
 
         try {
+            if (immediate) {
+                camelContext.getShutdownStrategy().setShutdownNowOnTimeout(true);
+                camelContext.getShutdownStrategy().setTimeout(1);
+                camelContext.getShutdownStrategy().setTimeUnit(TimeUnit.SECONDS);
+            } else if (timeout > 0) {
+                camelContext.getShutdownStrategy().setTimeout(timeout);
+                camelContext.getShutdownStrategy().setTimeUnit(TimeUnit.SECONDS);
+            }
+
             camelContext.stop();
         } catch (Exception e) {
             throw new IllegalStateException("Failed to stop Camel context '%s'".formatted(contextName), e);
         }
 
         logger.info("Stopped Camel context '%s'".formatted(contextName));
+    }
+
+    public String getContextName() {
+        return contextName;
+    }
+
+    public long getTimeout() {
+        return timeout;
+    }
+
+    public boolean isImmediate() {
+        return immediate;
     }
 
     /**
@@ -67,10 +90,24 @@ public class StopCamelContextAction extends AbstractCamelAction {
             implements CamelStopContextActionBuilder<StopCamelContextAction, Builder> {
 
         private String contextName = CamelSettings.getContextName();
+        private long timeout = -1;
+        private boolean immediate = false;
 
         @Override
         public Builder contextName(String name) {
             this.contextName = name;
+            return this;
+        }
+
+        @Override
+        public Builder timeout(long timeout) {
+            this.timeout = timeout;
+            return this;
+        }
+
+        @Override
+        public Builder immediate() {
+            this.immediate = true;
             return this;
         }
 

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/Camel.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/Camel.java
@@ -120,6 +120,12 @@ public class Camel implements TestActionBuilder<TestAction>, ReferenceResolverAw
         StopCamelContextAction.Builder builder = new StopCamelContextAction.Builder();
         builder.contextName(stopContext.getName());
 
+        if (Boolean.TRUE.equals(stopContext.isImmediate())) {
+            builder.immediate();
+        } else if (stopContext.getTimeout() != null) {
+            builder.timeout(stopContext.getTimeout());
+        }
+
         this.builder = builder;
     }
 

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/CamelContext.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/CamelContext.java
@@ -30,6 +30,12 @@ public class CamelContext {
     @XmlAttribute
     protected boolean autoStart = true;
 
+    @XmlAttribute
+    protected Long timeout;
+
+    @XmlAttribute
+    protected Boolean immediate;
+
     public String getName() {
         return name;
     }
@@ -44,5 +50,21 @@ public class CamelContext {
 
     public void setAutoStart(boolean autoStart) {
         this.autoStart = autoStart;
+    }
+
+    public Long getTimeout() {
+        return timeout;
+    }
+
+    public void setTimeout(Long timeout) {
+        this.timeout = timeout;
+    }
+
+    public Boolean isImmediate() {
+        return immediate;
+    }
+
+    public void setImmediate(Boolean immediate) {
+        this.immediate = immediate;
     }
 }

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/StopContext.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/StopContext.java
@@ -27,6 +27,18 @@ public class StopContext implements CamelActionBuilderWrapper<StopCamelContextAc
         builder.contextName(contextName);
     }
 
+    @SchemaProperty(description = "The shutdown timeout in seconds.")
+    public void setTimeout(long timeout) {
+        builder.timeout(timeout);
+    }
+
+    @SchemaProperty(description = "Enable immediate shutdown without waiting for in-flight exchanges.")
+    public void setImmediate(boolean immediate) {
+        if (immediate) {
+            builder.immediate();
+        }
+    }
+
     @Override
     public StopCamelContextAction.Builder getBuilder() {
         return builder;

--- a/endpoints/citrus-camel/src/main/resources/org/citrusframework/schema/citrus-camel-testcase-5.1.0-SNAPSHOT.xsd
+++ b/endpoints/citrus-camel/src/main/resources/org/citrusframework/schema/citrus-camel-testcase-5.1.0-SNAPSHOT.xsd
@@ -60,6 +60,8 @@
         <xs:element ref="description" minOccurs="0"/>
       </xs:sequence>
       <xs:attribute name="name" type="xs:string"/>
+      <xs:attribute name="timeout" type="xs:long"/>
+      <xs:attribute name="immediate" type="xs:boolean"/>
     </xs:complexType>
   </xs:element>
 

--- a/endpoints/citrus-camel/src/main/resources/org/citrusframework/schema/citrus-camel-testcase.xsd
+++ b/endpoints/citrus-camel/src/main/resources/org/citrusframework/schema/citrus-camel-testcase.xsd
@@ -60,6 +60,8 @@
         <xs:element ref="description" minOccurs="0"/>
       </xs:sequence>
       <xs:attribute name="name" use="required" type="xs:string"/>
+      <xs:attribute name="timeout" type="xs:long"/>
+      <xs:attribute name="immediate" type="xs:boolean"/>
     </xs:complexType>
   </xs:element>
 

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/actions/StopCamelContextActionTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/actions/StopCamelContextActionTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.actions;
+
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.spi.Registry;
+import org.apache.camel.spi.ShutdownStrategy;
+import org.citrusframework.camel.CamelSettings;
+import org.citrusframework.testng.AbstractTestNGUnitTest;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class StopCamelContextActionTest extends AbstractTestNGUnitTest {
+
+    private final CamelContext camelContext = Mockito.mock(CamelContext.class);
+    private final ShutdownStrategy shutdownStrategy = Mockito.mock(ShutdownStrategy.class);
+    private final Registry registry = Mockito.mock(Registry.class);
+
+    @BeforeMethod
+    public void setup() {
+        Mockito.reset(camelContext, shutdownStrategy, registry);
+        when(camelContext.getRegistry()).thenReturn(registry);
+        when(registry.findByType(any())).thenReturn(Collections.emptySet());
+        when(registry.findByTypeWithName(any())).thenReturn(Collections.emptyMap());
+    }
+
+    @Test
+    public void testStopContext() throws Exception {
+        context.getReferenceResolver().bind(CamelSettings.getContextName(), camelContext);
+
+        StopCamelContextAction action = new StopCamelContextAction.Builder()
+                .context(camelContext)
+                .build();
+        action.execute(context);
+
+        verify(camelContext).stop();
+        verify(camelContext, never()).getShutdownStrategy();
+        Assert.assertFalse(action.isImmediate());
+    }
+
+    @Test
+    public void testStopContextWithTimeout() throws Exception {
+        when(camelContext.getShutdownStrategy()).thenReturn(shutdownStrategy);
+        context.getReferenceResolver().bind("myCamelContext", camelContext);
+
+        StopCamelContextAction action = new StopCamelContextAction.Builder()
+                .context(camelContext)
+                .contextName("myCamelContext")
+                .timeout(60)
+                .build();
+        action.execute(context);
+
+        verify(shutdownStrategy).setTimeout(60);
+        verify(shutdownStrategy).setTimeUnit(TimeUnit.SECONDS);
+        verify(camelContext).stop();
+
+        Assert.assertEquals(action.getTimeout(), 60L);
+        Assert.assertEquals(action.getContextName(), "myCamelContext");
+        Assert.assertFalse(action.isImmediate());
+    }
+
+    @Test
+    public void testStopContextImmediate() throws Exception {
+        when(camelContext.getShutdownStrategy()).thenReturn(shutdownStrategy);
+        context.getReferenceResolver().bind("myCamelContext", camelContext);
+
+        StopCamelContextAction action = new StopCamelContextAction.Builder()
+                .context(camelContext)
+                .contextName("myCamelContext")
+                .immediate()
+                .build();
+        action.execute(context);
+
+        verify(shutdownStrategy).setShutdownNowOnTimeout(true);
+        verify(shutdownStrategy).setTimeout(1);
+        verify(shutdownStrategy).setTimeUnit(TimeUnit.SECONDS);
+        verify(camelContext).stop();
+
+        Assert.assertTrue(action.isImmediate());
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class)
+    public void testStopContextWithException() throws Exception {
+        context.getReferenceResolver().bind(CamelSettings.getContextName(), camelContext);
+        Mockito.doThrow(new RuntimeException("Failed to stop")).when(camelContext).stop();
+
+        StopCamelContextAction action = new StopCamelContextAction.Builder()
+                .context(camelContext)
+                .build();
+        action.execute(context);
+    }
+}

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/xml/StopContextTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/xml/StopContextTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.xml;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.camel.actions.StopCamelContextAction;
+import org.citrusframework.xml.XmlTestLoader;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class StopContextTest extends AbstractXmlActionTest {
+
+    @Test
+    public void shouldLoadCamelActions() throws Exception {
+        XmlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/camel/xml/camel-stop-context.citrus.it.xml");
+
+        CamelContext defaultContext = new DefaultCamelContext();
+        defaultContext.start();
+        context.getReferenceResolver().bind("defaultContext", defaultContext);
+
+        CamelContext timeoutContext = new DefaultCamelContext();
+        timeoutContext.start();
+        context.getReferenceResolver().bind("timeoutContext", timeoutContext);
+
+        CamelContext immediateContext = new DefaultCamelContext();
+        immediateContext.start();
+        context.getReferenceResolver().bind("immediateContext", immediateContext);
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "CamelStopContextTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 3L);
+
+        StopCamelContextAction action = (StopCamelContextAction) result.getTestAction(0);
+        Assert.assertEquals(action.getClass(), StopCamelContextAction.class);
+        Assert.assertEquals(action.getName(), "camel:stop-context");
+        Assert.assertEquals(action.getContextName(), "defaultContext");
+        Assert.assertEquals(action.getTimeout(), -1L);
+        Assert.assertFalse(action.isImmediate());
+
+        action = (StopCamelContextAction) result.getTestAction(1);
+        Assert.assertEquals(action.getContextName(), "timeoutContext");
+        Assert.assertEquals(action.getTimeout(), 60L);
+        Assert.assertFalse(action.isImmediate());
+
+        action = (StopCamelContextAction) result.getTestAction(2);
+        Assert.assertEquals(action.getContextName(), "immediateContext");
+        Assert.assertTrue(action.isImmediate());
+    }
+}

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/yaml/StopContextTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/yaml/StopContextTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.yaml;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.camel.actions.StopCamelContextAction;
+import org.citrusframework.yaml.YamlTestLoader;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class StopContextTest extends AbstractYamlActionTest {
+
+    @Test
+    public void shouldLoadCamelActions() throws Exception {
+        YamlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/camel/yaml/camel-stop-context.citrus.it.yaml");
+
+        CamelContext defaultContext = new DefaultCamelContext();
+        defaultContext.start();
+        context.getReferenceResolver().bind("defaultContext", defaultContext);
+
+        CamelContext timeoutContext = new DefaultCamelContext();
+        timeoutContext.start();
+        context.getReferenceResolver().bind("timeoutContext", timeoutContext);
+
+        CamelContext immediateContext = new DefaultCamelContext();
+        immediateContext.start();
+        context.getReferenceResolver().bind("immediateContext", immediateContext);
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "CamelStopContextTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 3L);
+
+        StopCamelContextAction action = (StopCamelContextAction) result.getTestAction(0);
+        Assert.assertEquals(action.getClass(), StopCamelContextAction.class);
+        Assert.assertEquals(action.getName(), "camel:stop-context");
+        Assert.assertEquals(action.getContextName(), "defaultContext");
+        Assert.assertEquals(action.getTimeout(), -1L);
+        Assert.assertFalse(action.isImmediate());
+
+        action = (StopCamelContextAction) result.getTestAction(1);
+        Assert.assertEquals(action.getContextName(), "timeoutContext");
+        Assert.assertEquals(action.getTimeout(), 60L);
+        Assert.assertFalse(action.isImmediate());
+
+        action = (StopCamelContextAction) result.getTestAction(2);
+        Assert.assertEquals(action.getContextName(), "immediateContext");
+        Assert.assertTrue(action.isImmediate());
+    }
+}

--- a/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/xml/camel-stop-context.citrus.it.xml
+++ b/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/xml/camel-stop-context.citrus.it.xml
@@ -1,0 +1,34 @@
+<!--
+  ~ Copyright the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<test name="CamelStopContextTest" author="Christoph" status="FINAL" xmlns="http://citrusframework.org/schema/xml/testcase"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://citrusframework.org/schema/xml/testcase http://citrusframework.org/schema/xml/testcase/citrus-testcase.xsd">
+  <description>Test stop context action with shutdown strategy options</description>
+  <actions>
+    <camel>
+      <stop-context name="defaultContext"/>
+    </camel>
+
+    <camel>
+      <stop-context name="timeoutContext" timeout="60"/>
+    </camel>
+
+    <camel>
+      <stop-context name="immediateContext" immediate="true"/>
+    </camel>
+  </actions>
+</test>

--- a/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/yaml/camel-stop-context.citrus.it.yaml
+++ b/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/yaml/camel-stop-context.citrus.it.yaml
@@ -1,0 +1,17 @@
+name: "CamelStopContextTest"
+author: "Christoph"
+status: "FINAL"
+actions:
+  - camel:
+      stopContext:
+        name: "defaultContext"
+
+  - camel:
+      stopContext:
+        name: "timeoutContext"
+        timeout: 60
+
+  - camel:
+      stopContext:
+        name: "immediateContext"
+        immediate: true

--- a/tools/schema-generator/src/test/resources/control/citrus-catalog-aggregate-test-actions.json
+++ b/tools/schema-generator/src/test/resources/control/citrus-catalog-aggregate-test-actions.json
@@ -1676,6 +1676,16 @@
           "type": "string",
           "title": "Name",
           "description": "The Camel context name."
+        },
+        "timeout": {
+          "type": "integer",
+          "title": "Timeout",
+          "description": "The shutdown timeout in seconds."
+        },
+        "immediate": {
+          "type": "boolean",
+          "title": "Immediate",
+          "description": "Enable immediate shutdown without waiting for in-flight exchanges."
         }
       },
       "additionalProperties": false    }


### PR DESCRIPTION
## Summary
- Adds `timeout` and `immediate` shutdown strategy options to the Camel context stop test action
- `timeout(long)` configures the shutdown timeout in seconds on the Camel ShutdownStrategy before stopping
- `immediate()` enables forced shutdown by setting `shutdownNowOnTimeout(true)` with a minimal timeout
- Supported in all three DSLs: Java builder, YAML, and XML

## Changes
- **API**: Added `timeout(long)` and `immediate()` to `CamelStopContextActionBuilder` interface
- **Action**: Updated `StopCamelContextAction` to configure `ShutdownStrategy` before calling `context.stop()`
- **YAML DSL**: Added `timeout` and `immediate` properties to `StopContext`
- **XML DSL**: Added `timeout` and `immediate` attributes to `CamelContext` model and XSD schemas
- **Tests**: Added unit tests (Java builder), YAML parser tests, and XML parser tests
- **Catalog**: Updated schema-generator control file with new properties

Closes #1697

## Test plan
- [x] Unit tests for all builder options (default, timeout, immediate, exception handling)
- [x] YAML DSL parser test with all three variants
- [x] XML DSL parser test with all three variants
- [x] Module build passes (`mvn verify` in `endpoints/citrus-camel`)
- [x] Full repository build passes (`mvn clean install -DskipTests`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)