### PR TITLE
fix(#1192): honour explicit correlationId header checks

### DIFF
--- a/core/citrus-api/src/main/java/org/citrusframework/message/MessageHeaderUtils.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/message/MessageHeaderUtils.java
@@ -38,6 +38,8 @@ public final class MessageHeaderUtils {
      * <p>
      * This is given if header name starts with internal header prefix or
      * matches one of Spring's internal header names.
+     * {@code correlationId} is excluded so an explicitly set application header
+     * can be transported and validated (for example over HTTP).
      */
     public static boolean isSpringInternalHeader(String headerName) {
         // "springintegration_" makes Citrus work with Spring Integration 1.x release
@@ -54,8 +56,6 @@ public final class MessageHeaderUtils {
         } else if (headerName.equals("contentType")) {
             return true;
         } else if (headerName.equals(PRIORITY)) {
-            return true;
-        } else if (headerName.equals("correlationId")) {
             return true;
         } else if (headerName.equals("routingSlip")) {
             return true;

--- a/core/citrus-api/src/test/java/org/citrusframework/message/MessageHeaderUtilsTest.java
+++ b/core/citrus-api/src/test/java/org/citrusframework/message/MessageHeaderUtilsTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.message;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class MessageHeaderUtilsTest {
+
+    @Test
+    public void shouldNotTreatCorrelationIdAsSpringInternalHeader() {
+        assertFalse(MessageHeaderUtils.isSpringInternalHeader("correlationId"));
+    }
+
+    @Test
+    public void shouldTreatInfrastructureHeadersAsSpringInternal() {
+        assertTrue(MessageHeaderUtils.isSpringInternalHeader("id"));
+        assertTrue(MessageHeaderUtils.isSpringInternalHeader("timestamp"));
+        assertTrue(MessageHeaderUtils.isSpringInternalHeader("contentType"));
+        assertTrue(MessageHeaderUtils.isSpringInternalHeader("replyChannel"));
+    }
+}

--- a/core/citrus-base/src/test/java/org/citrusframework/base/validation/DefaultMessageHeaderValidatorTest.java
+++ b/core/citrus-base/src/test/java/org/citrusframework/base/validation/DefaultMessageHeaderValidatorTest.java
@@ -132,4 +132,43 @@ public class DefaultMessageHeaderValidatorTest extends UnitTestSupport {
 
         validator.validateMessage(receivedMessage, controlMessage, context, validationContext);
     }
+
+    @Test(expectedExceptions = ValidationException.class)
+    public void testValidateCorrelationIdHeaderMismatch() {
+        Message receivedMessage = new DefaultMessage("Hello World!")
+                .setHeader("correlationId", "my-correlation-id");
+        Message controlMessage = new DefaultMessage("Hello World!")
+                .setHeader("correlationId", "NOT-my-correlation-id");
+
+        validator.validateMessage(receivedMessage, controlMessage, context, validationContext);
+    }
+
+    @Test
+    public void testValidateCorrelationIdHeaderMatch() {
+        Message receivedMessage = new DefaultMessage("Hello World!")
+                .setHeader("correlationId", "my-correlation-id");
+        Message controlMessage = new DefaultMessage("Hello World!")
+                .setHeader("correlationId", "my-correlation-id");
+
+        validator.validateMessage(receivedMessage, controlMessage, context, validationContext);
+    }
+
+    @Test(expectedExceptions = ValidationException.class)
+    public void testValidateCorrelationIdHeaderMissing() {
+        Message receivedMessage = new DefaultMessage("Hello World!");
+        Message controlMessage = new DefaultMessage("Hello World!")
+                .setHeader("correlationId", "my-correlation-id");
+
+        validator.validateMessage(receivedMessage, controlMessage, context, validationContext);
+    }
+
+    @Test
+    public void testValidateIgnoresSpringIdAndTimestampHeaders() {
+        Message receivedMessage = new DefaultMessage("Hello World!");
+        Message controlMessage = new DefaultMessage("Hello World!")
+                .setHeader("id", "control-id")
+                .setHeader("timestamp", "1");
+
+        validator.validateMessage(receivedMessage, controlMessage, context, validationContext);
+    }
 }

--- a/endpoints/citrus-http/src/test/java/org/citrusframework/http/message/HttpMessageConverterTest.java
+++ b/endpoints/citrus-http/src/test/java/org/citrusframework/http/message/HttpMessageConverterTest.java
@@ -350,6 +350,18 @@ public class HttpMessageConverterTest {
     }
 
     @Test
+    public void testCorrelationIdHeaderIsCopiedOnOutbound() {
+        // GIVEN
+        message.setHeader("correlationId", "my-correlation-id");
+
+        // WHEN
+        final HttpEntity<?> httpEntity = messageConverter.convertOutbound(message, endpointConfiguration, testContext);
+
+        // THEN
+        assertEquals("my-correlation-id", httpEntity.getHeaders().getFirst("correlationId"));
+    }
+
+    @Test
     public void testCitrusDefaultHeaderAreSetOnInbound() {
         // WHEN
         final HttpMessage httpMessage = messageConverter.convertInbound(HttpEntity.EMPTY, endpointConfiguration, testContext);


### PR DESCRIPTION
## Summary

`MessageHeaderUtils.isSpringInternalHeader` treated `correlationId` as a Spring Integration infrastructure header. That made `DefaultMessageHeaderValidator` skip an explicit control value, so a receive check such as `.header("correlationId", "NOT-my-correlation-id")` could never fail. The same classification also dropped the header from outbound HTTP conversion.

This change:

- Stops classifying `correlationId` as Spring-internal (id/timestamp and other SI headers stay skipped)
- Lets header validation fail on mismatch or a missing value
- Copies `correlationId` onto the outbound HTTP request

Fixes #1192

## Test plan

- [x] `./mvnw -pl core/citrus-base -am test -Dtest=DefaultMessageHeaderValidatorTest#testValidateCorrelationIdHeaderMismatch -Dsurefire.failIfNoSpecifiedTests=false` — RED (no ValidationException)
- [x] `./mvnw -pl core/citrus-api,core/citrus-base,endpoints/citrus-http -am test -Dtest=DefaultMessageHeaderValidatorTest,MessageHeaderUtilsTest,HttpMessageConverterTest -Dsurefire.failIfNoSpecifiedTests=false` — GREEN (2 + 12 + 32)
- [x] `./mvnw -pl core/citrus-api,core/citrus-base test` — citrus-api 318/318 and citrus-base 11142/11142 GREEN