### PR TITLE
fix(#1705): Add times(int) option to iterating containers

### DIFF
--- a/core/citrus-api/src/main/java/org/citrusframework/AbstractIteratingContainerBuilder.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/AbstractIteratingContainerBuilder.java
@@ -21,6 +21,7 @@ import java.time.Duration;
 import org.citrusframework.api.container.IteratingActionContainer;
 import org.citrusframework.api.container.IteratingConditionExpression;
 import org.citrusframework.api.container.IteratingContainerBuilder;
+import org.citrusframework.api.container.IterationCountConditionExpression;
 
 public abstract class AbstractIteratingContainerBuilder<T extends IteratingActionContainer, S extends AbstractIteratingContainerBuilder<T, S>>
         extends AbstractTestContainerBuilder<T, S> implements IteratingContainerBuilder<T, S> {
@@ -59,6 +60,12 @@ public abstract class AbstractIteratingContainerBuilder<T extends IteratingActio
     @Override
     public S startsWith(int index) {
         this.start = index;
+        return self;
+    }
+
+    @Override
+    public S times(int numberOfIterations) {
+        this.conditionExpression = IterationCountConditionExpression.untilCount(numberOfIterations);
         return self;
     }
 

--- a/core/citrus-api/src/main/java/org/citrusframework/api/container/IteratingContainerBuilder.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/api/container/IteratingContainerBuilder.java
@@ -49,4 +49,9 @@ public interface IteratingContainerBuilder<T extends IteratingActionContainer, B
      */
     B startsWith(int index);
 
+    /**
+     * Sets the number of iterations to execute.
+     */
+    B times(int numberOfIterations);
+
 }

--- a/core/citrus-api/src/main/java/org/citrusframework/api/container/IterationCountConditionExpression.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/api/container/IterationCountConditionExpression.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.api.container;
+
+import org.citrusframework.context.TestContext;
+
+/**
+ * Condition expression that limits iteration to a fixed number of executions.
+ * Supports both "while" semantics (for iterate containers) and "until" semantics
+ * (for repeat/repeatOnError containers).
+ */
+public class IterationCountConditionExpression implements IteratingConditionExpression {
+
+    private final int numberOfIterations;
+    private final boolean untilSemantics;
+
+    private IterationCountConditionExpression(int numberOfIterations, boolean untilSemantics) {
+        if (numberOfIterations <= 0) {
+            throw new IllegalArgumentException("Number of iterations must be a positive integer");
+        }
+        this.numberOfIterations = numberOfIterations;
+        this.untilSemantics = untilSemantics;
+    }
+
+    /**
+     * Creates a condition for "while" style containers (e.g. iterate).
+     * Returns true while the index has not exceeded the iteration count.
+     */
+    public static IterationCountConditionExpression whileCount(int numberOfIterations) {
+        return new IterationCountConditionExpression(numberOfIterations, false);
+    }
+
+    /**
+     * Creates a condition for "until" style containers (e.g. repeat, repeatOnError).
+     * Returns true when the index has exceeded the iteration count, signaling the loop to stop.
+     */
+    public static IterationCountConditionExpression untilCount(int numberOfIterations) {
+        return new IterationCountConditionExpression(numberOfIterations, true);
+    }
+
+    @Override
+    public boolean evaluate(int index, TestContext context) {
+        if (untilSemantics) {
+            return index > numberOfIterations;
+        }
+        return index <= numberOfIterations;
+    }
+
+    public int getNumberOfIterations() {
+        return numberOfIterations;
+    }
+}

--- a/core/citrus-base/src/main/java/org/citrusframework/container/Iterate.java
+++ b/core/citrus-base/src/main/java/org/citrusframework/container/Iterate.java
@@ -18,6 +18,7 @@ package org.citrusframework.container;
 
 import org.citrusframework.AbstractIteratingContainerBuilder;
 import org.citrusframework.api.container.IterateContainerBuilder;
+import org.citrusframework.api.container.IterationCountConditionExpression;
 import org.citrusframework.context.TestContext;
 
 /**
@@ -73,6 +74,12 @@ public class Iterate extends AbstractIteratingActionContainer {
         @Override
         public Builder step(int step) {
             this.step = step;
+            return this;
+        }
+
+        @Override
+        public Builder times(int numberOfIterations) {
+            this.conditionExpression = IterationCountConditionExpression.whileCount(numberOfIterations);
             return this;
         }
 

--- a/core/citrus-base/src/test/java/org/citrusframework/container/IterateTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/container/IterateTest.java
@@ -149,4 +149,21 @@ public class IterateTest extends UnitTestSupport {
 
         verify(action, times(5)).execute(context);
     }
+
+    @Test
+    public void testIterationTimes() {
+        reset(action);
+
+        Iterate iterate = new Iterate.Builder()
+                .times(5)
+                .index("i")
+                .actions(() -> action)
+                .build();
+        iterate.execute(context);
+
+        Assert.assertNotNull(context.getVariable("${i}"));
+        Assert.assertEquals(context.getVariable("${i}"), "5");
+
+        verify(action, times(5)).execute(context);
+    }
 }

--- a/core/citrus-base/src/test/java/org/citrusframework/container/RepeatOnErrorUntilTrueTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/container/RepeatOnErrorUntilTrueTest.java
@@ -131,4 +131,31 @@ public class RepeatOnErrorUntilTrueTest extends UnitTestSupport {
 
         verify(action, times(4)).execute(context);
     }
+
+    @Test
+    public void testRepeatOnErrorSuccessOnFirstIterationTimes() {
+        RepeatOnErrorUntilTrue repeat = new RepeatOnErrorUntilTrue.Builder()
+                .times(5)
+                .index("i")
+                .actions(() -> action)
+                .build();
+
+        repeat.execute(context);
+
+        verify(action).execute(context);
+    }
+
+    @Test(expectedExceptions = CitrusRuntimeException.class)
+    public void testRepeatOnErrorNoSuccessTimes() {
+        RepeatOnErrorUntilTrue repeat = new RepeatOnErrorUntilTrue.Builder()
+                .times(5)
+                .index("i")
+                .autoSleep(Duration.ofMillis(0))
+                .actions(() -> action, new FailAction.Builder())
+                .build();
+
+        repeat.execute(context);
+
+        verify(action, times(5)).execute(context);
+    }
 }

--- a/core/citrus-base/src/test/java/org/citrusframework/container/RepeatUntilTrueTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/container/RepeatUntilTrueTest.java
@@ -89,4 +89,21 @@ public class RepeatUntilTrueTest extends UnitTestSupport {
 
         verify(action, times(4)).execute(context);
     }
+
+    @Test
+    public void testRepeatTimes() {
+        reset(action);
+
+        RepeatUntilTrue repeatUntilTrue = new RepeatUntilTrue.Builder()
+                .times(5)
+                .index("i")
+                .actions(() -> action)
+                .build();
+        repeatUntilTrue.execute(context);
+
+        Assert.assertNotNull(context.getVariable("${i}"));
+        Assert.assertEquals(context.getVariable("${i}"), "5");
+
+        verify(action, times(5)).execute(context);
+    }
 }

--- a/runtime/citrus-xml/src/main/java/org/citrusframework/xml/container/Iterate.java
+++ b/runtime/citrus-xml/src/main/java/org/citrusframework/xml/container/Iterate.java
@@ -46,9 +46,14 @@ public class Iterate implements TestActionBuilder<org.citrusframework.container.
         builder.description(value);
     }
 
-    @XmlAttribute(name = "condition", required = true)
+    @XmlAttribute(name = "condition")
     public void setCondition(String condition) {
         builder.condition(condition);
+    }
+
+    @XmlAttribute
+    public void setTimes(int times) {
+        builder.times(times);
     }
 
     @XmlAttribute

--- a/runtime/citrus-xml/src/main/java/org/citrusframework/xml/container/Repeat.java
+++ b/runtime/citrus-xml/src/main/java/org/citrusframework/xml/container/Repeat.java
@@ -46,9 +46,14 @@ public class Repeat implements TestActionBuilder<org.citrusframework.container.R
         builder.description(value);
     }
 
-    @XmlAttribute(name = "until", required = true)
+    @XmlAttribute(name = "until")
     public void setUntil(String condition) {
         builder.until(condition);
+    }
+
+    @XmlAttribute
+    public void setTimes(int times) {
+        builder.times(times);
     }
 
     @XmlAttribute

--- a/runtime/citrus-xml/src/main/java/org/citrusframework/xml/container/RepeatOnError.java
+++ b/runtime/citrus-xml/src/main/java/org/citrusframework/xml/container/RepeatOnError.java
@@ -46,9 +46,14 @@ public class RepeatOnError implements TestActionBuilder<org.citrusframework.cont
         builder.description(value);
     }
 
-    @XmlAttribute(required = true)
+    @XmlAttribute
     public void setUntil(String condition) {
         builder.until(condition);
+    }
+
+    @XmlAttribute
+    public void setTimes(int times) {
+        builder.times(times);
     }
 
     @SuppressWarnings("deprecation")

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-5.1.0-SNAPSHOT.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-5.1.0-SNAPSHOT.xsd
@@ -1819,10 +1819,11 @@
       <xs:element name="description" type="xs:string" minOccurs="0"/>
       <xs:element name="actions" type="tns:TestActions" minOccurs="0"/>
     </xs:sequence>
-    <xs:attribute name="condition" type="xs:string" use="required"/>
+    <xs:attribute name="condition" type="xs:string"/>
     <xs:attribute name="index" type="xs:string"/>
     <xs:attribute name="startsWith" type="xs:int"/>
     <xs:attribute name="step" type="xs:int"/>
+    <xs:attribute name="times" type="xs:int"/>
   </xs:complexType>
 
   <xs:complexType name="Sequential">
@@ -1853,7 +1854,8 @@
     </xs:sequence>
     <xs:attribute name="index" type="xs:string"/>
     <xs:attribute name="startsWith" type="xs:int"/>
-    <xs:attribute name="until" type="xs:string" use="required"/>
+    <xs:attribute name="times" type="xs:int"/>
+    <xs:attribute name="until" type="xs:string"/>
   </xs:complexType>
 
   <xs:complexType name="RepeatOnError">
@@ -1865,7 +1867,8 @@
     <xs:attribute name="auto-sleep" type="xs:long"/>
     <xs:attribute name="index" type="xs:string"/>
     <xs:attribute name="startsWith" type="xs:int"/>
-    <xs:attribute name="until" type="xs:string" use="required"/>
+    <xs:attribute name="times" type="xs:int"/>
+    <xs:attribute name="until" type="xs:string"/>
   </xs:complexType>
 
   <xs:complexType name="Conditional">

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
@@ -1819,10 +1819,11 @@
       <xs:element name="description" type="xs:string" minOccurs="0"/>
       <xs:element name="actions" type="tns:TestActions" minOccurs="0"/>
     </xs:sequence>
-    <xs:attribute name="condition" type="xs:string" use="required"/>
+    <xs:attribute name="condition" type="xs:string"/>
     <xs:attribute name="index" type="xs:string"/>
     <xs:attribute name="startsWith" type="xs:int"/>
     <xs:attribute name="step" type="xs:int"/>
+    <xs:attribute name="times" type="xs:int"/>
   </xs:complexType>
 
   <xs:complexType name="Sequential">
@@ -1853,7 +1854,8 @@
     </xs:sequence>
     <xs:attribute name="index" type="xs:string"/>
     <xs:attribute name="startsWith" type="xs:int"/>
-    <xs:attribute name="until" type="xs:string" use="required"/>
+    <xs:attribute name="times" type="xs:int"/>
+    <xs:attribute name="until" type="xs:string"/>
   </xs:complexType>
 
   <xs:complexType name="RepeatOnError">
@@ -1865,7 +1867,8 @@
     <xs:attribute name="auto-sleep" type="xs:long"/>
     <xs:attribute name="index" type="xs:string"/>
     <xs:attribute name="startsWith" type="xs:int"/>
-    <xs:attribute name="until" type="xs:string" use="required"/>
+    <xs:attribute name="times" type="xs:int"/>
+    <xs:attribute name="until" type="xs:string"/>
   </xs:complexType>
 
   <xs:complexType name="Conditional">

--- a/runtime/citrus-xml/src/test/java/org/citrusframework/xml/container/IterateTest.java
+++ b/runtime/citrus-xml/src/test/java/org/citrusframework/xml/container/IterateTest.java
@@ -19,6 +19,7 @@ package org.citrusframework.xml.container;
 import org.citrusframework.TestCase;
 import org.citrusframework.TestCaseMetaInfo;
 import org.citrusframework.actions.EchoAction;
+import org.citrusframework.api.container.IterationCountConditionExpression;
 import org.citrusframework.container.Iterate;
 import org.citrusframework.xml.XmlTestLoader;
 import org.citrusframework.xml.actions.AbstractXmlActionTest;
@@ -36,7 +37,7 @@ public class IterateTest extends AbstractXmlActionTest {
         Assert.assertEquals(result.getName(), "IterateTest");
         Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
         Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
-        Assert.assertEquals(result.getActionCount(), 3L);
+        Assert.assertEquals(result.getActionCount(), 4L);
 
         Assert.assertEquals(result.getTestAction(0).getClass(), Iterate.class);
 
@@ -65,5 +66,15 @@ public class IterateTest extends AbstractXmlActionTest {
         Assert.assertEquals(action.getActionCount(), 2L);
         Assert.assertEquals(action.getTestAction(0).getClass(), EchoAction.class);
         Assert.assertEquals(action.getTestAction(1).getClass(), EchoAction.class);
+
+        action = (Iterate) result.getTestAction(3);
+        Assert.assertNull(action.getCondition());
+        Assert.assertTrue(action.getConditionExpression() instanceof IterationCountConditionExpression);
+        Assert.assertEquals(((IterationCountConditionExpression) action.getConditionExpression()).getNumberOfIterations(), 5);
+        Assert.assertEquals(action.getIndexName(), "i");
+        Assert.assertEquals(action.getStep(), 1);
+        Assert.assertEquals(action.getStart(), 1);
+        Assert.assertEquals(action.getActionCount(), 1L);
+        Assert.assertEquals(action.getTestAction(0).getClass(), EchoAction.class);
     }
 }

--- a/runtime/citrus-xml/src/test/java/org/citrusframework/xml/container/RepeatOnErrorTest.java
+++ b/runtime/citrus-xml/src/test/java/org/citrusframework/xml/container/RepeatOnErrorTest.java
@@ -19,6 +19,7 @@ package org.citrusframework.xml.container;
 import org.citrusframework.TestCase;
 import org.citrusframework.TestCaseMetaInfo;
 import org.citrusframework.actions.EchoAction;
+import org.citrusframework.api.container.IterationCountConditionExpression;
 import org.citrusframework.container.RepeatOnErrorUntilTrue;
 import org.citrusframework.xml.XmlTestLoader;
 import org.citrusframework.xml.actions.AbstractXmlActionTest;
@@ -37,7 +38,7 @@ public class RepeatOnErrorTest extends AbstractXmlActionTest {
         Assert.assertEquals(result.getName(), "RepeatOnErrorTest");
         Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
         Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
-        Assert.assertEquals(result.getActionCount(), 4L);
+        Assert.assertEquals(result.getActionCount(), 5L);
 
         Assert.assertEquals(result.getTestAction(0).getClass(), RepeatOnErrorUntilTrue.class);
 
@@ -71,6 +72,15 @@ public class RepeatOnErrorTest extends AbstractXmlActionTest {
         Assert.assertEquals(action.getIndexName(), "i");
         Assert.assertEquals(action.getStart(), 1);
         Assert.assertEquals(action.getAutoSleep(), Long.valueOf(250L));
+        Assert.assertEquals(action.getActionCount(), 1);
+        Assert.assertEquals(action.getTestAction(0).getClass(), EchoAction.class);
+
+        action = (RepeatOnErrorUntilTrue) result.getTestAction(4);
+        Assert.assertNull(action.getCondition());
+        Assert.assertTrue(action.getConditionExpression() instanceof IterationCountConditionExpression);
+        Assert.assertEquals(((IterationCountConditionExpression) action.getConditionExpression()).getNumberOfIterations(), 5);
+        Assert.assertEquals(action.getIndexName(), "i");
+        Assert.assertEquals(action.getStart(), 1);
         Assert.assertEquals(action.getActionCount(), 1);
         Assert.assertEquals(action.getTestAction(0).getClass(), EchoAction.class);
     }

--- a/runtime/citrus-xml/src/test/java/org/citrusframework/xml/container/RepeatTest.java
+++ b/runtime/citrus-xml/src/test/java/org/citrusframework/xml/container/RepeatTest.java
@@ -19,6 +19,7 @@ package org.citrusframework.xml.container;
 import org.citrusframework.TestCase;
 import org.citrusframework.TestCaseMetaInfo;
 import org.citrusframework.actions.EchoAction;
+import org.citrusframework.api.container.IterationCountConditionExpression;
 import org.citrusframework.container.RepeatUntilTrue;
 import org.citrusframework.xml.XmlTestLoader;
 import org.citrusframework.xml.actions.AbstractXmlActionTest;
@@ -36,7 +37,7 @@ public class RepeatTest extends AbstractXmlActionTest {
         Assert.assertEquals(result.getName(), "RepeatTest");
         Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
         Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
-        Assert.assertEquals(result.getActionCount(), 3L);
+        Assert.assertEquals(result.getActionCount(), 4L);
 
         Assert.assertEquals(result.getTestAction(0).getClass(), RepeatUntilTrue.class);
 
@@ -61,5 +62,14 @@ public class RepeatTest extends AbstractXmlActionTest {
         Assert.assertEquals(action.getActionCount(), 2);
         Assert.assertEquals(action.getTestAction(0).getClass(), EchoAction.class);
         Assert.assertEquals(action.getTestAction(1).getClass(), EchoAction.class);
+
+        action = (RepeatUntilTrue) result.getTestAction(3);
+        Assert.assertNull(action.getCondition());
+        Assert.assertTrue(action.getConditionExpression() instanceof IterationCountConditionExpression);
+        Assert.assertEquals(((IterationCountConditionExpression) action.getConditionExpression()).getNumberOfIterations(), 5);
+        Assert.assertEquals(action.getIndexName(), "i");
+        Assert.assertEquals(action.getStart(), 1);
+        Assert.assertEquals(action.getActionCount(), 1);
+        Assert.assertEquals(action.getTestAction(0).getClass(), EchoAction.class);
     }
 }

--- a/runtime/citrus-xml/src/test/resources/org/citrusframework/xml/container/iterate.citrus.it.xml
+++ b/runtime/citrus-xml/src/test/resources/org/citrusframework/xml/container/iterate.citrus.it.xml
@@ -37,5 +37,11 @@
         <echo><message>Hello You!</message></echo>
       </actions>
     </iterate>
+
+    <iterate times="5">
+      <actions>
+        <echo><message>Hello Citrus!</message></echo>
+      </actions>
+    </iterate>
   </actions>
 </test>

--- a/runtime/citrus-xml/src/test/resources/org/citrusframework/xml/container/repeat-on-error.citrus.it.xml
+++ b/runtime/citrus-xml/src/test/resources/org/citrusframework/xml/container/repeat-on-error.citrus.it.xml
@@ -43,5 +43,11 @@
         <echo><message>Hello Citrus!</message></echo>
       </actions>
     </repeat-on-error>
+
+    <repeat-on-error times="5">
+      <actions>
+        <echo><message>Hello Citrus!</message></echo>
+      </actions>
+    </repeat-on-error>
   </actions>
 </test>

--- a/runtime/citrus-xml/src/test/resources/org/citrusframework/xml/container/repeat.citrus.it.xml
+++ b/runtime/citrus-xml/src/test/resources/org/citrusframework/xml/container/repeat.citrus.it.xml
@@ -37,5 +37,11 @@
         <echo><message>Hello You!</message></echo>
       </actions>
     </repeat>
+
+    <repeat times="5">
+      <actions>
+        <echo><message>Hello Citrus!</message></echo>
+      </actions>
+    </repeat>
   </actions>
 </test>

--- a/runtime/citrus-yaml/src/main/java/org/citrusframework/yaml/container/Iterate.java
+++ b/runtime/citrus-yaml/src/main/java/org/citrusframework/yaml/container/Iterate.java
@@ -44,9 +44,14 @@ public class Iterate implements TestActionBuilder<org.citrusframework.container.
         builder.description(value);
     }
 
-    @SchemaProperty(required = true, description = "Condition that keeps the iteration running.")
+    @SchemaProperty(description = "Condition that keeps the iteration running.")
     public void setCondition(String condition) {
         builder.condition(condition);
+    }
+
+    @SchemaProperty(description = "Number of iterations to execute.")
+    public void setTimes(int times) {
+        builder.times(times);
     }
 
     @SchemaProperty(advanced = true, description = "Test variable holding the current iteration index.")

--- a/runtime/citrus-yaml/src/main/java/org/citrusframework/yaml/container/Repeat.java
+++ b/runtime/citrus-yaml/src/main/java/org/citrusframework/yaml/container/Repeat.java
@@ -54,6 +54,11 @@ public class Repeat implements TestActionBuilder<RepeatUntilTrue>, ReferenceReso
         builder.until(condition);
     }
 
+    @SchemaProperty(description = "Number of iterations to execute.")
+    public void setTimes(int times) {
+        builder.times(times);
+    }
+
     @SchemaProperty(advanced = true, description = "Test variable holding the current iteration index.")
     public void setIndex(String index) {
         builder.index(index);

--- a/runtime/citrus-yaml/src/main/java/org/citrusframework/yaml/container/RepeatOnError.java
+++ b/runtime/citrus-yaml/src/main/java/org/citrusframework/yaml/container/RepeatOnError.java
@@ -54,6 +54,11 @@ public class RepeatOnError implements TestActionBuilder<RepeatOnErrorUntilTrue>,
         builder.until(condition);
     }
 
+    @SchemaProperty(description = "Number of iterations to execute.")
+    public void setTimes(int times) {
+        builder.times(times);
+    }
+
     @SuppressWarnings("deprecation")
     @SchemaProperty(description = "Automatically sleep the time in milliseconds with each attempt.")
     public void setAutoSleep(long milliseconds) {

--- a/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/container/IterateTest.java
+++ b/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/container/IterateTest.java
@@ -19,6 +19,7 @@ package org.citrusframework.yaml.container;
 import org.citrusframework.TestCase;
 import org.citrusframework.TestCaseMetaInfo;
 import org.citrusframework.actions.EchoAction;
+import org.citrusframework.api.container.IterationCountConditionExpression;
 import org.citrusframework.container.Iterate;
 import org.citrusframework.yaml.YamlTestLoader;
 import org.citrusframework.yaml.actions.AbstractYamlActionTest;
@@ -36,7 +37,7 @@ public class IterateTest extends AbstractYamlActionTest {
         Assert.assertEquals(result.getName(), "IterateTest");
         Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
         Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
-        Assert.assertEquals(result.getActionCount(), 3L);
+        Assert.assertEquals(result.getActionCount(), 4L);
 
         Assert.assertEquals(result.getTestAction(0).getClass(), Iterate.class);
 
@@ -65,5 +66,15 @@ public class IterateTest extends AbstractYamlActionTest {
         Assert.assertEquals(action.getActionCount(), 2L);
         Assert.assertEquals(action.getTestAction(0).getClass(), EchoAction.class);
         Assert.assertEquals(action.getTestAction(1).getClass(), EchoAction.class);
+
+        action = (Iterate) result.getTestAction(3);
+        Assert.assertNull(action.getCondition());
+        Assert.assertTrue(action.getConditionExpression() instanceof IterationCountConditionExpression);
+        Assert.assertEquals(((IterationCountConditionExpression) action.getConditionExpression()).getNumberOfIterations(), 5);
+        Assert.assertEquals(action.getIndexName(), "i");
+        Assert.assertEquals(action.getStep(), 1);
+        Assert.assertEquals(action.getStart(), 1);
+        Assert.assertEquals(action.getActionCount(), 1L);
+        Assert.assertEquals(action.getTestAction(0).getClass(), EchoAction.class);
     }
 }

--- a/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/container/RepeatOnErrorTest.java
+++ b/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/container/RepeatOnErrorTest.java
@@ -19,6 +19,7 @@ package org.citrusframework.yaml.container;
 import org.citrusframework.TestCase;
 import org.citrusframework.TestCaseMetaInfo;
 import org.citrusframework.actions.EchoAction;
+import org.citrusframework.api.container.IterationCountConditionExpression;
 import org.citrusframework.container.RepeatOnErrorUntilTrue;
 import org.citrusframework.yaml.YamlTestLoader;
 import org.citrusframework.yaml.actions.AbstractYamlActionTest;
@@ -37,7 +38,7 @@ public class RepeatOnErrorTest extends AbstractYamlActionTest {
         Assert.assertEquals(result.getName(), "RepeatOnErrorTest");
         Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
         Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
-        Assert.assertEquals(result.getActionCount(), 4L);
+        Assert.assertEquals(result.getActionCount(), 5L);
 
         Assert.assertEquals(result.getTestAction(0).getClass(), RepeatOnErrorUntilTrue.class);
 
@@ -71,6 +72,16 @@ public class RepeatOnErrorTest extends AbstractYamlActionTest {
         Assert.assertEquals(action.getIndexName(), "i");
         Assert.assertEquals(action.getStart(), 1);
         Assert.assertEquals(action.getAutoSleep(), Long.valueOf(250L));
+        Assert.assertEquals(action.getActionCount(), 1);
+        Assert.assertEquals(action.getTestAction(0).getClass(), EchoAction.class);
+
+        action = (RepeatOnErrorUntilTrue) result.getTestAction(4);
+        Assert.assertNull(action.getCondition());
+        Assert.assertTrue(action.getConditionExpression() instanceof IterationCountConditionExpression);
+        Assert.assertEquals(((IterationCountConditionExpression) action.getConditionExpression()).getNumberOfIterations(), 5);
+        Assert.assertEquals(action.getIndexName(), "i");
+        Assert.assertEquals(action.getStart(), 1);
+        Assert.assertEquals(action.getAutoSleep(), Long.valueOf(1000L));
         Assert.assertEquals(action.getActionCount(), 1);
         Assert.assertEquals(action.getTestAction(0).getClass(), EchoAction.class);
     }

--- a/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/container/RepeatTest.java
+++ b/runtime/citrus-yaml/src/test/java/org/citrusframework/yaml/container/RepeatTest.java
@@ -19,6 +19,7 @@ package org.citrusframework.yaml.container;
 import org.citrusframework.TestCase;
 import org.citrusframework.TestCaseMetaInfo;
 import org.citrusframework.actions.EchoAction;
+import org.citrusframework.api.container.IterationCountConditionExpression;
 import org.citrusframework.container.RepeatUntilTrue;
 import org.citrusframework.yaml.YamlTestLoader;
 import org.citrusframework.yaml.actions.AbstractYamlActionTest;
@@ -36,7 +37,7 @@ public class RepeatTest extends AbstractYamlActionTest {
         Assert.assertEquals(result.getName(), "RepeatTest");
         Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
         Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
-        Assert.assertEquals(result.getActionCount(), 3L);
+        Assert.assertEquals(result.getActionCount(), 4L);
 
         Assert.assertEquals(result.getTestAction(0).getClass(), RepeatUntilTrue.class);
 
@@ -61,5 +62,14 @@ public class RepeatTest extends AbstractYamlActionTest {
         Assert.assertEquals(action.getActionCount(), 2);
         Assert.assertEquals(action.getTestAction(0).getClass(), EchoAction.class);
         Assert.assertEquals(action.getTestAction(1).getClass(), EchoAction.class);
+
+        action = (RepeatUntilTrue) result.getTestAction(3);
+        Assert.assertNull(action.getCondition());
+        Assert.assertTrue(action.getConditionExpression() instanceof IterationCountConditionExpression);
+        Assert.assertEquals(((IterationCountConditionExpression) action.getConditionExpression()).getNumberOfIterations(), 5);
+        Assert.assertEquals(action.getIndexName(), "i");
+        Assert.assertEquals(action.getStart(), 1);
+        Assert.assertEquals(action.getActionCount(), 1);
+        Assert.assertEquals(action.getTestAction(0).getClass(), EchoAction.class);
     }
 }

--- a/runtime/citrus-yaml/src/test/resources/org/citrusframework/yaml/container/iterate.citrus.it.yaml
+++ b/runtime/citrus-yaml/src/test/resources/org/citrusframework/yaml/container/iterate.citrus.it.yaml
@@ -23,3 +23,8 @@ actions:
             message: Hello Citrus!
         - echo:
             message: Hello You!
+  - iterate:
+      times: 5
+      actions:
+        - echo:
+            message: Hello Citrus!

--- a/runtime/citrus-yaml/src/test/resources/org/citrusframework/yaml/container/repeat-on-error.citrus.it.yaml
+++ b/runtime/citrus-yaml/src/test/resources/org/citrusframework/yaml/container/repeat-on-error.citrus.it.yaml
@@ -29,3 +29,8 @@ actions:
       actions:
         - echo:
             message: Hello Citrus!
+  - repeatOnError:
+      times: 5
+      actions:
+        - echo:
+            message: Hello Citrus!

--- a/runtime/citrus-yaml/src/test/resources/org/citrusframework/yaml/container/repeat.citrus.it.yaml
+++ b/runtime/citrus-yaml/src/test/resources/org/citrusframework/yaml/container/repeat.citrus.it.yaml
@@ -22,3 +22,8 @@ actions:
             message: Hello Citrus!
         - echo:
             message: Hello You!
+  - repeat:
+      times: 5
+      actions:
+        - echo:
+            message: Hello Citrus!

--- a/src/manual/containers-iterate.adoc
+++ b/src/manual/containers-iterate.adoc
@@ -64,7 +64,58 @@ actions:
 
 The attribute "index" automatically defines a new variable that holds the actual loop index starting at "1". This index variable is available as a normal variable inside the iterate container. Therefore it is possible to print out the actual loop index in the echo action as shown in the above example.
 
-The condition string is mandatory and describes the actual end of the loop.
+=== Fixed number of iterations
+
+When you simply want to execute the actions a fixed number of times you can use the `times` option as a shortcut instead of writing a condition expression.
+
+.Java
+[source,java,indent=0,role="primary"]
+----
+@CitrusTest
+public void iterateTimesTest() {
+    $(iterate().times(5)
+        .actions(
+            echo().message("index is: ${i}")
+        )
+    );
+}
+----
+
+.XML
+[source,xml,indent=0,role="secondary"]
+----
+<test name="IterateTimesTest" xmlns="http://citrusframework.org/schema/xml/testcase">
+    <actions>
+        <iterate times="5">
+            <actions>
+                <echo>
+                    <message>index is: ${i}</message>
+                </echo>
+            </actions>
+        </iterate>
+    </actions>
+</test>
+----
+
+.YAML
+[source,yaml,indent=0,role="secondary"]
+----
+name: IterateTimesTest
+actions:
+  - iterate:
+      times: 5
+      actions:
+        - echo:
+            message: "index is: ${i}"
+----
+
+The `times` option automatically creates the proper condition expression to execute the loop exactly the given number of times. This is equivalent to setting `condition("i lt= 5")` but is more concise and readable.
+
+NOTE: The `times` option is an alternative to the `condition` expression. You should use one or the other, not both.
+
+=== Condition expression
+
+The condition string describes the actual end of the loop.
 In iterate containers the loop will break in case the condition evaluates to *_false_*.
 
 The condition string can be any Boolean expression and supports several operators:

--- a/src/manual/containers-repeat-onerror.adoc
+++ b/src/manual/containers-repeat-onerror.adoc
@@ -69,6 +69,59 @@ actions:
 
 In the code example the error-loop continues four times as the <fail> action definitely fails the test. During the fifth iteration the condition "i=5" evaluates to true and the loop breaks its processing leading to a final failure as the test actions were not successful.
 
+=== Fixed number of retries
+
+When you simply want to retry the actions a fixed number of times on error you can use the `times` option as a shortcut instead of writing a condition expression.
+
+.Java
+[source,java,indent=0,role="primary"]
+----
+@CitrusTest
+public void repeatOnErrorTimesTest() {
+    $(repeatOnError().times(5)
+        .actions(
+            echo().message("index is: ${i}"),
+            fail().message("Force loop to fail!")
+        )
+    );
+}
+----
+
+.XML
+[source,xml,indent=0,role="secondary"]
+----
+<test name="RepeatOnErrorTimesTest" xmlns="http://citrusframework.org/schema/xml/testcase">
+    <actions>
+        <repeat-on-error times="5">
+            <actions>
+                <echo>
+                    <message>index is: ${i}</message>
+                </echo>
+                <fail message="Force loop to fail!"/>
+            </actions>
+        </repeat-on-error>
+    </actions>
+</test>
+----
+
+.YAML
+[source,yaml,indent=0,role="secondary"]
+----
+name: RepeatOnErrorTimesTest
+actions:
+  - repeat-on-error:
+      times: 5
+      actions:
+        - echo:
+            message: "index is: ${i}"
+        - fail:
+            message: "Force loop to fail!"
+----
+
+The `times` option automatically creates the proper condition expression to retry the loop at most the given number of times. This is equivalent to setting `until("i gt 5")` but is more concise and readable.
+
+NOTE: The `times` option is an alternative to the `until` condition expression. You should use one or the other, not both.
+
 NOTE: The overall success of the test case depends on the error situation inside the repeat-onerror-until-true container. In case the loop breaks because of failing actions and the loop will discontinue its work the whole test case is failing too. The error loop processing is successful in case all embedded actions were not raising any errors during an iteration.
 
 The repeat-on-error container also offers an automatic sleep mechanism. This auto-sleep property will force the container to wait a given amount of time before executing the next iteration. We used this mechanism a lot when validating database entries. Let's say we want to check the existence of an order entry in the database. Unfortunately the system under test is not very well performing and may need some time to store the new order. This amount of time is not predictable, especially when dealing with different hardware on our test environments (local testing vs. server testing). Following from that our test case may fail unpredictably only because of runtime conditions.

--- a/src/manual/containers-repeat.adoc
+++ b/src/manual/containers-repeat.adoc
@@ -66,6 +66,57 @@ actions:
 
 As you can see the repeat container is only executed when the iterating condition expression evaluates to *false* . By the time the condition is *true* execution is discontinued. You can use basic logical operators such as *and*, *or* and so on.
 
+=== Fixed number of iterations
+
+When you simply want to repeat the actions a fixed number of times you can use the `times` option as a shortcut instead of writing a condition expression.
+
+.Java
+[source,java,indent=0,role="primary"]
+----
+@CitrusTest
+public void repeatTimesTest() {
+    $(repeat().times(5)
+        .actions(
+            echo("index is: ${i}")
+        )
+    );
+}
+----
+
+.XML
+[source,xml,indent=0,role="secondary"]
+----
+<test name="RepeatTimesTest" xmlns="http://citrusframework.org/schema/xml/testcase">
+    <actions>
+        <repeat times="5">
+            <actions>
+                <echo>
+                    <message>index is: ${i}</message>
+                </echo>
+            </actions>
+        </repeat>
+    </actions>
+</test>
+----
+
+.YAML
+[source,yaml,indent=0,role="secondary"]
+----
+name: RepeatTimesTest
+actions:
+  - repeat:
+      times: 5
+      actions:
+        - echo:
+            message: "index is: ${i}"
+----
+
+The `times` option automatically creates the proper condition expression to execute the loop exactly the given number of times. This is equivalent to setting `until("i gt 5")` but is more concise and readable.
+
+NOTE: The `times` option is an alternative to the `until` condition expression. You should use one or the other, not both.
+
+=== Hamcrest matcher conditions
+
 A more powerful way is given by Hamcrest matchers that are directly supported in condition expressions.
 
 .Java

--- a/tools/schema-generator/src/test/resources/control/citrus-catalog-aggregate-test-containers.json
+++ b/tools/schema-generator/src/test/resources/control/citrus-catalog-aggregate-test-containers.json
@@ -254,11 +254,15 @@
           "description": "The step added to the index for each iteration.",
           "default": 1,
           "$comment": "group:advanced"
+        },
+        "times": {
+          "type": "integer",
+          "title": "Times",
+          "description": "Number of iterations to execute."
         }
       },
       "required": [
-        "actions",
-        "condition"
+        "actions"
       ],
       "additionalProperties": false    }
   },
@@ -333,6 +337,11 @@
           "default": 1,
           "$comment": "group:advanced"
         },
+        "times": {
+          "type": "integer",
+          "title": "Times",
+          "description": "Number of iterations to execute."
+        },
         "until": {
           "type": "string",
           "title": "Until",
@@ -387,6 +396,11 @@
           "description": "Index starts with this value.",
           "default": 1,
           "$comment": "group:advanced"
+        },
+        "times": {
+          "type": "integer",
+          "title": "Times",
+          "description": "Number of iterations to execute."
         },
         "until": {
           "type": "string",


### PR DESCRIPTION
## Summary

- Adds a `times(int numberOfIterations)` shortcut to `iterate`, `repeat()`, and `repeatOnError()` containers as an alternative to verbose condition expressions like `condition((i, context) -> i <= 10)` or `until((i, context) -> i > 10)`
- Introduces `IterationCountConditionExpression` with two static factories (`whileCount` for iterate, `untilCount` for repeat/repeatOnError) to handle the opposite condition semantics
- Supports the new option across Java DSL, YAML DSL, XML DSL, XSD schema, and schema generator

## Test plan

- [x] Unit tests for `times()` on `Iterate`, `RepeatUntilTrue`, and `RepeatOnErrorUntilTrue` builders
- [x] YAML DSL parsing tests with `times: 5` for all three containers
- [x] XML DSL parsing tests with `times="5"` for all three containers
- [x] Schema generator control file updated and verified
- [x] All affected modules build successfully (`core/citrus-api`, `core/citrus-base`, `runtime/citrus-yaml`, `runtime/citrus-xml`, `tools/schema-generator`)

Closes #1705

🤖 Generated with [Claude Code](https://claude.com/claude-code)