### PR TITLE
feat(#1707): add KafkaMessageByKeySelector to filter records by key

### DIFF
--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaEndpoint.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/KafkaEndpoint.java
@@ -34,6 +34,7 @@ import static java.lang.Boolean.TRUE;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.kafkaHeaderEquals;
+import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByKeySelector.kafkaKeyEquals;
 import static org.citrusframework.kafka.message.KafkaMessageHeaders.KAFKA_PREFIX;
 import static org.citrusframework.util.StringUtils.hasText;
 import static org.springframework.util.CollectionUtils.isEmpty;
@@ -183,6 +184,17 @@ public class KafkaEndpoint extends AbstractEndpoint implements ShutdownPhase {
                         KafkaMessageFilter.kafkaMessageFilter()
                                 .eventLookbackWindow(lookbackWindow)
                                 .kafkaMessageSelector(kafkaHeaderEquals(key, value))
+                                .build()
+                )
+                .message();
+    }
+
+    public ReceiveMessageBuilderFactory<?, ?> findKafkaEventKeyEquals(Duration lookbackWindow, String key) {
+        return new DefaultTestActions().receive(this)
+                .selector(
+                        KafkaMessageFilter.kafkaMessageFilter()
+                                .eventLookbackWindow(lookbackWindow)
+                                .kafkaMessageSelector(kafkaKeyEquals(key))
                                 .build()
                 )
                 .message();

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/selector/KafkaMessageByKeySelector.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/selector/KafkaMessageByKeySelector.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.kafka.endpoint.selector;
+
+import jakarta.annotation.Nullable;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.ValueMatchingStrategy;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.ValueMatchingStrategy.CONTAINS;
+import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.ValueMatchingStrategy.EQUALS;
+import static org.citrusframework.util.StringUtils.isEmpty;
+
+/**
+ * A matcher for Kafka {@link ConsumerRecord}s based on the record {@code key()}. This class implements
+ * the {@link KafkaMessageSelector} interface and provides flexible matching for Kafka message keys.
+ *
+ * <p>The matching mechanism works as follows:</p>
+ * <ul>
+ *   <li>If the configured key is {@code null}, any non-null record key matches.</li>
+ *   <li>If both the configured key and the record key are specified, the configured
+ *       {@link ValueMatchingStrategy} is applied to the record key's string representation.</li>
+ * </ul>
+ *
+ * <p>The matching strategy can be one of the following:</p>
+ * <ul>
+ *   <li><code>EQUALS</code>: The record key must exactly match the specified value.</li>
+ *   <li><code>CONTAINS</code>: The record key must contain the specified value as a substring.</li>
+ *   <li><code>STARTS_WITH</code>: The record key must start with the specified value.</li>
+ *   <li><code>ENDS_WITH</code>: The record key must end with the specified value.</li>
+ * </ul>
+ *
+ * <p>If no matching strategy is specified, <code>EQUALS</code> is used by default.</p>
+ *
+ * @see ValueMatchingStrategy
+ */
+public class KafkaMessageByKeySelector implements KafkaMessageSelector<String> {
+
+    /**
+     * @see KafkaMessageByKeySelector#key
+     */
+    static final String KEY_FILTER_VALUE = "key-filter-value";
+
+    /**
+     * @see KafkaMessageByKeySelector#valueMatchingStrategy
+     */
+    static final String KEY_FILTER_COMPARATOR = "key-filter-comparator";
+
+    /**
+     * Key-filter being applied to Kafka records. Matches all non-null keys if {@code null}.
+     * Otherwise matches as specified in the {@link KafkaMessageByKeySelector#valueMatchingStrategy}.
+     */
+    private final @Nullable String key;
+
+    /**
+     * Specifies how the {@link KafkaMessageByKeySelector#key} should be matched.
+     */
+    private final @Nullable ValueMatchingStrategy valueMatchingStrategy;
+
+    public static KafkaMessageByKeySelectorBuilder builder() {
+        return new KafkaMessageByKeySelectorBuilder();
+    }
+
+    /**
+     * Creates a {@link KafkaMessageByKeySelector} that checks if the record key contains the given value.
+     *
+     * @param key The value to search for within the record key.
+     * @return A selector configured with {@link ValueMatchingStrategy#CONTAINS}.
+     */
+    public static KafkaMessageByKeySelector kafkaKeyContains(String key) {
+        return builder()
+                .key(key)
+                .valueMatchingStrategy(CONTAINS)
+                .build();
+    }
+
+    /**
+     * Creates a {@link KafkaMessageByKeySelector} that checks if the record key exactly equals the given value.
+     *
+     * @param key The exact record key to match.
+     * @return A selector configured with {@link ValueMatchingStrategy#EQUALS}.
+     */
+    public static KafkaMessageByKeySelector kafkaKeyEquals(String key) {
+        return builder()
+                .key(key)
+                .valueMatchingStrategy(EQUALS)
+                .build();
+    }
+
+    static <T> KafkaMessageByKeySelector fromSelector(Map<String, T> messageSelectors) {
+        var keyFilter = Optional.ofNullable(messageSelectors.get(KEY_FILTER_VALUE)).map(Objects::toString).orElse(null);
+        var comparator = Optional.ofNullable(messageSelectors.get(KEY_FILTER_COMPARATOR)).map(Object::toString).orElse(EQUALS.toString());
+
+        if (isEmpty(keyFilter)) {
+            throw new CitrusRuntimeException("No matcher specified when looking for Kafka messages");
+        }
+
+        return KafkaMessageByKeySelector.builder()
+                .key(keyFilter)
+                .valueMatchingStrategy(ValueMatchingStrategy.valueOf(comparator.toUpperCase()))
+                .build();
+    }
+
+    private KafkaMessageByKeySelector(@Nullable String key, @Nullable ValueMatchingStrategy valueMatchingStrategy) {
+        this.key = key;
+        this.valueMatchingStrategy = valueMatchingStrategy;
+    }
+
+    @Nullable
+    String getKey() {
+        return key;
+    }
+
+    @Nullable
+    ValueMatchingStrategy getValueMatchingStrategy() {
+        return valueMatchingStrategy;
+    }
+
+    @Override
+    public boolean matches(ConsumerRecord<Object, Object> consumerRecord) {
+        var recordKey = consumerRecord.key();
+        if (isNull(recordKey)) {
+            return false;
+        }
+
+        if (isNull(key)) {
+            return true;
+        }
+
+        var recordKeyString = String.valueOf(recordKey);
+        if (isNull(valueMatchingStrategy)) {
+            return recordKeyString.equals(key);
+        }
+
+        return switch (valueMatchingStrategy) {
+            case EQUALS -> recordKeyString.equals(key);
+            case CONTAINS -> recordKeyString.contains(key);
+            case STARTS_WITH -> recordKeyString.startsWith(key);
+            case ENDS_WITH -> recordKeyString.endsWith(key);
+        };
+    }
+
+    @Override
+    public Map<String, String> asSelector() {
+        Map<String, String> selector = new HashMap<>();
+
+        if (nonNull(key)) {
+            selector.put(KEY_FILTER_VALUE, key);
+        }
+
+        selector.put(KEY_FILTER_COMPARATOR, Optional.ofNullable(valueMatchingStrategy).orElse(EQUALS).toString());
+
+        return selector;
+    }
+
+    @Override
+    public String toString() {
+        return "KafkaMessageByKeySelector{" +
+                "key='" + key + '\'' +
+                ", valueMatchingStrategy=" + valueMatchingStrategy +
+                '}';
+    }
+
+    public static class KafkaMessageByKeySelectorBuilder {
+
+        private String key;
+        private ValueMatchingStrategy valueMatchingStrategy;
+
+        public KafkaMessageByKeySelectorBuilder key(String key) {
+            this.key = key;
+            return this;
+        }
+
+        public KafkaMessageByKeySelectorBuilder valueMatchingStrategy(ValueMatchingStrategy valueMatchingStrategy) {
+            this.valueMatchingStrategy = valueMatchingStrategy;
+            return this;
+        }
+
+        public KafkaMessageByKeySelector build() {
+            return new KafkaMessageByKeySelector(key, valueMatchingStrategy);
+        }
+    }
+}

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/selector/KafkaMessageByKeySelector.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/selector/KafkaMessageByKeySelector.java
@@ -20,6 +20,7 @@ import jakarta.annotation.Nullable;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.citrusframework.exceptions.CitrusRuntimeException;
 import org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.ValueMatchingStrategy;
+import org.citrusframework.kafka.message.KafkaMessageHeaders;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -109,7 +110,10 @@ public class KafkaMessageByKeySelector implements KafkaMessageSelector<String> {
     }
 
     static <T> KafkaMessageByKeySelector fromSelector(Map<String, T> messageSelectors) {
-        var keyFilter = Optional.ofNullable(messageSelectors.get(KEY_FILTER_VALUE)).map(Objects::toString).orElse(null);
+        var keyFilter = Optional.ofNullable(messageSelectors.get(KEY_FILTER_VALUE))
+                .or(() -> Optional.ofNullable(messageSelectors.get(KafkaMessageHeaders.MESSAGE_KEY)))
+                .map(Objects::toString)
+                .orElse(null);
         var comparator = Optional.ofNullable(messageSelectors.get(KEY_FILTER_COMPARATOR)).map(Object::toString).orElse(EQUALS.toString());
 
         if (isEmpty(keyFilter)) {

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/selector/KafkaMessageSelectorFactory.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/selector/KafkaMessageSelectorFactory.java
@@ -23,6 +23,7 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.kafka.message.KafkaMessageHeaders;
 
 import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.HEADER_FILTER_KEY;
 import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.HEADER_FILTER_VALUE;
@@ -34,7 +35,7 @@ public class KafkaMessageSelectorFactory {
 
     static {
         strategies.put(messageSelectors -> messageSelectors.containsKey(HEADER_FILTER_KEY) || messageSelectors.containsKey(HEADER_FILTER_VALUE), KafkaMessageByHeaderSelector::fromSelector);
-        strategies.put(messageSelectors -> messageSelectors.containsKey(KEY_FILTER_VALUE), KafkaMessageByKeySelector::fromSelector);
+        strategies.put(messageSelectors -> messageSelectors.containsKey(KEY_FILTER_VALUE) || messageSelectors.containsKey(KafkaMessageHeaders.MESSAGE_KEY), KafkaMessageByKeySelector::fromSelector);
     }
 
     private final KafkaMessageSelectorFactories customStrategies = new KafkaMessageSelectorFactories();

--- a/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/selector/KafkaMessageSelectorFactory.java
+++ b/endpoints/citrus-kafka/src/main/java/org/citrusframework/kafka/endpoint/selector/KafkaMessageSelectorFactory.java
@@ -26,6 +26,7 @@ import org.citrusframework.exceptions.CitrusRuntimeException;
 
 import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.HEADER_FILTER_KEY;
 import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.HEADER_FILTER_VALUE;
+import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByKeySelector.KEY_FILTER_VALUE;
 
 public class KafkaMessageSelectorFactory {
 
@@ -33,6 +34,7 @@ public class KafkaMessageSelectorFactory {
 
     static {
         strategies.put(messageSelectors -> messageSelectors.containsKey(HEADER_FILTER_KEY) || messageSelectors.containsKey(HEADER_FILTER_VALUE), KafkaMessageByHeaderSelector::fromSelector);
+        strategies.put(messageSelectors -> messageSelectors.containsKey(KEY_FILTER_VALUE), KafkaMessageByKeySelector::fromSelector);
     }
 
     private final KafkaMessageSelectorFactories customStrategies = new KafkaMessageSelectorFactories();

--- a/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/selector/KafkaMessageByKeySelectorTest.java
+++ b/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/selector/KafkaMessageByKeySelectorTest.java
@@ -35,6 +35,7 @@ import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByKeySelec
 import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByKeySelector.KEY_FILTER_VALUE;
 import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByKeySelector.kafkaKeyContains;
 import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByKeySelector.kafkaKeyEquals;
+import static org.citrusframework.kafka.message.KafkaMessageHeaders.MESSAGE_KEY;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
@@ -106,6 +107,19 @@ public class KafkaMessageByKeySelectorTest {
                 .satisfies(
                         m -> assertThat(m.getKey()).isEqualTo(key),
                         m -> assertThat(m.getValueMatchingStrategy()).isEqualTo(STARTS_WITH)
+                );
+    }
+
+    @Test
+    public void fromSelector_createsSelectorFromMessageKeyHeader() {
+        var key = "order-42";
+
+        var result = KafkaMessageByKeySelector.fromSelector(Map.of(MESSAGE_KEY, key));
+
+        assertThat(result)
+                .satisfies(
+                        m -> assertThat(m.getKey()).isEqualTo(key),
+                        m -> assertThat(m.getValueMatchingStrategy()).isEqualTo(EQUALS)
                 );
     }
 

--- a/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/selector/KafkaMessageByKeySelectorTest.java
+++ b/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/selector/KafkaMessageByKeySelectorTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.kafka.endpoint.selector;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.ValueMatchingStrategy;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Arrays.stream;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.ValueMatchingStrategy.CONTAINS;
+import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.ValueMatchingStrategy.EQUALS;
+import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.ValueMatchingStrategy.STARTS_WITH;
+import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByKeySelector.KEY_FILTER_COMPARATOR;
+import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByKeySelector.KEY_FILTER_VALUE;
+import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByKeySelector.kafkaKeyContains;
+import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByKeySelector.kafkaKeyEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class KafkaMessageByKeySelectorTest {
+
+    @Test
+    public void builder() {
+        var key = "order-42";
+
+        var fixture = KafkaMessageByKeySelector.builder()
+                .key(key)
+                .valueMatchingStrategy(EQUALS)
+                .build();
+
+        assertThat(fixture)
+                .satisfies(
+                        m -> assertThat(m.getKey()).isEqualTo(key),
+                        m -> assertThat(m.getValueMatchingStrategy()).isEqualTo(EQUALS)
+                );
+    }
+
+    @Test
+    public void kafkaKeyContains_returns_CONTAINS_matcher() {
+        var key = "order";
+
+        var fixture = kafkaKeyContains(key);
+
+        assertThat(fixture)
+                .satisfies(
+                        m -> assertThat(m.getKey()).isEqualTo(key),
+                        m -> assertThat(m.getValueMatchingStrategy()).isEqualTo(CONTAINS)
+                );
+    }
+
+    @Test
+    public void kafkaKeyEquals_returns_EQUALS_matcher() {
+        var key = "order-42";
+
+        var fixture = kafkaKeyEquals(key);
+
+        assertThat(fixture)
+                .satisfies(
+                        m -> assertThat(m.getKey()).isEqualTo(key),
+                        m -> assertThat(m.getValueMatchingStrategy()).isEqualTo(EQUALS)
+                );
+    }
+
+    @Test
+    public void fromSelector_throwsException_whenKeyValueMissing() {
+        var messageSelectors = new HashMap<String, Object>();
+
+        assertThatThrownBy(() -> KafkaMessageByKeySelector.fromSelector(messageSelectors))
+                .isInstanceOf(CitrusRuntimeException.class)
+                .hasMessage("No matcher specified when looking for Kafka messages");
+    }
+
+    @Test
+    public void fromSelector_createsKafkaMessageByKeySelector() {
+        var key = "order-42";
+
+        var messageSelectors = Map.of(
+                KEY_FILTER_VALUE, key,
+                KEY_FILTER_COMPARATOR, STARTS_WITH.toString()
+        );
+
+        var result = KafkaMessageByKeySelector.fromSelector(messageSelectors);
+
+        assertThat(result)
+                .satisfies(
+                        m -> assertThat(m.getKey()).isEqualTo(key),
+                        m -> assertThat(m.getValueMatchingStrategy()).isEqualTo(STARTS_WITH)
+                );
+    }
+
+    @Test
+    public void matches_exactRecordKey() {
+        var matcher = KafkaMessageByKeySelector.builder()
+                .key("order-42")
+                .build();
+
+        assertTrue(matcher.matches(recordWithKey("order-42")));
+        assertFalse(matcher.matches(recordWithKey("order-43")));
+    }
+
+    @Test
+    public void matches_doesNotMatchNullRecordKey() {
+        var matcher = KafkaMessageByKeySelector.builder()
+                .key("order-42")
+                .build();
+
+        assertFalse(matcher.matches(recordWithKey(null)));
+    }
+
+    @Test
+    public void matches_nonStringRecordKeyViaToString() {
+        var matcher = KafkaMessageByKeySelector.builder()
+                .key("42")
+                .build();
+
+        assertTrue(matcher.matches(recordWithKey(42)));
+    }
+
+    @DataProvider
+    public static Object[][] matchingMechanism() {
+        return stream(ValueMatchingStrategy.values())
+                .map(m -> new Object[]{m})
+                .toArray(Object[][]::new);
+    }
+
+    @Test(dataProvider = "matchingMechanism")
+    public void matches_usingSpecifiedMechanism(ValueMatchingStrategy mechanism) {
+        String recordKey = "testValue";
+        String matchValue = switch (mechanism) {
+            case EQUALS -> "testValue";
+            case CONTAINS -> "stVal";
+            case STARTS_WITH -> "test";
+            case ENDS_WITH -> "Value";
+        };
+
+        var matcher = KafkaMessageByKeySelector.builder()
+                .key(matchValue)
+                .valueMatchingStrategy(mechanism)
+                .build();
+
+        assertTrue(matcher.matches(recordWithKey(recordKey)));
+    }
+
+    @Test
+    public void matches_doesNotMatchWhenValueDoesNotMatchUsingSpecifiedMechanism() {
+        var matcher = KafkaMessageByKeySelector.builder()
+                .key("different")
+                .valueMatchingStrategy(EQUALS)
+                .build();
+
+        assertFalse(matcher.matches(recordWithKey("testValue")));
+    }
+
+    @Test
+    public void asSelector_exportsKeyAndDefaultEqualsComparator() {
+        var key = "order-42";
+
+        var fixture = KafkaMessageByKeySelector.builder()
+                .key(key)
+                .build();
+
+        var result = fixture.asSelector();
+
+        assertThat(result)
+                .containsEntry(KEY_FILTER_VALUE, key)
+                .containsEntry(KEY_FILTER_COMPARATOR, EQUALS.toString());
+    }
+
+    @Test
+    public void asSelector_ignoresNullKey() {
+        var fixture = KafkaMessageByKeySelector.builder().build();
+
+        var result = fixture.asSelector();
+
+        assertThat(result)
+                .doesNotContainKey(KEY_FILTER_VALUE)
+                .containsEntry(KEY_FILTER_COMPARATOR, EQUALS.toString());
+    }
+
+    private ConsumerRecord<Object, Object> recordWithKey(Object key) {
+        return new ConsumerRecord<>("topic", 0, 0, key, null);
+    }
+}

--- a/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/selector/KafkaMessageSelectorFactoryTest.java
+++ b/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/selector/KafkaMessageSelectorFactoryTest.java
@@ -29,6 +29,7 @@ import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSe
 import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.HEADER_FILTER_VALUE;
 import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByKeySelector.KEY_FILTER_VALUE;
 import static org.citrusframework.kafka.endpoint.selector.KafkaMessageSelectorFactory.KafkaMessageSelectorFactories.factoryWithKafkaMessageSelector;
+import static org.citrusframework.kafka.message.KafkaMessageHeaders.MESSAGE_KEY;
 import static org.mockito.Mockito.mock;
 
 public class KafkaMessageSelectorFactoryTest {
@@ -75,6 +76,17 @@ public class KafkaMessageSelectorFactoryTest {
     @Test
     public void parseFromSelector_returnsKafkaMessageByKeySelector_ifKeyFilterValueIsPresent() {
         var messageSelectors = Map.of(KEY_FILTER_VALUE, "order-42");
+
+        var result = fixture.parseFromSelector(messageSelectors);
+
+        assertThat(result)
+                .isInstanceOf(KafkaMessageByKeySelector.class)
+                .isNotNull();
+    }
+
+    @Test
+    public void parseFromSelector_returnsKafkaMessageByKeySelector_ifMessageKeyHeaderIsPresent() {
+        var messageSelectors = Map.of(MESSAGE_KEY, "order-42");
 
         var result = fixture.parseFromSelector(messageSelectors);
 

--- a/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/selector/KafkaMessageSelectorFactoryTest.java
+++ b/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/endpoint/selector/KafkaMessageSelectorFactoryTest.java
@@ -27,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.HEADER_FILTER_KEY;
 import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.HEADER_FILTER_VALUE;
+import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByKeySelector.KEY_FILTER_VALUE;
 import static org.citrusframework.kafka.endpoint.selector.KafkaMessageSelectorFactory.KafkaMessageSelectorFactories.factoryWithKafkaMessageSelector;
 import static org.mockito.Mockito.mock;
 
@@ -68,6 +69,17 @@ public class KafkaMessageSelectorFactoryTest {
 
         assertThat(result)
                 .isInstanceOf(KafkaMessageByHeaderSelector.class)
+                .isNotNull();
+    }
+
+    @Test
+    public void parseFromSelector_returnsKafkaMessageByKeySelector_ifKeyFilterValueIsPresent() {
+        var messageSelectors = Map.of(KEY_FILTER_VALUE, "order-42");
+
+        var result = fixture.parseFromSelector(messageSelectors);
+
+        assertThat(result)
+                .isInstanceOf(KafkaMessageByKeySelector.class)
                 .isNotNull();
     }
 

--- a/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/integration/KafkaEndpointJavaIT.java
+++ b/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/integration/KafkaEndpointJavaIT.java
@@ -39,6 +39,7 @@ import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSe
 import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.ValueMatchingStrategy.STARTS_WITH;
 import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.kafkaHeaderContains;
 import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.kafkaHeaderEquals;
+import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByKeySelector.kafkaKeyEquals;
 import static org.citrusframework.kafka.endpoint.selector.KafkaMessageSelectorFactory.KafkaMessageSelectorFactories.factoryWithKafkaMessageSelector;
 import static org.citrusframework.kafka.integration.KafkaEndpointJavaIT.KafkaMessageByKeySelector.MESSAGE_KEY_FILTER_KEY;
 
@@ -328,6 +329,47 @@ public class KafkaEndpointJavaIT extends TestNGCitrusSpringSupport implements Te
 
         then(
                 kafkaWithRandomConsumerGroupEndpoint.findKafkaEventHeaderEquals(Duration.ofSeconds(1L), key, value)
+                        .body(body)
+        );
+    }
+
+    @Test
+    @CitrusTest
+    public void findKafkaEvent_keyEquals_citrus_DSL() {
+        var messageKey = "built-in-key-selector";
+        var body = "findKafkaEvent_keyEquals_citrus_DSL";
+
+        when(
+                send(kafkaWithRandomConsumerGroupEndpoint)
+                        .message(new KafkaMessage(body).messageKey(messageKey))
+        );
+
+        then(
+                receive(kafkaWithRandomConsumerGroupEndpoint)
+                        .selector(
+                                kafkaMessageFilter()
+                                        .eventLookbackWindow(Duration.ofSeconds(1L))
+                                        .kafkaMessageSelector(kafkaKeyEquals(messageKey))
+                                        .build()
+                        )
+                        .message()
+                        .body(body)
+        );
+    }
+
+    @Test
+    @CitrusTest
+    public void findKafkaEvent_keyEquals_java_DSL() {
+        var messageKey = "built-in-key-selector-java";
+        var body = "findKafkaEvent_keyEquals_java_DSL";
+
+        when(
+                send(kafkaWithRandomConsumerGroupEndpoint)
+                        .message(new KafkaMessage(body).messageKey(messageKey))
+        );
+
+        then(
+                kafkaWithRandomConsumerGroupEndpoint.findKafkaEventKeyEquals(Duration.ofSeconds(1L), messageKey)
                         .body(body)
         );
     }

--- a/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/integration/KafkaEndpointJavaIT.java
+++ b/endpoints/citrus-kafka/src/test/java/org/citrusframework/kafka/integration/KafkaEndpointJavaIT.java
@@ -41,7 +41,7 @@ import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSe
 import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByHeaderSelector.kafkaHeaderEquals;
 import static org.citrusframework.kafka.endpoint.selector.KafkaMessageByKeySelector.kafkaKeyEquals;
 import static org.citrusframework.kafka.endpoint.selector.KafkaMessageSelectorFactory.KafkaMessageSelectorFactories.factoryWithKafkaMessageSelector;
-import static org.citrusframework.kafka.integration.KafkaEndpointJavaIT.KafkaMessageByKeySelector.MESSAGE_KEY_FILTER_KEY;
+import static org.citrusframework.kafka.integration.KafkaEndpointJavaIT.KafkaMessageByTopicSelector.TOPIC_FILTER_KEY;
 
 @Test(singleThreaded = true)
 public class KafkaEndpointJavaIT extends TestNGCitrusSpringSupport implements TestActionSupport {
@@ -139,16 +139,16 @@ public class KafkaEndpointJavaIT extends TestNGCitrusSpringSupport implements Te
 
     @Test
     @CitrusTest
-    public void findKafkaEvent_customSelector_byKey_citrus_DSL() {
+    public void findKafkaEvent_customSelector_byTopic_citrus_DSL() {
         var messageKey = "important random key";
-        var body = "findKafkaEvent_customSelector_byKey_citrus_DSL";
+        var body = "findKafkaEvent_customSelector_byTopic_citrus_DSL";
 
         kafkaWithRandomConsumerGroupEndpoint.getEndpointConfiguration()
                 .getKafkaMessageSelectorFactory()
                 .setCustomStrategies(
                         factoryWithKafkaMessageSelector(
-                                messageSelectors -> messageSelectors.containsKey(MESSAGE_KEY_FILTER_KEY),
-                                messageSelectors -> new KafkaMessageByKeySelector((String) messageSelectors.get(MESSAGE_KEY_FILTER_KEY))
+                                messageSelectors -> messageSelectors.containsKey(TOPIC_FILTER_KEY),
+                                messageSelectors -> new KafkaMessageByTopicSelector((String) messageSelectors.get(TOPIC_FILTER_KEY))
                         )
                 );
 
@@ -163,7 +163,7 @@ public class KafkaEndpointJavaIT extends TestNGCitrusSpringSupport implements Te
                                 kafkaMessageFilter()
                                         .eventLookbackWindow(Duration.ofSeconds(1L))
                                         .kafkaMessageSelector(
-                                                new KafkaMessageByKeySelector(messageKey)
+                                                new KafkaMessageByTopicSelector(messageKey)
                                         )
                                         .build()
                         )
@@ -172,17 +172,17 @@ public class KafkaEndpointJavaIT extends TestNGCitrusSpringSupport implements Te
         );
     }
 
-    record KafkaMessageByKeySelector(String key) implements KafkaMessageSelector<String> {
-        static final String MESSAGE_KEY_FILTER_KEY = "message-key";
+    record KafkaMessageByTopicSelector(String topic) implements KafkaMessageSelector<String> {
+        static final String TOPIC_FILTER_KEY = "topic-filter";
 
         @Override
         public boolean matches(ConsumerRecord<Object, Object> consumerRecord) {
-            return nonNull(consumerRecord.key()) && consumerRecord.key().equals(key);
+            return nonNull(consumerRecord.key()) && consumerRecord.key().equals(topic);
         }
 
         @Override
         public Map<String, String> asSelector() {
-            return Map.of(MESSAGE_KEY_FILTER_KEY, key);
+            return Map.of(TOPIC_FILTER_KEY, topic);
         }
     }
 

--- a/src/manual/endpoint-kafka.adoc
+++ b/src/manual/endpoint-kafka.adoc
@@ -648,8 +648,11 @@ then(
 
 .Custom Selector Strategy
 
+Header-based and record-key selectors are built into Citrus and live side by side under <<kafka-message-selector-types,Selector Types>>.
+Use `kafkaHeaderEquals` / `kafkaHeaderContains` or `kafkaKeyEquals` / `kafkaKeyContains` for those cases.
+A custom strategy is only needed when you want a predicate those built-ins do not cover.
+
 In addition to the default Kafka message selection strategies in Citrus, it additionally allows you to define custom message selectors.
-This is especially useful when you want to select messages based on predicates Citrus does not (yet) support.
 
 A custom selector strategy consists of two parts:
 
@@ -665,32 +668,32 @@ kafkaWithRandomConsumerGroupEndpoint.getEndpointConfiguration()
     .getKafkaMessageSelectorFactory()
     .setCustomStrategies(
         factoryWithKafkaMessageSelector(
-            messageSelectors -> messageSelectors.containsKey(MESSAGE_KEY_FILTER_KEY),
-            messageSelectors -> new KafkaMessageByKeySelector(
-                (String) messageSelectors.get(MESSAGE_KEY_FILTER_KEY)
+            messageSelectors -> messageSelectors.containsKey(TOPIC_FILTER_KEY),
+            messageSelectors -> new KafkaMessageByTopicSelector(
+                (String) messageSelectors.get(TOPIC_FILTER_KEY)
             )
         )
     );
 ----
 
-Here, the `MESSAGE_KEY_FILTER_KEY` is a custom key used to recognize and extract the expected Kafka message key from the selector.
+Here, the `TOPIC_FILTER_KEY` is a custom key used to recognize and extract the expected Kafka topic from the selector.
 
-The `KafkaMessageByKeySelector` is an implementation of `KafkaMessageSelector` and matches messages by key:
+The `KafkaMessageByTopicSelector` is an implementation of `KafkaMessageSelector` and matches messages by topic name:
 
 .Java
 [source,java,indent=0,role="primary"]
 ----
-record KafkaMessageByKeySelector(String key) implements KafkaMessageSelector<String> {
-    static final String MESSAGE_KEY_FILTER_KEY = "message-key";
+record KafkaMessageByTopicSelector(String topic) implements KafkaMessageSelector<String> {
+    static final String TOPIC_FILTER_KEY = "topic-filter";
 
     @Override
     public boolean matches(ConsumerRecord<Object, Object> consumerRecord) {
-        return nonNull(consumerRecord.key()) && consumerRecord.key().equals(key);
+        return nonNull(consumerRecord.topic()) && consumerRecord.topic().equals(topic);
     }
 
     @Override
     public Map<String, String> asSelector() {
-        return Map.of(MESSAGE_KEY_FILTER_KEY, key);
+        return Map.of(TOPIC_FILTER_KEY, topic);
     }
 }
 ----

--- a/src/manual/endpoint-kafka.adoc
+++ b/src/manual/endpoint-kafka.adoc
@@ -449,7 +449,7 @@ Additionally, when receiving messages, you might want to use <<kafka-message-sel
 == Kafka Message Selector
 
 The Kafka Message Selector feature allows you to selectively receive messages from a Kafka topic based on specific criteria.
-This powerful functionality enables you to filter Kafka messages by different criteria, e.g. <<kafka-message-selector-types,based on headers>>.
+This powerful functionality enables you to filter Kafka messages by different criteria, e.g. <<kafka-message-selector-types,based on headers or record keys>>.
 Additionally, the defined time window for message retrieval significantly improves the performance.
 Imagine a large Kafka topic with thousands of events.
 Looking through all of these would require an immense amount of resources and time.
@@ -579,6 +579,68 @@ If the `value` is `null` however, all headers with the exact `key` match.
 | `valueMatchingStrategy`
 | `header-filter-comparator`
 | Specifies how the `value` is being matched.
+  Must be one of `EQUALS`, `CONTAINS`, `STARTS_WITH` or `ENDS_WITH`.
+  It defaults to `EQUALS`, if not specified.
+
+|===
+
+.Message Key
+
+The framework also provides selectors that filter on the Kafka record `key()`.
+From within the Java DSL, these can be invoked using statically provided methods:
+
+1. `kafkaKeyEquals`: Matches messages where the record key exactly equals the given value.
+2. `kafkaKeyContains`: Matches messages where the record key contains the given value as a substring.
+
+More advanced users might want to do pre- or suffix matching.
+That is also possible.
+
+.Java
+[source,java,indent=0,role="primary"]
+----
+then(
+    receive(kafkaEndpoint)
+        .selector(
+            kafkaMessageFilter()
+                .eventLookbackWindow(Duration.ofSeconds(1L))
+                .kafkaMessageSelector(kafkaKeyEquals("order-42"))
+                .build()
+        )
+);
+----
+
+.Java 2
+[source,java,indent=0,role="secondary"]
+----
+then(
+    kafkaEndpoint.findKafkaEventKeyEquals(Duration.ofSeconds(1L), "order-42")
+);
+----
+
+.XML
+[source,xml,indent=0,role="secondary"]
+----
+<receive endpoint="helloKafkaEndpoint">
+    <description>Receive Kafka message by record key</description>
+    <selector>
+      <element name="key-filter-value" value="order-42"/>
+      <element name="event-lookback-window" value="PT1S"/>
+    </selector>
+</receive>
+----
+
+[cols="2,2,2"]
+|===
+| Java DSL | XML DSL | Description
+
+| `key`
+| `key-filter-value`
+| Value-filter being applied to the Kafka record key.
+  Compared against `String.valueOf(record.key())`.
+
+| `valueMatchingStrategy`
+| `key-filter-comparator`
+| Specifies how the record key is being matched.
   Must be one of `EQUALS`, `CONTAINS`, `STARTS_WITH` or `ENDS_WITH`.
   It defaults to `EQUALS`, if not specified.
 

--- a/src/manual/endpoint-kafka.adoc
+++ b/src/manual/endpoint-kafka.adoc
@@ -629,14 +629,28 @@ then(
 </receive>
 ----
 
+`citrus_kafka_messageKey` is accepted as a shorthand for `key-filter-value` and defaults to `EQUALS` matching:
+
+.XML
+[source,xml,indent=0,role="secondary"]
+----
+<receive endpoint="helloKafkaEndpoint">
+    <selector>
+      <element name="citrus_kafka_messageKey" value="order-42"/>
+      <element name="event-lookback-window" value="PT1S"/>
+    </selector>
+</receive>
+----
+
 [cols="2,2,2"]
 |===
 | Java DSL | XML DSL | Description
 
-| `key`
-| `key-filter-value`
-| Value-filter being applied to the Kafka record key.
+|| `key`
+|| `key-filter-value` or `citrus_kafka_messageKey`
+|| Value-filter being applied to the Kafka record key.
   Compared against `String.valueOf(record.key())`.
+  `citrus_kafka_messageKey` is a shorthand and always uses `EQUALS`.
 
 | `valueMatchingStrategy`
 | `key-filter-comparator`


### PR DESCRIPTION
## Summary

`KafkaMessageByHeaderSelector` can filter consumed Kafka records by header, but there is no built-in selector for the record key. Tests currently have to register a custom `KafkaMessageSelector` for that common case.

This change:

- Adds `KafkaMessageByKeySelector` with builder, `kafkaKeyEquals` / `kafkaKeyContains`, and `EQUALS` / `CONTAINS` / `STARTS_WITH` / `ENDS_WITH` matching
- Registers the selector in `KafkaMessageSelectorFactory` on `key-filter-value`
- Adds `KafkaEndpoint.findKafkaEventKeyEquals` as a convenience DSL
- Documents the key selector next to the existing header selector

Fixes #1707

## Test plan

- [x] `./mvnw -pl endpoints/citrus-kafka -am test -Dtest=KafkaMessageByKeySelectorTest,KafkaMessageSelectorFactoryTest -Dsurefire.failIfNoSpecifiedTests=false` — 20/20 GREEN
- [x] `./mvnw -pl endpoints/citrus-kafka test -Dtest=KafkaMessageByKeySelectorTest,KafkaMessageSelectorFactoryTest,KafkaMessageByHeaderSelectorTest,KafkaEndpointTest,KafkaMessageFilterTest,KafkaMessageFilteringConsumerTest` — 81/81 GREEN
- [x] `./mvnw -pl endpoints/citrus-kafka verify -Dit.test=KafkaEndpointJavaIT -Dfailsafe.failIfNoSpecifiedTests=false -Dtest=None -Dsurefire.failIfNoSpecifiedTests=false` — 13/13 GREEN (includes `findKafkaEvent_keyEquals_citrus_DSL` and `findKafkaEvent_keyEquals_java_DSL`)