### PR TITLE
fix(#1691): Support dynamic consumer groups for dynamic Kafka endpoint URIs

### DIFF
--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaEndpointComponent.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaEndpointComponent.java
@@ -17,10 +17,12 @@
 package org.citrusframework.kafka.endpoint;
 
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.citrusframework.context.TestContext;
 import org.citrusframework.endpoint.AbstractEndpointComponent;
 import org.citrusframework.endpoint.Endpoint;
+import org.citrusframework.kafka.message.KafkaMessageHeaders;
 
 /**
  * Kafka endpoint component is able to create kafka endpoint from endpoint uri with parameters. Depending on uri creates a
@@ -31,6 +33,8 @@ import org.citrusframework.endpoint.Endpoint;
  * @since 2.8
  */
 public class KafkaEndpointComponent extends AbstractEndpointComponent {
+
+    private static final AtomicInteger CONSUMER_GROUP_INDEX = new AtomicInteger(1);
 
     /**
      * Default constructor using the name for this component.
@@ -52,6 +56,11 @@ public class KafkaEndpointComponent extends AbstractEndpointComponent {
 
         if (parameters.containsKey("server")) {
             parameters.put("bootstrapServers", parameters.remove("server"));
+        }
+
+        if (!parameters.containsKey("consumerGroup") && KafkaSettings.isDynamicConsumerGroup()) {
+            endpoint.getEndpointConfiguration().setConsumerGroup(
+                    KafkaMessageHeaders.KAFKA_PREFIX + "group_" + CONSUMER_GROUP_INDEX.getAndIncrement());
         }
 
         enrichEndpointConfiguration(endpoint.getEndpointConfiguration(), parameters, context);

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaSettings.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaSettings.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.kafka.endpoint;
+
+import org.citrusframework.config.CitrusConfigProperties;
+import org.citrusframework.config.CitrusConfigProperty;
+
+@CitrusConfigProperties(prefix = "citrus.kafka", description = "Kafka endpoint settings")
+public final class KafkaSettings {
+
+    private static final String KAFKA_PROPERTY_PREFIX = "citrus.kafka.";
+    private static final String KAFKA_ENV_PREFIX = "CITRUS_KAFKA_";
+
+    @CitrusConfigProperty(description = "When enabled, dynamic Kafka endpoint URIs automatically use a unique consumer group so that each consumer independently receives all messages from its subscribed topic.", type = "java.lang.Boolean", defaultValue = "true")
+    private static final String DYNAMIC_CONSUMER_GROUP_PROPERTY = KAFKA_PROPERTY_PREFIX + "dynamic.consumer.group";
+    private static final String DYNAMIC_CONSUMER_GROUP_ENV = KAFKA_ENV_PREFIX + "DYNAMIC_CONSUMER_GROUP";
+    private static final String DYNAMIC_CONSUMER_GROUP_DEFAULT = "true";
+
+    private KafkaSettings() {
+    }
+
+    /**
+     * When enabled, dynamic Kafka endpoint URIs automatically use a unique consumer group
+     * so that each consumer independently receives all messages from its subscribed topic.
+     */
+    public static boolean isDynamicConsumerGroup() {
+        return Boolean.parseBoolean(System.getProperty(DYNAMIC_CONSUMER_GROUP_PROPERTY,
+                System.getenv(DYNAMIC_CONSUMER_GROUP_ENV) != null ? System.getenv(DYNAMIC_CONSUMER_GROUP_ENV) : DYNAMIC_CONSUMER_GROUP_DEFAULT));
+    }
+}

--- a/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/KafkaEndpointComponentTest.java
+++ b/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/KafkaEndpointComponentTest.java
@@ -97,6 +97,49 @@ public class KafkaEndpointComponentTest {
     }
 
     @Test
+    public void testCreateEndpointWithDynamicConsumerGroup() {
+        KafkaEndpointComponent component = new KafkaEndpointComponent();
+
+        Endpoint endpoint1 = component.createEndpoint("kafka:topic-1", context);
+        Endpoint endpoint2 = component.createEndpoint("kafka:topic-2", context);
+
+        String group1 = ((KafkaEndpoint) endpoint1).getEndpointConfiguration().getConsumerGroup();
+        String group2 = ((KafkaEndpoint) endpoint2).getEndpointConfiguration().getConsumerGroup();
+
+        Assert.assertTrue(group1.startsWith("citrus_kafka_group_"), "Consumer group should start with 'citrus_kafka_group_' but was: " + group1);
+        Assert.assertTrue(group2.startsWith("citrus_kafka_group_"), "Consumer group should start with 'citrus_kafka_group_' but was: " + group2);
+        Assert.assertNotEquals(group1, group2, "Dynamic endpoints should have different consumer groups");
+    }
+
+    @Test
+    public void testCreateEndpointWithExplicitConsumerGroup() {
+        KafkaEndpointComponent component = new KafkaEndpointComponent();
+
+        Endpoint endpoint = component.createEndpoint("kafka:topic-1?consumerGroup=my-custom-group", context);
+
+        Assert.assertEquals(((KafkaEndpoint) endpoint).getEndpointConfiguration().getConsumerGroup(), "my-custom-group");
+    }
+
+    @Test
+    public void testCreateEndpointWithDynamicConsumerGroupDisabled() {
+        System.setProperty("citrus.kafka.dynamic.consumer.group", "false");
+        try {
+            KafkaEndpointComponent component = new KafkaEndpointComponent();
+
+            Endpoint endpoint1 = component.createEndpoint("kafka:topic-1", context);
+            Endpoint endpoint2 = component.createEndpoint("kafka:topic-2", context);
+
+            String group1 = ((KafkaEndpoint) endpoint1).getEndpointConfiguration().getConsumerGroup();
+            String group2 = ((KafkaEndpoint) endpoint2).getEndpointConfiguration().getConsumerGroup();
+
+            Assert.assertEquals(group1, "citrus_kafka_group");
+            Assert.assertEquals(group2, "citrus_kafka_group");
+        } finally {
+            System.clearProperty("citrus.kafka.dynamic.consumer.group");
+        }
+    }
+
+    @Test
     public void testInvalidEndpointUri() {
         KafkaEndpointComponent component = new KafkaEndpointComponent();
         try {

--- a/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/KafkaSettingsTest.java
+++ b/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/KafkaSettingsTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.kafka.endpoint;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class KafkaSettingsTest {
+
+    @Test
+    public void testDynamicConsumerGroupEnabledByDefault() {
+        Assert.assertTrue(KafkaSettings.isDynamicConsumerGroup());
+    }
+
+    @Test
+    public void testDynamicConsumerGroupDisabledBySystemProperty() {
+        System.setProperty("citrus.kafka.dynamic.consumer.group", "false");
+        try {
+            Assert.assertFalse(KafkaSettings.isDynamicConsumerGroup());
+        } finally {
+            System.clearProperty("citrus.kafka.dynamic.consumer.group");
+        }
+    }
+
+    @Test
+    public void testDynamicConsumerGroupEnabledBySystemProperty() {
+        System.setProperty("citrus.kafka.dynamic.consumer.group", "true");
+        try {
+            Assert.assertTrue(KafkaSettings.isDynamicConsumerGroup());
+        } finally {
+            System.clearProperty("citrus.kafka.dynamic.consumer.group");
+        }
+    }
+}

--- a/src/manual/endpoint-kafka.adoc
+++ b/src/manual/endpoint-kafka.adoc
@@ -650,6 +650,15 @@ A larger window might find older messages but could impact performance.
 As we have seen before the topic name can be overwritten in each send and receive operation by specifying the `citrus_kafka_topic`
 message header. In addition to that you can make use of completely dynamic Kafka endpoints, too.
 
+By default, dynamic Kafka endpoints automatically use a unique consumer group for each endpoint created via the `kafka:` URI scheme.
+This prevents multiple dynamic endpoints from sharing the same consumer group and accidentally stealing messages from each other (point-to-point semantics).
+The consumer group name follows the pattern `citrus_kafka_group_{index}` where `{index}` is an auto-incrementing counter.
+
+You can disable this behavior by setting the `citrus.kafka.dynamic.consumer.group` property to `false` (see <<kafka-settings>>).
+When disabled, dynamic endpoints fall back to the default consumer group `citrus_kafka_group`.
+You can always override the consumer group on a per-endpoint basis by specifying the `consumerGroup` parameter in the endpoint URI
+(e.g. `kafka:my-topic?consumerGroup=my-group`).
+
 The dynamic endpoint is created on the fly with respective settings. So you can use the `kafka` endpoint component in your
 test as follows:
 
@@ -763,5 +772,23 @@ The embedded server component provides following properties to set:
 | auto-delete-logs
 | java.lang.Boolean
 | Auto delete server log directories on exit. Default is true.
+
+|===
+
+[[kafka-settings]]
+== Kafka Settings
+
+Citrus provides global settings for the Kafka endpoint module. These settings can be configured via Java system properties or environment variables.
+
+[cols="3,3,2,5a"]
+|===
+| System Property | Environment Variable | Default | Description
+
+| `citrus.kafka.dynamic.consumer.group`
+| `CITRUS_KAFKA_DYNAMIC_CONSUMER_GROUP`
+| `true`
+| When enabled, dynamic Kafka endpoint URIs (e.g. `kafka:my-topic`) automatically use a unique consumer group for each endpoint.
+  This ensures each consumer independently receives all messages from its subscribed topic.
+  When disabled, dynamic endpoints share the default consumer group `citrus_kafka_group`.
 
 |===

--- a/tools/mcp-server/src/main/java/org/citrusframework/mcp/SettingsData.java
+++ b/tools/mcp-server/src/main/java/org/citrusframework/mcp/SettingsData.java
@@ -58,6 +58,7 @@ public class SettingsData {
         GROUPS.put("jbang", createJBangSettings());
         GROUPS.put("kubernetes", createKubernetesSettings());
         GROUPS.put("knative", createKnativeSettings());
+        GROUPS.put("kafka", createKafkaEndpointSettings());
         GROUPS.put("testcontainers", createTestContainersSettings());
         GROUPS.put("testcontainers-kafka", createKafkaSettings());
         GROUPS.put("testcontainers-localstack", createLocalStackSettings());
@@ -708,6 +709,17 @@ public class SettingsData {
 
         return new SettingsGroup("knative", "Knative Settings",
                 "Knative connector settings from KnativeSettings", "citrus-knative", settings);
+    }
+
+    private static SettingsGroup createKafkaEndpointSettings() {
+        List<SettingEntry> settings = new ArrayList<>();
+
+        settings.add(new SettingEntry("citrus.kafka.dynamic.consumer.group", "CITRUS_KAFKA_DYNAMIC_CONSUMER_GROUP",
+                "true", BOOLEAN,
+                "When enabled, dynamic Kafka endpoint URIs automatically use a unique consumer group for each endpoint"));
+
+        return new SettingsGroup("kafka", "Kafka Endpoint Settings",
+                "Kafka endpoint settings from KafkaSettings", "citrus-kafka", settings);
     }
 
     private static SettingsGroup createTestContainersSettings() {

--- a/tools/mcp-server/src/test/java/org/citrusframework/mcp/SettingsDataTest.java
+++ b/tools/mcp-server/src/test/java/org/citrusframework/mcp/SettingsDataTest.java
@@ -37,6 +37,7 @@ class SettingsDataTest {
                 "http", "ftp", "mail", "openapi",
                 "json", "yaml-validation",
                 "jbang", "kubernetes", "knative",
+                "kafka",
                 "testcontainers", "testcontainers-kafka",
                 "testcontainers-localstack", "testcontainers-postgresql",
                 "testcontainers-mongodb", "testcontainers-redpanda");
@@ -123,7 +124,7 @@ class SettingsDataTest {
 
         assertThat(moduleNames).contains(
                 "citrus-api", "citrus-spring", "citrus-camel",
-                "citrus-http", "citrus-kubernetes", "citrus-testcontainers");
+                "citrus-http", "citrus-kafka", "citrus-kubernetes", "citrus-testcontainers");
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #1691

When consuming messages via Kafka using dynamic endpoint URIs (e.g. `kafka:topic-1` and `kafka:topic-2`), both endpoints shared the same default consumer group `citrus_kafka_group`. This caused point-to-point semantics where only one consumer would receive messages, leading to unexpected behavior in tests.

This PR introduces a new Citrus Kafka setting `citrus.kafka.dynamic.consumer.group` (default: `true`) that automatically assigns unique consumer groups to dynamic Kafka endpoints. Each dynamic endpoint gets a consumer group following the pattern `citrus_kafka_group_{index}` where index is an auto-incrementing counter.

### Changes

- **New `KafkaSettings` class** — follows the established settings pattern (`CamelSettings`, `MailSettings`) with `@CitrusConfigProperties` annotations for IDE metadata generation. Exposes the `citrus.kafka.dynamic.consumer.group` setting via system property or `CITRUS_KAFKA_DYNAMIC_CONSUMER_GROUP` environment variable.
- **Modified `KafkaEndpointComponent`** — when creating dynamic endpoints, checks whether `consumerGroup` was explicitly provided in the URI. If not and the setting is enabled, assigns a unique consumer group via an `AtomicInteger` counter.
- **Tests** — unit tests for `KafkaSettings` and three new tests in `KafkaEndpointComponentTest` covering: dynamic consumer groups are unique, explicit consumer group is respected, and disabling the setting falls back to the default group.
- **Documentation** — updated `endpoint-kafka.adoc` with new "Kafka Settings" section documenting the setting, and added explanation in the "Dynamic Kafka Endpoints" section.

## Test plan

- [x] `KafkaSettingsTest` — verifies default enabled, system property override
- [x] `KafkaEndpointComponentTest.testCreateEndpointWithDynamicConsumerGroup` — verifies unique groups for multiple dynamic endpoints
- [x] `KafkaEndpointComponentTest.testCreateEndpointWithExplicitConsumerGroup` — verifies user-provided group is preserved
- [x] `KafkaEndpointComponentTest.testCreateEndpointWithDynamicConsumerGroupDisabled` — verifies fallback to default group
- [x] All existing tests continue to pass

Generated with [Claude Code](https://claude.com/claude-code)