### PR TITLE
fix/#1711: fix type of duration field in remote-result of citrus-agent-maven-plugin

### DIFF
--- a/tools/maven/citrus-agent-maven-plugin/pom.xml
+++ b/tools/maven/citrus-agent-maven-plugin/pom.xml
@@ -156,6 +156,13 @@
       <version>${log4j2.version}</version>
       <scope>compile</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <version>${jackson2.version}</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/tools/maven/citrus-agent-maven-plugin/src/main/java/org/citrusframework/agent/plugin/RunTestMojo.java
+++ b/tools/maven/citrus-agent-maven-plugin/src/main/java/org/citrusframework/agent/plugin/RunTestMojo.java
@@ -42,6 +42,7 @@ import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.LocalPortForward;
 import org.apache.hc.core5.http.ClassicHttpRequest;
@@ -359,6 +360,7 @@ public class RunTestMojo extends AbstractAgentMojo {
                     .disable(JsonParser.Feature.AUTO_CLOSE_SOURCE)
                     .enable(MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES)
                     .addMixIn(Resource.class, IgnoreTypeMixIn.class)
+                    .addModule(new JavaTimeModule())
                     .build()
                     .setDefaultPropertyInclusion(JsonInclude.Value.construct(JsonInclude.Include.NON_EMPTY, JsonInclude.Include.NON_EMPTY));
         }

--- a/tools/maven/citrus-agent-maven-plugin/src/main/java/org/citrusframework/agent/plugin/model/RemoteResult.java
+++ b/tools/maven/citrus-agent-maven-plugin/src/main/java/org/citrusframework/agent/plugin/model/RemoteResult.java
@@ -39,7 +39,7 @@ public class RemoteResult {
     private String className;
 
     /** Duration of the test run */
-    private Long duration;
+    private Duration duration;
 
     /** Failure cause */
     private String cause;
@@ -66,8 +66,7 @@ public class RemoteResult {
         remoteResult.setClassName(testResult.getClassName());
         remoteResult.setDuration(Optional.of(testResult)
                 .map(TestResult::getDuration)
-                .orElse(Duration.ZERO)
-                .toMillis());
+                .orElse(Duration.ZERO));
         remoteResult.setSuccess(testResult.isSuccess());
         remoteResult.setFailed(testResult.isFailed());
         remoteResult.setSkipped(testResult.isSkipped());
@@ -108,7 +107,7 @@ public class RemoteResult {
             throw new CitrusRuntimeException(
                     "Unexpected test result state " + remoteResult.getTestName());
         }
-        return result.withDuration(Duration.ofMillis(remoteResult.getDuration()));
+        return result.withDuration(remoteResult.getDuration());
     }
 
     public String getResult() {
@@ -135,11 +134,11 @@ public class RemoteResult {
         this.className = className;
     }
 
-    public long getDuration() {
+    public Duration getDuration() {
         return duration;
     }
 
-    public void setDuration(long duration) {
+    public void setDuration(Duration duration) {
         this.duration = duration;
     }
 


### PR DESCRIPTION
Closes #1711