### PR TITLE
fix(#1654): compile Java test sources into a temp output directory

### DIFF
--- a/core/citrus-base/src/main/java/org/citrusframework/common/JavaTestLoader.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/common/JavaTestLoader.java
@@ -18,13 +18,14 @@ package org.citrusframework.common;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.util.Comparator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 import javax.tools.JavaCompiler;
 import javax.tools.ToolProvider;
 
@@ -50,38 +51,48 @@ public class JavaTestLoader extends DefaultTestLoader implements TestSourceAware
 
     @Override
     public void doLoad() {
+        Path outputDirectory = null;
         try {
             Resource javaSource = getSource().getSourceFile();
-            // Compile source file.
+            // Compile into a temporary directory so .class files never land next to
+            // sources under target/test-classes (default-package sources would otherwise
+            // produce stale classes that Surefire mis-scans on subsequent builds).
+            outputDirectory = Files.createTempDirectory("citrus-java-test-");
             JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
-            int success = compiler.run(null, null, null, javaSource.file().getAbsolutePath());
+            int success = compiler.run(null, null, null,
+                    "-d", outputDirectory.toAbsolutePath().toString(),
+                    javaSource.file().getAbsolutePath());
             if (success != 0) {
                 throw new CitrusRuntimeException("Failed to compile Java source file: %s".formatted(javaSource.file().getAbsolutePath()));
             }
 
-            String packageName = extractPackageName(javaSource);
-            String qualifiedClassName = StringUtils.hasText(packageName) ? packageName + "." + getClassName() : getClassName();
+            String sourcePackageName = extractPackageName(javaSource);
+            String qualifiedClassName = StringUtils.hasText(sourcePackageName) ? sourcePackageName + "." + getClassName() : getClassName();
 
-            // Load and instantiate compiled class.
-            URLClassLoader classLoader = URLClassLoader.newInstance(new URL[] { getClassLoaderBaseURL(packageName, javaSource) }, ClassLoaderHelper.getClassLoader());
-            Class<?> cls = Class.forName(qualifiedClassName, true, classLoader);
-            Object instance = cls.getDeclaredConstructor().newInstance();
+            // Load and instantiate compiled class from the dedicated output directory.
+            try (URLClassLoader classLoader = URLClassLoader.newInstance(
+                    new URL[] { outputDirectory.toUri().toURL() }, ClassLoaderHelper.getClassLoader())) {
+                Class<?> cls = Class.forName(qualifiedClassName, true, classLoader);
+                Object instance = cls.getDeclaredConstructor().newInstance();
 
-            CitrusAnnotations.injectAll(instance, citrus, context);
-            CitrusAnnotations.injectTestRunner(instance, runner);
+                CitrusAnnotations.injectAll(instance, citrus, context);
+                CitrusAnnotations.injectTestRunner(instance, runner);
 
-            doWithTestCase(tc -> {
-                try {
-                    ReflectionHelper.invokeMethod(instance.getClass().getDeclaredMethod("run"), instance);
-                } catch (NoSuchMethodException e) {
-                    throw new CitrusRuntimeException("Failed to run Java test method 'run()' on class: %s".formatted(instance.getClass()), e);
-                }
-            });
+                doWithTestCase(tc -> {
+                    try {
+                        ReflectionHelper.invokeMethod(instance.getClass().getDeclaredMethod("run"), instance);
+                    } catch (NoSuchMethodException e) {
+                        throw new CitrusRuntimeException("Failed to run Java test method 'run()' on class: %s".formatted(instance.getClass()), e);
+                    }
+                });
 
-            super.doLoad();
+                super.doLoad();
+            }
         } catch (IOException | ClassNotFoundException | NoSuchMethodException | InstantiationException |
                  IllegalAccessException | InvocationTargetException e) {
             throw context.handleError(testName, packageName, "Failed to load Java test with name '" + testName + "'", e);
+        } finally {
+            deleteRecursively(outputDirectory);
         }
     }
 
@@ -132,24 +143,22 @@ public class JavaTestLoader extends DefaultTestLoader implements TestSourceAware
         return "";
     }
 
-    /**
-     * Get Class loader base URL for given Java file resource path.
-     * The package name of the class must be taken into account when walking the parent tree of the folder structure upwards.
-     * @param packageName
-     * @param javaSource
-     * @return
-     * @throws MalformedURLException
-     */
-    private static URL getClassLoaderBaseURL(String packageName, Resource javaSource) throws MalformedURLException {
-        Path clBase = Paths.get(javaSource.getURI()).getParent();
-
-        if (StringUtils.hasText(packageName)) {
-            for (int i = 0; i < packageName.split("\\.").length; i++) {
-                clBase = clBase.getParent();
-            }
+    private static void deleteRecursively(Path directory) {
+        if (directory == null || !Files.exists(directory)) {
+            return;
         }
 
-        return clBase.toUri().toURL();
+        try (Stream<Path> walk = Files.walk(directory)) {
+            walk.sorted(Comparator.reverseOrder()).forEach(path -> {
+                try {
+                    Files.deleteIfExists(path);
+                } catch (IOException e) {
+                    // Best-effort cleanup of temporary compile output
+                }
+            });
+        } catch (IOException e) {
+            // Best-effort cleanup of temporary compile output
+        }
     }
 
     /**

--- a/core/citrus-base/src/test/java/org/citrusframework/common/JavaTestLoaderTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/common/JavaTestLoaderTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.common;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.citrusframework.Citrus;
+import org.citrusframework.CitrusInstanceManager;
+import org.citrusframework.TestSource;
+import org.citrusframework.api.common.TestLoader;
+import org.citrusframework.base.DefaultTestCaseRunner;
+import org.citrusframework.base.UnitTestSupport;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JavaTestLoaderTest extends UnitTestSupport {
+
+    @Test
+    public void shouldNotWriteClassFilesNextToSourcesWithoutPackageDeclaration() throws Exception {
+        Path root = Files.createTempDirectory("citrus-java-loader-");
+        Path nestedDir = root.resolve("org")
+                .resolve("citrusframework")
+                .resolve("junit")
+                .resolve("jupiter")
+                .resolve("integration")
+                .resolve("java");
+        Files.createDirectories(nestedDir);
+
+        Path javaFile = nestedDir.resolve("StaleClassSourceTest.java");
+        Files.writeString(javaFile, """
+                public class StaleClassSourceTest {
+                    public void run() {
+                    }
+                }
+                """);
+
+        Path classBesideSource = nestedDir.resolve("StaleClassSourceTest.class");
+        assertThat(classBesideSource).doesNotExist();
+
+        loadJavaSource("StaleClassSourceTest", "", javaFile);
+
+        assertThat(classBesideSource)
+                .as("compiled class must not pollute the source directory (breaks subsequent Maven surefire scans)")
+                .doesNotExist();
+    }
+
+    @Test
+    public void shouldLoadPackagedSourceFromDedicatedOutputDirectory() throws Exception {
+        Path root = Files.createTempDirectory("citrus-java-loader-pkg-");
+        Path nestedDir = root.resolve("com").resolve("example");
+        Files.createDirectories(nestedDir);
+
+        Path javaFile = nestedDir.resolve("PackagedJavaTest.java");
+        Files.writeString(javaFile, """
+                package com.example;
+
+                public class PackagedJavaTest {
+                    public void run() {
+                    }
+                }
+                """);
+
+        Path classBesideSource = nestedDir.resolve("PackagedJavaTest.class");
+        assertThat(classBesideSource).doesNotExist();
+
+        loadJavaSource("PackagedJavaTest", "com.example", javaFile);
+
+        assertThat(classBesideSource).doesNotExist();
+    }
+
+    private void loadJavaSource(String testName, String packageName, Path javaFile) {
+        Citrus citrus = CitrusInstanceManager.getOrDefault();
+
+        JavaTestLoader loader = new JavaTestLoader();
+        loader.setCitrus(citrus);
+        loader.setContext(context);
+        loader.setRunner(new DefaultTestCaseRunner(context));
+        loader.setTestName(testName);
+        loader.setPackageName(packageName);
+
+        TestSource source = new TestSource(TestLoader.JAVA, testName, javaFile.toAbsolutePath().toString());
+        loader.setSource(source);
+
+        loader.load();
+    }
+}


### PR DESCRIPTION
## Summary

`JavaTestLoader` compiled on-disk Java test sources with `javac` without a `-d` output directory. For default-package sources living under a nested path in `target/test-classes`, that wrote `.class` files next to the `.java` resources. Surefire then discovered those stale classes on a subsequent `mvn verify` (without `clean`) and the JVM rejected them with wrong-name errors.

This change:

- Compiles into a temporary directory via `-d`
- Loads the compiled class from that output root
- Cleans up the temporary output after load
- Adds unit coverage for default-package and packaged sources

Fixes #1654

## Test plan

- [x] `./mvnw -pl core/citrus-base test -Dtest=JavaTestLoaderTest` — 2/2 GREEN
- [x] `./mvnw -pl runtime/citrus-junit-jupiter verify` twice without `clean` — no stale `JavaTest.class` / `EchoTest.class` / `DelayTest.class` beside sources; `JavaTestLoader_IT` 7/7 GREEN