### PR TITLE
fix(#1717): add Camel route statistics verification test action

### DIFF
--- a/core/citrus-api/src/main/java/org/citrusframework/api/actions/camel/CamelRouteActionBuilder.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/api/actions/camel/CamelRouteActionBuilder.java
@@ -66,4 +66,9 @@ public interface CamelRouteActionBuilder<T extends TestAction, B extends CamelRo
      * Verify a Camel route existence and status.
      */
     CamelVerifyRouteActionBuilder<?, ?> verify(String routeId);
+
+    /**
+     * Verify Camel route statistics such as completed exchanges.
+     */
+    CamelVerifyRouteStatsActionBuilder<?, ?> verifyRouteStats(String routeId);
 }

--- a/core/citrus-api/src/main/java/org/citrusframework/api/actions/camel/CamelVerifyRouteStatsActionBuilder.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/api/actions/camel/CamelVerifyRouteStatsActionBuilder.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.api.actions.camel;
+
+import org.citrusframework.TestAction;
+
+public interface CamelVerifyRouteStatsActionBuilder<T extends TestAction, B extends CamelVerifyRouteStatsActionBuilder<T, B>>
+        extends CamelRouteActionBuilderBase<T, B> {
+
+    B route(String routeId);
+
+    B completed(long completed);
+
+    B failed(long failed);
+
+    B stats(String expectedStatsJson);
+}

--- a/core/citrus-api/src/main/java/org/citrusframework/validation/context/json/JsonMessageValidationContext.java
+++ b/core/citrus-api/src/main/java/org/citrusframework/validation/context/json/JsonMessageValidationContext.java
@@ -28,6 +28,8 @@ import org.citrusframework.validation.context.MessageValidationContext;
  */
 public class JsonMessageValidationContext extends DefaultMessageValidationContext {
 
+    private final Boolean strict;
+
     /**
      * Default constructor.
      */
@@ -41,6 +43,11 @@ public class JsonMessageValidationContext extends DefaultMessageValidationContex
      */
     public JsonMessageValidationContext(Builder builder) {
         super(builder);
+        this.strict = builder.strict;
+    }
+
+    public Optional<Boolean> isStrict() {
+        return Optional.ofNullable(strict);
     }
 
     @Override
@@ -54,8 +61,15 @@ public class JsonMessageValidationContext extends DefaultMessageValidationContex
     public static final class Builder extends MessageValidationContext.Builder<JsonMessageValidationContext, Builder>
             implements JsonMessageValidationContextBuilder<JsonMessageValidationContext, Builder> {
 
+        private Boolean strict;
+
         public static Builder json() {
             return new Builder();
+        }
+
+        public Builder strict(boolean strict) {
+            this.strict = strict;
+            return self;
         }
 
         @Override

--- a/endpoints/citrus-camel/pom.xml
+++ b/endpoints/citrus-camel/pom.xml
@@ -66,6 +66,16 @@
       <artifactId>camel-endpointdsl</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-management</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.citrusframework</groupId>
+      <artifactId>citrus-validation-json</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
 
     <dependency>
       <groupId>jakarta.xml.bind</groupId>

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelRouteActionBuilder.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelRouteActionBuilder.java
@@ -151,6 +151,16 @@ public class CamelRouteActionBuilder extends AbstractReferenceResolverAwareTestA
     }
 
     @Override
+    public CamelVerifyRouteStatsAction.Builder verifyRouteStats(String routeId) {
+        CamelVerifyRouteStatsAction.Builder builder = new CamelVerifyRouteStatsAction.Builder()
+                .context(camelContext)
+                .route(routeId);
+
+        this.delegate = builder;
+        return builder;
+    }
+
+    @Override
     public RemoveCamelRouteAction.Builder remove(String... routes) {
         RemoveCamelRouteAction.Builder builder = new RemoveCamelRouteAction.Builder()
                 .context(camelContext)

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelVerifyRouteStatsAction.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/actions/CamelVerifyRouteStatsAction.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.actions;
+
+import java.util.List;
+
+import org.apache.camel.api.management.ManagedCamelContext;
+import org.apache.camel.api.management.mbean.ManagedRouteMBean;
+import org.citrusframework.api.actions.camel.CamelVerifyRouteStatsActionBuilder;
+import org.citrusframework.context.TestContext;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.exceptions.ValidationException;
+import org.citrusframework.message.DefaultMessage;
+import org.citrusframework.message.Message;
+import org.citrusframework.message.MessageType;
+import org.citrusframework.util.StringUtils;
+import org.citrusframework.validation.MessageValidator;
+import org.citrusframework.validation.context.ValidationContext;
+import org.citrusframework.validation.context.json.JsonMessageValidationContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CamelVerifyRouteStatsAction extends AbstractCamelRouteAction {
+
+    private static final Logger logger = LoggerFactory.getLogger(CamelVerifyRouteStatsAction.class);
+
+    private final String routeId;
+    private final Long completed;
+    private final Long failed;
+    private final String expectedStatsJson;
+
+    public CamelVerifyRouteStatsAction(Builder builder) {
+        super("verify-route-stats", builder);
+
+        this.routeId = builder.routeId;
+        this.completed = builder.completed;
+        this.failed = builder.failed;
+        this.expectedStatsJson = builder.expectedStatsJson;
+    }
+
+    @Override
+    public void doExecute(TestContext context) {
+        String resolvedRouteId = context.replaceDynamicContentInString(routeId);
+
+        ManagedCamelContext managedContext = camelContext.getCamelContextExtension()
+                .getContextPlugin(ManagedCamelContext.class);
+
+        if (managedContext == null) {
+            throw new CitrusRuntimeException(
+                    "Failed to get managed Camel context extension - make sure camel-management is on the classpath");
+        }
+
+        ManagedRouteMBean routeMBean = managedContext.getManagedRoute(resolvedRouteId);
+
+        if (routeMBean == null) {
+            throw new CitrusRuntimeException(
+                    "Failed to get managed route statistics for routeId '%s'"
+                            .formatted(resolvedRouteId));
+        }
+
+        if (completed != null) {
+            long actualCompleted = routeMBean.getExchangesCompleted();
+            if (actualCompleted != completed) {
+                throw new ValidationException(
+                        ("Route with routeId '%s' has %d completed exchanges " +
+                                "and did not match the expected value %d")
+                                .formatted(resolvedRouteId, actualCompleted, completed));
+            }
+            logger.info("Verified route '{}' has {} completed exchanges", resolvedRouteId, completed);
+        }
+
+        if (failed != null) {
+            long actualFailed = routeMBean.getExchangesFailed();
+            if (actualFailed != failed) {
+                throw new ValidationException(
+                        ("Route with routeId '%s' has %d failed exchanges " +
+                                "and did not match the expected value %d")
+                                .formatted(resolvedRouteId, actualFailed, failed));
+            }
+            logger.info("Verified route '{}' has {} failed exchanges", resolvedRouteId, failed);
+        }
+
+        if (StringUtils.hasText(expectedStatsJson)) {
+            try {
+                String actualStatsJson = routeMBean.dumpStatsAsJSon(false);
+                String resolvedExpectedJson = context.replaceDynamicContentInString(expectedStatsJson);
+
+                Message receivedMessage = new DefaultMessage(actualStatsJson)
+                        .setType(MessageType.JSON);
+                Message controlMessage = new DefaultMessage(resolvedExpectedJson)
+                        .setType(MessageType.JSON);
+
+                MessageValidator<? extends ValidationContext> validator = MessageValidator.lookup("json")
+                        .orElseThrow(() -> new CitrusRuntimeException(
+                                "No JSON message validator found - make sure citrus-validation-json is on the classpath"));
+
+                validator.validateMessage(receivedMessage, controlMessage, context,
+                        List.of(new JsonMessageValidationContext.Builder()
+                                .schemaValidation(false)
+                                .strict(false)
+                                .build()));
+
+                logger.info("Verified route '{}' statistics JSON matches expected values", resolvedRouteId);
+            } catch (ValidationException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new CitrusRuntimeException(
+                        "Failed to verify route statistics JSON for routeId '%s'"
+                                .formatted(resolvedRouteId), e);
+            }
+        }
+    }
+
+    public String getRouteId() {
+        return routeId;
+    }
+
+    public Long getCompleted() {
+        return completed;
+    }
+
+    public Long getFailed() {
+        return failed;
+    }
+
+    public String getExpectedStatsJson() {
+        return expectedStatsJson;
+    }
+
+    public static final class Builder extends AbstractCamelRouteAction.Builder<CamelVerifyRouteStatsAction, Builder>
+            implements CamelVerifyRouteStatsActionBuilder<CamelVerifyRouteStatsAction, Builder> {
+
+        private String routeId;
+        private Long completed;
+        private Long failed;
+        private String expectedStatsJson;
+
+        @Override
+        public Builder route(String routeId) {
+            this.routeId = routeId;
+            return this;
+        }
+
+        @Override
+        public Builder completed(long completed) {
+            this.completed = completed;
+            return this;
+        }
+
+        @Override
+        public Builder failed(long failed) {
+            this.failed = failed;
+            return this;
+        }
+
+        @Override
+        public Builder stats(String expectedStatsJson) {
+            this.expectedStatsJson = expectedStatsJson;
+            return this;
+        }
+
+        @Override
+        public CamelVerifyRouteStatsAction doBuild() {
+            return new CamelVerifyRouteStatsAction(this);
+        }
+    }
+}

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/Camel.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/Camel.java
@@ -549,6 +549,26 @@ public class Camel implements TestActionBuilder<TestAction>, ReferenceResolverAw
         this.builder = builder;
     }
 
+    @XmlElement(name = "verify-route-stats")
+    public void setVerifyRouteStats(VerifyRouteStats verifyRouteStats) {
+        CamelVerifyRouteStatsAction.Builder builder = new CamelVerifyRouteStatsAction.Builder()
+                .route(verifyRouteStats.getRoute());
+
+        if (verifyRouteStats.getCompleted() != null) {
+            builder.completed(verifyRouteStats.getCompleted());
+        }
+
+        if (verifyRouteStats.getFailed() != null) {
+            builder.failed(verifyRouteStats.getFailed());
+        }
+
+        if (verifyRouteStats.getStats() != null) {
+            builder.stats(verifyRouteStats.getStats());
+        }
+
+        this.builder = builder;
+    }
+
     @XmlElement(name = "remove-routes")
     public void setRemoveRoutes(Routes removeRoutes) {
         RemoveCamelRouteAction.Builder builder = new RemoveCamelRouteAction.Builder();

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/VerifyRouteStats.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/xml/VerifyRouteStats.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.xml;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "")
+public class VerifyRouteStats {
+
+    @XmlAttribute(name = "route", required = true)
+    protected String route;
+
+    @XmlAttribute(name = "completed")
+    protected Long completed;
+
+    @XmlAttribute(name = "failed")
+    protected Long failed;
+
+    @XmlElement(name = "stats")
+    protected String stats;
+
+    public String getRoute() {
+        return route;
+    }
+
+    public void setRoute(String route) {
+        this.route = route;
+    }
+
+    public Long getCompleted() {
+        return completed;
+    }
+
+    public void setCompleted(Long completed) {
+        this.completed = completed;
+    }
+
+    public Long getFailed() {
+        return failed;
+    }
+
+    public void setFailed(Long failed) {
+        this.failed = failed;
+    }
+
+    public String getStats() {
+        return stats;
+    }
+
+    public void setStats(String stats) {
+        this.stats = stats;
+    }
+}

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/Camel.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/Camel.java
@@ -118,6 +118,12 @@ public class Camel implements TestActionBuilder<TestAction>, ReferenceResolverAw
         this.delegate = builder;
     }
 
+    @SchemaProperty(kind = ACTION, group = CAMEL_GROUP, module=CAMEL_MODULE,
+            description = "Verify Camel route statistics such as completed or failed exchanges.")
+    public void setVerifyRouteStats(VerifyRouteStats builder) {
+        this.delegate = builder;
+    }
+
     @SchemaProperty(kind = GROUP, group = CAMEL_GROUP, module=CAMEL_MODULE,
             description = "Manage Camel infra services.")
     public void setInfra(Infra builder) {

--- a/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/VerifyRouteStats.java
+++ b/endpoints/citrus-camel/src/main/java/org/citrusframework/camel/yaml/VerifyRouteStats.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.yaml;
+
+import org.citrusframework.camel.actions.CamelVerifyRouteStatsAction;
+import org.citrusframework.api.yaml.SchemaProperty;
+
+public class VerifyRouteStats implements CamelActionBuilderWrapper<CamelVerifyRouteStatsAction.Builder> {
+
+    private final CamelVerifyRouteStatsAction.Builder builder = new CamelVerifyRouteStatsAction.Builder();
+
+    @SchemaProperty(description = "The Camel route id to verify statistics for.")
+    public void setRoute(String routeId) {
+        builder.route(routeId);
+    }
+
+    @SchemaProperty(description = "The expected number of completed exchanges.")
+    public void setCompleted(long completed) {
+        builder.completed(completed);
+    }
+
+    @SchemaProperty(description = "The expected number of failed exchanges.")
+    public void setFailed(long failed) {
+        builder.failed(failed);
+    }
+
+    @SchemaProperty(description = "Expected route statistics as JSON for comparison with the actual stats dump.")
+    public void setStats(String stats) {
+        builder.stats(stats);
+    }
+
+    @Override
+    public CamelVerifyRouteStatsAction.Builder getBuilder() {
+        return builder;
+    }
+}

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/actions/CamelVerifyRouteStatsActionTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/actions/CamelVerifyRouteStatsActionTest.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.actions;
+
+import org.apache.camel.api.management.ManagedCamelContext;
+import org.apache.camel.api.management.mbean.ManagedRouteMBean;
+import org.apache.camel.ExtendedCamelContext;
+import org.apache.camel.impl.engine.AbstractCamelContext;
+import org.citrusframework.exceptions.CitrusRuntimeException;
+import org.citrusframework.exceptions.ValidationException;
+import org.citrusframework.testng.AbstractTestNGUnitTest;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+public class CamelVerifyRouteStatsActionTest extends AbstractTestNGUnitTest {
+
+    private final AbstractCamelContext camelContext = Mockito.mock(AbstractCamelContext.class);
+    private final ExtendedCamelContext camelContextExtension = Mockito.mock(ExtendedCamelContext.class);
+    private final ManagedCamelContext managedCamelContext = Mockito.mock(ManagedCamelContext.class);
+    private final ManagedRouteMBean routeMBean = Mockito.mock(ManagedRouteMBean.class);
+
+    @Test
+    public void testVerifyCompletedExchanges() {
+        reset(camelContext, camelContextExtension, managedCamelContext, routeMBean);
+
+        when(camelContext.getCamelContextExtension()).thenReturn(camelContextExtension);
+        when(camelContextExtension.getContextPlugin(ManagedCamelContext.class)).thenReturn(managedCamelContext);
+        when(managedCamelContext.getManagedRoute("route_1")).thenReturn(routeMBean);
+        when(routeMBean.getExchangesCompleted()).thenReturn(5L);
+
+        CamelVerifyRouteStatsAction action = new CamelVerifyRouteStatsAction.Builder()
+                .context(camelContext)
+                .route("route_1")
+                .completed(5)
+                .build();
+        action.execute(context);
+    }
+
+    @Test(expectedExceptions = ValidationException.class,
+            expectedExceptionsMessageRegExp = ".*completed exchanges.*did not match.*")
+    public void testVerifyCompletedExchangesMismatch() {
+        reset(camelContext, camelContextExtension, managedCamelContext, routeMBean);
+
+        when(camelContext.getCamelContextExtension()).thenReturn(camelContextExtension);
+        when(camelContextExtension.getContextPlugin(ManagedCamelContext.class)).thenReturn(managedCamelContext);
+        when(managedCamelContext.getManagedRoute("route_1")).thenReturn(routeMBean);
+        when(routeMBean.getExchangesCompleted()).thenReturn(3L);
+
+        CamelVerifyRouteStatsAction action = new CamelVerifyRouteStatsAction.Builder()
+                .context(camelContext)
+                .route("route_1")
+                .completed(5)
+                .build();
+        action.execute(context);
+    }
+
+    @Test
+    public void testVerifyFailedExchanges() {
+        reset(camelContext, camelContextExtension, managedCamelContext, routeMBean);
+
+        when(camelContext.getCamelContextExtension()).thenReturn(camelContextExtension);
+        when(camelContextExtension.getContextPlugin(ManagedCamelContext.class)).thenReturn(managedCamelContext);
+        when(managedCamelContext.getManagedRoute("route_1")).thenReturn(routeMBean);
+        when(routeMBean.getExchangesFailed()).thenReturn(0L);
+
+        CamelVerifyRouteStatsAction action = new CamelVerifyRouteStatsAction.Builder()
+                .context(camelContext)
+                .route("route_1")
+                .failed(0)
+                .build();
+        action.execute(context);
+    }
+
+    @Test(expectedExceptions = ValidationException.class,
+            expectedExceptionsMessageRegExp = ".*failed exchanges.*did not match.*")
+    public void testVerifyFailedExchangesMismatch() {
+        reset(camelContext, camelContextExtension, managedCamelContext, routeMBean);
+
+        when(camelContext.getCamelContextExtension()).thenReturn(camelContextExtension);
+        when(camelContextExtension.getContextPlugin(ManagedCamelContext.class)).thenReturn(managedCamelContext);
+        when(managedCamelContext.getManagedRoute("route_1")).thenReturn(routeMBean);
+        when(routeMBean.getExchangesFailed()).thenReturn(2L);
+
+        CamelVerifyRouteStatsAction action = new CamelVerifyRouteStatsAction.Builder()
+                .context(camelContext)
+                .route("route_1")
+                .failed(0)
+                .build();
+        action.execute(context);
+    }
+
+    @Test(expectedExceptions = CitrusRuntimeException.class,
+            expectedExceptionsMessageRegExp = ".*Failed to get managed route statistics.*")
+    public void testVerifyStatsRouteNotManaged() {
+        reset(camelContext, camelContextExtension, managedCamelContext);
+
+        when(camelContext.getCamelContextExtension()).thenReturn(camelContextExtension);
+        when(camelContextExtension.getContextPlugin(ManagedCamelContext.class)).thenReturn(managedCamelContext);
+        when(managedCamelContext.getManagedRoute("unknown_route")).thenReturn(null);
+
+        CamelVerifyRouteStatsAction action = new CamelVerifyRouteStatsAction.Builder()
+                .context(camelContext)
+                .route("unknown_route")
+                .completed(0)
+                .build();
+        action.execute(context);
+    }
+
+    @Test
+    public void testVerifyWithVariableSupport() {
+        reset(camelContext, camelContextExtension, managedCamelContext, routeMBean);
+
+        context.setVariable("routeId", "route_1");
+
+        when(camelContext.getCamelContextExtension()).thenReturn(camelContextExtension);
+        when(camelContextExtension.getContextPlugin(ManagedCamelContext.class)).thenReturn(managedCamelContext);
+        when(managedCamelContext.getManagedRoute("route_1")).thenReturn(routeMBean);
+        when(routeMBean.getExchangesCompleted()).thenReturn(10L);
+
+        CamelVerifyRouteStatsAction action = new CamelVerifyRouteStatsAction.Builder()
+                .context(camelContext)
+                .route("${routeId}")
+                .completed(10)
+                .build();
+        action.execute(context);
+    }
+
+    @Test
+    public void testVerifyCompletedAndFailed() {
+        reset(camelContext, camelContextExtension, managedCamelContext, routeMBean);
+
+        when(camelContext.getCamelContextExtension()).thenReturn(camelContextExtension);
+        when(camelContextExtension.getContextPlugin(ManagedCamelContext.class)).thenReturn(managedCamelContext);
+        when(managedCamelContext.getManagedRoute("route_1")).thenReturn(routeMBean);
+        when(routeMBean.getExchangesCompleted()).thenReturn(5L);
+        when(routeMBean.getExchangesFailed()).thenReturn(0L);
+
+        CamelVerifyRouteStatsAction action = new CamelVerifyRouteStatsAction.Builder()
+                .context(camelContext)
+                .route("route_1")
+                .completed(5)
+                .failed(0)
+                .build();
+        action.execute(context);
+    }
+
+    @Test(expectedExceptions = CitrusRuntimeException.class,
+            expectedExceptionsMessageRegExp = ".*managed Camel context extension.*")
+    public void testVerifyStatsManagedContextMissing() {
+        reset(camelContext, camelContextExtension);
+
+        when(camelContext.getCamelContextExtension()).thenReturn(camelContextExtension);
+        when(camelContextExtension.getContextPlugin(ManagedCamelContext.class)).thenReturn(null);
+
+        CamelVerifyRouteStatsAction action = new CamelVerifyRouteStatsAction.Builder()
+                .context(camelContext)
+                .route("route_1")
+                .completed(0)
+                .build();
+        action.execute(context);
+    }
+
+    @Test
+    public void testVerifyStatsJson() {
+        reset(camelContext, camelContextExtension, managedCamelContext, routeMBean);
+
+        String actualJson = """
+                {"exchangesCompleted": 5, "exchangesFailed": 0, "meanProcessingTime": 42}""";
+
+        when(camelContext.getCamelContextExtension()).thenReturn(camelContextExtension);
+        when(camelContextExtension.getContextPlugin(ManagedCamelContext.class)).thenReturn(managedCamelContext);
+        when(managedCamelContext.getManagedRoute("route_1")).thenReturn(routeMBean);
+        when(routeMBean.dumpStatsAsJSon(false)).thenReturn(actualJson);
+
+        CamelVerifyRouteStatsAction action = new CamelVerifyRouteStatsAction.Builder()
+                .context(camelContext)
+                .route("route_1")
+                .stats("""
+                        {"exchangesCompleted": 5, "exchangesFailed": 0, "meanProcessingTime": 42}""")
+                .build();
+        action.execute(context);
+    }
+
+    @Test
+    public void testVerifyStatsJsonPartialMatch() {
+        reset(camelContext, camelContextExtension, managedCamelContext, routeMBean);
+
+        String actualJson = """
+                {"exchangesCompleted": 5, "exchangesFailed": 0, "meanProcessingTime": 42}""";
+
+        when(camelContext.getCamelContextExtension()).thenReturn(camelContextExtension);
+        when(camelContextExtension.getContextPlugin(ManagedCamelContext.class)).thenReturn(managedCamelContext);
+        when(managedCamelContext.getManagedRoute("route_1")).thenReturn(routeMBean);
+        when(routeMBean.dumpStatsAsJSon(false)).thenReturn(actualJson);
+
+        CamelVerifyRouteStatsAction action = new CamelVerifyRouteStatsAction.Builder()
+                .context(camelContext)
+                .route("route_1")
+                .stats("""
+                        {"exchangesCompleted": 5}""")
+                .build();
+        action.execute(context);
+    }
+
+    @Test(expectedExceptions = ValidationException.class)
+    public void testVerifyStatsJsonMismatch() {
+        reset(camelContext, camelContextExtension, managedCamelContext, routeMBean);
+
+        String actualJson = """
+                {"exchangesCompleted": 5, "exchangesFailed": 0}""";
+
+        when(camelContext.getCamelContextExtension()).thenReturn(camelContextExtension);
+        when(camelContextExtension.getContextPlugin(ManagedCamelContext.class)).thenReturn(managedCamelContext);
+        when(managedCamelContext.getManagedRoute("route_1")).thenReturn(routeMBean);
+        when(routeMBean.dumpStatsAsJSon(false)).thenReturn(actualJson);
+
+        CamelVerifyRouteStatsAction action = new CamelVerifyRouteStatsAction.Builder()
+                .context(camelContext)
+                .route("route_1")
+                .stats("""
+                        {"exchangesCompleted": 10}""")
+                .build();
+        action.execute(context);
+    }
+
+    @Test
+    public void testVerifyStatsJsonWithCompletedCheck() {
+        reset(camelContext, camelContextExtension, managedCamelContext, routeMBean);
+
+        String actualJson = """
+                {"exchangesCompleted": 5, "exchangesFailed": 0}""";
+
+        when(camelContext.getCamelContextExtension()).thenReturn(camelContextExtension);
+        when(camelContextExtension.getContextPlugin(ManagedCamelContext.class)).thenReturn(managedCamelContext);
+        when(managedCamelContext.getManagedRoute("route_1")).thenReturn(routeMBean);
+        when(routeMBean.getExchangesCompleted()).thenReturn(5L);
+        when(routeMBean.dumpStatsAsJSon(false)).thenReturn(actualJson);
+
+        CamelVerifyRouteStatsAction action = new CamelVerifyRouteStatsAction.Builder()
+                .context(camelContext)
+                .route("route_1")
+                .completed(5)
+                .stats("""
+                        {"exchangesFailed": 0}""")
+                .build();
+        action.execute(context);
+    }
+}

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/xml/VerifyRouteStatsTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/xml/VerifyRouteStatsTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.xml;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.camel.CamelSettings;
+import org.citrusframework.camel.actions.CamelVerifyRouteStatsAction;
+import org.citrusframework.xml.XmlTestLoader;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class VerifyRouteStatsTest extends AbstractXmlActionTest {
+
+    @Test
+    public void shouldLoadCamelActions() throws Exception {
+        XmlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/camel/xml/camel-verify-route-stats.citrus.it.xml");
+
+        CamelContext citrusCamelContext = new DefaultCamelContext();
+        citrusCamelContext.addRoutes(new RouteBuilder(citrusCamelContext) {
+            @Override
+            public void configure() {
+                from("direct:hello")
+                        .routeId("route_1")
+                        .to("log:info");
+            }
+        });
+
+        citrusCamelContext.start();
+
+        context.getReferenceResolver().bind(CamelSettings.getContextName(), citrusCamelContext);
+        context.getReferenceResolver().bind("camelContext", citrusCamelContext);
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "CamelVerifyRouteStatsTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 2L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), CamelVerifyRouteStatsAction.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "camel:verify-route-stats");
+
+        int actionIndex = 0;
+
+        CamelVerifyRouteStatsAction action = (CamelVerifyRouteStatsAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve(CamelSettings.getContextName(), CamelContext.class));
+        Assert.assertEquals(action.getRouteId(), "route_1");
+        Assert.assertEquals(action.getCompleted(), Long.valueOf(0));
+        Assert.assertNull(action.getFailed());
+
+        action = (CamelVerifyRouteStatsAction) result.getTestAction(actionIndex);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve("camelContext", CamelContext.class));
+        Assert.assertEquals(action.getRouteId(), "route_1");
+        Assert.assertEquals(action.getCompleted(), Long.valueOf(0));
+        Assert.assertEquals(action.getFailed(), Long.valueOf(0));
+    }
+}

--- a/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/yaml/VerifyRouteStatsTest.java
+++ b/endpoints/citrus-camel/src/test/java/org/citrusframework/camel/yaml/VerifyRouteStatsTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.camel.yaml;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.citrusframework.TestCase;
+import org.citrusframework.TestCaseMetaInfo;
+import org.citrusframework.camel.CamelSettings;
+import org.citrusframework.camel.actions.CamelVerifyRouteStatsAction;
+import org.citrusframework.yaml.YamlTestLoader;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class VerifyRouteStatsTest extends AbstractYamlActionTest {
+
+    @Test
+    public void shouldLoadCamelActions() throws Exception {
+        YamlTestLoader testLoader = createTestLoader("classpath:org/citrusframework/camel/yaml/camel-verify-route-stats.citrus.it.yaml");
+
+        CamelContext citrusCamelContext = new DefaultCamelContext();
+        citrusCamelContext.addRoutes(new RouteBuilder(citrusCamelContext) {
+            @Override
+            public void configure() {
+                from("direct:hello")
+                        .routeId("route_1")
+                        .to("log:info");
+            }
+        });
+
+        citrusCamelContext.start();
+
+        context.getReferenceResolver().bind(CamelSettings.getContextName(), citrusCamelContext);
+        context.getReferenceResolver().bind("camelContext", citrusCamelContext);
+
+        testLoader.load();
+
+        TestCase result = testLoader.getTestCase();
+        Assert.assertEquals(result.getName(), "CamelVerifyRouteStatsTest");
+        Assert.assertEquals(result.getMetaInfo().getAuthor(), "Christoph");
+        Assert.assertEquals(result.getMetaInfo().getStatus(), TestCaseMetaInfo.Status.FINAL);
+        Assert.assertEquals(result.getActionCount(), 2L);
+        Assert.assertEquals(result.getTestAction(0).getClass(), CamelVerifyRouteStatsAction.class);
+        Assert.assertEquals(result.getTestAction(0).getName(), "camel:verify-route-stats");
+
+        int actionIndex = 0;
+
+        CamelVerifyRouteStatsAction action = (CamelVerifyRouteStatsAction) result.getTestAction(actionIndex++);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve(CamelSettings.getContextName(), CamelContext.class));
+        Assert.assertEquals(action.getRouteId(), "route_1");
+        Assert.assertEquals(action.getCompleted(), Long.valueOf(0));
+        Assert.assertNull(action.getFailed());
+
+        action = (CamelVerifyRouteStatsAction) result.getTestAction(actionIndex);
+        Assert.assertNotNull(action.getCamelContext());
+        Assert.assertEquals(action.getCamelContext(), context.getReferenceResolver().resolve("camelContext", CamelContext.class));
+        Assert.assertEquals(action.getRouteId(), "route_1");
+        Assert.assertEquals(action.getCompleted(), Long.valueOf(0));
+        Assert.assertEquals(action.getFailed(), Long.valueOf(0));
+    }
+}

--- a/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/xml/camel-verify-route-stats.citrus.it.xml
+++ b/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/xml/camel-verify-route-stats.citrus.it.xml
@@ -1,0 +1,30 @@
+<!--
+  ~ Copyright the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<test name="CamelVerifyRouteStatsTest" author="Christoph" status="FINAL" xmlns="http://citrusframework.org/schema/xml/testcase"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://citrusframework.org/schema/xml/testcase http://citrusframework.org/schema/xml/testcase/citrus-testcase.xsd">
+  <description>Sample test in XML</description>
+  <actions>
+    <camel>
+      <verify-route-stats route="route_1" completed="0"/>
+    </camel>
+
+    <camel camel-context="camelContext">
+      <verify-route-stats route="route_1" completed="0" failed="0"/>
+    </camel>
+  </actions>
+</test>

--- a/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/yaml/camel-verify-route-stats.citrus.it.yaml
+++ b/endpoints/citrus-camel/src/test/resources/org/citrusframework/camel/yaml/camel-verify-route-stats.citrus.it.yaml
@@ -1,0 +1,15 @@
+name: "CamelVerifyRouteStatsTest"
+author: "Christoph"
+status: "FINAL"
+actions:
+  - camel:
+      verifyRouteStats:
+        route: "route_1"
+        completed: 0
+
+  - camel:
+      camelContext: "camelContext"
+      verifyRouteStats:
+        route: "route_1"
+        completed: 0
+        failed: 0

--- a/pom.xml
+++ b/pom.xml
@@ -982,6 +982,11 @@
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
+        <artifactId>camel-management</artifactId>
+        <version>${apache.camel.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.camel</groupId>
         <artifactId>camel-tooling-maven</artifactId>
         <version>${apache.camel.version}</version>
       </dependency>

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-5.1.0-SNAPSHOT.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase-5.1.0-SNAPSHOT.xsd
@@ -3223,6 +3223,28 @@
             <xs:attribute name="kamelets-version" type="xs:string"/>
           </xs:complexType>
         </xs:element>
+        <xs:element name="verify-route">
+          <xs:annotation>
+            <xs:documentation>Verify a Camel route existence and status</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:attribute name="route" type="xs:string" use="required"/>
+            <xs:attribute name="status" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="verify-route-stats">
+          <xs:annotation>
+            <xs:documentation>Verify Camel route statistics such as completed or failed exchanges</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="stats" type="xs:string" minOccurs="0"/>
+            </xs:sequence>
+            <xs:attribute name="route" type="xs:string" use="required"/>
+            <xs:attribute name="completed" type="xs:long"/>
+            <xs:attribute name="failed" type="xs:long"/>
+          </xs:complexType>
+        </xs:element>
       </xs:choice>
     </xs:sequence>
     <xs:attribute name="actor" type="xs:string"/>

--- a/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
+++ b/runtime/citrus-xml/src/main/resources/org/citrusframework/schema/xml/testcase/citrus-testcase.xsd
@@ -3223,6 +3223,28 @@
             <xs:attribute name="kamelets-version" type="xs:string"/>
           </xs:complexType>
         </xs:element>
+        <xs:element name="verify-route">
+          <xs:annotation>
+            <xs:documentation>Verify a Camel route existence and status</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:attribute name="route" type="xs:string" use="required"/>
+            <xs:attribute name="status" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="verify-route-stats">
+          <xs:annotation>
+            <xs:documentation>Verify Camel route statistics such as completed or failed exchanges</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="stats" type="xs:string" minOccurs="0"/>
+            </xs:sequence>
+            <xs:attribute name="route" type="xs:string" use="required"/>
+            <xs:attribute name="completed" type="xs:long"/>
+            <xs:attribute name="failed" type="xs:long"/>
+          </xs:complexType>
+        </xs:element>
       </xs:choice>
     </xs:sequence>
     <xs:attribute name="actor" type="xs:string"/>

--- a/src/manual/endpoint-camel.adoc
+++ b/src/manual/endpoint-camel.adoc
@@ -805,6 +805,109 @@ actions:
 When no `status` is given, the action only verifies that the route exists in the Camel context.
 The action throws an exception when the route does not exist or when the actual status does not match the expected value.
 
+[[camel-route-verify-stats]]
+== Camel route statistics verification
+
+The verify route stats action accesses Camel route management statistics using the `camel-management` dependency (`ManagedCamelContext`).
+You can verify individual route metrics like completed and failed exchange counts, or compare the full route statistics JSON returned by `dumpStatsAsJSon()`.
+
+NOTE: The `camel-management` dependency must be on the classpath to use this action.
+For JSON stats comparison, `citrus-validation-json` is also required.
+
+=== Verifying individual metrics
+
+.Java
+[source,java,indent=0,role="primary"]
+----
+public class CamelRouteStatsIT extends TestNGCitrusSpringSupport {
+
+    @Autowired
+    private CamelContext camelContext;
+
+    @Test
+    @CitrusTest
+    public void verifyRouteStats() {
+        $(camel().camelContext(camelContext)
+            .route()
+            .verifyRouteStats("route_1")
+            .completed(5)
+            .failed(0));
+    }
+}
+----
+
+.XML
+[source,xml,indent=0,role="secondary"]
+----
+<testcase name="CamelRouteStatsIT">
+  <actions>
+      <camel:verify-route-stats route="route_1" completed="5" failed="0"/>
+  </actions>
+</testcase>
+----
+
+.YAML
+[source,yaml,indent=0,role="secondary"]
+----
+actions:
+  - camel:
+      verifyRouteStats:
+        route: "route_1"
+        completed: 5
+        failed: 0
+----
+
+The action verifies the number of completed and/or failed exchanges on the given route.
+Both `completed` and `failed` are optional - you can verify one or both.
+
+=== Verifying route statistics JSON
+
+You can also verify the full route statistics JSON using the Citrus JSON message validator.
+The expected JSON supports partial matching - you only need to specify the fields you want to verify.
+
+.Java
+[source,java,indent=0,role="primary"]
+----
+public class CamelRouteStatsJsonIT extends TestNGCitrusSpringSupport {
+
+    @Autowired
+    private CamelContext camelContext;
+
+    @Test
+    @CitrusTest
+    public void verifyRouteStatsJson() {
+        $(camel().camelContext(camelContext)
+            .route()
+            .verifyRouteStats("route_1")
+            .stats("{\"exchangesCompleted\": 5, \"exchangesFailed\": 0}"));
+    }
+}
+----
+
+.XML
+[source,xml,indent=0,role="secondary"]
+----
+<testcase name="CamelRouteStatsJsonIT">
+  <actions>
+      <camel:verify-route-stats route="route_1">
+          <stats>{"exchangesCompleted": 5, "exchangesFailed": 0}</stats>
+      </camel:verify-route-stats>
+  </actions>
+</testcase>
+----
+
+.YAML
+[source,yaml,indent=0,role="secondary"]
+----
+actions:
+  - camel:
+      verifyRouteStats:
+        route: "route_1"
+        stats: '{"exchangesCompleted": 5, "exchangesFailed": 0}'
+----
+
+You can combine individual metric checks with JSON stats comparison in a single action.
+
 [[camel-controlbus-actions]]
 == Camel controlbus actions
 

--- a/tools/schema-generator/src/test/resources/control/citrus-catalog-aggregate-test-actions.json
+++ b/tools/schema-generator/src/test/resources/control/citrus-catalog-aggregate-test-actions.json
@@ -1744,6 +1744,41 @@
       },
       "additionalProperties": false    }
   },
+  "camel-verifyRouteStats": {
+    "kind": "testAction",
+    "version": "${citrus.version}",
+    "name": "camel-verifyRouteStats",
+    "group": "camel",
+    "module": "citrus-camel",
+    "title": "VerifyRouteStats",
+    "description": "Verify Camel route statistics such as completed or failed exchanges.",
+    "propertiesSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "route": {
+          "type": "string",
+          "title": "Route",
+          "description": "The Camel route id to verify statistics for."
+        },
+        "completed": {
+          "type": "integer",
+          "title": "Completed",
+          "description": "The expected number of completed exchanges."
+        },
+        "failed": {
+          "type": "integer",
+          "title": "Failed",
+          "description": "The expected number of failed exchanges."
+        },
+        "stats": {
+          "type": "string",
+          "title": "Stats",
+          "description": "Expected route statistics as JSON for comparison with the actual stats dump."
+        }
+      },
+      "additionalProperties": false    }
+  },
   "createEndpoint": {
     "kind": "testAction",
     "version": "${citrus.version}",

--- a/validation/citrus-validation-json/src/main/java/org/citrusframework/validation/json/JsonTextMessageValidator.java
+++ b/validation/citrus-validation-json/src/main/java/org/citrusframework/validation/json/JsonTextMessageValidator.java
@@ -77,7 +77,12 @@ public class JsonTextMessageValidator extends AbstractMessageValidator<MessageVa
             throw new ValidationException("Validation failed - expected message contents, but received empty message!");
         }
 
-        elementValidatorProvider.getValidator(strict, context, validationContext)
+        boolean effectiveStrict = strict;
+        if (validationContext instanceof JsonMessageValidationContext jsonContext) {
+            effectiveStrict = jsonContext.isStrict().orElse(strict);
+        }
+
+        elementValidatorProvider.getValidator(effectiveStrict, context, validationContext)
             .validate(parseJson(permissiveMode, receivedJsonText, controlJsonText));
 
         logger.debug("JSON message validation successful: All values OK");


### PR DESCRIPTION
## Summary
- Adds a new `CamelVerifyRouteStatsAction` that validates Apache Camel route statistics (completed/failed exchanges) using the `camel-management` MBean API
- Supports individual metric checks (`completed`, `failed`) and full JSON stats comparison via `dumpStatsAsJSon()` with the Citrus JSON message validator
- Wired into Java DSL (`route().verifyStats("routeId")`), YAML DSL (`verifyRouteStats`), and XML DSL (`<verify-route-stats>`)

Closes #1717

## Test plan
- [x] Unit tests for completed/failed exchange verification, mismatch detection, missing managed context, variable support
- [x] YAML DSL parsing test with test resource file
- [x] XML DSL parsing test with test resource file
- [x] Full module test suite passes (unit + integration tests, 0 failures)
- [x] Full reactor build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)