### PR TITLE
fix(http): synchronize RestTemplate initialization

### DIFF
--- a/endpoints/citrus-http/src/main/java/org/citrusframework/http/client/HttpEndpointConfiguration.java
+++ b/endpoints/citrus-http/src/main/java/org/citrusframework/http/client/HttpEndpointConfiguration.java
@@ -234,7 +234,7 @@ public class HttpEndpointConfiguration extends AbstractPollableEndpointConfigura
      * Gets the restTemplate.
      * @return the restTemplate
      */
-    public RestTemplate getRestTemplate() {
+    public synchronized RestTemplate getRestTemplate() {
         if (restTemplate == null) {
             restTemplate = new RestTemplate();
             restTemplate.setInterceptors(new ArrayList<>(clientInterceptors));


### PR DESCRIPTION
## Summary

- serialize access to the lazily initialized `RestTemplate`
- prevent concurrent initialization from mutating the interceptor list at the same time

Fixes #1690

## Testing

`./mvnw -pl endpoints/citrus-http -am -Dtest=HttpClientTest#testConcurrentGetRestTemplate -Dsurefire.failIfNoSpecifiedTests=false test`
