### PR TITLE
fix(#1695): Add verify Camel route test action to check route existence and status

### DIFF
--- a/core/citrus-api/src/main/java/org/citrusframework/api/actions/camel/CamelRouteActionBuilder.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/api/actions/camel/CamelRouteActionBuilder.java
@@ -61,4 +61,9 @@ public interface CamelRouteActionBuilder<T extends TestAction, B extends CamelRo
      * Remove these Camel routes.
      */
     CamelRemoveRouteActionBuilder<?, ?> remove(String... routes);
+
+    /**
+     * Verify a Camel route existence and status.
+     */
+    CamelVerifyRouteActionBuilder<?, ?> verify(String routeId);
 }

--- a/core/citrus-api/src/main/java/org/citrusframework/api/actions/camel/CamelVerifyRouteActionBuilder.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/api/actions/camel/CamelVerifyRouteActionBuilder.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.api.actions.camel;
+
+import org.citrusframework.TestAction;
+
+public interface CamelVerifyRouteActionBuilder<T extends TestAction, B extends CamelVerifyRouteActionBuilder<T, B>>
+        extends CamelRouteActionBuilderBase<T, B> {
+
+    B route(String routeId);
+
+    B status(Enum<?> status);
+
+    B status(String status);
+}

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelRouteActionBuilder.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelRouteActionBuilder.java
@@ -141,6 +141,16 @@ public class CamelRouteActionBuilder extends AbstractReferenceResolverAwareTestA
     }
 
     @Override
+    public CamelVerifyRouteAction.Builder verify(String routeId) {
+        CamelVerifyRouteAction.Builder builder = new CamelVerifyRouteAction.Builder()
+                .context(camelContext)
+                .route(routeId);
+
+        this.delegate = builder;
+        return builder;
+    }
+
+    @Override
     public RemoveCamelRouteAction.Builder remove(String... routes) {
         RemoveCamelRouteAction.Builder builder = new RemoveCamelRouteAction.Builder()
                 .context(camelContext)

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelVerifyRouteAction.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelVerifyRouteAction.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.actions;
+
+import org.apache.camel.ServiceStatus;
+import org.citrusframework.api.actions.camel.CamelVerifyRouteActionBuilder;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.util.StringUtils;
+import org.citrusframework.validation.ValidationUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CamelVerifyRouteAction extends AbstractCamelRouteAction {
+
+    private static final Logger logger = LoggerFactory.getLogger(CamelVerifyRouteAction.class);
+
+    private final String routeId;
+    private final String status;
+
+    public CamelVerifyRouteAction(Builder builder) {
+        super("verify-route", builder);
+
+        this.routeId = builder.routeId;
+        this.status = builder.status;
+    }
+
+    @Override
+    public void doExecute(TestContext context) {
+        String resolvedRouteId = context.replaceDynamicContentInString(routeId);
+
+        if (camelContext.getRoute(resolvedRouteId) == null) {
+            throw new CitrusRuntimeException(
+                    "Camel route '%s' does not exist in context '%s'"
+                            .formatted(resolvedRouteId, camelContext.getName()));
+        }
+
+        logger.info("Verified Camel route '{}' exists in context '{}'", resolvedRouteId, camelContext.getName());
+
+        if (StringUtils.hasText(status)) {
+            String expectedStatus = context.replaceDynamicContentInString(status);
+            ServiceStatus routeStatus = camelContext.getRouteController().getRouteStatus(resolvedRouteId);
+
+            if (routeStatus == null) {
+                throw new CitrusRuntimeException(
+                        "Unable to retrieve status for Camel route '%s' in context '%s'"
+                                .formatted(resolvedRouteId, camelContext.getName()));
+            }
+
+            ValidationUtils.validateValues(routeStatus.name(), expectedStatus, "camelRouteStatus", context);
+            logger.info("Verified Camel route '{}' has status '{}'", resolvedRouteId, expectedStatus);
+        }
+    }
+
+    public String getRouteId() {
+        return routeId;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public static final class Builder extends AbstractCamelRouteAction.Builder<CamelVerifyRouteAction, Builder>
+            implements CamelVerifyRouteActionBuilder<CamelVerifyRouteAction, Builder> {
+
+        private String routeId;
+        private String status;
+
+        @Override
+        public Builder route(String routeId) {
+            this.routeId = routeId;
+            return this;
+        }
+
+        public Builder status(ServiceStatus status) {
+            this.status = status.name();
+            return this;
+        }
+
+        @Override
+        public Builder status(Enum<?> status) {
+            if (status instanceof ServiceStatus serviceStatus) {
+                this.status = serviceStatus.name();
+            }
+            return this;
+        }
+
+        @Override
+        public Builder status(String status) {
+            this.status = status;
+            return this;
+        }
+
+        @Override
+        public CamelVerifyRouteAction doBuild() {
+            return new CamelVerifyRouteAction(this);
+        }
+    }
+}

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/Camel.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/Camel.java
@@ -537,6 +537,18 @@ public class Camel implements TestActionBuilder<TestAction>, ReferenceResolverAw
         this.builder = builder;
     }
 
+    @XmlElement(name = "verify-route")
+    public void setVerifyRoute(VerifyRoute verifyRoute) {
+        CamelVerifyRouteAction.Builder builder = new CamelVerifyRouteAction.Builder()
+                .route(verifyRoute.getRoute());
+
+        if (verifyRoute.getStatus() != null) {
+            builder.status(verifyRoute.getStatus());
+        }
+
+        this.builder = builder;
+    }
+
     @XmlElement(name = "remove-routes")
     public void setRemoveRoutes(Routes removeRoutes) {
         RemoveCamelRouteAction.Builder builder = new RemoveCamelRouteAction.Builder();

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/VerifyRoute.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/VerifyRoute.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.xml;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "")
+public class VerifyRoute {
+
+    @XmlAttribute(name = "route", required = true)
+    protected String route;
+
+    @XmlAttribute(name = "status")
+    protected String status;
+
+    public String getRoute() {
+        return route;
+    }
+
+    public void setRoute(String route) {
+        this.route = route;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+}

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/Camel.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/Camel.java
@@ -112,6 +112,12 @@ public class Camel implements TestActionBuilder<TestAction>, ReferenceResolverAw
         this.delegate = builder;
     }
 
+    @SchemaProperty(kind = ACTION, group = CAMEL_GROUP, module=CAMEL_MODULE,
+            description = "Verify a Camel route existence and status.")
+    public void setVerifyRoute(VerifyRoute builder) {
+        this.delegate = builder;
+    }
+
     @SchemaProperty(kind = GROUP, group = CAMEL_GROUP, module=CAMEL_MODULE,
             description = "Manage Camel infra services.")
     public void setInfra(Infra builder) {

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/VerifyRoute.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/VerifyRoute.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.yaml;
+
+import org.citrusframework.camel.actions.CamelVerifyRouteAction;
+import org.citrusframework.api.yaml.SchemaProperty;
+
+public class VerifyRoute implements CamelActionBuilderWrapper<CamelVerifyRouteAction.Builder> {
+
+    private final CamelVerifyRouteAction.Builder builder = new CamelVerifyRouteAction.Builder();
+
+    @SchemaProperty(description = "The Camel route id to verify.")
+    public void setRoute(String routeId) {
+        builder.route(routeId);
+    }
+
+    @SchemaProperty(description = "The expected route status (e.g. Started, Stopped).")
+    public void setStatus(String status) {
+        builder.status(status);
+    }
+
+    @Override
+    public CamelVerifyRouteAction.Builder getBuilder() {
+        return builder;
+    }
+}

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/actions/CamelVerifyRouteActionTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/actions/CamelVerifyRouteActionTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.actions;
+
+import org.apache.camel.Route;
+import org.apache.camel.ServiceStatus;
+import org.apache.camel.spi.RouteController;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.exceptions.ValidationException;
+import org.citrusframework.testng.AbstractTestNGUnitTest;
+import org.apache.camel.impl.engine.AbstractCamelContext;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+public class CamelVerifyRouteActionTest extends AbstractTestNGUnitTest {
+
+    private final AbstractCamelContext camelContext = Mockito.mock(AbstractCamelContext.class);
+    private final RouteController routeController = Mockito.mock(RouteController.class);
+    private final Route route = Mockito.mock(Route.class);
+
+    @Test
+    public void testVerifyRouteExists() {
+        reset(camelContext);
+
+        when(camelContext.getName()).thenReturn("camel_context");
+        when(camelContext.getRoute("route_1")).thenReturn(route);
+
+        CamelVerifyRouteAction action = new CamelVerifyRouteAction.Builder()
+                .context(camelContext)
+                .route("route_1")
+                .build();
+        action.execute(context);
+    }
+
+    @Test(expectedExceptions = CitrusRuntimeException.class,
+            expectedExceptionsMessageRegExp = ".*does not exist.*")
+    public void testVerifyRouteNotExists() {
+        reset(camelContext);
+
+        when(camelContext.getName()).thenReturn("camel_context");
+        when(camelContext.getRoute("unknown_route")).thenReturn(null);
+
+        CamelVerifyRouteAction action = new CamelVerifyRouteAction.Builder()
+                .context(camelContext)
+                .route("unknown_route")
+                .build();
+        action.execute(context);
+    }
+
+    @Test
+    public void testVerifyRouteStatusStarted() {
+        reset(camelContext, routeController);
+
+        when(camelContext.getName()).thenReturn("camel_context");
+        when(camelContext.getRoute("route_1")).thenReturn(route);
+        when(camelContext.getRouteController()).thenReturn(routeController);
+        when(routeController.getRouteStatus("route_1")).thenReturn(ServiceStatus.Started);
+
+        CamelVerifyRouteAction action = new CamelVerifyRouteAction.Builder()
+                .context(camelContext)
+                .route("route_1")
+                .status(ServiceStatus.Started)
+                .build();
+        action.execute(context);
+    }
+
+    @Test
+    public void testVerifyRouteStatusStopped() {
+        reset(camelContext, routeController);
+
+        when(camelContext.getName()).thenReturn("camel_context");
+        when(camelContext.getRoute("route_1")).thenReturn(route);
+        when(camelContext.getRouteController()).thenReturn(routeController);
+        when(routeController.getRouteStatus("route_1")).thenReturn(ServiceStatus.Stopped);
+
+        CamelVerifyRouteAction action = new CamelVerifyRouteAction.Builder()
+                .context(camelContext)
+                .route("route_1")
+                .status(ServiceStatus.Stopped)
+                .build();
+        action.execute(context);
+    }
+
+    @Test(expectedExceptions = ValidationException.class)
+    public void testVerifyRouteStatusMismatch() {
+        reset(camelContext, routeController);
+
+        when(camelContext.getName()).thenReturn("camel_context");
+        when(camelContext.getRoute("route_1")).thenReturn(route);
+        when(camelContext.getRouteController()).thenReturn(routeController);
+        when(routeController.getRouteStatus("route_1")).thenReturn(ServiceStatus.Stopped);
+
+        CamelVerifyRouteAction action = new CamelVerifyRouteAction.Builder()
+                .context(camelContext)
+                .route("route_1")
+                .status(ServiceStatus.Started)
+                .build();
+        action.execute(context);
+    }
+
+    @Test
+    public void testVerifyRouteWithVariableSupport() {
+        reset(camelContext, routeController);
+
+        context.setVariable("routeId", "route_1");
+        context.setVariable("expectedStatus", "Started");
+
+        when(camelContext.getName()).thenReturn("camel_context");
+        when(camelContext.getRoute("route_1")).thenReturn(route);
+        when(camelContext.getRouteController()).thenReturn(routeController);
+        when(routeController.getRouteStatus("route_1")).thenReturn(ServiceStatus.Started);
+
+        CamelVerifyRouteAction action = new CamelVerifyRouteAction.Builder()
+                .context(camelContext)
+                .route("${routeId}")
+                .status("${expectedStatus}")
+                .build();
+        action.execute(context);
+    }
+
+    @Test
+    public void testVerifyRouteStatusWithStringStatus() {
+        reset(camelContext, routeController);
+
+        when(camelContext.getName()).thenReturn("camel_context");
+        when(camelContext.getRoute("route_1")).thenReturn(route);
+        when(camelContext.getRouteController()).thenReturn(routeController);
+        when(routeController.getRouteStatus("route_1")).thenReturn(ServiceStatus.Started);
+
+        CamelVerifyRouteAction action = new CamelVerifyRouteAction.Builder()
+                .context(camelContext)
+                .route("route_1")
+                .status("Started")
+                .build();
+        action.execute(context);
+    }
+}

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/xml/VerifyRouteTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/xml/VerifyRouteTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.xml;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.camel.CamelSettings;
+import org.citrusframework.camel.actions.CamelVerifyRouteAction;
+import org.citrusframework.xml.XmlTestLoader;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class VerifyRouteTest extends AbstractXmlActionTest {
+
+    @Test
+    public void shouldLoadCamelActions() throws Exception {
+        XmlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/camel/xml/camel-verify-route.citrus.it.xml");
+
+        CamelContext citrusCamelContext = new DefaultCamelContext();
+        citrusCamelContext.addRoutes(new RouteBuilder(citrusCamelContext) {
+            @Override
+            public void configure() {
+                from("direct:hello")
+                        .routeId("route_1")
+                        .to("log:info");
+            }
+        });
+
+        citrusCamelContext.start();
+
+        context.getReferenceResolver().bind(CamelSettings.getContextName(), citrusCamelContext);
+        context.getReferenceResolver().bind("camelContext", citrusCamelContext);
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "CamelVerifyRouteTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 2L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), CamelVerifyRouteAction.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "camel:verify-route");
+
+        int actionIndex = 0;
+
+        CamelVerifyRouteAction action = (CamelVerifyRouteAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve(CamelSettings.getContextName(), CamelContext.class));
+        Assert.assertEquals(action.getRouteId(), "route_1");
+        Assert.assertNull(action.getStatus());
+
+        action = (CamelVerifyRouteAction) result.getTestAction(actionIndex);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve("camelContext", CamelContext.class));
+        Assert.assertEquals(action.getRouteId(), "route_1");
+        Assert.assertEquals(action.getStatus(), "Started");
+    }
+}

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/yaml/VerifyRouteTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/yaml/VerifyRouteTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.yaml;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.camel.CamelSettings;
+import org.citrusframework.camel.actions.CamelVerifyRouteAction;
+import org.citrusframework.yaml.YamlTestLoader;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class VerifyRouteTest extends AbstractYamlActionTest {
+
+    @Test
+    public void shouldLoadCamelActions() throws Exception {
+        YamlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/camel/yaml/camel-verify-route.citrus.it.yaml");
+
+        CamelContext citrusCamelContext = new DefaultCamelContext();
+        citrusCamelContext.addRoutes(new RouteBuilder(citrusCamelContext) {
+            @Override
+            public void configure() {
+                from("direct:hello")
+                        .routeId("route_1")
+                        .to("log:info");
+            }
+        });
+
+        citrusCamelContext.start();
+
+        context.getReferenceResolver().bind(CamelSettings.getContextName(), citrusCamelContext);
+        context.getReferenceResolver().bind("camelContext", citrusCamelContext);
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "CamelVerifyRouteTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 2L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), CamelVerifyRouteAction.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "camel:verify-route");
+
+        int actionIndex = 0;
+
+        CamelVerifyRouteAction action = (CamelVerifyRouteAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve(CamelSettings.getContextName(), CamelContext.class));
+        Assert.assertEquals(action.getRouteId(), "route_1");
+        Assert.assertNull(action.getStatus());
+
+        action = (CamelVerifyRouteAction) result.getTestAction(actionIndex);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve("camelContext", CamelContext.class));
+        Assert.assertEquals(action.getRouteId(), "route_1");
+        Assert.assertEquals(action.getStatus(), "Started");
+    }
+}

--- a/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/xml/camel-verify-route.citrus.it.xml
+++ b/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/xml/camel-verify-route.citrus.it.xml
@@ -1,0 +1,30 @@
+<!--
+  ~ Copyright the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<test name="CamelVerifyRouteTest" author="Christoph" status="FINAL" xmlns="http://citrusframework.org/schema/xml/testcase"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://citrusframework.org/schema/xml/testcase http://citrusframework.org/schema/xml/testcase/citrus-testcase.xsd">
+  <description>Sample test in XML</description>
+  <actions>
+    <camel>
+      <verify-route route="route_1"/>
+    </camel>
+
+    <camel camel-context="camelContext">
+      <verify-route route="route_1" status="Started"/>
+    </camel>
+  </actions>
+</test>

--- a/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/yaml/camel-verify-route.citrus.it.yaml
+++ b/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/yaml/camel-verify-route.citrus.it.yaml
@@ -1,0 +1,13 @@
+name: "CamelVerifyRouteTest"
+author: "Christoph"
+status: "FINAL"
+actions:
+  - camel:
+      verifyRoute:
+        route: "route_1"
+
+  - camel:
+      camelContext: "camelContext"
+      verifyRoute:
+        route: "route_1"
+        status: "Started"

--- a/src/manual/endpoint-camel.adoc
+++ b/src/manual/endpoint-camel.adoc
@@ -757,6 +757,54 @@ Starting and stopping Camel routes at runtime is important when temporarily Citr
 We can stop a route, use a Citrus camel endpoint instead for validation and start the route after the test is done.
 This way we can also simulate errors and failure scenarios in a Camel route interaction.
 
+[camel-route-verify]
+=== Verify route
+
+You can verify that a Camel route exists in the context and optionally assert its current status (e.g. `Started`, `Stopped`).
+This is useful when you need to wait for or assert that a route has reached a certain state before continuing with the test.
+
+.Java
+[source,java,indent=0,role="primary"]
+----
+public class CamelRouteActionIT extends TestNGCitrusSpringSupport {
+
+    @Autowired
+    private CamelContext camelContext;
+
+    @Test
+    @CitrusTest
+    public void verifyRouteStatus() {
+        $(camel().camelContext(camelContext)
+            .route()
+            .verify("route_1")
+            .status(ServiceStatus.Started));
+    }
+}
+----
+
+.XML
+[source,xml,indent=0,role="secondary"]
+----
+<testcase name="CamelRouteIT">
+  <actions>
+      <camel:verify-route route="route_1" status="Started"/>
+  </actions>
+</testcase>
+----
+
+.YAML
+[source,yaml,indent=0,role="secondary"]
+----
+actions:
+  - camel:
+      verifyRoute:
+        route: "route_1"
+        status: "Started"
+----
+
+When no `status` is given, the action only verifies that the route exists in the Camel context.
+The action throws an exception when the route does not exist or when the actual status does not match the expected value.
+
 [[camel-controlbus-actions]]
 == Camel controlbus actions
 

--- a/tools/schema-generator/src/test/resources/control/citrus-catalog-aggregate-test-actions.json
+++ b/tools/schema-generator/src/test/resources/control/citrus-catalog-aggregate-test-actions.json
@@ -1715,6 +1715,31 @@
       },
       "additionalProperties": false    }
   },
+  "camel-verifyRoute": {
+    "kind": "testAction",
+    "version": "${citrus.version}",
+    "name": "camel-verifyRoute",
+    "group": "camel",
+    "module": "citrus-camel",
+    "title": "VerifyRoute",
+    "description": "Verify a Camel route existence and status.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "route": {
+          "type": "string",
+          "title": "Route",
+          "description": "The Camel route id to verify."
+        },
+        "status": {
+          "type": "string",
+          "title": "Status",
+          "description": "The expected route status (e.g. Started, Stopped)."
+        }
+      },
+      "additionalProperties": false    }
+  },
   "createEndpoint": {
     "kind": "testAction",
     "version": "${citrus.version}",


### PR DESCRIPTION
## Summary
- Adds new `CamelVerifyRouteAction` test action that verifies a Camel route's existence and optionally its status (`Started`, `Stopped`, etc.) in a CamelContext
- Accessible via `camel().verifyRoute(routeId).status(ServiceStatus.Started)` in Java DSL
- Includes YAML and XML DSL support (`verifyRoute` / `<verify-route>`)
- Uses `CamelContext.getRoute()` for existence check and `RouteController.getRouteStatus()` for status validation

Closes #1695

## Test plan
- [x] Unit tests for route existence, status verification, status mismatch, and variable support
- [x] YAML DSL parsing test
- [x] XML DSL parsing test
- [x] Full module build (`mvn verify`) passes
- [x] Full reactor build passes

Generated with [Claude Code](https://claude.ai/code)